### PR TITLE
fix: update execution-plan.md status on stage completion

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
@@ -300,7 +300,7 @@ Create `aidlc-docs/construction/build-and-test/build-and-test-summary.md`:
 
 Update `aidlc-docs/aidlc-state.md`:
 - Mark Build and Test stage as complete
-- Update Build and Test status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update Build and Test status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
 - Update current status
 
 ---

--- a/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
@@ -300,6 +300,7 @@ Create `aidlc-docs/construction/build-and-test/build-and-test-summary.md`:
 
 Update `aidlc-docs/aidlc-state.md`:
 - Mark Build and Test stage as complete
+- Update Build and Test status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
 - Update current status
 
 ---

--- a/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
@@ -300,7 +300,7 @@ Create `aidlc-docs/construction/build-and-test/build-and-test-summary.md`:
 
 Update `aidlc-docs/aidlc-state.md`:
 - Mark Build and Test stage as complete
-- Update Build and Test status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update Build and Test status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
 - Update current status
 
 ---

--- a/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
@@ -167,7 +167,7 @@ This stage generates code for each unit of work through two integrated parts:
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Code Generation stage as complete for this unit in aidlc-state.md
-- Update Code Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update Code Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
 
 ---
 

--- a/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
@@ -167,7 +167,7 @@ This stage generates code for each unit of work through two integrated parts:
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Code Generation stage as complete for this unit in aidlc-state.md
-- Update Code Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update Code Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
 
 ---
 

--- a/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
@@ -88,6 +88,7 @@ This stage generates code for each unit of work through two integrated parts:
 
 ## Step 9: Update Progress
 - [ ] Mark Code Generation Part 1 (Planning) complete in `aidlc-state.md`
+- [ ] Update Code Generation Part 1 (Planning) status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
 - [ ] Update the "Current Status" section
 - [ ] Prepare for transition to Code Generation
 
@@ -166,6 +167,7 @@ This stage generates code for each unit of work through two integrated parts:
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Code Generation stage as complete for this unit in aidlc-state.md
+- Update Code Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
 
 ---
 

--- a/aidlc-rules/aws-aidlc-rule-details/construction/functional-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/functional-design.md
@@ -117,3 +117,4 @@ Design detailed business logic for the unit, technology-agnostic and focused pur
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Functional Design stage complete in aidlc-state.md
+- Update Functional Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`

--- a/aidlc-rules/aws-aidlc-rule-details/construction/functional-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/functional-design.md
@@ -117,4 +117,4 @@ Design detailed business logic for the unit, technology-agnostic and focused pur
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Functional Design stage complete in aidlc-state.md
-- Update Functional Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update Functional Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/construction/functional-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/functional-design.md
@@ -117,4 +117,4 @@ Design detailed business logic for the unit, technology-agnostic and focused pur
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Functional Design stage complete in aidlc-state.md
-- Update Functional Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update Functional Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/construction/infrastructure-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/infrastructure-design.md
@@ -97,4 +97,4 @@ Map logical software components to actual infrastructure choices for deployment 
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Infrastructure Design stage complete in aidlc-state.md
-- Update Infrastructure Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update Infrastructure Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/construction/infrastructure-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/infrastructure-design.md
@@ -97,4 +97,4 @@ Map logical software components to actual infrastructure choices for deployment 
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Infrastructure Design stage complete in aidlc-state.md
-- Update Infrastructure Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update Infrastructure Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/construction/infrastructure-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/infrastructure-design.md
@@ -97,3 +97,4 @@ Map logical software components to actual infrastructure choices for deployment 
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark Infrastructure Design stage complete in aidlc-state.md
+- Update Infrastructure Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`

--- a/aidlc-rules/aws-aidlc-rule-details/construction/nfr-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/nfr-design.md
@@ -93,4 +93,4 @@ Incorporate NFR requirements into unit design using patterns and logical compone
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark NFR Design stage complete in aidlc-state.md
-- Update NFR Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update NFR Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/construction/nfr-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/nfr-design.md
@@ -93,3 +93,4 @@ Incorporate NFR requirements into unit design using patterns and logical compone
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark NFR Design stage complete in aidlc-state.md
+- Update NFR Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`

--- a/aidlc-rules/aws-aidlc-rule-details/construction/nfr-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/nfr-design.md
@@ -93,4 +93,4 @@ Incorporate NFR requirements into unit design using patterns and logical compone
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark NFR Design stage complete in aidlc-state.md
-- Update NFR Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update NFR Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/construction/nfr-requirements.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/nfr-requirements.md
@@ -97,4 +97,4 @@ Determine non-functional requirements for the unit and make tech stack choices.
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark NFR Requirements stage complete in aidlc-state.md
-- Update NFR Requirements status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update NFR Requirements status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/construction/nfr-requirements.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/nfr-requirements.md
@@ -97,3 +97,4 @@ Determine non-functional requirements for the unit and make tech stack choices.
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark NFR Requirements stage complete in aidlc-state.md
+- Update NFR Requirements status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`

