### PR TITLE
Issue #30. Added code placement rules for greenfield/brownfield for monolith/microservice architectures

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
@@ -5,6 +5,8 @@ This stage generates code for each unit of work through two integrated parts:
 - **Part 1 - Planning**: Create detailed code generation plan with explicit steps
 - **Part 2 - Generation**: Execute approved plan to generate code, tests, and artifacts
 
+**Note**: For brownfield projects, "generate" means modify existing files when appropriate, not create duplicates.
+
 ## Prerequisites
 - Unit Design Generation must be complete for the unit
 - NFR Implementation (if executed) must be complete for the unit
@@ -22,7 +24,12 @@ This stage generates code for each unit of work through two integrated parts:
 - [ ] Validate unit is ready for code generation
 
 ## Step 2: Create Detailed Unit Code Generation Plan
+- [ ] Read workspace root and project type from `aidlc-docs/aidlc-state.md`
+- [ ] Determine code location (see Critical Rules for structure patterns)
+- [ ] **Brownfield only**: Review reverse engineering code-structure.md for existing files to modify
+- [ ] Document exact paths (never aidlc-docs/)
 - [ ] Create explicit steps for unit generation:
+  - Project Structure Setup (greenfield only)
   - Business Logic Generation
   - Business Logic Unit Testing
   - Business Logic Summary
@@ -32,11 +39,11 @@ This stage generates code for each unit of work through two integrated parts:
   - Repository Layer Generation
   - Repository Layer Unit Testing
   - Repository Layer Summary
-  - Database Migration Scripts Generation (if data models exist)
+  - Database Migration Scripts (if data models exist)
   - Documentation Generation (API docs, README updates)
   - Deployment Artifacts Generation
 - [ ] Number each step sequentially
-- [ ] Include story mapping references for this unit
+- [ ] Include story mapping references
 - [ ] Add checkboxes [ ] for each step
 
 ## Step 3: Include Unit Generation Context
@@ -91,15 +98,23 @@ This stage generates code for each unit of work through two integrated parts:
 - [ ] Load the context for that step (unit, dependencies, stories)
 
 ## Step 11: Execute Current Step
-- [ ] Perform exactly what the current step describes
-- [ ] Generate code, tests, or documentation as specified
-- [ ] Follow the unit's story requirements
-- [ ] Respect dependencies and interfaces defined in the plan
+- [ ] Verify target directory from plan (never aidlc-docs/)
+- [ ] **Brownfield only**: Check if target file exists
+- [ ] Generate exactly what the current step describes:
+  - **If file exists**: Modify it in-place (never create `ClassName_modified.java`, `ClassName_new.java`, etc.)
+  - **If file doesn't exist**: Create new file
+- [ ] Write to correct locations:
+  - **Application Code**: Workspace root per project structure
+  - **Documentation**: `aidlc-docs/construction/{unit-name}/code/` (markdown only)
+  - **Build/Config Files**: Workspace root
+- [ ] Follow unit story requirements
+- [ ] Respect dependencies and interfaces
 
 ## Step 12: Update Progress
 - [ ] Mark the completed step as [x] in the unit code generation plan
 - [ ] Mark associated unit stories as [x] when their generation is finished
 - [ ] Update `aidlc-docs/aidlc-state.md` current status
+- [ ] **Brownfield only**: Verify no duplicate files created (e.g., no `ClassName_modified.java` alongside `ClassName.java`)
 - [ ] Save all generated artifacts
 
 ## Step 13: Continue or Complete Generation
@@ -114,18 +129,18 @@ This stage generates code for each unit of work through two integrated parts:
 # 💻 Code Generation Complete - [unit-name]
 ```
 
-     2. **AI Summary** (optional): Provide structured bullet-point summary of code generation
-        - Format: "Code generation has created [description]:"
-        - List key code artifacts generated (bullet points)
-        - List test coverage and documentation created
-        - Mention deployment artifacts and configuration files
-        - DO NOT include workflow instructions ("please review", "let me know", "proceed to next phase", "before we proceed")
-        - Keep factual and content-focused
+     2. **AI Summary** (optional): Provide structured bullet-point summary
+        - **Brownfield**: Distinguish modified vs created files (e.g., "• Modified: `src/services/user-service.ts`", "• Created: `src/services/auth-service.ts`")
+        - **Greenfield**: List created files with paths (e.g., "• Created: `src/services/user-service.ts`")
+        - List tests, documentation, deployment artifacts with paths
+        - Keep factual, no workflow instructions
      3. **Formatted Workflow Message** (mandatory): Always end with this exact format:
 
 ```markdown
 > **📋 <u>**REVIEW REQUIRED:**</u>**  
