### PR TITLE
Fix for Issues 82 and 84

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,28 +165,30 @@ xcopy "..\aidlc-workflows\aidlc-rules\aws-aidlc-rule-details" ".aidlc-rule-detai
 
 AI-DLC uses [Kiro Steering Files](https://kiro.dev/docs/cli/steering/) to implement its intelligent workflow.
 
+> **Note**: Kiro CLI resolves relative paths from the steering file location, so `.aidlc-rule-details/` must be placed inside the `aws-aidlc-rules/` directory alongside `core-workflow.md`.
+
 **Unix/Linux/macOS:**
 ```bash
 mkdir -p .kiro/steering
 cp -R ../aidlc-workflows/aidlc-rules/aws-aidlc-rules .kiro/steering/
-mkdir -p .aidlc-rule-details
-cp -R ../aidlc-workflows/aidlc-rules/aws-aidlc-rule-details/* .aidlc-rule-details/
+mkdir -p .kiro/steering/aws-aidlc-rules/.aidlc-rule-details
+cp -R ../aidlc-workflows/aidlc-rules/aws-aidlc-rule-details/* .kiro/steering/aws-aidlc-rules/.aidlc-rule-details/
 ```
 
 **Windows PowerShell:**
 ```powershell
 New-Item -ItemType Directory -Force -Path ".kiro\steering"
 Copy-Item "..\aidlc-workflows\aidlc-rules\aws-aidlc-rules" ".kiro\steering\" -Recurse
-New-Item -ItemType Directory -Force -Path ".aidlc-rule-details"
-Copy-Item "..\aidlc-workflows\aidlc-rules\aws-aidlc-rule-details\*" ".aidlc-rule-details\" -Recurse
+New-Item -ItemType Directory -Force -Path ".kiro\steering\aws-aidlc-rules\.aidlc-rule-details"
+Copy-Item "..\aidlc-workflows\aidlc-rules\aws-aidlc-rule-details\*" ".kiro\steering\aws-aidlc-rules\.aidlc-rule-details\" -Recurse
 ```
 
 **Windows CMD:**
 ```cmd
 mkdir .kiro\steering
 xcopy "..\aidlc-workflows\aidlc-rules\aws-aidlc-rules" ".kiro\steering\" /E /I
-mkdir .aidlc-rule-details
-xcopy "..\aidlc-workflows\aidlc-rules\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I
+mkdir .kiro\steering\aws-aidlc-rules\.aidlc-rule-details
+xcopy "..\aidlc-workflows\aidlc-rules\aws-aidlc-rule-details" ".kiro\steering\aws-aidlc-rules\.aidlc-rule-details\" /E /I
 ```
 
 **Verify Setup:**
@@ -199,15 +201,15 @@ xcopy "..\aidlc-workflows\aidlc-rules\aws-aidlc-rule-details" ".aidlc-rule-detai
 **Directory Structure:**
 ```
 <my-project>/
-├── .kiro/
-│   └── steering/
-│       └── aws-aidlc-rules/
-│           └── core-workflow.md
-└── .aidlc-rule-details/
-    ├── common/
-    ├── inception/
-    ├── construction/
-    └── operations/
+└── .kiro/
+    └── steering/
+        └── aws-aidlc-rules/
+            ├── core-workflow.md
+            └── .aidlc-rule-details/
+                ├── common/
+                ├── inception/
+                ├── construction/
+                └── operations/
 ```
 
 ---
@@ -587,6 +589,7 @@ Deployment and monitoring (future)
 #### Amazon Q Developer / Kiro CLI
 - Use `/context show` to verify rules are loaded
 - Check `.amazonq/rules/` or `.kiro/steering/` directory structure
+- For Kiro CLI, ensure `.aidlc-rule-details/` is inside `.kiro/steering/aws-aidlc-rules/` (not the project root)
 
 #### Cursor
 - For "Apply Intelligently", ensure a description is defined in frontmatter


### PR DESCRIPTION
# Fix platform setup instructions for GitHub Copilot and Kiro CLI

## Summary

Corrects the setup instructions in README.md for GitHub Copilot [#82](https://github.com/awslabs/aidlc-workflows/issues/82) and Kiro CLI [#84](https://github.com/awslabs/aidlc-workflows/issues/84).

## Changes

**GitHub Copilot [#82](https://github.com/awslabs/aidlc-workflows/issues/82):** The previous instructions used instructions.md and COPILOT.md, neither of which are recognized by VS Code. Replaced with copilot-instructions.md, which is the officially supported location that VS Code auto-detects and applies to all chat requests.

**Kiro CLI [#84](https://github.com/awslabs/aidlc-workflows/issues/84):** Kiro CLI resolves relative paths from the steering file location, not the project root. The setup was placing .aidlc-rule-details/ at the project root, causing core-workflow.md references to fail with path resolution errors. Moved .aidlc-rule-details/ into .kiro/steering/aws-aidlc-rules/ so relative paths resolve correctly without modifying the shared core-workflow.md.

_Both fixes also update the troubleshooting section and version control recommendations to stay consistent._

## Testing
Verified no references to .copilot/ or COPILOT.md remain in the README
Verified all Kiro CLI paths point to the new location inside the steering directory
Confirmed core-workflow.md is unchanged — relative path references work from both new locations
Confirmed no other platform sections were affected
Closes [#82](https://github.com/awslabs/aidlc-workflows/issues/82), closes [#84](https://github.com/awslabs/aidlc-workflows/issues/84)