--- a/aidlc-rules/aws-aidlc-rule-details/construction/nfr-requirements.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/nfr-requirements.md
@@ -97,4 +97,4 @@ Determine non-functional requirements for the unit and make tech stack choices.
 - Log approval in audit.md with timestamp
 - Record the user's approval response with timestamp
 - Mark NFR Requirements stage complete in aidlc-state.md
-- Update NFR Requirements status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update NFR Requirements status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/inception/application-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/application-design.md
@@ -143,6 +143,6 @@ If the analysis in step 8 reveals ANY ambiguous answers, you MUST:
 
 ### 15. Update Progress
 - Mark Application Design stage complete in `aidlc-docs/aidlc-state.md`
-- Update Application Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update Application Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
 - Update the "Current Status" section
 - Prepare for transition to next stage

--- a/aidlc-rules/aws-aidlc-rule-details/inception/application-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/application-design.md
@@ -143,6 +143,6 @@ If the analysis in step 8 reveals ANY ambiguous answers, you MUST:
 
 ### 15. Update Progress
 - Mark Application Design stage complete in `aidlc-docs/aidlc-state.md`
-- Update Application Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update Application Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
 - Update the "Current Status" section
 - Prepare for transition to next stage

--- a/aidlc-rules/aws-aidlc-rule-details/inception/application-design.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/application-design.md
@@ -143,5 +143,6 @@ If the analysis in step 8 reveals ANY ambiguous answers, you MUST:
 
 ### 15. Update Progress
 - Mark Application Design stage complete in `aidlc-docs/aidlc-state.md`
+- Update Application Design status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
 - Update the "Current Status" section
 - Prepare for transition to next stage

--- a/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
@@ -188,4 +188,4 @@ Update `aidlc-docs/aidlc-state.md`:
    - Wait for explicit user approval before proceeding
    - Record approval response with timestamp
    - Update Requirements Analysis stage complete in aidlc-state.md
-   - Update Requirements Analysis status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+   - Update Requirements Analysis status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
@@ -188,4 +188,4 @@ Update `aidlc-docs/aidlc-state.md`:
    - Wait for explicit user approval before proceeding
    - Record approval response with timestamp
    - Update Requirements Analysis stage complete in aidlc-state.md
-   - Update Requirements Analysis status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+   - Update Requirements Analysis status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)

--- a/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
@@ -188,3 +188,4 @@ Update `aidlc-docs/aidlc-state.md`:
    - Wait for explicit user approval before proceeding
    - Record approval response with timestamp
    - Update Requirements Analysis stage complete in aidlc-state.md
+   - Update Requirements Analysis status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`

--- a/aidlc-rules/aws-aidlc-rule-details/inception/reverse-engineering.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/reverse-engineering.md
@@ -287,6 +287,8 @@ Update `aidlc-docs/aidlc-state.md`:
 - **Artifacts Location**: aidlc-docs/inception/reverse-engineering/
 ```
 