-> Please examine the generated code at: `aidlc-docs/construction/[unit-name]/code/`
+> Please examine the generated code at:
+> - **Application Code**: `[actual-workspace-path]`
+> - **Documentation**: `aidlc-docs/construction/[unit-name]/code/`
 
 
 
@@ -152,6 +167,23 @@ This stage generates code for each unit of work through two integrated parts:
 ---
 
 ## Critical Rules
+
+### Code Location Rules
+- **Application code**: Workspace root only (NEVER aidlc-docs/)
+- **Documentation**: aidlc-docs/ only (markdown summaries)
+- **Read workspace root** from aidlc-state.md before generating code
+
+**Structure patterns by project type**:
+- **Brownfield**: Use existing structure (e.g., `src/main/java/`, `lib/`, `pkg/`)
+- **Greenfield single unit**: `src/`, `tests/`, `config/` in workspace root
+- **Greenfield multi-unit (microservices)**: `{unit-name}/src/`, `{unit-name}/tests/`
+- **Greenfield multi-unit (monolith)**: `src/{unit-name}/`, `tests/{unit-name}/`
+
+### Brownfield File Modification Rules
+- Check if file exists before generating
+- If exists: Modify in-place (never create copies like `ClassName_modified.java`)
+- If doesn't exist: Create new file
+- Verify no duplicate files after generation (Step 12)
 
 ### Planning Phase Rules
 - Create explicit, numbered steps for all generation activities

--- a/aidlc-rules/aws-aidlc-rule-details/inception/reverse-engineering.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/reverse-engineering.md
@@ -112,6 +112,12 @@ Create `aidlc-docs/inception/reverse-engineering/code-structure.md`:
 ## Key Classes/Modules
 [Mermaid class diagram or module hierarchy]
 
+### Existing Files Inventory
+[List all source files with their purposes - these are candidates for modification in brownfield projects]
+
+**Example format**:
+- `[path/to/file]` - [Purpose/responsibility]
+
 ## Design Patterns
 ### [Pattern Name]
 - **Location**: [Where used]

--- a/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
@@ -30,6 +30,7 @@ This stage decomposes the system into manageable units of work through two integ
 - [ ] Generate `aidlc-docs/inception/application-design/unit-of-work.md` with unit definitions and responsibilities
 - [ ] Generate `aidlc-docs/inception/application-design/unit-of-work-dependency.md` with dependency matrix
 - [ ] Generate `aidlc-docs/inception/application-design/unit-of-work-story-map.md` mapping stories to units
+- [ ] **Greenfield only**: Document code organization strategy in `unit-of-work.md` (see code-generation.md for structure patterns)
 - [ ] Validate unit boundaries and dependencies
 - [ ] Ensure all stories are assigned to units
 
@@ -46,6 +47,7 @@ This stage decomposes the system into manageable units of work through two integ
 - **Team Alignment** - Only if team structure or ownership is unclear
 - **Technical Considerations** - Only if scalability/deployment requirements differ across units
 - **Business Domain** - Only if domain boundaries or bounded contexts are unclear
+- **Code Organization (Greenfield multi-unit only)** - Ask deployment model and directory structure preferences
 
 ## Step 4: Store UOW Plan
 - Save as `aidlc-docs/inception/plans/unit-of-work-plan.md`

--- a/aidlc-rules/aws-aidlc-rule-details/inception/workspace-detection.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/workspace-detection.md
@@ -14,6 +14,7 @@ Check if `aidlc-docs/aidlc-state.md` exists:
 - Scan workspace for source code files (.java, .py, .js, .ts, .jsx, .tsx, .kt, .kts, .scala, .groovy, .go, .rs, .rb, .php, .c, .h, .cpp, .hpp, .cc, .cs, .fs, etc.)
 - Check for build files (pom.xml, package.json, build.gradle, etc.)
 - Look for project structure indicators
+- Identify workspace root directory (NOT aidlc-docs/)
 
 **Record findings:**
 ```markdown
@@ -22,6 +23,7 @@ Check if `aidlc-docs/aidlc-state.md` exists:
 - **Programming Languages**: [List if found]
 - **Build System**: [Maven/Gradle/npm/etc. if found]
 - **Project Structure**: [Monolith/Microservices/Library/Empty]
+- **Workspace Root**: [Absolute path]
 ```
 
 ## Step 3: Determine Next Phase
@@ -51,6 +53,12 @@ Create `aidlc-docs/aidlc-state.md`:
 ## Workspace State
 - **Existing Code**: [Yes/No]
 - **Reverse Engineering Needed**: [Yes/No]
+- **Workspace Root**: [Absolute path]
+
+## Code Location Rules
+- **Application Code**: Workspace root (NEVER in aidlc-docs/)
+- **Documentation**: aidlc-docs/ only
+- **Structure patterns**: See code-generation.md Critical Rules
 
 ## Stage Progress
 [Will be populated as workflow progresses]

