### PR TITLE
Fix for premature generation of requirements.md

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
@@ -103,7 +103,12 @@ Analyze whatever the user has provided:
    - **MANDATORY**: Analyze ALL answers for ambiguities and create follow-up questions if needed
    - **MANDATORY**: Keep asking questions until ALL ambiguities are resolved OR user explicitly asks to proceed
 
+### ⛔ GATE: Await User Answers
+DO NOT proceed to Step 7 until all questions in requirement-verification-questions.md are answered and validated.
+Present the question file to the user and STOP.
+
 ### Step 7: Generate Requirements Document
+   - **PREREQUISITE**: Step 6 gate must be passed — all answers received and analyzed
    - Create `aidlc-docs/inception/requirements/requirements.md`
    - Include intent analysis summary at the top:
      - User request


### PR DESCRIPTION
*Issue #, if available:* #64

*Description of changes:*

A new gate has been added between step 6 and 7 in `requirements-analysis.md` rules file that ensures that the questions in `requirement-verification-questions.md` are answered before `requirements.md` is generated. The new language added to enforce this behavior is minimal.

The test result of the fix is shown in the screenshot below.

<img width="2029" height="1256" alt="req_fix" src="https://github.com/user-attachments/assets/5472251d-09ad-41a2-88ac-39f7bce56fa6" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
