### PR TITLE
Clarification for downloads folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ AI-DLC uses [Kiro Steering Files](https://kiro.dev/docs/cli/steering/) within yo
 2. Copy `aws-aidlc-rules/` into `.kiro/steering/`.
 3. Copy `aws-aidlc-rule-details/` into `.kiro/`.
 
+The commands below assume you extracted the zip to your `Downloads` folder. If you used a different location, replace `Downloads` with your actual folder path.
+
 On macOS/Linux:
 ```bash
 mkdir -p .kiro/steering
@@ -69,6 +71,8 @@ AI-DLC uses [Amazon Q Rules](https://docs.aws.amazon.com/amazonq/latest/qdevelop
 1. Create the directories `.amazonq/rules` and `.amazonq/aws-aidlc-rule-details` in your project root.
 2. Copy `aws-aidlc-rules/` into `.amazonq/rules/`.
 3. Copy `aws-aidlc-rule-details/` into `.amazonq/`.
+
+The commands below assume you extracted the zip to your `Downloads` folder. If you used a different location, replace `Downloads` with your actual folder path.
 
 On macOS/Linux:
 ```bash


### PR DESCRIPTION

*Description of changes:*

Clarified that the user may have download and extracted the ai-dlc rules zip into a different folder than Downloads and in such case they should replace the Downloads folder with their custom folder path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