+Update Reverse Engineering status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist).
+
 ## Step 12: Present Completion Message to User
 
 ```markdown

--- a/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
@@ -98,6 +98,7 @@ If the analysis in step 7 reveals ANY ambiguous answers, you MUST:
 
 ## Step 11: Update Progress
 - Mark Units Planning complete in aidlc-state.md
+- Update Units Planning status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
 - Update the "Current Status" section
 - Prepare for transition to Units Generation
 
@@ -156,6 +157,7 @@ If the analysis in step 7 reveals ANY ambiguous answers, you MUST:
 
 ## Step 19: Update Progress
 - Mark Units Generation stage complete in `aidlc-docs/aidlc-state.md`
+- Update Units Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
 - Update the "Current Status" section
 - Prepare for transition to CONSTRUCTION PHASE
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
@@ -98,7 +98,7 @@ If the analysis in step 7 reveals ANY ambiguous answers, you MUST:
 
 ## Step 11: Update Progress
 - Mark Units Planning complete in aidlc-state.md
-- Update Units Planning status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update Units Planning status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
 - Update the "Current Status" section
 - Prepare for transition to Units Generation
 
@@ -157,7 +157,7 @@ If the analysis in step 7 reveals ANY ambiguous answers, you MUST:
 
 ## Step 19: Update Progress
 - Mark Units Generation stage complete in `aidlc-docs/aidlc-state.md`
-- Update Units Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update Units Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
 - Update the "Current Status" section
 - Prepare for transition to CONSTRUCTION PHASE
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/units-generation.md
@@ -98,7 +98,7 @@ If the analysis in step 7 reveals ANY ambiguous answers, you MUST:
 
 ## Step 11: Update Progress
 - Mark Units Planning complete in aidlc-state.md
-- Update Units Planning status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update Units Planning status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
 - Update the "Current Status" section
 - Prepare for transition to Units Generation
 
@@ -157,7 +157,7 @@ If the analysis in step 7 reveals ANY ambiguous answers, you MUST:
 
 ## Step 19: Update Progress
 - Mark Units Generation stage complete in `aidlc-docs/aidlc-state.md`
-- Update Units Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update Units Generation status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
 - Update the "Current Status" section
 - Prepare for transition to CONSTRUCTION PHASE
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/user-stories.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/user-stories.md
@@ -298,7 +298,7 @@ If the analysis in step 9 reveals ANY ambiguous answers, you MUST:
 
 ## Step 23: Update Progress
 - Mark User Stories stage complete in `aidlc-state.md`
-- Update User Stories status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+- Update User Stories status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
 - Update the "Current Status" section
 - Prepare for transition to next stage
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/user-stories.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/user-stories.md
@@ -298,6 +298,7 @@ If the analysis in step 9 reveals ANY ambiguous answers, you MUST:
 
 ## Step 23: Update Progress
 - Mark User Stories stage complete in `aidlc-state.md`
+- Update User Stories status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
 - Update the "Current Status" section
 - Prepare for transition to next stage
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/user-stories.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/user-stories.md
@@ -298,7 +298,7 @@ If the analysis in step 9 reveals ANY ambiguous answers, you MUST:
 
 ## Step 23: Update Progress
 - Mark User Stories stage complete in `aidlc-state.md`
-- Update User Stories status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`
+- Update User Stories status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
 - Update the "Current Status" section
 - Prepare for transition to next stage
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
@@ -289,7 +289,7 @@ flowchart TD
     %% Apply styling based on status
 ```
 
-**Note**: Replace STATUS placeholders with actual phase status (COMPLETED/SKIP/EXECUTE) and apply appropriate styling. When updating a stage status to COMPLETED, update it in **both** the Mermaid flowchart and the checklist below.
+**Note**: Replace STATUS placeholders with actual phase status (COMPLETED/SKIP/EXECUTE) and apply appropriate styling. When updating a stage status to COMPLETED, update it in the Mermaid flowchart, text alternative, and checklist.
 
 ## Phases to Execute
 
@@ -454,7 +454,7 @@ I recommend skipping [Y] stages:
 ## Step 10: Handle User Response
 
 - **If approved**:
-  1. Update Workflow Planning status from IN PROGRESS to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+  1. Update Workflow Planning status from IN PROGRESS to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist)
   2. Proceed to next stage in execution plan
 - **If changes requested**: Update execution plan and re-confirm
 - **If user wants to force include/exclude stages**: Update plan accordingly

--- a/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
@@ -453,7 +453,7 @@ I recommend skipping [Y] stages:
 
 ## Step 10: Handle User Response
 
-- **If approved**: Proceed to next stage in execution plan
+- **If approved**: Proceed to next stage in execution plan. Update Workflow Planning status from IN PROGRESS to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`.
 - **If changes requested**: Update execution plan and re-confirm
 - **If user wants to force include/exclude stages**: Update plan accordingly
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
@@ -289,7 +289,7 @@ flowchart TD
     %% Apply styling based on status
 ```
 
-**Note**: Replace STATUS placeholders with actual phase status (COMPLETED/SKIP/EXECUTE) and apply appropriate styling
+**Note**: Replace STATUS placeholders with actual phase status (COMPLETED/SKIP/EXECUTE) and apply appropriate styling. When updating a stage status to COMPLETED, update it in **both** the Mermaid flowchart and the checklist below.
 
 ## Phases to Execute
 
@@ -453,7 +453,7 @@ I recommend skipping [Y] stages:
 
 ## Step 10: Handle User Response
 
-- **If approved**: Proceed to next stage in execution plan. Update Workflow Planning status from IN PROGRESS to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md`.
+- **If approved**: Proceed to next stage in execution plan. Update Workflow Planning status from IN PROGRESS to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist).
 - **If changes requested**: Update execution plan and re-confirm
 - **If user wants to force include/exclude stages**: Update plan accordingly
 

--- a/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/workflow-planning.md
@@ -453,7 +453,9 @@ I recommend skipping [Y] stages:
 
 ## Step 10: Handle User Response
 
-- **If approved**: Proceed to next stage in execution plan. Update Workflow Planning status from IN PROGRESS to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist).
+- **If approved**:
+  1. Update Workflow Planning status from IN PROGRESS to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist)
+  2. Proceed to next stage in execution plan
 - **If changes requested**: Update execution plan and re-confirm
 - **If user wants to force include/exclude stages**: Update plan accordingly
 

