### PR TITLE
docs: add Windows CMD setup instructions and ZIP download note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ cp -R aidlc-rules/aws-aidlc-rules .kiro/steering/
 cp -R aidlc-rules/aws-aidlc-rule-details .kiro/
 ```
 
+On Windows (CMD):
+```cmd
+mkdir .kiro\steering
+xcopy aidlc-rules\aws-aidlc-rules .kiro\steering\aws-aidlc-rules\ /E /I
+xcopy aidlc-rules\aws-aidlc-rule-details .kiro\aws-aidlc-rule-details\ /E /I
+```
+
+> **Note**: If you downloaded a ZIP from the [Releases page](../../releases/latest), the extracted folder may contain a top-level directory (e.g., `aidlc-workflows-0.1.0/`). Navigate into it first so that `aidlc-rules/` is directly accessible.
+
 Your project should look like:
 ```
 <project-root>/
@@ -67,6 +76,15 @@ mkdir -p .amazonq/rules
 cp -R aidlc-rules/aws-aidlc-rules .amazonq/rules/
 cp -R aidlc-rules/aws-aidlc-rule-details .amazonq/
 ```
+
+On Windows (CMD):
+```cmd
+mkdir .amazonq\rules
+xcopy aidlc-rules\aws-aidlc-rules .amazonq\rules\aws-aidlc-rules\ /E /I
+xcopy aidlc-rules\aws-aidlc-rule-details .amazonq\aws-aidlc-rule-details\ /E /I
+```
+
+> **Note**: If you downloaded a ZIP from the [Releases page](../../releases/latest), the extracted folder may contain a top-level directory (e.g., `aidlc-workflows-0.1.0/`). Navigate into it first so that `aidlc-rules/` is directly accessible.
 
 Your project should look like:
 ```


### PR DESCRIPTION
## Description

Add setup instructions for Windows CMD users and a note about ZIP download directory structure, as requested in #57.

### Changes

- Added Windows CMD equivalents (`mkdir`, `xcopy`) for both Kiro and Amazon Q Developer setup sections
- Added a note explaining that ZIP downloads from the Releases page may contain a top-level directory that users need to navigate into first

### Affected Files

- `README.md`

Closes #57

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.