### PR TITLE
Removed redundant, confusing installation instructions in README for Kiro/Q

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,7 @@ AI-DLC is an intelligent software development workflow that adapts to your needs
 
 ### Kiro
 
-AI-DLC uses [Kiro Steering Files](https://kiro.dev/docs/cli/steering/) within your project workspace. Copy the rules into your project's `.kiro` folder:
-
-1. Create the directories `.kiro/steering` and `.kiro/aws-aidlc-rule-details` in your project root.
-2. Copy `aws-aidlc-rules/` into `.kiro/steering/`.
-3. Copy `aws-aidlc-rule-details/` into `.kiro/`.
+AI-DLC uses [Kiro Steering Files](https://kiro.dev/docs/cli/steering/) within your project workspace.  
 
 The commands below assume you extracted the zip to your `Downloads` folder. If you used a different location, replace `Downloads` with your actual folder path.
 
@@ -94,11 +90,7 @@ Run `kiro-cli`, then `/context show`, and confirm entries for `.kiro/steering/aw
 
 ### Amazon Q Developer IDE Plugin/Extension
 
-AI-DLC uses [Amazon Q Rules](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/context-project-rules.html) within your project workspace. Copy the rules into your project's `.amazonq` folder:
-
-1. Create the directories `.amazonq/rules` and `.amazonq/aws-aidlc-rule-details` in your project root.
-2. Copy `aws-aidlc-rules/` into `.amazonq/rules/`.
-3. Copy `aws-aidlc-rule-details/` into `.amazonq/`.
+AI-DLC uses [Amazon Q Rules](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/context-project-rules.html) within your project workspace. 
 
 The commands below assume you extracted the zip to your `Downloads` folder. If you used a different location, replace `Downloads` with your actual folder path.
 


### PR DESCRIPTION
*Description of changes:* We had slightly redundant instructions in README for Kiro and Q for AI-DLC steering placement. This was causing confusing whether the user had to do this themselves when we had the actual commands for these right below.

Removed the redundant instructions to clarify the installation steps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
