### PR TITLE
feat: Add Kiro CLI Knowledge Base support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ If you do not see the `aws-aidlc-rules` rules loaded, please check the directory
 
 ![AI-DLC Rules in Kiro CLI](./assets/images/kiro-cli-aidlc-rules-loaded.png?raw=true "AI-DLC Rules in Kiro CLI")
 
+### Kiro CLI (Knowledge Base Mode)
+
+For larger projects or when you want better token efficiency, you can use AI-DLC as a custom agent with Knowledge Base support. This mode indexes the rule details and loads them on-demand instead of including everything in context.
+
+Copy the custom agent configuration to your Kiro CLI agents directory:
+
+```bash
+# Global installation (available in all projects)
+mkdir -p ~/.kiro/agents
+cp ../aidlc-workflows/agents/ai-dlc.yaml ~/.kiro/agents/
+
+# Or project-specific installation
+mkdir -p .kiro/agents
+cp ../aidlc-workflows/agents/ai-dlc.yaml .kiro/agents/
+```
+
+Also copy the rule files to the expected location:
+
+```bash
+cp -R ../aidlc-workflows/aidlc-rules .kiro/
+```
+
+To use the AI-DLC agent:
+
+```bash
+kiro-cli --agent ai-dlc
+```
+
+Benefits of Knowledge Base mode:
+- Better token efficiency (rule details loaded on-demand)
+- Faster context loading for large rule sets
+- Auto-indexing keeps knowledge current
+
 ### Usage
 
 1. Start any software development project by stating your intent starting with the phrase "Using AI-DLC, ..." in the chat. 

--- a/agents/ai-dlc.yaml
+++ b/agents/ai-dlc.yaml
@@ -1,0 +1,15 @@
+name: ai-dlc
+description: AI-Driven Development Life Cycle - Adaptive software development workflow that guides you through inception, construction, and operations phases.
+
+resources:
+  # Core workflow (always loaded as steering)
+  - type: context
+    source: file://./aidlc-rules/aws-aidlc-rules/core-workflow.md
+
+  # Rule details (indexed for efficient search)
+  - type: knowledgeBase
+    source: file://./aidlc-rules/aws-aidlc-rule-details
+    name: AI-DLC Rule Details
+    description: Detailed rules for each phase including common rules, inception, construction, and operations
+    indexType: best
+    autoUpdate: true

--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -11,7 +11,11 @@ The AI model intelligently assesses what stages are needed based on:
 4. Risk and impact assessment
 
 ## MANDATORY: Rule Details Loading
-**CRITICAL**: When performing any phase, you MUST read and use relevant content from rule detail files in `.kiro/aws-aidlc-rule-details/` or `.amazonq/aws-aidlc-rule-details/` directory.
+**CRITICAL**: When performing any phase, you MUST read and use relevant content from rule detail files.
+
+**Loading Method**:
+- **Steering mode**: Read from `.kiro/aws-aidlc-rule-details/` or `.amazonq/aws-aidlc-rule-details/` directory
+- **Knowledge Base mode**: Search the "AI-DLC Rule Details" knowledge base for the relevant file by name
 
 **Common Rules**: ALWAYS load common rules at workflow start:
 - Load `common/process-overview.md` for workflow overview


### PR DESCRIPTION
## Summary

This PR adds support for Kiro CLI's Knowledge Base feature, enabling efficient on-demand loading of AI-DLC rule details.

## Problem

Currently, all rule detail files are loaded into context when using steering mode. For large rule sets, this consumes significant tokens even when only specific rules are needed.

## Solution

Add a custom agent configuration (`agents/ai-dlc.yaml`) that:
- Keeps `core-workflow.md` as always-loaded steering context
- Indexes `aws-aidlc-rule-details/` as a Knowledge Base for efficient search and retrieval

## Changes

1. **`agents/ai-dlc.yaml`** - New custom agent configuration with Knowledge Base resource
2. **`aidlc-rules/aws-aidlc-rules/core-workflow.md`** - Added Loading Method section supporting both Steering and Knowledge Base modes
3. **`README.md`** - Added installation instructions for Knowledge Base mode

## Compatibility

- **Backward compatible**: Existing steering mode continues to work unchanged
- **Additive**: Knowledge Base mode is an additional option for Kiro CLI users
- **Independent**: Does not conflict with PR #36 (release pipeline) or PR #37 (multi-platform support)

## Benefits

- **Token efficiency**: Rule details loaded on-demand via search instead of all at once
- **Scalability**: Better suited for growing rule sets
- **User choice**: Users can choose between ste- Keeps `core-workflow.md` as always-loaded steering 

By subm- Indexes `aws-aidlc-rule-details/` as you can use, modify, c
## Changes

1. **`agents/ai-dlc.yaml`** - New custom agent configuratio
