### PR TITLE
fix: correct copy-paste error in error-handling.md

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/common/error-handling.md
+++ b/aidlc-rules/aws-aidlc-rule-details/common/error-handling.md
@@ -249,8 +249,17 @@
 **Consider Fresh Start If**:
 - Multiple phases have errors
 - State file is severely corrupted
+- User requirements have changed significantly
+- Architectural decision needs to be reversed
 - User cannot provide missing information
 - Artifacts are inconsistent across phases
+
+**Before Starting Over**:
+1. Archive all existing work
+2. Document lessons learned
+3. Identify what to preserve
+4. Get user confirmation
+5. Create new execution plan
 
 ## Session Resumption Errors
 
@@ -324,16 +333,7 @@
 3. **Fail fast**: Stop immediately if critical artifacts are missing
 4. **Communicate clearly**: Tell user exactly what's missing and why it's needed
 5. **Offer options**: Regenerate, provide manually, or start fresh
-6. **Document recovery**: Log all recovery actions in audit.md State file is severely corrupted
-- User requirements have changed significantly
-- Architectural decision needs to be reversed
-
-**Before Starting Over**:
-1. Archive all existing work
-2. Document lessons learned
-3. Identify what to preserve
-4. Get user confirmation
-5. Create new execution plan
+6. **Document recovery**: Log all recovery actions in audit.md
 
 ## Logging Requirements
 


### PR DESCRIPTION
## Summary

Fix misplaced content in `error-handling.md` where text from the "When to Suggest Starting Over" section appears to have been accidentally appended to the "Resumption Best Practices" section, likely due to a copy-paste error.

## Problem

Item 6 of "Resumption Best Practices" seems to have trailing content from another section:

```markdown
6. **Document recovery**: Log all recovery actions in audit.md State file is severely corrupted
- User requirements have changed significantly
- Architectural decision needs to be reversed

**Before Starting Over**:
1. Archive all existing work
...
```

These items appear to belong to the `Consider Fresh Start If` list and the `When to Suggest Starting Over` section, where similar content already exists.