--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -451,6 +451,7 @@ The Operations stage will eventually include:
 - **Transparent Planning**: Always show execution plan before starting
 - **User Control**: User can request stage inclusion/exclusion
 - **Progress Tracking**: Update aidlc-state.md with executed and skipped stages
+- **Execution Plan Tracking**: When completing ANY stage, update that stage's status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist). This is MANDATORY for every stage completion.
 - **Complete Audit Trail**: Log ALL user inputs and AI responses in audit.md with timestamps
   - **CRITICAL**: Capture user's COMPLETE RAW INPUT exactly as provided
   - **CRITICAL**: Never summarize or paraphrase user input in audit log

--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -451,7 +451,7 @@ The Operations stage will eventually include:
 - **Transparent Planning**: Always show execution plan before starting
 - **User Control**: User can request stage inclusion/exclusion
 - **Progress Tracking**: Update aidlc-state.md with executed and skipped stages
-- **Execution Plan Tracking**: When completing ANY stage, update that stage's status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (both Mermaid flowchart and checklist). This is MANDATORY for every stage completion.
+- **Execution Plan Tracking**: When completing ANY stage, update that stage's status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` (Mermaid flowchart, text alternative, and checklist). This is MANDATORY for every stage completion.
 - **Complete Audit Trail**: Log ALL user inputs and AI responses in audit.md with timestamps
   - **CRITICAL**: Capture user's COMPLETE RAW INPUT exactly as provided
   - **CRITICAL**: Never summarize or paraphrase user input in audit log


### PR DESCRIPTION
## Problem

When stages complete, `aidlc-state.md` is updated correctly, but `execution-plan.md` is never updated. This leaves the execution plan with stale status values (e.g., `IN PROGRESS` or `EXECUTE`) even after stages have finished.

## Solution

1. Added an instruction to update the corresponding stage status to COMPLETED in `aidlc-docs/inception/plans/execution-plan.md` at every stage completion point across all rule-details files
2. Explicitly specified `(Mermaid flowchart, text alternative, and checklist)` to ensure all three representations are updated
3. Added a MANDATORY execution plan tracking principle in `core-workflow.md` to ensure AI agents prioritize this update

## Changes

**`core-workflow.md` (1 file):**
- Added `Execution Plan Tracking` as a MANDATORY Key Principle

**Inception phase (7 files):**
- `workflow-planning.md` — update on user approval (numbered sub-list for visibility) + note in execution-plan template
- `reverse-engineering.md` — Step 10: Update State Tracking
- `requirements-analysis.md` — approval handling
- `user-stories.md` — Step 23: Update Progress
- `application-design.md` — Step 15: Update Progress
- `units-generation.md` — Step 11 (Units Planning) and Step 19 (Units Generation)

**Construction phase (6 files):**
- `functional-design.md` — approval handling
- `nfr-requirements.md` — approval handling
- `nfr-design.md` — approval handling
- `infrastructure-design.md` — approval handling
- `code-generation.md` — Code Planning (Step 9) and Code Generation completion
- `build-and-test.md` — Step 8: Update State Tracking

## Test Evidence

Tested by running a full AI-DLC workflow (simple TODO CLI app in Python) with the modified rules in Kiro CLI.

### Test Setup
- Clean project directory with modified rules copied to `.kiro/steering/` and `.kiro/aws-aidlc-rule-details/`
- Ran: `Using AI-DLC, create a simple TODO list CLI app in Python`

### Results — `execution-plan.md` status updates

| Stage | Mermaid Flowchart | Checklist |
|-------|------------------|-----------|
| Workflow Planning (approve) | ✅ `IN PROGRESS` → `COMPLETED` | ✅ Updated |
| Code Generation (completion) | ✅ `EXECUTE` → `COMPLETED` | ✅ `EXECUTE` → `COMPLETED` |

### Before (Workflow Planning created, before approve)
```
L26: WP["Workflow Planning<br/><b>IN PROGRESS</b>"]
L71: - [x] Workflow Planning (IN PROGRESS)
L30: CG["Code Generation<br/><b>EXECUTE</b>"]
L89: - [ ] Code Generation - EXECUTE (ALWAYS)
```

### After (Code Generation completed)
```
L26: WP["Workflow Planning<br/><b>COMPLETED</b>"]
L71: - [x] Workflow Planning (COMPLETED)
L30: CG["Code Generation<br/><b>COMPLETED</b>"]
L89: - [x] Code Generation - COMPLETED
```

### Key Findings
- The MANDATORY principle in `core-workflow.md` was essential for making the AI consistently perform the updates. Without it (tested in earlier iterations), the AI skipped the `execution-plan.md` updates despite instructions in individual stage files.
- Initial testing only specified "Mermaid flowchart and checklist", which left the text alternative section stale. Updated all instructions to include text alternative as well.

Closes #23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.