--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -479,67 +479,31 @@ The Operations stage will eventually include:
 ## Directory Structure
 
 ```text
-aidlc-docs/
-├── inception/                  # 🔵 INCEPTION PHASE artifacts
-│   ├── plans/
-│   │   ├── workspace-detection.md
-│   │   ├── workflow-planning.md
-│   │   ├── story-generation-plan.md
-│   │   └── unit-of-work-plan.md
-│   ├── reverse-engineering/        # Brownfield only
-│   │   ├── architecture.md
-│   │   ├── code-structure.md
-│   │   ├── api-documentation.md
-│   │   ├── component-inventory.md
-│   │   ├── technology-stack.md
-│   │   ├── dependencies.md
-│   │   ├── code-quality-assessment.md
-│   │   └── reverse-engineering-timestamp.md
-│   ├── requirements/
-│   │   ├── requirements.md
-│   │   └── requirement-verification-questions.md
-│   ├── user-stories/
-│   │   ├── stories.md
-│   │   └── personas.md
-│   └── application-design/
-│       ├── components.md
-│       ├── component-methods.md
-│       ├── services.md
-│       ├── component-dependency.md
-│       ├── unit-of-work.md
-│       ├── unit-of-work-dependency.md
-│       └── unit-of-work-story-map.md
-├── construction/               # 🟢 CONSTRUCTION PHASE artifacts
-│   ├── plans/
-│   │   ├── {unit-name}-functional-design-plan.md
-│   │   ├── {unit-name}-nfr-requirements-plan.md
-│   │   ├── {unit-name}-nfr-design-plan.md
-│   │   ├── {unit-name}-infrastructure-design-plan.md
-│   │   └── {unit-name}-code-generation-plan.md
-│   ├── {unit-name}/
-│   │   ├── functional-design/
-│   │   │   ├── business-logic-model.md
-│   │   │   ├── business-rules.md
-│   │   │   └── domain-entities.md
-│   │   ├── nfr-requirements/
-│   │   │   ├── nfr-requirements.md
-│   │   │   └── tech-stack-decisions.md
-│   │   ├── nfr-design/
-│   │   │   ├── nfr-design-patterns.md
-│   │   │   └── logical-components.md
-│   │   ├── infrastructure-design/
-│   │   │   ├── infrastructure-design.md
-│   │   │   └── deployment-architecture.md
-│   │   └── code/
-│   │       └── [generated code files]
-│   └── build-and-test/
-│       ├── build-instructions.md
-│       ├── unit-test-instructions.md
-│       ├── integration-test-instructions.md
-│       ├── performance-test-instructions.md
-│       └── build-and-test-summary.md
-├── operations/                 # 🟡 OPERATIONS PHASE artifacts (placeholder)
-│   └── [Future: deployment and monitoring artifacts]
-├── aidlc-state.md             # Dynamic state tracking
-└── audit.md                    # Complete audit trail
+<WORKSPACE-ROOT>/                   # ⚠️ APPLICATION CODE HERE
+├── [project-specific structure]    # Varies by project (see code-generation.md)
+│
+├── aidlc-docs/                     # 📄 DOCUMENTATION ONLY
+│   ├── inception/                  # 🔵 INCEPTION PHASE
+│   │   ├── plans/
+│   │   ├── reverse-engineering/    # Brownfield only
+│   │   ├── requirements/
+│   │   ├── user-stories/
+│   │   └── application-design/
+│   ├── construction/               # 🟢 CONSTRUCTION PHASE
+│   │   ├── plans/
+│   │   ├── {unit-name}/
+│   │   │   ├── functional-design/
+│   │   │   ├── nfr-requirements/
+│   │   │   ├── nfr-design/
+│   │   │   ├── infrastructure-design/
+│   │   │   └── code/               # Markdown summaries only
+│   │   └── build-and-test/
+│   ├── operations/                 # 🟡 OPERATIONS PHASE (placeholder)
+│   ├── aidlc-state.md
+│   └── audit.md
 ```
+
+**CRITICAL RULE**:
+- Application code: Workspace root (NEVER in aidlc-docs/)
+- Documentation: aidlc-docs/ only
+- Project structure: See code-generation.md for patterns by project type


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aidlc-workflows/issues/30

*Description of changes:*

The AI-DLC rules language has been enhanced and tested to address this issue for both greenfield and brownfield projects. The language has been made concise to eliminate verbosity and duplication without losing confidence in the instructions. The enhanced rules language also addresses how code structure will be created when there are multiple units of work. 


Test results:
<img width="2896" height="1993" alt="code_gen" src="https://github.com/user-attachments/assets/371c4461-4adf-46bf-b569-4d591ebd04cc" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
