### PR TITLE
Protection check to avoid overwriting of the audit file

### DIFF
--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -67,8 +67,13 @@ The AI model intelligently assesses what stages are needed based on:
 
 ## Workspace Detection (ALWAYS EXECUTE)
 
-1. **MANDATORY**: Log initial user request in audit.md with complete raw input
-2. Load all steps from `inception/workspace-detection.md`
+1. **MANDATORY - FIRST**: Basic existing project check:
+   - Check if `aidlc-docs/audit.md` exists
+   - **IF exists AND user requests NEW project**: STOP and present protection message
+   - **IF exists AND user requests CONTINUE/RESUME**: Continue normally
+   - **IF not exists**: Continue with new project creation
+2. **MANDATORY**: Log initial user request in audit.md with complete raw input
+3. Load all steps from `inception/workspace-detection.md`
 3. Execute workspace detection:
    - Check for existing aidlc-state.md (resume if found)
    - Scan workspace for existing code


### PR DESCRIPTION
Issue 8: https://github.com/awslabs/aidlc-workflows/issues/8

added a protection check before the audit file is updated at the beginning of the workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
