### PR TITLE
feat: add CodeBuild workflow

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -70,16 +70,33 @@ jobs:
               install:
                 commands:
                   - echo "install ${TEST_ONE}" | tee --append ./codebuild.out
+                  - dnf install -y lshw || echo "dnf install failed"
               pre_build:
                 commands:
                   - echo "pre_build ${TEST_ONE}" | tee --append ./codebuild.out
+                  - echo "=== OS ==="
+                  - cat /etc/os-release
+                  - echo "=== Kernel ==="
+                  - uname -a
+                  - echo "=== CPU ==="
+                  - lscpu
+                  - echo "=== Memory ==="
+                  - free -h
+                  - echo "=== Kisk ==="
+                  - df -h
+                  - echo "=== Block Devices ==="
+                  - lsblk
+                  - echo "=== Hardward Summary ==="
+                  - lshw -short || echo "lshw failed"
               build:
                 commands:
                   - echo "build ${TEST_ONE}" | tee --append ./codebuild.out
+                  - ls -alR
               post_build:
                 commands:
                   - echo "post_build ${TEST_ONE}" | tee --append ./codebuild.out
                   - echo "Build completed with status $CODEBUILD_BUILD_SUCCEEDING"
+                  - cat ./codebuild.out
             artifacts:
               files:
                 - '**/codebuild.out'


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that triggers AWS CodeBuild via `workflow_dispatch`
- Cache build reports (`report-<ref>-<sha>.zip`) in GitHub Actions cache to skip redundant builds
- Download CodeBuild artifacts from S3, zip, and cache with automatic cleanup of old caches per branch
- Add workflow-level concurrency to cancel in-progress runs on the same branch
- Use a protected `codebuild` environment for approval gating

## Test plan
- [x] Trigger workflow manually on a branch and verify CodeBuild runs successfully
- [x] Verify report is zipped and cached after build
- [x] Re-trigger on the same commit and verify cache hit skips the build
- [x] Trigger a new commit on the same branch and verify old cache is cleaned up
- [x] Verify concurrency cancels an in-progress run when a new one is dispatched