### PR TITLE
Minor clarifications in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ We use Kiro IDE in Vibe mode to run the AI-DLC workflow. This ensures that AI-DL
 
 <img src="./assets/images/kiro-sdd-nudge.png" alt="Staying in Kiro Vibe mode" width="500" height="175">
 
-#### Verify Kiro CLI
+#### Verify in Kiro CLI
 Run `kiro-cli`, then `/context show`, and confirm entries for `.kiro/steering/aws-aidlc-rules`.
 
 <img src="./assets/images/kiro-cli-aidlc-rules-loaded.png?raw=true" alt="AI-DLC Rules in Kiro CLI" width="700" height="660">


### PR DESCRIPTION
*Description of changes:*

Cleans up the Quick Start section in README.md: clarifies that rule-detail files are conditionally referenced (not just "supporting documents"), simplifies step 3 to point readers to the platform-specific setup instructions instead of combining copy + setup in one step, removes the note about nested zip directories, and makes the verification headers more actionable. All minor wording/formatting improvements, no functional changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
