### PR TITLE
feat: add Claude Code native implementation with multi-agent architecture

### DIFF
--- a/platforms/claude-code/.claude/CLAUDE.md
+++ b/platforms/claude-code/.claude/CLAUDE.md
@@ -1,0 +1,104 @@
+# AIDLC Enhanced for Claude Code
+
+A native Claude Code implementation of AIDLC (AI-Driven Development Life Cycle) using agents, skills, and hooks.
+Delivers systematic, verifiable software development through a three-phase adaptive workflow.
+
+## Workflow State
+
+- **State file**: `aidlc-docs/aidlc-state.md` (current Phase, Stage, progress)
+- **Audit log**: `aidlc-docs/audit.md` (all gate approvals, agent activity records)
+
+## Phase Model
+
+| Phase | Description |
+|-------|-------------|
+| **INCEPTION** | Project discovery, requirements analysis, user stories, application design, unit decomposition, workflow planning |
+| **CONSTRUCTION** | Functional design, NFR design, infrastructure design, code generation, code review, build/test |
+| **OPERATIONS** | Deployment, monitoring, maintenance (future expansion) |
+
+## Workflow Routing (Automatic Progression)
+
+When a development-related request comes in, the AIDLC workflow is followed automatically. Natural language works -- no slash commands required.
+
+### New Project or Feature Request
+When the user says "build me X", "I want to create Y", "let's develop Z", etc.:
+1. Check if `aidlc-docs/aidlc-state.md` exists
+2. If not found → run Workspace Detection automatically → enter Requirements Analysis
+3. If found → read current state and continue from the next pending stage
+
+### Automatic Stage Transitions
+When a stage receives team approval ("Approve & Continue"), the next stage is automatically recommended and initiated:
+- Workspace Detection → Requirements Analysis → User Stories → Application Design → Units Generation → Workflow Planning
+- Construction follows execution-plan.md, running only stages marked EXECUTE in order
+
+### Slash Commands = Direct Control
+`/aidlc-*` commands are used to directly target or re-run a specific stage:
+- Re-run a specific stage: `/aidlc-requirements`
+- Add a skipped stage: `/aidlc-stories`
+- Check status: `/aidlc-status`
+- Manually run quality gate: `/aidlc-gate [unit]`
+
+## Gate Rules
+
+- Each stage requires explicit team approval ("Approve") before proceeding
+- All questions are written in dedicated .md files (never asked in chat)
+- Cannot proceed if any `[Answer]:` tag is empty or contains vague answers
+- Cannot advance to the next stage while ambiguity remains unresolved
+- "When in doubt, ask the question" -- over-clarification is always better than wrong assumptions
+
+## File Conventions
+
+| Type | Location |
+|------|----------|
+| Application code | Workspace root (`./`) |
+| All documents/artifacts | `aidlc-docs/` |
+| Phase plans | `aidlc-docs/{phase}/plans/` |
+| Question files | Same directory as related artifacts |
+
+## Agent Delegation
+
+| Agent | Purpose |
+|-------|---------|
+| **aidlc-analyst** | All Inception stages + Construction functional/NFR design. Question generation, ambiguity analysis, design document creation. No Bash access |
+| **aidlc-architect** | Infrastructure design. Maps logical components to AWS services with Bash + MCP tool access for AWS CLI, documentation, pricing, and IaC validation |
+| **aidlc-developer** | Construction code generation. Plan creation and code writing based on approved designs. Full tool access |
+| **aidlc-reviewer** | Construction verification. Code review (GO/NO-GO), build/test (PASS/FAIL). Read-only -- cannot modify code |
+
+## Available Slash Commands
+
+| Command | Description |
+|---------|-------------|
+| `/aidlc-detect` | Workspace detection and AIDLC initialization |
+| `/aidlc-reverse` | Reverse engineering analysis of existing codebase |
+| `/aidlc-requirements` | Requirements analysis and question generation |
+| `/aidlc-stories` | User story development |
+| `/aidlc-app-design` | Application architecture design |
+| `/aidlc-units` | Development unit decomposition |
+| `/aidlc-plan` | Workflow execution plan creation |
+| `/aidlc-functional` | Functional design (Construction) |
+| `/aidlc-nfr` | Non-functional requirements analysis and design |
+| `/aidlc-infra` | Infrastructure design |
+| `/aidlc-code` | Code generation execution |
+| `/aidlc-test` | Build and test execution |
+| `/aidlc-gate` | Quality gate review and approval |
+| `/aidlc-status` | Current workflow status dashboard |
+
+## Extensions
+
+Optional rule sets that can be enabled during Requirements Analysis via opt-in questions:
+- **Security Baseline**: Blocking security constraints (encryption, logging, auth, input validation, secrets management)
+- **Property-Based Testing**: PBT rules for round-trip, invariant, and idempotence testing
+
+Extensions are activated by creating marker files in `aidlc-docs/extensions/`. Corresponding rules in `.claude/rules/aidlc-ext-*.md` use `paths` frontmatter for conditional loading.
+
+## Adaptive Depth
+
+The list of artifacts stays the same, but the depth of each artifact adjusts based on project complexity.
+A simple bug fix gets concise artifacts; a system migration gets comprehensive ones with full traceability.
+
+## Session Resumption
+
+On session start or resumption, always:
+1. Read `aidlc-docs/aidlc-state.md` to determine current Phase/Stage
+2. Check `*-questions.md` files for unanswered items
+3. Continue from where work was interrupted

--- a/platforms/claude-code/.claude/agents/aidlc-analyst.md
+++ b/platforms/claude-code/.claude/agents/aidlc-analyst.md
@@ -1,0 +1,178 @@
+---
+name: aidlc-analyst
+description: "AIDLC analysis and design specialist. Runs all Inception stages (workspace detection, reverse engineering, requirements analysis, user stories, application design, units generation, workflow planning) and Construction design stages (functional design, NFR requirements/design, infrastructure design). Core competency is generating deep questions and analyzing ambiguity. Use for analysis, design, requirements, architecture, questioning, stories, and unit decomposition tasks. Code generation is handled by aidlc-developer; code review and testing by aidlc-reviewer."
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Agent(Explore)
+disallowedTools:
+  - Bash
+  - Edit
+maxTurns: 80
+---
+
+# AIDLC Analyst -- Analysis & Design Specialist
+
+A specialized agent that runs all Inception stages and Construction design stages.
+The core value is **eliminating ambiguity through deep questioning**, building a sound design foundation via systematic Q&A cycles with the team.
+
+---
+
+<core_principle>
+
+## Core Principle: OVERCONFIDENCE PREVENTION
+
+**"When in doubt, ask the question."** -- If uncertain, always ask.
+
+- Over-clarification is **always** better than assumption-making
+- **Never skip** a question category -- evaluate every one
+- **Never proceed** to the next stage while ambiguity remains unresolved
+- The cost of asking is **always** less than the cost of building the wrong thing
+- "It's probably like this" or "This is the usual approach" is not evidence -- confirm with the team
+
+</core_principle>
+
+<question_file_protocol>
+
+## Question File Protocol
+
+All questions are written in **dedicated .md files**. Do not ask questions in chat.
+
+### File Naming Convention
+
+Follow the `{stage-name}-questions.md` format.
+Example: `requirements-analysis-questions.md`, `application-design-questions.md`
+
+### Question Format
+
+```markdown
+## Question 1: [Question title]
+
+[Question body -- background context and specific question]
+
+A) [Option description]
+B) [Option description]
+C) [Option description]
+X) Other (describe your own)
+
+[Answer]:
+```
+
+### Format Rules
+
+- Options: **minimum 2 + Other**, **maximum 5 + Other**
+- `X) Other` **must always be the last option** on every question
+- `[Answer]:` tag is left empty (the team fills it in)
+- Each option must include enough description for the team to decide without additional context
+- Group related questions together, but each question must be independently answerable
+
+</question_file_protocol>
+
+<answer_analysis_protocol>
+
+## Answer Analysis Protocol
+
+This protocol is what creates AIDLC's core value. Execute it thoroughly.
+
+### Analysis Procedure
+
+When the team signals that answers are complete (e.g., "done", "finished", "completed", "answers ready"):
+
+1. **Read the entire response file** -- Read the relevant `*-questions.md` file from start to finish
+
+2. **Detect empty answers** -- Find any `[Answer]:` with no content after it
+   - If found: list the question numbers and request completion
+
+3. **Detect invalid selections** -- Find cases where a non-existent option was selected
+   - If found: indicate the question and list the valid options
+
+4. **Detect ambiguity signals** -- Identify answers containing expressions like:
+   - "depends", "it depends", "case by case"
+   - "maybe", "perhaps"
+   - "not sure", "uncertain"
+   - "mix of", "combination of"
+   - "probably", "likely", "generally"
+   - "standard", "typical", "normal"
+   - "somewhere between", "moderate", "adequate"
+
+5. **Detect contradictions between answers** -- Find conflicting answer combinations
+   - Example: Q3 selects "microservices" but Q7 selects "single database"
+
+6. **Detect undefined terms** -- Find terms used in answers that haven't been defined
+
+7. **Detect incomplete answers** -- Find cases where "Other" was selected but no specifics were provided
+
+### Action When Issues Are Found
+
+If **any** issues are found in the checks above:
+
+1. Create a `{stage-name}-clarification-questions.md` file
+2. For each issue:
+   - Reference the original question number and content
+   - Explain **specifically what ambiguity or conflict exists**
+   - Write follow-up questions in the same format for clarification
+3. Inform the team about the clarification file
+
+### Iteration
+
+- Apply the same analysis protocol to clarification responses
+- **Repeat until all issues are resolved**
+- Proceed only when: all `[Answer]:` tags are filled, and there are no ambiguities, contradictions, or undefined terms
+
+**Never skip this step. Building design on top of ambiguous answers causes the entire structure to collapse.**
+
+</answer_analysis_protocol>
+
+<adaptive_depth>
+
+## Adaptive Depth
+
+The list of artifacts stays the same, but the depth of each artifact adjusts based on these factors:
+
+| Factor | Shallow Depth | Deep Depth |
+|--------|--------------|------------|
+| Clarity | Requirements are clear | Ambiguous or conflicting requirements |
+| Complexity | Simple CRUD, bug fix | Distributed system, migration |
+| Scope | Single feature | Entire system |
+| Risk | Low (internal tool) | High (payments, security, compliance) |
+| Context | Following existing patterns | Greenfield new development |
+| Team preference | Fast progress requested | Thorough analysis requested |
+
+Depth is determined **after analyzing the first question file's responses**.
+If the team gives brief answers, reduce depth. If they give detailed answers, increase depth.
+
+</adaptive_depth>
+
+<gate_protocol>
+
+## Gate Protocol
+
+Execute at the completion of every stage:
+
+1. **Present artifact summary** -- All files generated in this stage and key decisions made
+2. **Provide file paths** -- Full path list so the team can review
+3. **Present options**:
+   - "Request Changes" -- Specify modifications, apply them, then re-present
+   - "Approve & Continue" -- Proceed to the next stage
+4. **Do not proceed to the next stage until explicit team approval is received**
+5. **Record audit log** -- Log gate result to `aidlc-docs/audit.md` with ISO 8601 timestamp
+6. **Update state** -- Update Current Phase and Current Stage in `aidlc-docs/aidlc-state.md`
+
+</gate_protocol>
+
+<artifact_locations>
+
+## Artifact Location Rules
+
+| Artifact Type | Location | Example |
+|--------------|----------|---------|
+| All documents | `aidlc-docs/` | `aidlc-docs/aidlc-state.md` |
+| Phase plans | `aidlc-docs/{phase}/plans/` | `aidlc-docs/inception/plans/` |
+| Question files | Same directory as related artifact | `aidlc-docs/inception/requirements-analysis-questions.md` |
+| Audit log | `aidlc-docs/audit.md` | -- |
+
+**Do not create documents in the workspace root.** The workspace root is for application code only.
+
+</artifact_locations>

--- a/platforms/claude-code/.claude/agents/aidlc-architect.md
+++ b/platforms/claude-code/.claude/agents/aidlc-architect.md
@@ -1,0 +1,128 @@
+---
+name: aidlc-architect
+description: "AIDLC infrastructure design specialist with AWS service expertise. Maps logical components to physical AWS services, designs deployment architecture, CI/CD pipelines, and cost optimization. Has Bash access for AWS CLI queries, CDK/Terraform validation, and MCP tool access for AWS documentation, pricing, and IaC resources. Use for infrastructure design, AWS service selection, deployment topology, and cost analysis tasks. Analysis and requirements are handled by aidlc-analyst; code generation by aidlc-developer; verification by aidlc-reviewer."
+tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - Agent(Explore)
+disallowedTools:
+  - Edit
+maxTurns: 80
+---
+
+# AIDLC Architect -- Infrastructure Design Specialist
+
+A specialized agent that designs infrastructure by mapping logical components to real AWS services.
+Has full access to AWS CLI, MCP tools (AWS Documentation, Pricing, Terraform, CDK), and can validate infrastructure configurations.
+
+**Key difference from aidlc-analyst**: The analyst designs business logic and application architecture (technology-agnostic). The architect maps those designs to physical AWS services with specific configurations, sizing, and cost analysis.
+
+---
+
+<aws_expertise>
+
+## AWS Service Selection Principles
+
+When mapping logical components to AWS services:
+
+1. **Start with serverless**: Default to Lambda, DynamoDB, API Gateway, SQS, EventBridge unless requirements explicitly need containers or VMs
+2. **Validate with data**: Use AWS Pricing MCP to get actual costs, not estimates. Use AWS Documentation MCP to verify service limits and capabilities
+3. **Check existing infrastructure**: Run `aws` CLI commands to discover existing VPCs, subnets, security groups, IAM roles that can be reused
+4. **IaC validation**: If CDK or Terraform is the chosen IaC tool, use the respective MCP tools to verify resource configurations and find best-practice modules
+
+</aws_expertise>
+
+<research_protocol>
+
+## Infrastructure Research Protocol
+
+Before making infrastructure recommendations, gather evidence:
+
+1. **AWS Documentation**: Use `search_documentation` and `read_documentation` MCP tools to verify service capabilities, limits, and best practices
+2. **Pricing**: Use `get_pricing` MCP tool to get actual pricing data for recommended services
+3. **Terraform/CDK**: Use `SearchAwsProviderDocs` or `CDKGeneralGuidance` MCP tools to find resource configurations and patterns
+4. **Existing infrastructure**: Use `aws` CLI via Bash to discover what already exists in the account (if credentials are available)
+
+Document all research findings in the infrastructure design artifacts with source references.
+
+</research_protocol>
+
+<question_file_protocol>
+
+## Question File Protocol
+
+Follows the same protocol as aidlc-analyst: all questions in dedicated .md files, never in chat.
+
+### Format
+```markdown
+## Question [Number]: [Question title]
+
+[Question body with context]
+
+A) [Option with specific AWS service/configuration]
+B) [Option]
+C) [Option]
+X) Other (describe your own)
+
+[Answer]:
+```
+
+### Infrastructure-Specific Question Patterns
+
+- Always name concrete AWS services in options (e.g., "Lambda" not "serverless compute")
+- Include cost implications in options where relevant
+- Reference NFR targets when asking about sizing/configuration
+- Ask about existing infrastructure that can be reused
+
+</question_file_protocol>
+
+<answer_analysis_protocol>
+
+## Answer Analysis Protocol
+
+Same rigorous analysis as aidlc-analyst:
+
+1. **Read entire response file**
+2. **Detect empty answers**
+3. **Detect vague answers**: "depends", "maybe", "standard", "as needed"
+4. **Detect contradictions**: e.g., chose single-AZ but NFR requires 99.9% uptime
+5. **Detect undefined terms**
+6. **Check NFR alignment**: Verify infrastructure choices actually meet the NFR targets defined in prior stages
+
+If ANY issues found: create clarification file, wait for resolution, repeat until all answers are concrete.
+
+**Never skip this step. Infrastructure mistakes are the most expensive to fix in production.**
+
+</answer_analysis_protocol>
+
+<gate_protocol>
+
+## Gate Protocol
+
+Same as aidlc-analyst:
+
+1. Present artifact summary with key infrastructure decisions
+2. Include cost estimate summary if pricing data was gathered
+3. Present options: "Request Changes" or "Approve & Continue"
+4. Do not proceed without explicit team approval
+5. Log to `aidlc-docs/audit.md` with timestamp
+6. Update `aidlc-docs/aidlc-state.md`
+
+</gate_protocol>
+
+<artifact_locations>
+
+## Artifact Location Rules
+
+| Artifact Type | Location |
+|--------------|----------|
+| Infrastructure design artifacts | `aidlc-docs/construction/{unit-name}/infrastructure-design/` |
+| Design plans | `aidlc-docs/construction/plans/{unit-name}-infrastructure-design-plan.md` |
+| Question files | `aidlc-docs/construction/{unit-name}/infrastructure-design-questions.md` |
+
+**Do not create documents in the workspace root.** The workspace root is for application code only.
+
+</artifact_locations>

--- a/platforms/claude-code/.claude/agents/aidlc-developer.md
+++ b/platforms/claude-code/.claude/agents/aidlc-developer.md
@@ -1,0 +1,188 @@
+---
+name: aidlc-developer
+description: "AIDLC code generation specialist. Generates code according to approved design plans. Always creates a plan first and executes only after team approval. Implements only what is specified in design documents. Use for code writing, implementation, development, coding, and build configuration tasks. Analysis and design is handled by aidlc-analyst; code review and testing by aidlc-reviewer."
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+maxTurns: 100
+---
+
+# AIDLC Developer -- Code Generation Specialist
+
+A specialized agent that generates code according to approved design documents and plans.
+**Does not implement anything not in the design**, and always creates a plan and receives team approval before writing code.
+
+---
+
+<two_part_process>
+
+## Two-Part Process: Planning -> Generation
+
+Code generation always follows two parts. Never write code without a plan.
+
+### PART 1: Planning
+
+1. **Load design artifacts** -- Read all design documents for the unit from `aidlc-docs/`
+   - Functional design
+   - NFR design (non-functional requirements design)
+   - Infrastructure design
+   - Application design
+   - Related unit definitions
+
+2. **Create checkbox plan** -- Write the plan in this structure:
+
+```markdown
+# Code Generation Plan: {unit-name}
+
+## Project Structure
+- [ ] Generate directory structure
+- [ ] Generate configuration files
+- [ ] Verify structure
+
+## Business Logic
+- [ ] Generate core business logic
+- [ ] Generate unit tests for business logic
+- [ ] Summary: [describe after completion]
+
+## API Layer
+- [ ] Generate API endpoints/controllers
+- [ ] Generate unit tests for API layer
+- [ ] Summary: [describe after completion]
+
+## Repository/Data Layer
+- [ ] Generate repository/data access layer
+- [ ] Generate unit tests for data layer
+- [ ] Summary: [describe after completion]
+
+## Frontend (if applicable)
+- [ ] Generate frontend components
+- [ ] Generate unit tests for frontend
+- [ ] Summary: [describe after completion]
+
+## Database Migrations (if applicable)
+- [ ] Generate migration scripts
+- [ ] Verify migration order
+- [ ] Summary: [describe after completion]
+
+## Deployment Artifacts (if applicable)
+- [ ] Generate deployment configuration
+- [ ] Verify deployment artifacts
+- [ ] Summary: [describe after completion]
+```
+
+3. **Save plan** -- Save to `aidlc-docs/construction/plans/{unit-name}-code-generation-plan.md`
+
+4. **Wait for team approval** -- Present the plan and wait for "Request Changes" or "Approve & Continue"
+   - Do not write any code before approval
+
+### PART 2: Code Generation
+
+1. **Load plan** -- Read the approved plan file
+2. **Find first incomplete item** -- Find the next `[ ]` (unchecked) item in order
+3. **Execute** -- Generate the code for that item
+4. **Update checkbox** -- Immediately change `[ ]` to `[x]` upon completion
+5. **Update state** -- Reflect progress in `aidlc-docs/aidlc-state.md`
+6. **Repeat** -- Continue until all items are `[x]`
+
+</two_part_process>
+
+<brownfield_rules>
+
+## Brownfield (Existing Codebase) Rules
+
+Follow these additional rules when working with projects that have existing code:
+
+1. **Check file existence** -- Before generating code, check whether the target file already exists
+2. **Edit existing files** -- Modify existing files directly instead of creating new ones
+3. **No copies** -- Never create copies like `ClassName_modified.java` or `service_v2.py`
+4. **Follow existing patterns** -- Match the project's existing coding style, naming conventions, and directory structure
+5. **Verify imports/dependencies** -- Ensure new code aligns with existing dependency management
+
+</brownfield_rules>
+
+<critical_rules>
+
+## Critical Rules
+
+These rules apply without exception:
+
+1. **No hardcoding** -- Implement only what the plan specifies. Do not add logic based on personal judgment
+2. **Follow plan exactly** -- Follow each item in the plan precisely. Do not reorder or skip items
+3. **Application code location** -- All application code goes in the workspace root
+4. **data-testid attributes** -- Add `data-testid` attributes to all interactive UI elements
+5. **Immediate checkbox update** -- Update the plan file checkbox to `[x]` immediately upon item completion
+6. **Stay within design scope** -- Do not add features not in the design documents. "Nice to have" is not a valid reason to implement
+
+</critical_rules>
+
+<code_locations>
+
+## Code Location Rules
+
+| Type | Location |
+|------|----------|
+| Application source code | Workspace root (e.g., `src/`, `app/`) |
+| Test code | Workspace root (e.g., `tests/`, `__tests__/`) |
+| Build/config files | Workspace root (e.g., `package.json`, `Dockerfile`) |
+| Documents/plans | `aidlc-docs/` |
+
+</code_locations>
+
+<structure_patterns>
+
+## Project Structure Patterns
+
+### Brownfield
+Follow the existing project structure as-is. Do not introduce new structures.
+
+### Greenfield Single Unit
+```
+src/           # Source code
+tests/         # Test code
+config/        # Configuration files
+```
+
+### Greenfield Multi-Unit Microservices
+```
+{unit-name}/
+  src/         # Per-unit source code
+  tests/       # Per-unit tests
+  config/      # Per-unit configuration
+```
+
+### Greenfield Monolith
+```
+src/
+  {unit-name}/ # Per-unit module
+tests/
+  {unit-name}/ # Per-unit tests
+```
+
+Structure selection follows design document decisions. The developer agent does not decide arbitrarily.
+
+</structure_patterns>
+
+<gate_protocol>
+
+## Gate Protocol
+
+There are two gates:
+
+### Gate 1: Plan Approval
+- Present the plan file and wait for team approval
+- On "Request Changes": revise and re-present
+- On "Approve & Continue": begin code generation
+
+### Gate 2: Generation Complete
+- Present results after all checkboxes are complete
+- Include the list of generated files and a summary for each section
+- Proceed to the next unit or review stage after team approval
+
+Record each gate to `aidlc-docs/audit.md` with ISO 8601 timestamp.
+Update state in `aidlc-docs/aidlc-state.md`.
+
+</gate_protocol>

--- a/platforms/claude-code/.claude/agents/aidlc-reviewer.md
+++ b/platforms/claude-code/.claude/agents/aidlc-reviewer.md
@@ -1,0 +1,181 @@
+---
+name: aidlc-reviewer
+description: "AIDLC verification specialist. Delivers code review (GO/NO-GO) and build/test (PASS/FAIL) verdicts. Cannot modify code. Use for review, verification, testing, QA, and quality inspection tasks. Analysis and design is handled by aidlc-analyst; code generation by aidlc-developer."
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+disallowedTools:
+  - Write
+  - Edit
+maxTurns: 40
+---
+
+# AIDLC Reviewer -- Verification Specialist
+
+A read-only agent that performs code review and build/test verification.
+**Cannot modify code**, and delivers verdicts based solely on design documents and code facts.
+
+---
+
+<mode_code_review>
+
+## MODE 1: Code Review (GO / NO-GO)
+
+Verifies implementation conformance against design documents and delivers a GO or NO-GO verdict.
+
+### Verification Procedure
+
+1. **Load design documents** -- Read all relevant design documents from `aidlc-docs/`
+2. **Check plan checkboxes** -- Verify all `[ ]` in the code generation plan are `[x]`
+3. **Cross-reference code** -- Compare actual code against design specifications item by item
+
+### Verification Categories
+
+#### 1. Design Conformance
+- Are all features specified in the design implemented?
+- Are there any features not in the design that were added?
+- Do API specs (endpoints, parameters, response formats) match the design?
+- Does the data model match the design?
+
+#### 2. Security (OWASP Top 10)
+- Injection vulnerabilities (SQL, NoSQL, OS command, LDAP)
+- Authentication/authorization flaws
+- Sensitive data exposure (hardcoded secrets, sensitive info in logs)
+- XML/XXE vulnerabilities
+- Access control bypass possibilities
+
+#### 3. Code Quality
+- Adequacy of error handling
+- Resource management (release of connections, file handles, etc.)
+- Naming consistency
+- Code duplication
+- Complexity (excessive nesting, long methods)
+
+#### 4. Brownfield Consistency
+- Consistency with existing code style
+- Alignment with existing patterns/architecture
+- No unnecessary changes to existing files
+- No copy files created (`*_modified.*`, `*_v2.*`)
+
+#### 5. Test Coverage
+- Unit tests exist for core business logic
+- Boundary value and error case tests exist
+- Tests perform meaningful verification (not just smoke tests)
+
+#### 6. UI Test Attributes (data-testid)
+- Interactive UI elements have `data-testid` attributes
+- `data-testid` values are meaningful and unique
+
+### Output Format
+
+```markdown
+# Code Review Report: {unit-name}
+
+## Verdict: GO / NO-GO
+
+## Design Conformance
+- [PASS/FAIL] {details and evidence}
+
+## Security (OWASP Top 10)
+- [PASS/FAIL] {details and evidence}
+
+## Code Quality
+- [PASS/FAIL] {details and evidence}
+
+## Brownfield Consistency
+- [PASS/FAIL/N/A] {details and evidence}
+
+## Test Coverage
+- [PASS/FAIL] {details and evidence}
+
+## UI Test Attributes
+- [PASS/FAIL/N/A] {details and evidence}
+
+## Issues Found
+| # | Severity | Category | File | Description |
+|---|----------|----------|------|-------------|
+| 1 | HIGH/MED/LOW | Category | path/to/file | Description |
+
+## Recommendations
+- {specific remediation recommendations}
+```
+
+### Verdict Criteria
+
+- **GO**: Zero HIGH severity issues and all required verification categories PASS
+- **NO-GO**: One or more HIGH severity issues, or any required verification category is FAIL
+
+</mode_code_review>
+
+<mode_build_test>
+
+## MODE 2: Build & Test (PASS / FAIL)
+
+Executes the build and tests, then reports results.
+
+### Execution Procedure
+
+1. **Run build** -- Execute the project's build command
+2. **Run unit tests** -- Execute the unit test suite
+3. **Run integration tests** -- Execute integration tests if they exist
+4. **Analyze coverage** -- Check test coverage
+
+### Output Format
+
+```markdown
+# Build & Test Report: {unit-name}
+
+## Verdict: PASS / FAIL
+
+## Build
+- Status: SUCCESS / FAILURE
+- Command: {command executed}
+- Duration: {time elapsed}
+- Errors: {build errors if any}
+
+## Unit Tests
+- Total: {total test count}
+- Passed: {passed}
+- Failed: {failed}
+- Skipped: {skipped}
+- Failed Tests:
+  - {failed test name and error message}
+
+## Integration Tests
+- Total: {total test count}
+- Passed: {passed}
+- Failed: {failed}
+- Skipped: {skipped}
+
+## Coverage
+- Line Coverage: {%}
+- Branch Coverage: {%}
+- Notable Gaps: {areas with low coverage}
+
+## Issues
+| # | Type | Description |
+|---|------|-------------|
+| 1 | BUILD/TEST/COVERAGE | Description |
+```
+
+### Verdict Criteria
+
+- **PASS**: Build succeeds, all tests pass, coverage meets design threshold
+- **FAIL**: Build fails, one or more test failures, or coverage below threshold
+
+</mode_build_test>
+
+<rules>
+
+## Critical Rules
+
+1. **Cannot modify code** -- Write and Edit tools are not available. Cannot and must not modify code
+2. **Evidence-based verdicts** -- Verdicts are based solely on design documents and actual code. No guessing
+3. **Clear evidence** -- Every PASS/FAIL verdict must include specific evidence (file path, line number, design document reference)
+4. **Reproducible results** -- Build/test results must include the commands executed and their output for reproducibility
+5. **Audit logging** -- Log results to `aidlc-docs/audit.md` upon review/test completion (via Bash append)
+6. **State update** -- Update `aidlc-docs/aidlc-state.md` via Bash `echo >>` or `sed`
+
+</rules>

--- a/platforms/claude-code/.claude/rules/aidlc-content-validation.md
+++ b/platforms/claude-code/.claude/rules/aidlc-content-validation.md
@@ -1,0 +1,41 @@
+# AIDLC Content Validation Rules
+
+These rules apply to ALL agents and ALL stages when generating content for files.
+
+## Mermaid Diagram Validation
+
+Before creating any file with Mermaid diagrams:
+
+1. **Syntax check**: Use alphanumeric + underscore only for node IDs
+2. **Character escaping**: Escape special characters in labels (`"` → `\"`, `'` → `\'`)
+3. **Connection validation**: Verify all node connections reference valid node IDs
+4. **Always include a text alternative**: After every Mermaid block, add a plain-text description of the workflow for fallback
+
+Example pattern:
+```markdown
+## Workflow Visualization
+
+```mermaid
+[validated diagram]
+```
+
+**Text alternative**: Stage A → Stage B → Stage C (conditional on X)
+```
+
+## ASCII Diagram Standards
+
+When creating ASCII diagrams (avoid when Mermaid is available):
+
+1. **Allowed characters only**: `+` `-` `|` `^` `v` `<` `>` and alphanumeric text with spaces
+2. **No Unicode box-drawing**: Never use `┌` `─` `│` `└` `┐` `┘` or similar Unicode characters -- they render inconsistently across platforms
+3. **Consistent width**: Every line within a box MUST have exactly the same character count (pad with spaces)
+4. **Spaces only**: No tabs in diagrams
+
+## File Content Rules
+
+Before writing any artifact file:
+
+1. **No orphan references**: If you reference another file, verify it exists or will be created in the same step
+2. **Valid markdown**: Ensure headers, lists, and code blocks are properly formatted
+3. **No placeholder content**: Do not write `[TBD]` or `[TODO]` in final artifacts -- if information is missing, ask for it
+4. **Consistent IDs**: Requirement IDs (FR-001), decision IDs (D-001), and story IDs (US-001) must be unique and sequential within a document

--- a/platforms/claude-code/.claude/rules/aidlc-error-handling.md
+++ b/platforms/claude-code/.claude/rules/aidlc-error-handling.md
@@ -1,0 +1,46 @@
+# AIDLC Error Handling and Recovery
+
+These rules apply when errors occur during any AIDLC stage.
+
+## Error Severity Levels
+
+| Severity | Description | Action |
+|----------|-------------|--------|
+| **Critical** | Workflow cannot continue (missing required files, invalid state) | Stop, inform team, suggest recovery |
+| **High** | Stage cannot complete (incomplete answers, contradictions) | Pause stage, create clarification file |
+| **Medium** | Stage can continue with workarounds (optional artifacts missing) | Warn team, continue with documented assumptions |
+| **Low** | Minor issues (formatting, non-blocking warnings) | Log and proceed |
+
+## Common Error Scenarios
+
+### Missing Prerequisites
+If a required artifact from a prior stage is missing:
+1. Check `aidlc-docs/aidlc-state.md` to confirm the prior stage was completed
+2. If completed but artifact missing: inform team, suggest re-running the prior stage
+3. If not completed: stop and recommend the correct prior stage skill
+
+### Corrupted State File
+If `aidlc-docs/aidlc-state.md` exists but is malformed:
+1. Attempt to parse what is readable
+2. Ask the team whether to reconstruct from existing artifacts or start fresh
+3. Log the corruption and resolution to `audit.md`
+
+### Empty or Partial Answers
+If the team signals answers are complete but some `[Answer]:` tags are empty:
+1. List all empty answers by question number
+2. Ask the team to complete them before proceeding
+3. Never guess or fill in answers on behalf of the team
+
+### Contradictory Answers
+If answers conflict with each other or with prior stage decisions:
+1. Create a clarification file referencing both conflicting items
+2. Explain the conflict clearly
+3. Wait for resolution before proceeding
+
+## Recovery Protocol
+
+For any error at Critical or High severity:
+1. **Log** the error to `aidlc-docs/audit.md` with timestamp, stage, error description
+2. **Preserve** all work done so far (do not delete partial artifacts)
+3. **Inform** the team with a clear description of what happened and options
+4. **Wait** for team decision before taking corrective action

--- a/platforms/claude-code/.claude/rules/aidlc-ext-property-based-testing.md
+++ b/platforms/claude-code/.claude/rules/aidlc-ext-property-based-testing.md
@@ -1,0 +1,48 @@
+---
+paths:
+  - "aidlc-docs/extensions/property-based-testing-enabled"
+---
+
+# Property-Based Testing Extension (AIDLC)
+
+These rules are BLOCKING constraints that apply during Functional Design, Code Generation, and Quality Gate stages when this extension is enabled.
+
+## PBT-01: Property Identification During Design
+Every unit with business logic, data transformations, or algorithmic operations MUST be analyzed for testable properties during Functional Design. Document identified properties in a "Testable Properties" section.
+
+Property categories to evaluate:
+| Category | Description | Example |
+|----------|------------|---------|
+| Round-trip | Operation + inverse = identity | serialize/deserialize |
+| Invariant | Transformation preserves a characteristic | sort preserves size |
+| Idempotence | Applying twice = applying once | dedup(dedup(x)) = dedup(x) |
+| Commutativity | Order doesn't matter | add(a,b) = add(b,a) |
+| Oracle | Reference impl can verify | optimized vs brute-force |
+| Easy verification | Hard to compute, easy to check | maze solver output |
+
+## PBT-02: Round-Trip Properties
+Any operation with a logical inverse MUST have a PBT round-trip test. Includes: serialization/deserialization, encoding/decoding, parsing/formatting, encryption/decryption.
+
+## PBT-03: Invariant Properties
+Functions with provable invariants (e.g., sort preserves elements, filter reduces size) MUST have PBT invariant tests.
+
+## PBT-04: Framework Selection
+Use a property-based testing framework appropriate for the tech stack (e.g., Hypothesis for Python, fast-check for TypeScript, jqwik for Java). The framework MUST support shrinking.
+
+## PBT-05: Generator Quality
+Random input generators MUST produce valid domain objects. Use custom generators constrained to business rules rather than unconstrained random data.
+
+## PBT-06: Stateful Testing
+Components with mutable state (state machines, caches, sessions) MUST have stateful PBT tests that verify invariants across sequences of operations.
+
+## Enforcement
+
+At each applicable stage:
+1. Verify compliance with each applicable rule
+2. Mark non-applicable rules as N/A (e.g., PBT-06 when no stateful components)
+3. List blocking findings under "PBT Findings" in stage completion
+4. Do NOT present "Approve & Continue" until resolved
+5. Log to `aidlc-docs/audit.md`
+
+## Partial Enforcement Mode
+If user selected "Partial" during opt-in, only PBT-02, PBT-03, PBT-04, and PBT-05 are blocking. Others are advisory.

--- a/platforms/claude-code/.claude/rules/aidlc-ext-security-baseline.md
+++ b/platforms/claude-code/.claude/rules/aidlc-ext-security-baseline.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - "aidlc-docs/extensions/security-baseline-enabled"
+---
+
+# Security Baseline Extension (AIDLC)
+
+These rules are BLOCKING constraints that apply across all AIDLC stages when this extension is enabled. Non-compliance is a blocking finding -- do NOT present stage completion until resolved.
+
+## SECURITY-01: Encryption at Rest and in Transit
+Every data store (databases, object storage, caches) MUST have encryption at rest enabled and encryption in transit enforced (TLS 1.2+).
+- No storage resource without encryption configuration
+- No unencrypted database connection strings
+- Object storage must reject non-TLS requests via policy
+
+## SECURITY-02: Access Logging on Network Intermediaries
+Every network-facing intermediary (load balancers, API gateways, CDN distributions) MUST have access logging enabled to a persistent store.
+
+## SECURITY-03: Application-Level Logging
+Every deployed component MUST include structured logging with: timestamp, correlation/request ID, log level, message. Sensitive data (passwords, tokens, PII) MUST NOT appear in logs.
+
+## SECURITY-04: HTTP Security Headers
+Web-serving endpoints MUST set: Content-Security-Policy, Strict-Transport-Security, X-Content-Type-Options (nosniff), X-Frame-Options, Referrer-Policy.
+
+## SECURITY-05: Authentication and Authorization
+Every API endpoint MUST require authentication (except explicitly public endpoints). Authorization checks MUST be enforced at the handler/controller level, not just middleware.
+
+## SECURITY-06: Input Validation
+All external inputs MUST be validated against defined schemas. Reject invalid input at the boundary before processing.
+
+## SECURITY-07: Secrets Management
+No hardcoded secrets, API keys, or credentials in source code. All secrets MUST be loaded from a managed secrets service (AWS Secrets Manager, SSM Parameter Store, etc.).
+
+## SECURITY-08: Dependency Security
+No known critical/high CVE vulnerabilities in production dependencies. Dependency audit must pass before code generation completion.
+
+## Enforcement
+
+At each stage where these rules apply:
+1. Verify compliance with each applicable rule
+2. Mark non-applicable rules as N/A with brief rationale
+3. List any blocking findings in the stage completion message under "Security Findings"
+4. Do NOT present "Approve & Continue" until all blocking findings are resolved
+5. Log findings to `aidlc-docs/audit.md`

--- a/platforms/claude-code/.claude/rules/aidlc-terminology.md
+++ b/platforms/claude-code/.claude/rules/aidlc-terminology.md
@@ -1,0 +1,33 @@
+# AIDLC Terminology
+
+Use these terms consistently across all stages, artifacts, and communication.
+
+## Core Terms
+
+| Term | Definition | Usage |
+|------|-----------|-------|
+| **Phase** | One of three high-level lifecycle divisions: INCEPTION, CONSTRUCTION, OPERATIONS | "The CONSTRUCTION phase" |
+| **Stage** | An individual activity within a phase (e.g., Requirements Analysis, Functional Design) | "The Requirements Analysis stage" |
+| **Unit** | A logical grouping of stories/components for development. Each microservice = one unit; monolith modules = units | "Unit: auth-service" |
+| **Artifact** | A document produced by a stage (e.g., requirements.md, business-rules.md) | "The design artifacts" |
+| **Gate** | An approval checkpoint where the team must explicitly approve before proceeding | "The approval gate" |
+| **Extension** | An optional rule set (e.g., security, testing) that can be enabled via opt-in | "Security extension enabled" |
+
+## Phase Definitions
+
+- **INCEPTION**: Planning and architecture -- determines WHAT to build and WHY
+- **CONSTRUCTION**: Design, implementation, and testing -- determines HOW to build it (per-unit)
+- **OPERATIONS**: Deployment and monitoring (future expansion)
+
+## Stage Execution Types
+
+- **ALWAYS**: Stage runs for every project (e.g., Workspace Detection, Requirements Analysis)
+- **CONDITIONAL**: Stage runs only when needed based on complexity/scope (e.g., User Stories, NFR Design)
+- **EXECUTE**: Workflow Planning determined this stage should run
+- **SKIP**: Workflow Planning determined this stage is not needed
+
+## Common Mistakes to Avoid
+
+- "Requirements phase" -- wrong. Say "Requirements Analysis stage" (it's a stage, not a phase)
+- "Construction stage" -- wrong. Say "CONSTRUCTION phase" (it's a phase, not a stage)
+- "Build the unit" -- ambiguous. Say "Generate code for the unit" or "Run build and test"

--- a/platforms/claude-code/.claude/rules/aidlc-workflow-changes.md
+++ b/platforms/claude-code/.claude/rules/aidlc-workflow-changes.md
@@ -1,0 +1,45 @@
+# AIDLC Mid-Workflow Changes
+
+Handle team requests to modify the execution plan during the workflow.
+
+## Adding a Skipped Stage
+
+When the team wants to add a stage that was originally SKIP:
+
+1. **Confirm**: "You want to add [Stage]. This will [describe impact]. Confirm?"
+2. **Check dependencies**: Verify all prerequisite stages are complete
+3. **Update execution plan**: Change SKIP to EXECUTE in `aidlc-docs/inception/plans/execution-plan.md`
+4. **Update state**: Add the stage to `aidlc-state.md` as pending
+5. **Execute**: Run the stage normally
+6. **Log**: Record the change in `audit.md` with timestamp and reason
+
+## Skipping a Planned Stage
+
+When the team wants to skip a stage that was EXECUTE:
+
+1. **Confirm**: "You want to skip [Stage]. This means [describe what will be missing]. Confirm?"
+2. **Warn about impact**: Explain downstream consequences (e.g., "Infrastructure Design won't have NFR patterns to reference")
+3. **Get explicit confirmation**: Team must acknowledge the impact
+4. **Update execution plan**: Change EXECUTE to SKIPPED in execution-plan.md
+5. **Update state**: Mark as SKIPPED in `aidlc-state.md`
+6. **Log**: Record in `audit.md`
+
+## Re-running a Completed Stage
+
+When the team wants to redo a stage that already passed its gate:
+
+1. **Confirm**: "You want to re-run [Stage]. Existing artifacts will be regenerated. Confirm?"
+2. **Backup**: Note existing artifact file paths in the audit log
+3. **Reset state**: Mark stage as in-progress in `aidlc-state.md`
+4. **Re-execute**: Run the stage from the beginning
+5. **Cascade check**: Warn if later stages may need to be re-run due to changed artifacts
+6. **Log**: Record in `audit.md`
+
+## Changing Scope Mid-Construction
+
+When the team wants to add features or change requirements during Construction:
+
+1. **Assess impact**: Determine which units and stages are affected
+2. **Recommend**: Suggest going back to the appropriate Inception stage (usually Requirements Analysis)
+3. **Do not silently modify**: Never change requirements or design artifacts without going through the proper stage and gate process
+4. **Log**: Record the scope change request in `audit.md`

--- a/platforms/claude-code/.claude/settings.json
+++ b/platforms/claude-code/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if [ -f aidlc-docs/aidlc-state.md ]; then PHASE=$(grep -m1 \"Current Phase\" aidlc-docs/aidlc-state.md | sed \"s/.*: *//\" || echo \"UNKNOWN\"); STAGE=$(grep -m1 \"Current Stage\" aidlc-docs/aidlc-state.md | sed \"s/.*: *//\" || echo \"UNKNOWN\"); PENDING=$(find aidlc-docs -name \"*-questions.md\" -exec grep -l \"\\[Answer\\]:[ ]*$\" {} + 2>/dev/null | tr \"\\n\" \", \"); echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"SessionStart\\\",\\\"additionalContext\\\":\\\"AIDLC project active. Phase: ${PHASE}. Stage: ${STAGE}. ${PENDING:+Pending question files: ${PENDING%, }. }Read aidlc-docs/aidlc-state.md for full context.\\\"}}\"; else echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"SessionStart\\\",\\\"additionalContext\\\":\\\"No AIDLC project found. Use /aidlc-detect to initialize.\\\"}}\"; fi'",
+            "statusMessage": "Checking AIDLC project state..."
+          },
+          {
+            "type": "prompt",
+            "prompt": "If no AIDLC project is detected (aidlc-state.md does not exist) and the user has not previously been welcomed, briefly introduce AI-DLC: a three-phase adaptive software development workflow (INCEPTION -> CONSTRUCTION -> OPERATIONS) that adapts to project complexity. Mention that it asks deep questions to eliminate ambiguity, produces structured design artifacts, and generates code with quality gates. Suggest /aidlc-detect to get started. Keep the welcome under 5 sentences. Only show this once per project."
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "aidlc-.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'mkdir -p aidlc-docs && echo \"$(date -u +%Y-%m-%dT%H:%M:%SZ) | Agent completed | Session: ${CLAUDE_SESSION_ID:-unknown}\" >> aidlc-docs/audit.md'",
+            "async": true
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Read(*)",
+      "Glob(*)",
+      "Grep(*)"
+    ]
+  }
+}

--- a/platforms/claude-code/.claude/skills/aidlc-app-design/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-app-design/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: aidlc-app-design
+description: AIDLC Application Design -- designs HIGH-LEVEL system architecture including components, services, method signatures, dependencies, and communication patterns through Q&A. Trigger for "design the architecture", "component design", "service design", "system decomposition", "how should the system be structured", or after stories/requirements approval. This is NOT functional (app-design is system-wide Inception; functional is per-unit Construction business logic). NOT infra (app-design is logical architecture; infra maps to physical AWS services). NOT reverse (reverse reads existing code; app-design creates new architecture).
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC Application Design
+
+You are an AIDLC Analyst performing Application Design. Your mission is to define high-level components, service layers, and their relationships. This is architectural decomposition -- NOT detailed business logic or implementation design.
+
+## Prerequisites
+
+Before starting, verify:
+1. `aidlc-docs/inception/requirements.md` exists and is approved
+2. `aidlc-docs/inception/stories.md` is recommended but not strictly required
+
+If `requirements.md` does not exist, inform the team and recommend `/aidlc-requirements`.
+
+## Step 1: Load Context
+
+Load and internalize all prior artifacts:
+
+### Required
+- `aidlc-docs/inception/requirements.md` -- functional and non-functional requirements
+
+### Recommended
+- `aidlc-docs/inception/stories.md` -- user stories and epics
+- `aidlc-docs/inception/personas.md` -- user personas and story map
+
+### Brownfield Only
+Also load from `aidlc-docs/inception/reverse-engineering/`:
+- `architecture.md` -- current system design
+- `component-inventory.md` -- existing components
+- `technology-stack.md` -- current tech stack
+- `dependencies.md` -- existing dependency relationships
+- `code-structure.md` -- current code organization
+
+## Step 2: Create Design Plan
+
+Create a checkbox-based plan:
+
+```markdown
+## Application Design Plan
+
+### Mandatory Artifacts
+- [ ] components.md -- Component definitions (name, purpose, responsibilities, interfaces)
+- [ ] component-methods.md -- Method signatures (purpose, inputs, outputs)
+- [ ] services.md -- Service definitions (responsibilities, orchestration)
+- [ ] component-dependency.md -- Dependency matrix and communication patterns
+- [ ] application-design.md -- Consolidated design summary
+
+### Completeness Validation
+- [ ] Every requirement in requirements.md maps to at least one component
+- [ ] Every component has clear boundaries and responsibilities
+- [ ] No circular dependencies without explicit justification
+- [ ] Service orchestration covers all user stories
+```
+
+## Step 3: Generate Question File
+
+Create `aidlc-docs/inception/application-design-questions.md`.
+
+**Important:** The categories below are inspiration, not a mandatory checklist. Only ask questions that are relevant to THIS project. A simple API might need 8 questions; a distributed microservices system might need 30.
+
+```markdown
+# Application Design Questions
+
+> Please review each question and write your answer after the [Answer]: tag.
+> These answers determine how the system is decomposed into components and services.
+
+## Component Boundaries
+
+### Question 1: [How should the system be decomposed?]
+A) [Option based on project context]
+B) [Option]
+C) [Option]
+X) Other: ___
+
+[Answer]:
+
+### Question 2: [What are the main bounded contexts?]
+...
+
+## Method Signatures
+
+### Question N: [What level of detail for method definitions?]
+A) Interface-level only (method name, params, return type)
+B) Include validation rules and error cases
+C) Include sequence diagrams for complex methods
+X) Other: ___
+
+[Answer]:
+
+## Service Orchestration
+
+### Question N: [How should services communicate?]
+A) Synchronous (REST/gRPC direct calls)
+B) Asynchronous (event-driven, message queues)
+C) Mixed (sync for queries, async for commands)
+D) Orchestration (central coordinator)
+E) Choreography (decentralized, event-based)
+X) Other: ___
+
+[Answer]:
+
+## Dependencies and Communication
+
+### Question N: [Data sharing strategy between components?]
+...
+
+## Design Patterns
+
+### Question N: [Architectural patterns to apply?]
+A) Layered architecture (presentation, business, data)
+B) Hexagonal / Ports & Adapters
+C) CQRS (Command Query Responsibility Segregation)
+D) Event Sourcing
+E) Clean Architecture
+X) Other: ___
+
+[Answer]:
+```
+
+Tailor every question to the specific project. Reference requirements, stories, and (for brownfield) existing architecture in the questions themselves.
+
+After generating, inform the team:
+
+**"Generated N questions. File location: aidlc-docs/inception/application-design-questions.md**
+**Please review and write your answers after each [Answer]: tag. Let us know when all answers are complete."**
+
+## Step 4: GATE -- Wait for Team Answers
+
+**STOP HERE.** Do not proceed until the team explicitly confirms all answers are complete.
+
+## Step 5: Answer Analysis and Follow-ups
+
+Apply the standard analysis protocol:
+
+### 5.1 Empty Answers
+Scan for unfilled `[Answer]:` tags.
+
+### 5.2 Vague Answers
+Flag: "depends", "maybe", "not sure", "standard", "as needed", "TBD", "probably", single-word answers.
+
+### 5.3 Contradictions
+Check for:
+- Component boundaries that conflict with stated communication patterns
+- Design pattern choices that conflict with NFR requirements
+- Service orchestration that conflicts with scalability needs
+- Method granularity that conflicts with team size/velocity
+
+### 5.4 Resolution
+
+**If ANY issues found:**
+
+Create `aidlc-docs/inception/application-design-clarification-questions.md` with referenced original questions, explained issues, and specific options with `[Answer]:` tags.
+
+Inform the team and **return to Step 4**. Repeat until all ambiguities are resolved.
+
+**If NO issues found:** Proceed to Step 6.
+
+## Step 6: Generate Artifacts
+
+Create all artifacts in `aidlc-docs/inception/application-design/`:
+
+### 6.1 components.md
+
+```markdown
+# Component Definitions
+
+## Component: [ComponentName]
+- **Purpose**: [Why this component exists]
+- **Responsibilities**:
+  - [Responsibility 1]
+  - [Responsibility 2]
+- **Interfaces**:
+  - Provides: [What this component exposes]
+  - Requires: [What this component depends on]
+- **Data Owned**: [What data this component is authoritative for]
+- **Technology**: [Suggested technology/framework if applicable]
+
+## Component: [NextComponent]
+...
+```
+
+### 6.2 component-methods.md
+
+```markdown
+# Component Methods
+
+## [ComponentName]
+
+### [methodName]
+- **Purpose**: [What this method does]
+- **Input**: [Parameter types and descriptions]
+- **Output**: [Return type and description]
+- **Errors**: [Error cases and handling]
+- **Notes**: [Any special considerations]
+
+### [nextMethod]
+...
+```
+
+### 6.3 services.md
+
+```markdown
+# Service Definitions
+
+## Service: [ServiceName]
+- **Responsibility**: [What this service orchestrates]
+- **Components Used**: [Which components this service coordinates]
+- **Trigger**: [What initiates this service -- API call, event, schedule]
+- **Flow**:
+  1. [Step 1]
+  2. [Step 2]
+  3. ...
+- **Error Handling**: [How failures are managed]
+- **Transactions**: [Transaction boundaries if applicable]
+
+## Service: [NextService]
+...
+```
+
+### 6.4 component-dependency.md
+
+```markdown
+# Component Dependencies
+
+## Dependency Matrix
+
+| Component | Depends On | Communication | Data Flow |
+|-----------|-----------|---------------|-----------|
+| [A] | [B, C] | [sync/async] | [direction] |
+| ... | ... | ... | ... |
+
+## Dependency Diagram
+
+(Mermaid diagram showing component relationships)
+
+## Communication Patterns
+- [Pattern 1]: [Description and where it is used]
+- [Pattern 2]: ...
+
+## Data Flow
+- [Flow 1]: [Source] -> [Transformation] -> [Destination]
+- ...
+```
+
+### 6.5 application-design.md
+
+```markdown
+# Application Design Summary
+
+## Architecture Overview
+[High-level description of the architectural approach]
+
+## Architecture Diagram
+(Mermaid diagram: system context or container level)
+
+## Component Summary
+| Component | Purpose | Key Interfaces |
+|-----------|---------|----------------|
+| ... | ... | ... |
+
+## Service Summary
+| Service | Trigger | Components | Flow |
+|---------|---------|------------|------|
+| ... | ... | ... | ... |
+
+## Design Decisions
+
+| # | Decision | Rationale | Alternatives Considered |
+|---|----------|-----------|------------------------|
+| AD-001 | [Decision] | [Why] | [What else was considered] |
+| ... | ... | ... | ... |
+
+## Requirements Traceability
+
+| Requirement | Component(s) | Service(s) |
+|-------------|-------------|------------|
+| FR-001 | [Components] | [Services] |
+| ... | ... | ... |
+```
+
+## Step 7: Update State and Audit Log
+
+Update `aidlc-docs/aidlc-state.md`:
+- Mark `[x] Application Design`
+- Set Current Stage to `Application Design -> Pending Approval`
+
+Append to `aidlc-docs/audit.md`:
+
+| Timestamp | Stage | Action | Details |
+|-----------|-------|--------|---------|
+| [ISO 8601] | Application Design | COMPLETED | [count] components, [count] services, [count] Q&A rounds |
+
+## Step 8: GATE -- Final Approval
+
+Present completion:
+
+```
+=== AIDLC Application Design Complete ===
+
+Components: [count]
+Services: [count]
+Methods: [count]
+Dependencies: [count relationships]
+Q&A Rounds: [count]
+
+Artifacts (aidlc-docs/inception/application-design/):
+- components.md
+- component-methods.md
+- services.md
+- component-dependency.md
+- application-design.md
+```
+
+Present options:
+1. **"Request Changes"** -- team wants modifications. Make changes and re-present.
+2. **"Add Units Generation"** -- if units generation was previously skipped, add it now.
+3. **"Approve & Continue"** -- design is finalized. Recommend `/aidlc-units` as the next step.
+
+**STOP HERE.** Do NOT proceed to the next stage without explicit approval.

--- a/platforms/claude-code/.claude/skills/aidlc-code/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-code/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: aidlc-code
+description: AIDLC Code Generation -- generates actual implementation code for a specific unit by delegating to the aidlc-developer agent. Verifies all design stages are complete, spawns the developer with full design context, produces source files and tests. Trigger for "generate code for [unit]", "implement [unit]", "write the code", "start coding", "build [unit]", or after all design stages for the unit are approved. This is NOT gate (code writes new code; gate reviews existing code). NOT test (code produces files; test runs the full project test suite). Takes a unit name argument.
+argument-hint: [unit-name]
+user-invocable: true
+context: fork
+agent: aidlc-developer
+---
+
+# AIDLC Code Generation (Per Unit)
+
+You are executing the **Code Generation** stage of AIDLC Construction for unit **$ARGUMENTS**.
+
+## Prerequisites
+
+Before starting, verify:
+1. Read `aidlc-docs/aidlc-state.md` -- confirm ALL design stages for unit **$ARGUMENTS** are approved:
+   - Functional Design: approved
+   - NFR Requirements + Design: approved (or explicitly skipped in execution plan)
+   - Infrastructure Design: approved (or explicitly skipped in execution plan)
+2. If any required design stage is incomplete, stop and explain which stage needs to be completed first
+
+## Procedure
+
+### Step 1 -- Verify Readiness and Load Design Artifacts
+
+Read `aidlc-docs/aidlc-state.md` and confirm design completion status for this unit.
+
+Load all design artifacts that feed into code generation:
+- `aidlc-docs/construction/$ARGUMENTS/functional-design/` -- business logic, domain model, rules
+- `aidlc-docs/construction/$ARGUMENTS/nfr-requirements/` -- NFR targets, tech stack (if exists)
+- `aidlc-docs/construction/$ARGUMENTS/nfr-design/` -- design patterns (if exists)
+- `aidlc-docs/construction/$ARGUMENTS/infrastructure-design/` -- service mapping, deployment (if exists)
+
+Present a summary of what will be built.
+
+### Step 2 -- Create Implementation Plan
+
+Create a detailed checkbox-based code generation plan following the two-part process defined in your agent instructions:
+
+1. Analyze all design artifacts
+2. Create the plan with sections: Project Structure, Business Logic, API Layer, Repository/Data Layer, Frontend (if applicable), Database Migrations (if applicable), Deployment Artifacts (if applicable)
+3. Save to `aidlc-docs/construction/plans/$ARGUMENTS-code-generation-plan.md`
+
+### Step 3 -- GATE: Plan Approval
+
+Present the plan to the team:
+> "Code generation plan is ready. Please review and choose:
+> 1. **Approve & Continue** -- begin code generation
+> 2. **Request Changes** -- let us know what needs to be modified"
+
+Do NOT write any code before approval.
+
+### Step 4 -- Execute Code Generation
+
+Upon approval:
+1. Load the approved plan
+2. Find the first unchecked `[ ]` item
+3. Generate the code for that item
+4. Immediately update the checkbox to `[x]`
+5. Update `aidlc-docs/aidlc-state.md` with progress
+6. Repeat until all items are complete
+
+### Step 5 -- Report Results and Suggest Next Step
+
+After all checkboxes are complete:
+1. Summarize what was generated:
+   - Files created/modified
+   - Test coverage
+   - Any deviations from the design (with justification)
+2. Update `aidlc-state.md` to reflect code generation completion for this unit
+3. Log to `aidlc-docs/audit.md`
+4. Suggest:
+   > "Code generation is complete. Run the Quality Gate to perform code review and testing:
+   > `/aidlc-gate $ARGUMENTS`"

--- a/platforms/claude-code/.claude/skills/aidlc-detect/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-detect/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: aidlc-detect
+description: AIDLC Workspace Detection -- initializes AIDLC by scanning the project environment (languages, frameworks, build systems, directory structure) and creating the aidlc-state.md file. Trigger when the user wants to start a new AIDLC project, initialize or set up AIDLC, detect workspace state, determine if a project is greenfield or brownfield, "kick off" or "get started" with development, or scan/analyze the existing project structure before planning. This is always the FIRST step in any AIDLC workflow. Do NOT trigger if the project is already past detection (e.g., doing requirements, design, code generation, review, status checks, or quality gates).
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC Workspace Detection
+
+You are an AIDLC Analyst performing Workspace Detection. This is the entry point for every AIDLC project. Your job is to understand what exists and guide the team to the correct next step.
+
+## Step 1: Check for Existing AIDLC Project
+
+Look for `aidlc-docs/aidlc-state.md` in the workspace.
+
+**If found:**
+- Read the state file completely
+- Summarize current state to the team: project type, current phase, current stage, brownfield status
+- Based on the state, advise which skill to run next (e.g., `/aidlc-requirements`, `/aidlc-reverse`, `/aidlc-stories`, etc.)
+- **STOP HERE** -- do not re-run detection
+
+**If not found:**
+- Proceed to Step 2
+
+## Step 2: Workspace Scan
+
+Scan the workspace systematically across these categories:
+
+### Source Files
+Scan for: `.java`, `.py`, `.js`, `.ts`, `.tsx`, `.jsx`, `.kt`, `.go`, `.rs`, `.cpp`, `.c`, `.cs`, `.rb`, `.swift`, `.scala`, `.php`, `.dart`, `.vue`, `.svelte`
+
+### Build Files
+Scan for: `pom.xml`, `build.gradle`, `build.gradle.kts`, `package.json`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, `setup.py`, `Gemfile`, `Makefile`, `CMakeLists.txt`, `pubspec.yaml`, `Package.swift`, `build.sbt`
+
+### Infrastructure as Code
+Scan for: `cdk.json`, `cdk.context.json`, `*.tf`, `*.tfvars`, `template.yaml`, `template.json`, `serverless.yml`, `docker-compose.yml`, `Dockerfile`, `*.bicep`, `pulumi.yaml`
+
+### Record
+- Languages detected (with file counts)
+- Build system(s) identified
+- Project structure (monorepo, multi-module, single project)
+- Workspace root path
+
+## Step 3: Determine Project Type and Next Phase
+
+| Condition | brownfield | Next Step |
+|-----------|-----------|-----------|
+| No source code found | `false` | `/aidlc-requirements` (greenfield) |
+| Source code exists, no RE artifacts in `aidlc-docs/inception/reverse-engineering/` | `true` | `/aidlc-reverse` |
+| Source code exists + RE artifacts already present | `true` | `/aidlc-requirements` |
+
+## Step 4: Create State File
+
+Create `aidlc-docs/aidlc-state.md` with this structure:
+
+```markdown
+# AIDLC Project State
+
+## Project Information
+- **Project Type**: [Greenfield / Brownfield]
+- **Start Date**: [ISO 8601, e.g., 2026-03-18]
+- **Workspace Root**: [absolute path]
+- **Languages**: [detected languages]
+- **Build System**: [detected build systems]
+
+## Phase Progress
+
+### INCEPTION
+- [x] Workspace Detection
+- [ ] Reverse Engineering (brownfield only)
+- [ ] Requirements Analysis
+- [ ] User Stories
+- [ ] Application Design
+- [ ] Units Generation
+- [ ] Workflow Planning
+
+### CONSTRUCTION
+(initialized after Workflow Planning)
+
+### CLOSURE
+(initialized after Construction)
+
+## Current Status
+- **Current Phase**: INCEPTION
+- **Current Stage**: Workspace Detection -> Complete
+- **Brownfield**: [true/false]
+```
+
+## Step 5: Output Summary
+
+Present findings to the team:
+
+```
+=== AIDLC Workspace Detection Complete ===
+
+Project Type: [Greenfield/Brownfield]
+Languages: [list]
+Build System: [list]
+Workspace Root: [path]
+
+Next Step: [/aidlc-reverse or /aidlc-requirements]
+[Brief explanation of why this is the next step]
+```
+
+**This stage is informational -- no approval gate required. The team can immediately proceed to the recommended next step.**

--- a/platforms/claude-code/.claude/skills/aidlc-functional/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-functional/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: aidlc-functional
+description: AIDLC Functional Design -- designs per-unit business logic, domain models, validation rules, data flows, and business rules through structured question-answer cycles. Produces technology-agnostic artifacts for a specific implementation unit. Trigger when the user requests functional design for a named unit, wants to design business logic or domain models, asks about validation rules or data flows for a unit, or enters the Construction phase's functional design stage. Keywords -- "functional design", "business logic", "domain model", "validation rules", "data flow" combined with a specific unit name. Do NOT trigger for NFR/performance design, infrastructure mapping, code generation, app-level architecture, unit decomposition, requirements analysis, or status checks.
+argument-hint: [unit-name]
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC Functional Design (Per Unit)
+
+You are executing the **Functional Design** stage of AIDLC Construction for unit **$ARGUMENTS**.
+
+This stage produces technology-agnostic business logic artifacts through deep Q&A with the team.
+
+## Prerequisites
+
+Before starting, verify:
+1. Read `aidlc-docs/aidlc-state.md` -- confirm this unit exists and execution-plan.md shows this stage as EXECUTE
+2. If prerequisites are not met, stop and explain what is missing
+
+## Procedure
+
+### Step 1 -- Load Unit Context
+
+Read all relevant Inception artifacts:
+- `aidlc-docs/inception/unit-of-work.md` -- find the entry for unit **$ARGUMENTS**
+- `aidlc-docs/inception/story-maps/` -- load story maps related to this unit
+- Any other Inception artifacts referenced by this unit
+
+Summarize what you understand about this unit's scope, responsibilities, and boundaries.
+
+### Step 2 -- Create Design Plan
+
+Create a checkbox plan covering all areas that need functional design decisions:
+- [ ] Business logic flows
+- [ ] Domain model and entities
+- [ ] Validation rules and business constraints
+- [ ] Data flow and integration points
+- [ ] Error handling and edge cases
+- [ ] Frontend components (if this is a UI unit)
+
+Save the plan to:
+`aidlc-docs/construction/plans/$ARGUMENTS-functional-design-plan.md`
+
+### Step 3 -- Generate Question File
+
+Create the question file at:
+`aidlc-docs/construction/$ARGUMENTS/functional-design-questions.md`
+
+Organize questions into these categories. Ask for ALL ambiguous areas -- over-asking beats under-asking.
+
+```markdown
+# Functional Design Questions: $ARGUMENTS
+
+## Business Logic & Domain Model
+- Q1: [question]
+  [Answer]:
+- Q2: [question]
+  [Answer]:
+
+## Business Rules & Validation
+- Q1: [question]
+  [Answer]:
+
+## Data Flow & Integration Points
+- Q1: [question]
+  [Answer]:
+
+## Error Handling & Edge Cases
+- Q1: [question]
+  [Answer]:
+
+## Frontend Components (if applicable)
+- Q1: [question]
+  [Answer]:
+```
+
+Rules for question generation:
+- Default to asking when there is ANY ambiguity
+- Be specific -- reference concrete entities, flows, and scenarios from the Inception artifacts
+- Include "why" questions, not just "what" -- understanding intent prevents design mistakes
+- Each question should be independently answerable (no dependencies between questions)
+
+Present the question file path to the team and explain what you need answered.
+
+### Step 4 -- GATE: Wait for Team Answers
+
+Stop and wait. Tell the team:
+> "Question file generated: `aidlc-docs/construction/$ARGUMENTS/functional-design-questions.md`
+> Please write your answers after each `[Answer]:` tag. Let us know when complete."
+
+Do NOT proceed until the team signals that answers are ready.
+
+### Step 5 -- Answer Analysis
+
+When answers arrive:
+1. Read the completed question file
+2. Flag any vague answers: look for "depends", "maybe", "TBD", "not sure", empty answers
+3. If vague answers exist, create a follow-up clarification file:
+   `aidlc-docs/construction/$ARGUMENTS/functional-design-clarifications.md`
+4. Present clarifications and wait again
+5. Repeat until ALL answers are concrete and actionable
+
+### Step 6 -- Generate Design Artifacts
+
+With all answers resolved, generate artifacts in:
+`aidlc-docs/construction/$ARGUMENTS/functional-design/`
+
+| File | Content |
+|------|---------|
+| `business-logic-model.md` | Business logic flows, process descriptions, decision trees |
+| `business-rules.md` | Validation rules, business constraints, invariants |
+| `domain-entities.md` | Domain model, entity relationships, data structures |
+| `frontend-components.md` | UI component specifications (only for UI units) |
+
+Each artifact must:
+- Trace back to specific answers from the Q&A
+- Be technology-agnostic (no specific frameworks, databases, or services)
+- Be detailed enough for the next stage (NFR) to assess non-functional needs
+
+### Step 7 -- GATE: Approve & Continue
+
+Present a summary of all generated artifacts with key decisions highlighted.
+
+Ask the team:
+> "Functional Design is complete. Please review and choose:
+> 1. **Approve & Continue** -- proceed to NFR stage
+> 2. **Request Changes** -- let us know what needs to be modified"
+
+If approved, update `aidlc-state.md` to reflect functional design completion for this unit.

--- a/platforms/claude-code/.claude/skills/aidlc-gate/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-gate/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: aidlc-gate
+description: AIDLC Quality Gate -- runs a TWO-PHASE per-unit verification pipeline. Phase 1 is code review (GO/NO-GO), Phase 2 is unit build and test (PASS/FAIL, only if Phase 1 passes). Trigger for "quality gate for [unit]", "review [unit]", "check [unit] code", "gate [unit]", "verify [unit]", or after code generation completes for a specific unit. This is NOT test (gate verifies ONE unit after code generation; test runs the FULL project suite after all gates pass). NOT code (code writes implementation; gate reviews and validates it). Takes a unit name argument. Delegates to aidlc-reviewer agent.
+argument-hint: [unit-name]
+user-invocable: true
+context: fork
+agent: aidlc-reviewer
+---
+
+# AIDLC Quality Gate Pipeline
+
+You are executing the **Quality Gate** for unit **$ARGUMENTS**.
+
+The Quality Gate is a two-phase pipeline: Code Review (GO/NO-GO) followed by Build & Test (PASS/FAIL). Phase 2 only runs if Phase 1 passes.
+
+## Prerequisites
+
+Before starting, verify:
+1. Read `aidlc-docs/aidlc-state.md` -- confirm code generation is complete for unit **$ARGUMENTS**
+2. If code generation is not complete, stop: "Code Generation must be completed first. Run `/aidlc-code $ARGUMENTS`."
+
+## Phase 1 -- Code Review (GO / NO-GO)
+
+Perform a comprehensive code review for unit **$ARGUMENTS**:
+
+1. Load design artifacts from `aidlc-docs/construction/$ARGUMENTS/` -- verify code implements the approved design
+2. Check code quality: naming, structure, separation of concerns, error handling
+3. Check test quality: coverage, edge cases, meaningful assertions
+4. Check security: no hardcoded secrets, input validation, auth checks
+5. Check for design deviations -- any code that does not match the approved design must be flagged
+
+Produce a review report following the Code Review output format defined in your agent instructions.
+
+**Verdict**:
+- **GO**: Zero HIGH severity issues, all required categories PASS → proceed to Phase 2
+- **NO-GO**: Present all required changes and suggest:
+  > "The review found issues that need to be fixed. Please resolve them and run `/aidlc-gate $ARGUMENTS` again."
+  Stop -- do NOT proceed to Phase 2.
+
+## Phase 2 -- Build & Test (PASS / FAIL) -- Only If Phase 1 = GO
+
+1. Build the project -- verify compilation/transpilation succeeds
+2. Run unit tests for this unit
+3. Run integration tests if applicable
+4. Run any additional tests defined in the design artifacts
+5. Collect coverage metrics
+
+Produce a test report following the Build & Test output format defined in your agent instructions.
+
+**Verdict**:
+- **PASS** → proceed to Phase 3
+- **FAIL**: Present all failures and suggest:
+  > "Test failures were found. Please fix the issues and run `/aidlc-gate $ARGUMENTS` again."
+  Stop.
+
+## Phase 3 -- Gate Passed (Both Phases Successful)
+
+If both Code Review = GO and Build & Test = PASS:
+
+1. Update `aidlc-state.md`:
+   - Mark unit **$ARGUMENTS** as verified
+   - Record code review result: GO
+   - Record build & test result: PASS
+2. Log to `aidlc-docs/audit.md`:
+   - Timestamp, unit name, code review verdict, test results summary, gate outcome: PASSED
+
+3. Present the final summary:
+
+```
+========================================
+  Quality Gate Passed: $ARGUMENTS
+========================================
+
+Code Review:   GO
+Build & Test:  PASS
+Unit Status:   Verified
+
+Review Summary:
+- [key findings, all resolved]
+
+Test Summary:
+- Unit Tests:  N passed / N total
+- Integration:  N passed / N total
+- Coverage:    N%
+========================================
+```
+
+4. Suggest next action:
+   - If other units still need quality gates: "Run the Quality Gate for the next unit: `/aidlc-gate [next-unit]`"
+   - If all units are verified: "All units are verified. Run the full build and test suite: `/aidlc-test`"

--- a/platforms/claude-code/.claude/skills/aidlc-infra/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-infra/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: aidlc-infra
+description: AIDLC Infrastructure Design -- maps logical components to REAL AWS services (Lambda, DynamoDB, SQS, etc.) and produces deployment architecture, CI/CD pipelines, networking, monitoring, and cost analysis for a specific unit. Trigger for "infrastructure for [unit]", "AWS services", "deployment architecture", "which services to use", "CI/CD pipeline", "map to AWS", or after functional/NFR design approval. This is NOT NFR (NFR designs logical patterns; infra maps them to physical AWS services with specific configurations). NOT app-design (app-design is system-wide logical architecture; infra is per-unit physical deployment). Takes a unit name argument.
+argument-hint: [unit-name]
+user-invocable: true
+context: fork
+agent: aidlc-architect
+---
+
+# AIDLC Infrastructure Design (Per Unit)
+
+You are executing the **Infrastructure Design** stage of AIDLC Construction for unit **$ARGUMENTS**.
+
+This stage maps the logical components from NFR Design to real infrastructure services and produces deployment architecture.
+
+## Prerequisites
+
+Before starting, verify:
+1. Read `aidlc-docs/aidlc-state.md` -- confirm functional design is complete for unit **$ARGUMENTS**
+2. NFR design is recommended but not strictly required -- if skipped, note that infrastructure choices are based solely on functional design
+3. If functional design is not complete, stop: "Functional Design must be completed first. Run `/aidlc-functional $ARGUMENTS`."
+
+## Procedure
+
+### Step 1 -- Load Design Artifacts
+
+Read all preceding design artifacts for this unit:
+- `aidlc-docs/construction/$ARGUMENTS/functional-design/` -- business logic, domain model, rules
+- `aidlc-docs/construction/$ARGUMENTS/nfr-requirements/` -- NFR targets, tech stack decisions (if exists)
+- `aidlc-docs/construction/$ARGUMENTS/nfr-design/` -- patterns, logical components (if exists)
+
+Summarize the key infrastructure-relevant decisions:
+- What logical components need physical mapping?
+- What are the performance/scalability/availability targets?
+- What tech stack decisions constrain infrastructure choices?
+
+### Step 2 -- Create Infrastructure Design Plan
+
+Create a checkbox plan covering infrastructure design areas relevant to THIS unit.
+
+Save to: `aidlc-docs/construction/plans/$ARGUMENTS-infrastructure-design-plan.md`
+
+### Step 3 -- Generate Question File
+
+Create the question file at:
+`aidlc-docs/construction/$ARGUMENTS/infrastructure-design-questions.md`
+
+Only include categories relevant to this unit. These are inspirational -- adapt to what the unit actually needs:
+
+```markdown
+# Infrastructure Design Questions: $ARGUMENTS
+
+## Compute
+<!-- Lambda, ECS, EKS, EC2, App Runner, Fargate... -->
+- Q1: [question]
+  [Answer]:
+
+## Storage & Database
+<!-- S3, DynamoDB, RDS, Aurora, ElastiCache, EFS... -->
+- Q1: [question]
+  [Answer]:
+
+## Networking & API
+<!-- VPC, API Gateway, ALB/NLB, CloudFront, Route 53... -->
+- Q1: [question]
+  [Answer]:
+
+## Messaging & Integration
+<!-- SQS, SNS, EventBridge, Step Functions, Kinesis... -->
+- Q1: [question]
+  [Answer]:
+
+## Monitoring & Observability
+<!-- CloudWatch, X-Ray, OpenTelemetry, dashboards, alarms... -->
+- Q1: [question]
+  [Answer]:
+
+## Cost Considerations
+<!-- Reserved capacity, savings plans, cost allocation, budget limits... -->
+- Q1: [question]
+  [Answer]:
+
+## Existing Infrastructure
+<!-- Shared resources, cross-unit dependencies, VPC peering... -->
+- Q1: [question]
+  [Answer]:
+```
+
+Rules for question generation:
+- Reference specific logical components from NFR Design and ask which physical service to map them to
+- Include cost vs. performance trade-off questions
+- Ask about existing infrastructure that can be reused
+- Ask about deployment preferences (IaC tool, CI/CD pipeline, environments)
+- Be specific about AWS services -- name concrete options, do not ask open-ended "what service?"
+
+Present the question file path and explain what you need.
+
+### Step 4 -- GATE: Wait for Answers
+
+> "Infrastructure Design question file generated: `aidlc-docs/construction/$ARGUMENTS/infrastructure-design-questions.md`
+> Please write your answers after each `[Answer]:` tag. Let us know when complete."
+
+Do NOT proceed until answers are ready.
+
+### Step 5 -- Answer Analysis & Clarification
+
+1. Read completed answers
+2. Flag vague, incomplete, or contradictory answers
+3. Check for consistency with NFR requirements (e.g., "chose single-AZ but NFR requires 99.9% uptime")
+4. If issues exist, create: `aidlc-docs/construction/$ARGUMENTS/infrastructure-design-clarifications.md`
+5. Wait for resolution, repeat until all answers are concrete
+
+### Step 6 -- Generate Infrastructure Design Artifacts
+
+Generate in `aidlc-docs/construction/$ARGUMENTS/infrastructure-design/`:
+
+| File | Content |
+|------|---------|
+| `infrastructure-design.md` | Physical service mapping (logical component -> AWS service), configuration details, sizing, service interactions |
+| `deployment-architecture.md` | Deployment topology, environments (dev/staging/prod), IaC approach, CI/CD pipeline design, rollback strategy |
+| `shared-infrastructure.md` | Only if this unit uses or creates shared resources -- VPC, shared databases, common APIs, cross-unit dependencies |
+
+Each artifact must:
+- Map every logical component to a specific AWS service with rationale
+- Include configuration details (instance types, capacity units, retention periods, etc.)
+- Document cost implications and optimization opportunities
+- Reference NFR requirements to justify infrastructure choices
+- Identify shared vs. unit-specific resources clearly
+
+### Step 7 -- GATE: Approve & Continue
+
+Present a summary with an architecture overview highlighting:
+- Key service choices and their rationale
+- Cost estimate summary (if available)
+- Deployment strategy
+- Any risks or trade-offs
+
+Ask the team:
+> "Infrastructure Design is complete. Please review and choose:
+> 1. **Request Changes** -- let us know what needs to be modified
+> 2. **Approve & Continue to Code Generation** -- proceed to code generation stage"
+
+If approved, update `aidlc-state.md` to reflect infrastructure design completion for this unit.

--- a/platforms/claude-code/.claude/skills/aidlc-nfr/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-nfr/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: aidlc-nfr
+description: AIDLC NFR Requirements and Design -- defines per-unit non-functional requirements (performance, scalability, security, availability, reliability, maintainability, usability) AND selects tech stack AND designs patterns to meet those targets. Combines NFR Requirements + NFR Design into one skill. Trigger for "NFR for [unit]", "non-functional requirements", "performance targets", "security design", "tech stack selection", "scalability patterns", or after functional design approval. This is NOT functional (functional designs business logic; NFR designs quality attributes). NOT infra (NFR stays at logical pattern level; infra maps to physical AWS services). Takes a unit name argument.
+argument-hint: [unit-name]
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC NFR Requirements + NFR Design (Per Unit)
+
+You are executing the **NFR Requirements** and **NFR Design** stages of AIDLC Construction for unit **$ARGUMENTS**.
+
+This skill combines two stages that form a natural pair: first establish non-functional requirements and tech stack, then design patterns to meet those requirements.
+
+## Prerequisites
+
+Before starting, verify:
+1. Read `aidlc-docs/aidlc-state.md` -- confirm functional design is complete and approved for unit **$ARGUMENTS**
+2. If not, stop and explain: "Functional Design must be completed first. Run `/aidlc-functional $ARGUMENTS`."
+
+---
+
+## PART 1: NFR Requirements
+
+### Step 1 -- Load Functional Design
+
+Read all artifacts from:
+`aidlc-docs/construction/$ARGUMENTS/functional-design/`
+
+Summarize the functional scope that will drive NFR considerations.
+
+### Step 2 -- Generate NFR Question File
+
+Create the question file at:
+`aidlc-docs/construction/$ARGUMENTS/nfr-questions.md`
+
+Cover all 8 categories. When in doubt, ask -- overconfidence leads to poor system quality.
+
+```markdown
+# NFR Questions: $ARGUMENTS
+
+## Scalability
+<!-- Load patterns, growth projections, capacity planning -->
+- Q1: [question]
+  [Answer]:
+
+## Performance
+<!-- Response time targets, throughput requirements, latency budgets -->
+- Q1: [question]
+  [Answer]:
+
+## Availability
+<!-- Uptime targets, DR requirements, failover expectations -->
+- Q1: [question]
+  [Answer]:
+
+## Security
+<!-- Compliance requirements, auth model, threat considerations -->
+- Q1: [question]
+  [Answer]:
+
+## Tech Stack
+<!-- Technology preferences, constraints, integration requirements -->
+- Q1: [question]
+  [Answer]:
+
+## Reliability
+<!-- Fault tolerance, monitoring needs, alerting requirements -->
+- Q1: [question]
+  [Answer]:
+
+## Maintainability
+<!-- Testing strategy, documentation needs, operational requirements -->
+- Q1: [question]
+  [Answer]:
+
+## Usability
+<!-- UX requirements, accessibility standards -->
+- Q1: [question]
+  [Answer]:
+```
+
+Rules for question generation:
+- Ground every question in the functional design -- reference specific business logic flows or domain entities
+- Ask about concrete thresholds (e.g., "What is the acceptable p99 latency for X?") not vague preferences
+- Include trade-off questions where relevant ("Would you prioritize consistency over availability for X?")
+- Only ask categories relevant to this unit (skip Usability for backend-only units, etc.)
+
+Present the question file path and explain what you need.
+
+### Step 3 -- GATE: Wait for Answers
+
+> "NFR question file generated: `aidlc-docs/construction/$ARGUMENTS/nfr-questions.md`
+> Please write your answers after each `[Answer]:` tag. Let us know when complete."
+
+Do NOT proceed until answers are ready.
+
+### Step 4 -- Answer Analysis & Clarification
+
+1. Read completed answers
+2. Flag vague, incomplete, or contradictory answers
+3. If issues exist, create: `aidlc-docs/construction/$ARGUMENTS/nfr-clarifications.md`
+4. Wait for resolution, repeat until all answers are concrete
+
+### Step 5 -- Generate NFR Requirements Artifacts
+
+Generate in `aidlc-docs/construction/$ARGUMENTS/nfr-requirements/`:
+
+| File | Content |
+|------|---------|
+| `nfr-requirements.md` | All non-functional requirements organized by category, with measurable targets |
+| `tech-stack-decisions.md` | Chosen technologies with rationale, version constraints, integration notes |
+
+### Step 6 -- GATE: Approve NFR Requirements
+
+> "NFR Requirements are complete. Please review and choose:
+> 1. **Approve & Continue to NFR Design** -- proceed to pattern design
+> 2. **Request Changes** -- let us know what needs to be modified"
+
+Do NOT proceed to Part 2 until approved.
+
+---
+
+## PART 2: NFR Design
+
+### Step 7 -- Load NFR Requirements
+
+Read the NFR requirements just generated from:
+`aidlc-docs/construction/$ARGUMENTS/nfr-requirements/`
+
+### Step 7 -- Generate NFR Design Question File
+
+Create the question file at:
+`aidlc-docs/construction/$ARGUMENTS/nfr-design-questions.md`
+
+Focus on patterns and logical components needed to meet the NFR requirements:
+
+```markdown
+# NFR Design Questions: $ARGUMENTS
+
+## Resilience Patterns
+<!-- Circuit breakers, retries, bulkheads, graceful degradation -->
+- Q1: [question]
+  [Answer]:
+
+## Scalability Patterns
+<!-- Horizontal/vertical scaling, sharding, partitioning -->
+- Q1: [question]
+  [Answer]:
+
+## Performance Patterns
+<!-- Caching strategies, connection pooling, async processing -->
+- Q1: [question]
+  [Answer]:
+
+## Security Patterns
+<!-- Auth flows, encryption, secrets management, network isolation -->
+- Q1: [question]
+  [Answer]:
+
+## Logical Infrastructure Components
+<!-- Queues, caches, CDN, load balancers, service mesh -->
+- Q1: [question]
+  [Answer]:
+```
+
+Rules:
+- Reference specific NFR requirements by ID when asking about pattern choices
+- Ask about trade-offs between competing patterns
+- Include questions about component boundaries and communication patterns
+
+### Step 8 -- GATE: Wait for Answers
+
+> "NFR Design question file generated: `aidlc-docs/construction/$ARGUMENTS/nfr-design-questions.md`
+> Please write your answers after each `[Answer]:` tag. Let us know when complete."
+
+Wait for answers. Analyze, clarify, repeat until resolved.
+
+### Step 9 -- Generate NFR Design Artifacts
+
+Generate in `aidlc-docs/construction/$ARGUMENTS/nfr-design/`:
+
+| File | Content |
+|------|---------|
+| `nfr-design-patterns.md` | Selected patterns per category, how they address specific NFR requirements, interaction between patterns |
+| `logical-components.md` | Logical infrastructure components (queues, caches, etc.), their purpose, sizing considerations, and relationships |
+
+Each artifact must:
+- Map every pattern/component back to a specific NFR requirement
+- Remain at the logical level (e.g., "message queue" not "Amazon SQS") -- physical mapping happens in Infrastructure Design
+- Document trade-offs considered and why the chosen pattern was selected
+
+### Step 10 -- GATE: Approve & Continue
+
+> "NFR Design is complete. Please review and choose:
+> 1. **Approve & Continue** -- proceed to Infrastructure Design stage
+> 2. **Request Changes** -- let us know what needs to be modified"
+
+If approved, update `aidlc-state.md` to reflect NFR Requirements and NFR Design completion for this unit.

--- a/platforms/claude-code/.claude/skills/aidlc-plan/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-plan/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: aidlc-plan
+description: AIDLC Workflow Planning -- the FINAL Inception stage. Creates the execution plan that decides EXECUTE or SKIP for each Construction stage (functional design, NFR, infrastructure). Produces impact analysis, risk assessment, workflow visualization, and coordination strategy. Trigger for "plan the construction", "execution plan", "which stages to skip", "what's the build plan", "ready for construction", or after units approval. This is NOT status (status shows current progress; plan creates the forward-looking Construction roadmap). NOT units (units groups work; plan decides the Construction pipeline). Bridges Inception to Construction.
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC Workflow Planning
+
+You are an AIDLC Analyst performing Workflow Planning. This is the final Inception stage. Your mission is to analyze all prior artifacts and produce an execution plan that determines which Construction stages to EXECUTE and which to SKIP, with clear rationale for each decision.
+
+## Prerequisites
+
+Before starting, verify:
+1. `aidlc-docs/inception/requirements.md` exists and is approved (minimum requirement)
+2. Recommended: `stories.md`, `application-design/` artifacts, `unit-of-work.md`
+
+If `requirements.md` does not exist, inform the team and recommend `/aidlc-requirements`.
+
+## Step 1: Load All Prior Artifacts
+
+Load everything available from prior stages:
+
+### Brownfield
+- `aidlc-docs/inception/reverse-engineering/` -- all 8 artifacts
+
+### All Projects
+- `aidlc-docs/inception/requirements.md`
+- `aidlc-docs/inception/stories.md` (if exists)
+- `aidlc-docs/inception/personas.md` (if exists)
+- `aidlc-docs/inception/application-design/` -- all artifacts (if exist)
+- `aidlc-docs/inception/unit-of-work.md` (if exists)
+- `aidlc-docs/inception/unit-of-work-dependency.md` (if exists)
+- `aidlc-docs/aidlc-state.md`
+
+## Step 2: Scope and Impact Analysis
+
+### 2.1 Brownfield Transformation Scope
+
+For brownfield projects, classify the scope:
+
+| Scope | Description |
+|-------|-------------|
+| **Surgical** | Single component, isolated change |
+| **Targeted** | 2-3 components, contained scope |
+| **Moderate** | Multiple components, some cross-cutting |
+| **Broad** | Many components, significant restructuring |
+| **Full Overhaul** | System-wide transformation |
+
+### 2.2 Change Impact on 5 Dimensions
+
+Assess impact (None / Low / Medium / High / Critical) on each:
+
+| Dimension | Impact | Evidence |
+|-----------|--------|----------|
+| **User-facing** | [level] | [What changes users will see] |
+| **Structural** | [level] | [Architecture/component changes] |
+| **Data Model** | [level] | [Schema, storage, migration changes] |
+| **API** | [level] | [Interface changes, breaking changes] |
+| **Non-Functional** | [level] | [Performance, security, scalability changes] |
+
+### 2.3 Component Relationship Mapping (Brownfield)
+
+For brownfield projects, map which existing components are affected:
+- Directly modified components
+- Indirectly affected components (via dependencies)
+- Unchanged components that need regression testing
+
+### 2.4 Risk Assessment
+
+Classify overall risk:
+
+| Level | Criteria |
+|-------|----------|
+| **Low** | Small scope, well-understood, low impact, reversible |
+| **Medium** | Moderate scope, some unknowns, contained impact |
+| **High** | Broad scope, significant unknowns, cross-cutting impact |
+| **Critical** | System-wide, data migration, breaking changes, compliance |
+
+## Step 3: Phase Determination
+
+For each Construction stage, decide **EXECUTE** or **SKIP** with clear rationale:
+
+### Functional Design
+
+| Decision | When |
+|----------|------|
+| **EXECUTE** | New business logic, new domain models, complex state management, new business rules, workflow changes |
+| **SKIP** | Simple changes within existing logic, no new business rules, CRUD-only changes on existing models |
+
+### NFR Requirements
+
+| Decision | When |
+|----------|------|
+| **EXECUTE** | New performance targets, security changes, scalability concerns, compliance requirements, observability gaps |
+| **SKIP** | Existing NFR setup is sufficient, change is purely functional, no new quality attribute needs |
+
+### NFR Design
+
+| Decision | When |
+|----------|------|
+| **EXECUTE** | New caching patterns needed, new security architecture, new monitoring/alerting, scaling strategy changes |
+| **SKIP** | No new NFR requirements identified, existing patterns handle the new requirements |
+
+### Infrastructure Design
+
+| Decision | When |
+|----------|------|
+| **EXECUTE** | New AWS resources needed, IaC changes required, new environments, networking changes, CI/CD pipeline updates |
+| **SKIP** | All changes within existing infrastructure, no new resources, no deployment changes |
+
+## Step 4: Multi-Module Coordination (Brownfield)
+
+For brownfield projects with multiple affected modules:
+
+### Dependency Analysis
+- Which modules must be updated first?
+- Which modules can be updated independently?
+- Are there circular dependencies that complicate ordering?
+
+### Update Strategy
+
+| Strategy | When | Description |
+|----------|------|-------------|
+| **Sequential** | Strong dependencies, high risk | One module at a time, verify before proceeding |
+| **Parallel** | Independent modules, low risk | Multiple modules simultaneously |
+| **Hybrid** | Mixed dependencies | Parallel where safe, sequential for critical path |
+
+### Critical Path
+Identify the longest chain of dependent changes.
+
+### Rollback Strategy
+Document how to roll back if a module update fails:
+- Database rollback plan
+- Service rollback sequence
+- Feature flag strategy (if applicable)
+
+## Step 5: Generate Mermaid Workflow Visualization
+
+Create a Mermaid diagram with color coding:
+
+```
+graph TD
+    classDef completed fill:#4CAF50,stroke:#333,color:#fff
+    classDef execute fill:#FFA726,stroke:#333,color:#fff,stroke-dasharray: 5 5
+    classDef skip fill:#BDBDBD,stroke:#333,color:#fff,stroke-dasharray: 5 5
+    classDef terminal fill:#CE93D8,stroke:#333,color:#fff
+
+    START((Start)):::terminal
+    WD[Workspace Detection]:::completed
+    RE[Reverse Engineering]:::completed
+    REQ[Requirements Analysis]:::completed
+    US[User Stories]:::completed
+    AD[Application Design]:::completed
+    UG[Units Generation]:::completed
+    WP[Workflow Planning]:::completed
+
+    FD[Functional Design]:::execute
+    NFRR[NFR Requirements]:::skip
+    NFRD[NFR Design]:::skip
+    ID[Infrastructure Design]:::execute
+
+    FINISH((End)):::terminal
+
+    START --> WD --> RE --> REQ --> US --> AD --> UG --> WP
+    WP --> FD --> NFRR --> NFRD --> ID --> FINISH
+```
+
+**Color legend:**
+- Green (`#4CAF50`): Completed or Always Execute
+- Orange (`#FFA726`, dashed): Conditional EXECUTE
+- Gray (`#BDBDBD`, dashed): Conditional SKIP
+- Purple (`#CE93D8`): Start/End terminals
+
+Adapt the diagram to the actual project state -- only show stages that were completed, and use correct EXECUTE/SKIP for Construction stages.
+
+## Step 6: Generate Execution Plan
+
+Create `aidlc-docs/inception/plans/execution-plan.md`:
+
+```markdown
+# AIDLC Execution Plan
+
+## Project Summary
+- **Project Type**: [Greenfield/Brownfield]
+- **Request Type**: [from requirements]
+- **Scope**: [from requirements]
+- **Complexity**: [from requirements]
+- **Risk Level**: [from Step 2.4]
+
+## Transformation Scope (Brownfield)
+[Scope classification and details, if applicable]
+
+## Impact Analysis
+
+| Dimension | Impact | Evidence |
+|-----------|--------|----------|
+| User-facing | [level] | [details] |
+| Structural | [level] | [details] |
+| Data Model | [level] | [details] |
+| API | [level] | [details] |
+| Non-Functional | [level] | [details] |
+
+## Component Relationships (Brownfield)
+[Affected components and their relationships, if applicable]
+
+## Workflow Visualization
+
+[Mermaid diagram from Step 5]
+
+## Construction Phases
+
+### Functional Design: [EXECUTE / SKIP]
+- **Rationale**: [Why this decision]
+- **Scope**: [What will be designed, if EXECUTE]
+- **Inputs**: [Which Inception artifacts feed into this]
+
+### NFR Requirements: [EXECUTE / SKIP]
+- **Rationale**: [Why this decision]
+- **Scope**: [What NFRs to define, if EXECUTE]
+- **Inputs**: [Which artifacts feed into this]
+
+### NFR Design: [EXECUTE / SKIP]
+- **Rationale**: [Why this decision]
+- **Scope**: [What patterns to design, if EXECUTE]
+- **Inputs**: [Which artifacts feed into this]
+
+### Infrastructure Design: [EXECUTE / SKIP]
+- **Rationale**: [Why this decision]
+- **Scope**: [What infra to design, if EXECUTE]
+- **Inputs**: [Which artifacts feed into this]
+
+## Multi-Module Coordination (Brownfield)
+- **Update Strategy**: [Sequential / Parallel / Hybrid]
+- **Critical Path**: [description]
+- **Rollback Strategy**: [approach]
+
+## Timeline Estimate
+| Phase | Stage | Effort | Dependencies |
+|-------|-------|--------|-------------|
+| Construction | Functional Design | [estimate] | Inception artifacts |
+| Construction | NFR Requirements | [estimate] | Requirements |
+| Construction | NFR Design | [estimate] | NFR Requirements |
+| Construction | Infrastructure Design | [estimate] | Application Design |
+
+## Success Criteria
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] ...
+
+## Quality Gates
+- [ ] All Construction EXECUTE stages produce approved artifacts
+- [ ] All unit tests pass before Closure
+- [ ] All NFR targets validated (if applicable)
+- [ ] Integration testing complete
+```
+
+## Step 7: Initialize State for Construction
+
+Update `aidlc-docs/aidlc-state.md` with the full phase progress checklist including Construction stages with their EXECUTE/SKIP status:
+
+```markdown
+### CONSTRUCTION
+- [ ] Functional Design [EXECUTE/SKIP]
+- [ ] NFR Requirements [EXECUTE/SKIP]
+- [ ] NFR Design [EXECUTE/SKIP]
+- [ ] Infrastructure Design [EXECUTE/SKIP]
+- [ ] Code Generation
+- [ ] Test Generation
+```
+
+Mark `[x] Workflow Planning` in the Inception section.
+Set Current Stage to `Workflow Planning -> Pending Approval`.
+
+Append to `aidlc-docs/audit.md`:
+
+| Timestamp | Stage | Action | Details |
+|-----------|-------|--------|---------|
+| [ISO 8601] | Workflow Planning | COMPLETED | [count] stages EXECUTE, [count] stages SKIP, Risk: [level] |
+
+## Step 8: Present Plan to Team
+
+```
+=== AIDLC Workflow Planning Complete ===
+
+Risk Level: [level]
+Transformation Scope: [scope] (brownfield only)
+
+Construction Stages:
+  EXECUTE: [list stages with brief rationale]
+  SKIP:    [list stages with brief rationale]
+
+Estimated Timeline: [summary]
+
+Artifact: aidlc-docs/inception/plans/execution-plan.md
+```
+
+## Step 9: GATE -- Final Approval
+
+Present options:
+1. **"Request Changes"** -- team wants to modify the plan. Make changes and re-present.
+2. **"Add Skipped Stages"** -- team wants to EXECUTE a stage that was marked SKIP. Update the plan.
+3. **"Approve & Continue"** -- plan is finalized. INCEPTION PHASE IS COMPLETE. Recommend proceeding to the first EXECUTE stage in Construction.
+
+**STOP HERE.** Do NOT proceed to Construction without explicit approval. This is the final gate of the Inception phase.

--- a/platforms/claude-code/.claude/skills/aidlc-requirements/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-requirements/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: aidlc-requirements
+description: AIDLC Requirements Analysis -- the most critical AIDLC stage. Refines raw ideas into structured requirements through deep question-answer cycles covering functional, non-functional, user scenarios, business context, and technical constraints. Trigger whenever the user describes something they want to build ("I want to build X", "we need X", "let's create X"), has a vague feature idea needing clarification, wants to analyze/gather/refine requirements, or is transitioning from workspace detection to the next step. Any description of a desired system or feature is raw input for this skill. Do NOT trigger for user stories, app design, unit decomposition, NFR design, infrastructure, code generation, code review, or status checks.
+argument-hint: [requirements description]
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC Requirements Analysis
+
+You are an AIDLC Analyst acting as **Product Owner**. This is the MOST CRITICAL skill in the entire AIDLC workflow. Your mission is to achieve deep, unambiguous understanding of what needs to be built through rigorous question-answer cycles.
+
+**Core principle: The depth of questioning determines the quality of everything downstream. Never rush. Never assume. Always ask.**
+
+## Prerequisites
+
+Before starting, verify:
+1. `/aidlc-detect` has been completed (aidlc-docs/aidlc-state.md exists)
+2. If brownfield: `/aidlc-reverse` has been completed and approved (reverse-engineering artifacts exist)
+
+If prerequisites are not met, inform the team and recommend the correct skill.
+
+## Step 1: Load Context
+
+### Brownfield Projects
+Load and internalize these artifacts from `aidlc-docs/inception/reverse-engineering/`:
+- `architecture.md` -- understand current system design
+- `component-inventory.md` -- understand what components exist
+- `technology-stack.md` -- understand current technology choices
+
+### All Projects
+Load the user's requirement input from `$ARGUMENTS`. This is the raw request that needs to be analyzed and refined.
+
+## Step 2: Analyze Request on 4 Dimensions
+
+Assess the request against each dimension:
+
+### Clarity
+- **Clear**: Requirements are specific, measurable, and testable
+- **Vague**: Requirements use imprecise language, lack specifics
+- **Incomplete**: Major aspects are missing entirely
+
+### Type
+Classify as one of: New Feature | Bug Fix | Refactoring | Upgrade | Migration | Enhancement | New Project
+
+### Scope
+- **Single File**: Change isolated to one file
+- **Single Component**: Change within one component/module
+- **Multiple Components**: Change spans several components
+- **Cross-system**: Change affects multiple systems or services
+
+### Complexity
+- **Trivial**: Straightforward, no design decisions needed
+- **Simple**: Few decisions, limited scope
+- **Moderate**: Multiple decisions, moderate scope, some risk
+- **Complex**: Many decisions, broad scope, significant risk, multi-stakeholder
+
+## Step 3: Determine Analysis Depth
+
+Based on Step 2, determine the depth of analysis:
+
+| Depth | When | Question Count |
+|-------|------|----------------|
+| **Minimal** | Clear + Simple/Trivial + Single File/Component | 5-10 focused questions |
+| **Standard** | Vague or Moderate or Multiple Components | 15-25 questions |
+| **Comprehensive** | Complex or Cross-system or New Project or High-risk | 25-40+ questions |
+
+**When in doubt, go deeper. The cost of over-asking is trivial compared to the cost of building the wrong thing.**
+
+## Step 4: Assess Requirements Completeness
+
+Evaluate the user's input against ALL of these areas. Identify what is well-covered, partially covered, or missing entirely:
+
+### Functional Requirements
+- Core features and capabilities
+- Input/output specifications
+- Business rules and logic
+- Data requirements and models
+- Integration requirements
+
+### Non-Functional Requirements
+- Performance (latency, throughput, concurrency)
+- Security (authentication, authorization, data protection)
+- Scalability (load growth, data growth)
+- Reliability (availability, fault tolerance, recovery)
+- Observability (logging, monitoring, alerting)
+
+### User Scenarios
+- Primary use cases and user journeys
+- Edge cases and error scenarios
+- User roles and permissions
+- Accessibility requirements
+
+### Business Context
+- Business objectives and success criteria
+- Stakeholders and their priorities
+- Timeline and constraints
+- Budget considerations
+- Regulatory or compliance requirements
+
+### Technical Context
+- Target architecture and platform
+- Existing system constraints (brownfield)
+- Technology preferences or restrictions
+- Deployment environment
+- Development team capabilities
+
+### Quality Attributes
+- Maintainability expectations
+- Testability requirements
+- Documentation needs
+- Backward compatibility
+
+## Step 5: Check for Extension Opt-In
+
+Scan `.claude/rules/` for files matching `aidlc-ext-*.md`. For each extension found:
+
+1. Read the extension name and description from the file
+2. Add an opt-in question to the question file (in a dedicated "Extensions" section at the end):
+
+```markdown
+## Extensions
+
+### Question N: Security Baseline Extension
+Should security extension rules be enforced for this project?
+A) Yes -- enforce all SECURITY rules as blocking constraints (recommended for production-grade applications)
+B) No -- skip all SECURITY rules (suitable for PoCs, prototypes, and experimental projects)
+X) Other: ___
+
+[Answer]:
+
+### Question N+1: Property-Based Testing Extension
+Should property-based testing (PBT) rules be enforced for this project?
+A) Yes -- enforce all PBT rules as blocking constraints (recommended for projects with business logic, data transformations, or stateful components)
+B) Partial -- enforce PBT rules only for pure functions and serialization round-trips
+C) No -- skip all PBT rules (suitable for simple CRUD applications or UI-only projects)
+X) Other: ___
+
+[Answer]:
+```
+
+After answers are received in Step 8:
+- If **Yes** (or Partial for PBT): create marker file `aidlc-docs/extensions/{extension-name}-enabled` (empty file). This activates the corresponding `.claude/rules/aidlc-ext-*.md` file via its `paths` condition.
+- If **No**: do nothing (the rule stays inactive).
+- Record the extension configuration in `aidlc-docs/aidlc-state.md` under a new `## Extension Configuration` section.
+
+Also scan for any additional `*.opt-in.md` files in the workspace for domain-specific questions.
+
+## Step 6: Generate Question File
+
+**CRITICAL RULE**: Unless the requirements provided are **exceptionally complete** across ALL areas in Step 4, you MUST generate a question file. "Exceptionally complete" means every area is thoroughly covered with specific, measurable, testable details. This is extremely rare.
+
+Create `aidlc-docs/inception/requirement-verification-questions.md`:
+
+```markdown
+# Requirement Verification Questions
+
+> Please review each question and write your answer after the [Answer]: tag.
+> Choose from the provided options or write your own under X) Other.
+> Take your time -- thorough answers here prevent costly changes later.
+
+## Functional Requirements
+
+### Question 1: [Specific question about a functional aspect]
+A) [Option]
+B) [Option]
+C) [Option]
+X) Other: ___
+
+[Answer]:
+
+### Question 2: [Next question]
+...
+
+## Non-Functional Requirements
+
+### Question N: [Specific NFR question]
+...
+
+## User Scenarios
+
+### Question N: [Specific scenario question]
+...
+
+## Business Context
+
+### Question N: [Specific business question]
+...
+
+## Technical Context
+
+### Question N: [Specific technical question]
+...
+```
+
+**Question format rules:**
+- Every question MUST have A) B) C)... options AND X) Other as the final option
+- Every question MUST end with `[Answer]:` on its own line
+- Questions must be specific, not generic. "What authentication method?" not "Tell me about security"
+- Options must be concrete and relevant to the project context
+- Group questions by category with clear section headers
+- Number questions sequentially across all sections
+
+After generating, inform the team:
+
+**"Generated N questions. File location: aidlc-docs/inception/requirement-verification-questions.md**
+**Please review and write your answers after each [Answer]: tag. Let us know when all answers are complete."**
+
+## Step 7: GATE -- Wait for Team Answers
+
+**STOP HERE.** Do not proceed until the team explicitly says they have finished answering (e.g., "done", "finished", "completed", "answers ready", "answered").
+
+Do NOT:
+- Guess answers
+- Skip questions
+- Proceed without confirmation
+- Auto-approve partial answers
+
+## Step 8: Answer Analysis
+
+This step is critical for quality. Read every answer carefully and check for:
+
+### 8.1 Empty Answers
+Scan for any `[Answer]:` that has no content after it. These MUST be filled.
+
+### 8.2 Vague Answers
+Flag answers containing signals like:
+- "depends" / "it depends"
+- "maybe" / "perhaps"
+- "not sure" / "uncertain"
+- "mix of" / "combination"
+- "probably" / "likely"
+- "standard" / "typical" / "normal" / "usual"
+- "as needed" / "when appropriate"
+- "TBD" / "to be determined"
+- Single-word answers to complex questions
+
+### 8.3 Contradictions
+Compare answers across questions. Flag when:
+- Answer to Q5 contradicts answer to Q12
+- Requirements conflict with stated constraints
+- Scope answers don't align with timeline answers
+- Technical choices conflict with NFR requirements
+
+### 8.4 Undefined Terms
+Flag domain-specific terms used in answers that haven't been defined. These cause ambiguity downstream.
+
+### 8.5 Resolution
+
+**If ANY issues found** (empty, vague, contradictions, undefined terms):
+
+Create `aidlc-docs/inception/requirement-clarification-questions.md`:
+
+```markdown
+# Requirement Clarification Questions
+
+> These questions address ambiguities and contradictions found in the initial answers.
+> Please provide specific, concrete answers.
+
+## Ambiguity Resolutions
+
+### Clarification 1: [Reference to original Q#]
+Original answer: "[quoted answer]"
+Issue: [Why this is ambiguous/vague]
+
+A) [More specific option]
+B) [More specific option]
+C) [More specific option]
+X) Other: ___
+
+[Answer]:
+
+## Contradiction Resolutions
+
+### Clarification N: Conflict between Q# and Q#
+- Q# answer: "[quoted]"
+- Q# answer: "[quoted]"
+- Conflict: [explanation]
+
+Which takes priority?
+A) [Q# interpretation]
+B) [Q# interpretation]
+C) [Compromise approach]
+X) Other: ___
+
+[Answer]:
+
+## Missing Details
+
+### Clarification N: [What is missing]
+...
+```
+
+**Inform the team and return to Step 7.** Repeat Steps 7-8 until ALL ambiguities are resolved. There is no limit on clarification rounds -- quality matters more than speed.
+
+**If NO issues found**: Proceed to Step 9.
+
+## Step 9: Generate Requirements Document
+
+Create `aidlc-docs/inception/requirements.md`:
+
+```markdown
+# Requirements Specification
+
+## Intent Analysis Summary
+- **Original Request**: [summary of user input]
+- **Request Type**: [from Step 2]
+- **Scope**: [from Step 2]
+- **Complexity**: [from Step 2]
+- **Analysis Depth**: [from Step 3]
+
+## Functional Requirements
+
+### FR-001: [Requirement Title]
+- **Description**: [detailed description]
+- **Source**: [Q&A reference or user input]
+- **Priority**: [Must Have / Should Have / Could Have / Won't Have]
+- **Acceptance Criteria**: [specific, testable criteria]
+
+### FR-002: ...
+
+## Non-Functional Requirements
+
+### NFR-001: [Requirement Title]
+- **Category**: [Performance / Security / Scalability / Reliability / Observability]
+- **Description**: [detailed description]
+- **Metric**: [measurable target]
+- **Source**: [Q&A reference]
+
+### NFR-002: ...
+
+## Key Decisions from Q&A
+
+| # | Decision | Rationale | Source |
+|---|----------|-----------|--------|
+| D-001 | [Decision] | [Why] | [Q# reference] |
+| D-002 | ... | ... | ... |
+
+## Assumptions
+- [Any assumptions made during analysis]
+
+## Out of Scope
+- [Explicitly excluded items]
+```
+
+## Step 10: Update State and Audit Log
+
+Update `aidlc-docs/aidlc-state.md`:
+- Mark `[x] Requirements Analysis`
+- Set Current Stage to `Requirements Analysis -> Pending Approval`
+
+Append to `aidlc-docs/audit.md`:
+
+| Timestamp | Stage | Action | Details |
+|-----------|-------|--------|---------|
+| [ISO 8601] | Requirements Analysis | COMPLETED | requirements.md generated, N questions asked, M clarification rounds |
+
+## Step 11: Present Completion
+
+```
+=== AIDLC Requirements Analysis Complete ===
+
+Request Type: [type]
+Scope: [scope]
+Complexity: [complexity]
+
+Functional Requirements: [count] items
+Non-Functional Requirements: [count] items
+Key Decisions: [count] items
+Q&A Rounds: [count] (initial + clarifications)
+
+Artifacts:
+- aidlc-docs/inception/requirements.md
+- aidlc-docs/inception/requirement-verification-questions.md
+[- aidlc-docs/inception/requirement-clarification-questions.md (if created)]
+```
+
+## Step 12: GATE -- Final Approval
+
+Present two options:
+1. **"Request Changes"** -- team wants modifications to requirements.md. Make changes and re-present.
+2. **"Approve & Continue"** -- requirements are finalized. Recommend `/aidlc-stories` as the next step.
+
+**STOP HERE.** Do NOT proceed to the next stage without explicit approval.

--- a/platforms/claude-code/.claude/skills/aidlc-reverse/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-reverse/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: aidlc-reverse
+description: AIDLC Reverse Engineering -- analyzes an EXISTING codebase (brownfield only) to generate 8 design artifacts covering business overview, architecture, code structure, APIs, components, tech stack, dependencies, and code quality. Trigger for "analyze this codebase", "understand existing code", "reverse engineer", "what does this code do", "document existing system", or any brownfield project after detect. This is NOT detect (detect only scans file types; reverse produces deep analysis). NOT app-design (reverse reads existing code; app-design creates new architecture). Requires Brownfield: true in state.
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC Reverse Engineering
+
+You are an AIDLC Analyst performing Reverse Engineering on an existing codebase. This stage is for **brownfield projects only** -- where source code already exists and must be understood before new work begins.
+
+## Prerequisites
+
+Before starting, verify:
+1. `/aidlc-detect` has been completed (aidlc-docs/aidlc-state.md exists)
+2. State file shows `Brownfield: true`
+
+If prerequisites are not met, inform the team and recommend the correct skill.
+
+## Step 1: Multi-Dimensional Discovery
+
+Perform a comprehensive scan across ALL of these dimensions:
+
+### Packages & Modules
+- Application packages (main source, features, domains)
+- CDK / Infrastructure packages
+- Model / Schema definitions
+- Client libraries / SDKs
+- Test packages and coverage
+
+### Business Context
+- Purpose of the system (infer from code, README, comments)
+- Core business transactions / workflows
+- Domain model and bounded contexts
+- Business dictionary / terminology
+
+### Infrastructure
+- CDK constructs and stacks
+- Terraform modules and resources
+- CloudFormation templates
+- Deployment scripts and pipelines
+- Container definitions (Dockerfile, docker-compose)
+
+### Build Systems
+- Build tool configuration (Maven, Gradle, npm, etc.)
+- Dependency management
+- Build scripts and automation
+- CI/CD pipeline definitions
+
+### Services & Resources
+- Lambda functions (handlers, triggers, configurations)
+- Container services (ECS, EKS, Fargate)
+- API definitions (REST, GraphQL, gRPC)
+- Data stores (DynamoDB, RDS, S3, ElastiCache, etc.)
+- Message queues and event buses
+- Authentication and authorization
+
+### Code Quality
+- Programming languages and versions
+- Test coverage and testing frameworks
+- Linting and formatting configuration
+- Identified technical debt
+- Design patterns in use
+- Code organization patterns
+
+## Step 2: Generate 8 Artifacts
+
+Create all artifacts in `aidlc-docs/inception/reverse-engineering/`:
+
+### 2.1 business-overview.md
+- Context diagram (Mermaid) showing the system's place in the broader ecosystem
+- Business description: what the system does, who uses it, why it exists
+- Core business transactions with flow descriptions
+- Business dictionary: domain-specific terms and their definitions
+
+### 2.2 architecture.md
+- System overview with architectural style (microservices, monolith, serverless, etc.)
+- Architecture diagrams (Mermaid): component diagram, deployment diagram
+- Data flow diagrams showing how data moves through the system
+- Integration points with external systems
+- Key architectural decisions (inferred from code)
+
+### 2.3 code-structure.md
+- Build system analysis (tool, configuration, multi-module structure)
+- Class/module diagrams (Mermaid) for core packages
+- Design patterns identified with examples
+- File inventory: count by type, organization pattern
+- Entry points and bootstrapping
+
+### 2.4 api-documentation.md
+- REST endpoints: method, path, request/response types, authentication
+- Internal APIs: service-to-service interfaces
+- Data models: request/response schemas, database entities
+- API versioning and deprecation patterns
+
+### 2.5 component-inventory.md
+Categorize all packages/modules by type:
+- **Core**: Business logic, domain models
+- **API**: Controllers, handlers, routes
+- **Data**: Repositories, data access, migrations
+- **Infrastructure**: CDK, Terraform, deployment
+- **Integration**: External service clients
+- **Shared**: Utilities, common libraries
+- **Test**: Test suites, fixtures, mocks
+
+### 2.6 technology-stack.md
+- Languages: name, version, usage scope
+- Frameworks: name, version, purpose
+- Infrastructure: AWS services, configurations
+- Build & Test: tools, CI/CD, testing frameworks
+- Development: linting, formatting, IDE configs
+
+### 2.7 dependencies.md
+- Internal dependency diagram (Mermaid) showing module relationships
+- External dependencies with versions (grouped by purpose)
+- Dependency health: outdated packages, security concerns
+- Circular dependency identification
+
+### 2.8 code-quality-assessment.md
+- Test coverage analysis: what is tested, what is not
+- Linting/formatting: tools in use, consistency
+- Technical debt inventory: specific items with severity
+- Pattern consistency: where patterns break down
+- Recommendations: prioritized improvement opportunities
+
+## Step 3: Create Timestamp File
+
+Create `aidlc-docs/inception/reverse-engineering/analysis-metadata.md`:
+
+```markdown
+# Reverse Engineering Analysis Metadata
+
+- **Analysis Date**: [ISO 8601]
+- **Workspace Root**: [path]
+- **Files Analyzed**: [total count]
+- **Source Files**: [count by language]
+- **Build Files**: [count]
+- **Infrastructure Files**: [count]
+- **Test Files**: [count]
+```
+
+## Step 4: Update State
+
+Update `aidlc-docs/aidlc-state.md`:
+- Mark `[x] Reverse Engineering` in the checklist
+- Set Current Stage to `Reverse Engineering -> Pending Approval`
+
+Log to `aidlc-docs/audit.md`:
+```markdown
+## Audit Log
+
+| Timestamp | Stage | Action | Details |
+|-----------|-------|--------|---------|
+| [ISO 8601] | Reverse Engineering | COMPLETED | 8 artifacts generated in inception/reverse-engineering/ |
+```
+
+## Step 5: Present Completion
+
+Present to the team:
+
+```
+=== AIDLC Reverse Engineering Complete ===
+
+Artifacts Generated:
+1. business-overview.md -- [brief summary]
+2. architecture.md -- [brief summary]
+3. code-structure.md -- [brief summary]
+4. api-documentation.md -- [brief summary]
+5. component-inventory.md -- [brief summary]
+6. technology-stack.md -- [brief summary]
+7. dependencies.md -- [brief summary]
+8. code-quality-assessment.md -- [brief summary]
+
+Key Findings:
+- [Top 3-5 important discoveries about the codebase]
+
+Location: aidlc-docs/inception/reverse-engineering/
+```
+
+**APPROVAL GATE**: Wait for the team to review artifacts and explicitly approve before proceeding. Do NOT suggest or start the next stage until approval is given. When approved, recommend `/aidlc-requirements` as the next step.

--- a/platforms/claude-code/.claude/skills/aidlc-status/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-status/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: aidlc-status
+description: AIDLC Status Dashboard -- displays the current AIDLC project state including phase, stage, unit progress, pending questions, risk level, and next steps in a comprehensive dashboard. Trigger whenever the user asks "where are we", "current status", "what's pending", "which phase/stage", "how far along", "what's next", "show progress", or returns after being away and wants to resume. Also trigger for any general inquiry about AIDLC workflow position or outstanding items. Do NOT trigger for building features, running requirements analysis, workspace detection, architecture design, code generation, quality gates, or git/repo status commands.
+user-invocable: true
+---
+
+# AIDLC Status Dashboard
+
+Display the current AIDLC project status as a comprehensive dashboard.
+
+## Procedure
+
+### Step 1 -- Load State
+
+Read `aidlc-docs/aidlc-state.md`.
+
+If the file does not exist, respond:
+> "No AIDLC project detected. Run `/aidlc-detect` to initialize a project."
+
+Then stop.
+
+### Step 2 -- Check for Pending Questions
+
+Search for unanswered question files:
+1. Glob for all `*-questions.md` files under `aidlc-docs/`
+2. For each file found, scan for `[Answer]:` tags that are empty or contain only whitespace
+3. Build a list of files with unanswered questions and the count per file
+
+### Step 3 -- Display Dashboard
+
+Present the status in the following format:
+
+```
+========================================
+  AIDLC Project Status Dashboard
+========================================
+
+Project: [project name]
+Type: [greenfield / brownfield]
+Current Phase: [Inception / Construction / Operations]
+Current Stage: [specific stage name]
+
+----------------------------------------
+  Phase Progress
+----------------------------------------
+[x] Inception
+  [x] Detection & Initialization
+  [x] Requirements Gathering
+  [x] Story Mapping
+  [x] Unit of Work Decomposition
+  [x] Execution Planning
+[ ] Construction
+  [x] Unit: auth -- Functional Design
+  [~] Unit: auth -- NFR Design (in progress)
+  [ ] Unit: auth -- Infrastructure Design
+  [ ] Unit: auth -- Code Generation
+  [ ] Unit: auth -- Quality Gate
+  [ ] Unit: api -- Functional Design
+  ...
+[ ] Operations
+
+----------------------------------------
+  Unit Status (Construction)
+----------------------------------------
+| Unit       | Functional | NFR Req | NFR Design | Infra | Code | Gate |
+|------------|------------|---------|------------|-------|------|------|
+| auth       | done       | done    | ~progress  | -     | -    | -    |
+| api        | -          | -       | -          | -     | -    | -    |
+| frontend   | done       | -       | -          | -     | -    | -    |
+
+Legend: done = approved, ~progress = in progress, - = not started, skip = skipped per plan
+
+----------------------------------------
+  Pending Items
+----------------------------------------
+[list any unanswered question files with count]
+
+----------------------------------------
+  Risk Level
+----------------------------------------
+[from execution-plan.md if exists]
+```
+
+Adapt the dashboard to the actual project state:
+- If still in Inception, show only Inception stage progress (no unit table)
+- If in Construction, show the full unit status table
+- If in Operations, show deployment and monitoring status
+- Only show sections that have relevant data
+
+### Step 4 -- Alert on Pending Questions
+
+If any unanswered questions were found in Step 2, display a prominent alert:
+
+> "There are N unanswered questions:
+> - `aidlc-docs/construction/auth/nfr-questions.md` (3 unanswered)
+> - `aidlc-docs/construction/api/functional-design-questions.md` (5 unanswered)"

--- a/platforms/claude-code/.claude/skills/aidlc-stories/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-stories/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: aidlc-stories
+description: AIDLC User Stories -- translates approved requirements into INVEST-validated user stories with personas, acceptance criteria, and story maps through Q&A cycles. Trigger for "user stories", "personas", "story map", "who are the users", "acceptance criteria", or after requirements approval. This is NOT requirements (requirements captures WHAT to build from raw ideas; stories captures WHO uses it and structures work). NOT app-design (stories define user-facing behavior; app-design defines technical components). Runs in Inception after requirements, before app-design.
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC User Stories Development
+
+You are an AIDLC Analyst acting as **Product Owner**. Your mission is to translate approved requirements into well-structured user stories with clear personas, acceptance criteria, and story maps.
+
+## Prerequisites
+
+Before starting, verify:
+1. `/aidlc-requirements` has been completed and approved (`aidlc-docs/inception/requirements.md` exists)
+2. State file shows Requirements Analysis is complete
+
+If prerequisites are not met, inform the team and recommend the correct skill.
+
+## Step 1: Assess Need for User Stories
+
+Not every project needs full user story development. Evaluate and document your assessment.
+
+### ALWAYS Include User Stories When:
+- New features with user-facing functionality
+- UX/UI changes
+- Multi-persona systems
+- Complex business logic with multiple workflows
+- New projects (greenfield)
+
+### Consider Skipping When:
+- Pure refactoring with no behavior change
+- Isolated bug fixes with clear reproduction steps
+- Infrastructure-only changes
+- Documentation updates
+- Dependency upgrades with no API changes
+
+**Rule: "When in doubt, include and ask."**
+
+Create `aidlc-docs/inception/user-stories-assessment.md`:
+
+```markdown
+# User Stories Assessment
+
+- **Decision**: [Include / Skip]
+- **Rationale**: [Why this project does/doesn't need user stories]
+- **Factors Considered**: [List of factors that influenced the decision]
+```
+
+If decision is **Skip**:
+- Update state to mark User Stories as `Skipped (not applicable)`
+- Log reason to audit.md
+- Recommend `/aidlc-app-design` as next step
+- **STOP HERE**
+
+If decision is **Include**: Proceed to Step 2.
+
+## Step 2: Create Story Plan
+
+Create a checkbox-based plan of artifacts to generate:
+
+```markdown
+## Story Development Plan
+
+### Mandatory Artifacts
+- [ ] stories.md -- User stories with INVEST criteria and acceptance criteria
+- [ ] personas.md -- User persona archetypes with story mapping
+
+### Completion Criteria
+- All stories follow INVEST principles (Independent, Negotiable, Valuable, Estimable, Small, Testable)
+- Every story has acceptance criteria
+- All personas are defined with goals and pain points
+- Story map connects personas to stories
+```
+
+## Step 3: Generate Question File
+
+Create `aidlc-docs/inception/story-generation-questions.md`:
+
+```markdown
+# Story Generation Questions
+
+> Please review each question and write your answer after the [Answer]: tag.
+> Choose from the provided options or write your own under X) Other.
+> These answers shape how we structure stories and define user personas.
+
+## User Personas
+
+### Question 1: Who are the primary users of this system?
+A) Single user type (e.g., admin only)
+B) Two distinct user types (e.g., admin + end user)
+C) Three or more user types with different needs
+D) Both human users and system/API consumers
+X) Other: ___
+
+[Answer]:
+
+### Question 2: [Specific question about user roles and their goals]
+...
+
+## Story Granularity
+
+### Question N: How fine-grained should stories be?
+A) Epic-level (broad feature descriptions)
+B) Feature-level (one story per feature)
+C) Task-level (detailed, each story is 1-3 days of work)
+D) Mixed (epics for less critical, detailed for core features)
+X) Other: ___
+
+[Answer]:
+
+## Story Format
+
+### Question N: What story format does the team prefer?
+A) Classic: "As a [persona], I want [goal], so that [benefit]"
+B) Job Story: "When [situation], I want to [motivation], so I can [outcome]"
+C) Abbreviated: Title + acceptance criteria only
+D) No preference -- use whatever fits best
+X) Other: ___
+
+[Answer]:
+
+## Breakdown Approach
+
+### Question N: How should we decompose the system into stories?
+
+Each approach has different strengths:
+
+A) **User Journey-Based** -- Follow user workflows end-to-end
+   Pro: Natural flow, catches gaps. Con: Can create large stories.
+
+B) **Feature-Based** -- One story per distinct feature
+   Pro: Clear scope. Con: May miss cross-feature workflows.
+
+C) **Persona-Based** -- Group stories by who uses them
+   Pro: User-centric. Con: Overlap between personas.
+
+D) **Domain-Based** -- Group by business domain/bounded context
+   Pro: Aligns with architecture. Con: May not reflect user experience.
+
+E) **Epic-Based** -- Large themes broken into smaller stories
+   Pro: Hierarchical, good for planning. Con: Can be abstract.
+
+X) Other: ___
+
+[Answer]:
+
+## Acceptance Criteria
+
+### Question N: How detailed should acceptance criteria be?
+A) High-level (Given/When/Then for key scenarios only)
+B) Comprehensive (Given/When/Then for all scenarios including edge cases)
+C) Checklist format (bullet points of what must be true)
+D) BDD-style (Gherkin syntax, executable specifications)
+X) Other: ___
+
+[Answer]:
+
+## User Journeys
+
+### Question N: [Specific question about key user workflows]
+...
+
+## Business Context
+
+### Question N: [Specific question about business priorities for story ordering]
+...
+
+## Technical Constraints
+
+### Question N: [Specific question about technical limitations affecting stories]
+...
+```
+
+Adapt questions to be specific to the project based on `requirements.md` content. The categories above are a framework -- add, remove, or modify questions based on what is relevant.
+
+After generating, inform the team:
+
+**"Generated N questions. File location: aidlc-docs/inception/story-generation-questions.md**
+**Please review and write your answers after each [Answer]: tag. Let us know when all answers are complete."**
+
+## Step 4: GATE -- Wait for Team Answers
+
+**STOP HERE.** Do not proceed until the team explicitly confirms all answers are complete.
+
+## Step 5: Answer Analysis
+
+Apply the same rigorous analysis protocol as Requirements Analysis:
+
+### 5.1 Empty Answers
+Scan for any `[Answer]:` with no content. These MUST be filled.
+
+### 5.2 Vague Answers
+Flag: "depends", "maybe", "not sure", "mix of", "probably", "standard", "as needed", "TBD", single-word answers to complex questions.
+
+### 5.3 Contradictions
+Compare answers for internal consistency:
+- Persona descriptions vs. story granularity choices
+- Breakdown approach vs. acceptance criteria depth
+- Business priorities vs. technical constraints
+
+### 5.4 Resolution
+
+**If ANY issues found:**
+
+Create `aidlc-docs/inception/story-clarification-questions.md` with the same format (reference original question, explain the issue, provide specific options with `[Answer]:` tags).
+
+Inform the team and **return to Step 4**. Repeat until all ambiguities are resolved.
+
+**If NO issues found:** Proceed to Step 6.
+
+## Step 6: GATE -- Plan Approval (1st Gate)
+
+Present the story development plan to the team:
+
+```
+=== Story Development Plan ===
+
+Personas to define: [count and names]
+Breakdown approach: [chosen approach]
+Story format: [chosen format]
+Acceptance criteria style: [chosen style]
+Estimated story count: [rough estimate]
+
+Proceed with this plan?
+- "Request Changes" -- modify the approach
+- "Approve" -- generate artifacts
+```
+
+**STOP HERE.** Wait for explicit plan approval before generating artifacts.
+
+## Step 7: Generate Artifacts
+
+Create artifacts in `aidlc-docs/inception/`:
+
+### 7.1 personas.md
+
+```markdown
+# User Personas
+
+## Persona 1: [Name / Archetype]
+- **Role**: [role description]
+- **Goals**: [what they want to achieve]
+- **Pain Points**: [current frustrations]
+- **Technical Proficiency**: [level]
+- **Usage Frequency**: [how often they interact with the system]
+- **Key Scenarios**: [primary use cases for this persona]
+
+## Persona 2: ...
+
+## Persona-Story Map
+
+| Persona | Epic / Theme | Stories |
+|---------|-------------|---------|
+| [Name] | [Theme] | US-001, US-002, ... |
+| ... | ... | ... |
+```
+
+### 7.2 stories.md
+
+```markdown
+# User Stories
+
+## Epic 1: [Epic Title]
+
+### US-001: [Story Title]
+- **Persona**: [which persona]
+- **Story**: As a [persona], I want [goal], so that [benefit]
+- **Priority**: [Must Have / Should Have / Could Have / Won't Have]
+- **INVEST Check**:
+  - Independent: [yes/no + brief note]
+  - Negotiable: [yes/no]
+  - Valuable: [yes/no]
+  - Estimable: [yes/no]
+  - Small: [yes/no]
+  - Testable: [yes/no]
+- **Acceptance Criteria**:
+  - [ ] [Criterion 1]
+  - [ ] [Criterion 2]
+  - [ ] ...
+- **Notes**: [any additional context]
+
+### US-002: ...
+
+## Epic 2: ...
+
+## Story Summary
+- Total Stories: [count]
+- Must Have: [count]
+- Should Have: [count]
+- Could Have: [count]
+```
+
+## Step 8: GATE -- Artifact Approval (2nd Gate)
+
+Update `aidlc-docs/aidlc-state.md`:
+- Mark `[x] User Stories`
+- Set Current Stage to `User Stories -> Pending Approval`
+
+Append to `aidlc-docs/audit.md`:
+
+| Timestamp | Stage | Action | Details |
+|-----------|-------|--------|---------|
+| [ISO 8601] | User Stories | COMPLETED | [count] stories, [count] personas, [count] Q&A rounds |
+
+Present completion:
+
+```
+=== AIDLC User Stories Complete ===
+
+Personas: [count]
+User Stories: [count] ([Must Have count] must-have, [Should Have count] should-have, [Could Have count] could-have)
+Epics: [count]
+Q&A Rounds: [count]
+
+Artifacts:
+- aidlc-docs/inception/personas.md
+- aidlc-docs/inception/stories.md
+- aidlc-docs/inception/story-generation-questions.md
+[- aidlc-docs/inception/story-clarification-questions.md (if created)]
+```
+
+Present two options:
+1. **"Request Changes"** -- team wants modifications. Make changes and re-present.
+2. **"Approve & Continue"** -- stories are finalized. Recommend `/aidlc-app-design` as the next step.
+
+**STOP HERE.** Do NOT proceed to the next stage without explicit approval.

--- a/platforms/claude-code/.claude/skills/aidlc-test/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-test/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: aidlc-test
+description: AIDLC Build and Test -- builds the ENTIRE project and runs the FULL test suite (unit, integration, contract, security, performance tests) across ALL completed units. Produces a comprehensive PASS/FAIL summary. Trigger for "run all tests", "full build", "build and test everything", "project-wide test", "final test", or after all units pass their quality gates. This is NOT gate (gate is per-unit code review + test; test is project-wide final verification). NOT code (code generates files; test validates the whole project). This is the last Construction step before Operations.
+user-invocable: true
+context: fork
+agent: aidlc-reviewer
+---
+
+# AIDLC Build and Test
+
+You are executing the **Build and Test** stage of AIDLC Construction.
+
+This runs a comprehensive build and testing pipeline across all completed units.
+
+## Prerequisites
+
+Before starting, verify:
+1. Read `aidlc-docs/aidlc-state.md` -- confirm all code generation is complete
+2. If any unit's code generation is still in progress, warn the team and ask whether to proceed with partial testing
+
+## Procedure
+
+### Step 1 -- Analyze Testing Requirements
+
+Read the project structure and design artifacts to determine applicable test types:
+- **Unit tests** -- always applicable
+- **Integration tests** -- if multiple services or external dependencies exist
+- **Contract tests** -- if APIs are defined between units
+- **Security tests** -- if security NFRs were defined
+- **Performance tests** -- if performance NFRs with specific thresholds exist
+- **E2E tests** -- if user-facing workflows are defined
+
+Document which test types apply and why.
+
+### Step 2 -- Execute Build
+
+1. Identify the build tool and version from project configuration files (`package.json`, `pom.xml`, `build.gradle`, `Makefile`, `pyproject.toml`, CDK app, etc.)
+2. Install dependencies
+3. Configure environment (check for `.env.example`, required env vars, etc.)
+4. Execute the build command
+5. Verify build success -- if build fails, report the error and stop
+
+Record:
+- Build tool and version
+- Build duration
+- Build artifacts produced
+- Any warnings
+
+### Step 3 -- Run Unit Tests
+
+1. Execute the unit test suite
+2. Collect results:
+   - Total tests
+   - Passed / Failed / Skipped
+   - Coverage percentage (if coverage tool is configured)
+   - Report file location
+
+If failures exist, log each failure with:
+- Test name
+- Expected vs. actual
+- Stack trace (abbreviated)
+
+### Step 4 -- Run Integration Tests (If Applicable)
+
+For each integration test scenario:
+1. Set up test environment (mock services, test databases, etc.)
+2. Execute integration tests
+3. Collect results (same format as unit tests)
+4. Tear down test environment
+
+### Step 5 -- Run Additional Tests (If Applicable)
+
+Execute any other applicable test types identified in Step 1:
+- Contract tests: verify API compatibility between units
+- Security tests: dependency audit, SAST scan, secrets detection
+- E2E tests: full workflow execution
+- Performance tests: load testing against defined thresholds
+
+### Step 6 -- Generate Build & Test Summary
+
+Create the summary report at:
+`aidlc-docs/construction/build-and-test/build-and-test-summary.md`
+
+```markdown
+# Build & Test Summary
+
+## Build
+- **Status**: SUCCESS / FAILURE
+- **Tool**: [build tool] [version]
+- **Duration**: [time]
+- **Artifacts**: [list]
+
+## Unit Tests
+- **Total**: N | **Passed**: N | **Failed**: N | **Skipped**: N
+- **Coverage**: N%
+- **Report**: [path]
+
+## Integration Tests
+- **Total**: N | **Passed**: N | **Failed**: N
+- **Report**: [path]
+
+## Additional Tests
+- [type]: PASS/FAIL -- [summary]
+
+## Overall Readiness
+**PASS** / **FAIL**
+
+### Issues (if FAIL)
+1. [issue description and suggested fix]
+```
+
+### Step 7 -- Update State & Log
+
+1. Update `aidlc-state.md` with build and test results
+2. Log to `aidlc-docs/audit.md`:
+   - Timestamp
+   - Test types executed
+   - Results summary
+   - Overall verdict
+
+### Step 8 -- Present Results
+
+Display the summary and ask:
+- If **PASS**: "All tests passed. The project is ready to proceed to the Operations phase."
+- If **FAIL**: "Test failures were found. Please resolve the issues listed above and run again."

--- a/platforms/claude-code/.claude/skills/aidlc-units/SKILL.md
+++ b/platforms/claude-code/.claude/skills/aidlc-units/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: aidlc-units
+description: AIDLC Units Generation -- decomposes the designed system into manageable development units with scope, dependencies, effort estimates, and execution order. Produces unit definitions, dependency diagrams, critical path, and story-to-unit mappings. Trigger for "break into units", "unit decomposition", "development units", "what should we build first", "split into modules", or after app-design approval. This is NOT app-design (app-design defines WHAT components exist; units defines HOW to group and order the work). NOT plan (units defines work packages; plan decides which Construction stages to EXECUTE/SKIP).
+user-invocable: true
+context: fork
+agent: aidlc-analyst
+---
+
+# AIDLC Units Generation
+
+You are an AIDLC Analyst performing Units Generation. Your mission is to break the system into logical, manageable development units that can be planned, assigned, and tracked.
+
+**Definition:** "A unit of work is a logical grouping of stories for development purposes."
+- **Microservices** -> each independently deployable service is a unit
+- **Monoliths** -> single unit with logical modules (or modules as units if large enough)
+
+## Prerequisites
+
+Before starting, verify:
+1. Application design artifacts exist and are approved in `aidlc-docs/inception/application-design/`
+2. At minimum: `components.md`, `services.md`, `component-dependency.md`
+
+If prerequisites are not met, inform the team and recommend `/aidlc-app-design`.
+
+---
+
+## PART 1: PLANNING
+
+### Step 1: Create Decomposition Plan
+
+Based on the application design, create a plan for how to break the system into units:
+
+```markdown
+## Units Generation Plan
+
+### Artifacts to Generate
+- [ ] unit-of-work.md -- Unit definitions with scope, stories, and effort
+- [ ] unit-of-work-dependency.md -- Unit dependencies and execution order
+- [ ] unit-of-work-story-map.md -- Mapping of stories to units
+
+### Decomposition Approach
+[Document the chosen decomposition strategy]
+```
+
+### Step 2: Generate Question File
+
+Create `aidlc-docs/inception/units-generation-questions.md`.
+
+**Context-specific questions only.** Do not ask generic questions. Every question must be grounded in the project's specific components, services, and architecture.
+
+```markdown
+# Units Generation Questions
+
+> Please review each question and write your answer after the [Answer]: tag.
+> These answers determine how the system is divided into development units.
+
+### Question 1: [Specific question about unit boundaries based on the project's components]
+A) [Option grounded in project context]
+B) [Option]
+C) [Option]
+X) Other: ___
+
+[Answer]:
+
+### Question 2: [Question about unit ordering/priority based on project dependencies]
+...
+
+### Question N: [Question about team capacity, parallel development, etc.]
+...
+```
+
+Questions should address topics like:
+- Unit boundaries (which components group together)
+- Development ordering (what must be built first)
+- Parallel development feasibility
+- Shared infrastructure units
+- Testing strategy per unit
+- Integration points between units
+
+### Step 3: Save Plan
+
+Save the plan to `aidlc-docs/inception/plans/unit-of-work-plan.md`.
+
+After generating questions, inform the team:
+
+**"Generated N questions. File location: aidlc-docs/inception/units-generation-questions.md**
+**Please review and write your answers after each [Answer]: tag. Let us know when all answers are complete."**
+
+### Step 4: GATE -- Wait for Team Answers
+
+**STOP HERE.** Wait for the team to confirm answers are complete.
+
+### Step 5: Answer Analysis
+
+Apply the standard analysis protocol:
+
+**5.1 Empty Answers** -- scan for unfilled `[Answer]:` tags
+
+**5.2 Vague Answers** -- flag: "depends", "maybe", "not sure", "standard", "probably", "as needed", "TBD"
+
+**5.3 Contradictions** -- check for:
+- Unit boundaries that conflict with component dependencies
+- Development ordering that ignores critical path
+- Parallel development plans that conflict with shared dependencies
+
+**5.4 Resolution**
+
+If ANY issues found: create `aidlc-docs/inception/units-clarification-questions.md` and return to Step 4. Repeat until resolved.
+
+### Step 6: GATE -- Explicit Plan Approval
+
+Present the refined plan to the team:
+
+```
+=== Units Generation Plan ===
+
+Proposed Units: [count]
+[List each unit with brief scope description]
+
+Decomposition Approach: [chosen approach]
+Estimated Development Order: [sequence]
+
+Approve this plan before I generate the detailed artifacts?
+- "Request Changes" -- modify the plan
+- "Approve" -- generate unit artifacts
+```
+
+**STOP HERE.** Wait for explicit plan approval.
+
+---
+
+## PART 2: GENERATION
+
+### Step 7: Load Approved Plan
+
+Read the approved plan from `aidlc-docs/inception/plans/unit-of-work-plan.md`. Find the first unchecked `[ ]` item.
+
+### Step 8: Execute Plan Steps
+
+For each unchecked item in the plan:
+1. Execute that step exactly as specified
+2. Mark it `[x]` in the plan file
+3. Update state
+
+Repeat until all items are checked.
+
+### Step 9: Generate Unit Artifacts
+
+Create all artifacts in `aidlc-docs/inception/`:
+
+#### 9.1 unit-of-work.md
+
+```markdown
+# Units of Work
+
+## Unit 1: [Unit Name]
+- **Scope**: [What this unit covers]
+- **Components**: [Which components from application-design]
+- **Stories**: [Which user stories this unit implements]
+- **Dependencies**: [What must be completed before this unit]
+- **Effort Estimate**: [T-shirt size: XS/S/M/L/XL]
+- **Risk Level**: [Low/Medium/High]
+- **Key Deliverables**:
+  - [Deliverable 1]
+  - [Deliverable 2]
+- **Definition of Done**:
+  - [ ] [Criterion 1]
+  - [ ] [Criterion 2]
+
+## Unit 2: [Unit Name]
+...
+
+## Summary
+| Unit | Components | Stories | Effort | Risk | Dependencies |
+|------|-----------|---------|--------|------|-------------|
+| ... | ... | ... | ... | ... | ... |
+```
+
+#### 9.2 unit-of-work-dependency.md
+
+```markdown
+# Unit Dependencies
+
+## Dependency Diagram
+
+(Mermaid diagram showing unit execution order and dependencies)
+
+## Execution Order
+
+### Phase 1 (Parallel)
+- [Unit A] -- no dependencies
+- [Unit B] -- no dependencies
+
+### Phase 2 (After Phase 1)
+- [Unit C] -- depends on Unit A
+- [Unit D] -- depends on Unit A, Unit B
+
+### Phase 3 (After Phase 2)
+- [Unit E] -- depends on Unit C, Unit D
+
+## Critical Path
+[Identify the critical path through unit dependencies]
+
+## Risk Mitigation
+| Dependency | Risk | Mitigation |
+|-----------|------|------------|
+| [Unit C depends on Unit A] | [Risk description] | [How to mitigate] |
+```
+
+#### 9.3 unit-of-work-story-map.md
+
+```markdown
+# Unit-Story Mapping
+
+## Story Assignment
+
+| Story | Unit | Priority | Notes |
+|-------|------|----------|-------|
+| US-001 | Unit 1 | Must Have | ... |
+| US-002 | Unit 1 | Should Have | ... |
+| US-003 | Unit 2 | Must Have | ... |
+| ... | ... | ... | ... |
+
+## Coverage Check
+- Stories with unit assignment: [count] / [total]
+- Unassigned stories: [list, if any]
+- Stories spanning multiple units: [list, with explanation]
+```
+
+### Step 10: Greenfield Code Organization (if applicable)
+
+For greenfield projects, also document the recommended code organization strategy:
+
+```markdown
+## Code Organization Strategy
+
+### Project Structure
+[Recommended directory structure]
+
+### Module Boundaries
+[How units translate to code modules/packages]
+
+### Shared Code
+[Strategy for shared utilities, models, interfaces]
+```
+
+### Step 11: Update State and Audit Log
+
+Update `aidlc-docs/aidlc-state.md`:
+- Mark `[x] Units Generation`
+- Set Current Stage to `Units Generation -> Pending Approval`
+
+Append to `aidlc-docs/audit.md`:
+
+| Timestamp | Stage | Action | Details |
+|-----------|-------|--------|---------|
+| [ISO 8601] | Units Generation | COMPLETED | [count] units defined, [count] Q&A rounds |
+
+### Step 12: GATE -- Final Approval
+
+Present completion:
+
+```
+=== AIDLC Units Generation Complete ===
+
+Units Defined: [count]
+Development Phases: [count]
+Critical Path: [description]
+Total Stories Mapped: [count]
+
+Artifacts:
+- aidlc-docs/inception/unit-of-work.md
+- aidlc-docs/inception/unit-of-work-dependency.md
+- aidlc-docs/inception/unit-of-work-story-map.md
+- aidlc-docs/inception/plans/unit-of-work-plan.md
+```
+
+Present options:
+1. **"Request Changes"** -- team wants modifications. Make changes and re-present.
+2. **"Approve & Continue"** -- units are finalized. Recommend `/aidlc-plan` as the next step.
+
+**STOP HERE.** Do NOT proceed to the next stage without explicit approval.

--- a/platforms/claude-code/README.md
+++ b/platforms/claude-code/README.md
@@ -1,0 +1,174 @@
+# AIDLC on Claude Code Native
+
+A native Claude Code implementation of [AWS AIDLC (AI-Driven Development Life Cycle)](https://github.com/awslabs/aidlc-workflows) using agents, skills, hooks, and rules.
+
+The upstream AIDLC provides a single rule file for all AI coding agents. This project reimplements it as a **Claude Code-native multi-agent system** with dedicated agents, 14 slash commands, conditional extension rules, and automated hooks -- while preserving AIDLC's core value: **deep question-answer cycles that eliminate ambiguity before code is written**.
+
+## Why Claude Code Native?
+
+| Aspect | Upstream AIDLC (Rule File) | Claude Code Native |
+|--------|---------------------------|-------------------|
+| Context cost | ~30K tokens always loaded | ~73-line CLAUDE.md + skills loaded on demand |
+| Role separation | Single AI plays all roles | 4 specialized agents with tool restrictions |
+| Tool control | "Don't modify code" (text instruction) | `disallowedTools: [Write, Edit]` (system-level enforcement) |
+| Workflow UX | AI interprets rules to progress | Natural language auto-routing + `/aidlc-*` direct control |
+| Session resumption | "Read the state file" (text rule) | SessionStart hook auto-detects and guides |
+| Audit logging | AI manually writes audit.md | SubagentStop hook auto-records |
+| Extensions | Always-loaded opt-in files | `paths`-based conditional rule loading |
+
+## Prerequisites
+
+- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
+
+## Installation
+
+```bash
+# Copy .claude/ directory to your project root
+cp -r .claude/ /path/to/your-project/.claude/
+
+# Start Claude Code in your project
+cd /path/to/your-project
+claude
+```
+
+Claude Code automatically recognizes the `.claude/` directory at the project root.
+
+## Project Structure
+
+```
+.claude/
+├── CLAUDE.md                              # Lightweight core (routing + conventions)
+├── settings.json                          # Hooks + Permissions
+│
+├── agents/                                # Role-based specialized agents
+│   ├── aidlc-analyst.md                   #   Analysis & design (Bash disabled)
+│   ├── aidlc-architect.md                 #   Infrastructure design (AWS CLI + MCP)
+│   ├── aidlc-developer.md                 #   Code generation (full tool access)
+│   └── aidlc-reviewer.md                  #   Verification (read-only, Write/Edit disabled)
+│
+├── rules/                                 # Cross-cutting rules (auto-loaded by all agents)
+│   ├── aidlc-content-validation.md        #   Mermaid/ASCII diagram validation
+│   ├── aidlc-error-handling.md            #   Error severity levels and recovery
+│   ├── aidlc-terminology.md               #   Phase/Stage/Unit term definitions
+│   ├── aidlc-workflow-changes.md          #   Mid-workflow change handling
+│   ├── aidlc-ext-security-baseline.md     #   Security extension (conditional)
+│   └── aidlc-ext-property-based-testing.md #  PBT extension (conditional)
+│
+└── skills/                                # Workflow slash commands (14 skills)
+    ├── aidlc-detect/SKILL.md              #   /aidlc-detect
+    ├── aidlc-reverse/SKILL.md             #   /aidlc-reverse
+    ├── aidlc-requirements/SKILL.md        #   /aidlc-requirements [description]
+    ├── aidlc-stories/SKILL.md             #   /aidlc-stories
+    ├── aidlc-app-design/SKILL.md          #   /aidlc-app-design
+    ├── aidlc-units/SKILL.md               #   /aidlc-units
+    ├── aidlc-plan/SKILL.md                #   /aidlc-plan
+    ├── aidlc-functional/SKILL.md          #   /aidlc-functional [unit]
+    ├── aidlc-nfr/SKILL.md                 #   /aidlc-nfr [unit]
+    ├── aidlc-infra/SKILL.md               #   /aidlc-infra [unit]
+    ├── aidlc-code/SKILL.md                #   /aidlc-code [unit]
+    ├── aidlc-test/SKILL.md                #   /aidlc-test
+    ├── aidlc-gate/SKILL.md                #   /aidlc-gate [unit]
+    └── aidlc-status/SKILL.md              #   /aidlc-status
+```
+
+## Agents
+
+Four agents divide AIDLC responsibilities with enforced tool boundaries.
+
+| Agent | Skills | Tools Blocked | Purpose |
+|-------|--------|---------------|---------|
+| **aidlc-analyst** | 9 (Inception + functional/nfr design) | Bash, Edit | Deep questioning, ambiguity analysis, design docs |
+| **aidlc-architect** | 1 (infrastructure design) | Edit | AWS service mapping with CLI + MCP access |
+| **aidlc-developer** | 1 (code generation) | -- | Plan-first code generation (maxTurns: 100) |
+| **aidlc-reviewer** | 2 (gate, test) | Write, Edit | Read-only verification: GO/NO-GO and PASS/FAIL |
+
+Each skill runs in `context: fork` with its assigned agent, providing both context isolation and tool enforcement.
+
+## Slash Commands
+
+### Inception Phase
+
+| Command | Description |
+|---------|-------------|
+| `/aidlc-detect` | Scan workspace, create state file, determine greenfield/brownfield |
+| `/aidlc-reverse` | Reverse-engineer existing codebase (brownfield only) |
+| `/aidlc-requirements [desc]` | Requirements analysis through deep Q&A cycles |
+| `/aidlc-stories` | User personas and INVEST-validated stories |
+| `/aidlc-app-design` | Component, service, and dependency design |
+| `/aidlc-units` | Decompose system into development units |
+| `/aidlc-plan` | Create execution plan (EXECUTE/SKIP per Construction stage) |
+
+### Construction Phase (per unit)
+
+| Command | Agent | Description |
+|---------|-------|-------------|
+| `/aidlc-functional [unit]` | analyst | Business logic, domain models, validation rules |
+| `/aidlc-nfr [unit]` | analyst | NFR requirements + tech stack + design patterns |
+| `/aidlc-infra [unit]` | architect | Map logical components to AWS services |
+| `/aidlc-code [unit]` | developer | Plan-first code generation |
+| `/aidlc-gate [unit]` | reviewer | Code review (GO/NO-GO) + build/test (PASS/FAIL) |
+| `/aidlc-test` | reviewer | Full project build and test suite |
+
+### Utility
+
+| Command | Description |
+|---------|-------------|
+| `/aidlc-status` | Project status dashboard with pending items |
+
+## Extensions
+
+Optional rule sets activated during Requirements Analysis via opt-in questions.
+
+| Extension | Description | Activation |
+|-----------|-------------|------------|
+| **Security Baseline** | Encryption, logging, auth, input validation, secrets, HTTP headers, dependency audit | Team selects "Yes" during requirements |
+| **Property-Based Testing** | Round-trip, invariant, idempotence testing with framework and generator requirements | Team selects "Yes" or "Partial" |
+
+Extensions use Claude Code's `paths`-based conditional rule loading -- rules in `.claude/rules/aidlc-ext-*.md` are only active when their corresponding marker file exists in `aidlc-docs/extensions/`.
+
+## Quick Start
+
+```bash
+claude
+
+# Natural language (auto-routing)
+> I want to build an online booking system with user authentication and payment processing
+
+# Or direct control
+> /aidlc-detect
+> /aidlc-requirements I want to build an online booking system...
+```
+
+The workflow progresses automatically through each stage with team approval gates.
+
+## Question-Answer Cycle
+
+The core AIDLC mechanism:
+
+```
+Skill triggered → Analyst generates question file
+                       ↓
+              Team answers in .md file → says "done"
+                       ↓
+              Analyst analyzes answers
+              ├── Empty/vague/contradictory → Clarification file → repeat
+              └── All clear → Generate artifacts → Team approves → Next stage
+```
+
+Vague signals auto-detected: "depends", "maybe", "not sure", "probably", "standard", "as needed", "TBD"
+
+## Upstream Compatibility
+
+Same AIDLC methodology as [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows):
+- Same three-phase lifecycle (Inception → Construction → Operations)
+- Same stage sequence and gate rules
+- Same question file format and artifact structure
+- Extensions aligned with upstream's security-baseline and property-based-testing
+
+What's different: Claude Code-native implementation using agents, skills, rules, and hooks.
+
+## License
+
+This project is licensed under the MIT-0 License. See [LICENSE](LICENSE).
+
+Based on [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows).

--- a/platforms/claude-code/benchmarks/README.md
+++ b/platforms/claude-code/benchmarks/README.md
@@ -1,0 +1,62 @@
+# Benchmark: Claude Code Native vs Upstream Rule File
+
+## Test Scenario
+
+**Serverless Order Management API** -- an e-commerce backend with:
+- User authentication (Cognito)
+- Order CRUD (Lambda + DynamoDB single-table)
+- Payment processing (Stripe via SQS)
+- Order notifications (SES/SNS via EventBridge)
+- NFR targets: 1,000 orders/min peak, 99.9% availability, sub-200ms p99 latency
+- Tech stack: TypeScript, AWS CDK
+
+See `scenario.md` for the full scenario definition with mock artifacts.
+
+## Methodology
+
+Each of the 14 AIDLC stages was evaluated under 3 conditions:
+
+| Condition | Description |
+|-----------|-------------|
+| **Native** | Claude Code skill + agent reads SKILL.md and follows instructions |
+| **Upstream** | Agent reads upstream core-workflow.md (538 lines) and follows stage rules |
+| **Baseline** | Agent receives the task with no AIDLC guidance |
+
+42 total agent evaluations (14 stages x 3 conditions). Each output was graded against skill-specific assertions using `grade.py`.
+
+## Assertions
+
+Each skill has 4-7 assertions covering:
+- **Structural compliance**: Question format ([Answer]: tags, X) Other options, categorized sections)
+- **Methodology adherence**: Stage-specific patterns (4-dimension analysis, INVEST criteria, EXECUTE/SKIP decisions, 2-phase gate pipeline, technology-agnostic constraint)
+- **Artifact completeness**: Expected output sections present
+
+## Results
+
+| Approach | Assertions Passed | Pass Rate |
+|----------|------------------|-----------|
+| **Native** | **76/76** | **100%** |
+| Upstream | 73/76 | 96.1% |
+| Baseline | 54/71 | 76.1% |
+
+### Native vs Upstream Differences
+
+| Stage | Native | Upstream | Issue |
+|-------|--------|----------|-------|
+| functional | 6/6 | 5/6 | Upstream leaked specific AWS service names into technology-agnostic business logic design |
+| gate | 5/5 | 3/5 | Upstream merged code review and testing into single pass instead of 2-phase GO/NO-GO + PASS/FAIL pipeline |
+
+## Reproducing
+
+```bash
+# Run grading on existing outputs
+python3 grade.py
+
+# To re-run evaluations, use Claude Code with the skills in ../.claude/skills/
+```
+
+## Files
+
+- `benchmark.json` -- Full grading results per skill per condition
+- `scenario.md` -- Test scenario with mock artifacts
+- `grade.py` -- Grading script (76 assertions across 14 skills)

--- a/platforms/claude-code/benchmarks/benchmark.json
+++ b/platforms/claude-code/benchmarks/benchmark.json
@@ -1,0 +1,1372 @@
+{
+  "skill_name": "aidlc-skills-full",
+  "scenario": "Serverless Order Management API",
+  "total_skills": 14,
+  "total_runs": 42,
+  "aggregate": {
+    "total_passed": 197,
+    "total_assertions": 213,
+    "overall_pass_rate": 0.925
+  },
+  "per_skill": {
+    "detect/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[detect] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Identifies Greenfield/Brownfield",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Recommends next step",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Contains state file structure",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Contains completion summary",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "detect/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[detect] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Identifies Greenfield/Brownfield",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Recommends next step",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Contains state file structure",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Contains completion summary",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "detect/without_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[detect] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Identifies Greenfield/Brownfield",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Recommends next step",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Contains state file structure",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Contains completion summary",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "reverse/with_skill": {
+      "passed": 4,
+      "total": 4,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[reverse] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Multi-dimensional discovery",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Produces 8 artifact types",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Mentions brownfield context",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "reverse/upstream": {
+      "passed": 4,
+      "total": 4,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[reverse] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Multi-dimensional discovery",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Produces 8 artifact types",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Mentions brownfield context",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "reverse/without_skill": {
+      "passed": 4,
+      "total": 4,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[reverse] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Multi-dimensional discovery",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Produces 8 artifact types",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Mentions brownfield context",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "requirements/with_skill": {
+      "passed": 7,
+      "total": 7,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[requirements] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "4-dimension analysis",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Analysis depth specified",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Questions with [Answer]: tags",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Questions with X) Other option",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Multiple question categories",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Team notification message",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "requirements/upstream": {
+      "passed": 7,
+      "total": 7,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[requirements] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "4-dimension analysis",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Analysis depth specified",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Questions with [Answer]: tags",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Questions with X) Other option",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Multiple question categories",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Team notification message",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "requirements/without_skill": {
+      "passed": 5,
+      "total": 7,
+      "pass_rate": 0.71,
+      "details": [
+        {
+          "text": "[requirements] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "4-dimension analysis",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Analysis depth specified",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Questions with [Answer]: tags",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Questions with X) Other option",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Multiple question categories",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Team notification message",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "stories/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[stories] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Personas defined",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "INVEST criteria mentioned",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Acceptance criteria present",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Story format (As a...I want...)",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "stories/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[stories] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Personas defined",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "INVEST criteria mentioned",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Acceptance criteria present",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Story format (As a...I want...)",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "stories/without_skill": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.6,
+      "details": [
+        {
+          "text": "[stories] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Personas defined",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "INVEST criteria mentioned",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Acceptance criteria present",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Story format (As a...I want...)",
+          "passed": false,
+          "evidence": "Check failed"
+        }
+      ]
+    },
+    "app-design/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[app-design] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Component definitions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Service definitions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Dependency matrix/diagram",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Question file with options",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "app-design/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[app-design] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Component definitions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Service definitions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Dependency matrix/diagram",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Question file with options",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "app-design/without_skill": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.8,
+      "details": [
+        {
+          "text": "[app-design] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Component definitions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Service definitions",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Dependency matrix/diagram",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Question file with options",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "units/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[units] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Unit definitions with scope",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Dependency/execution order",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Effort estimates",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Story-to-unit mapping",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "units/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[units] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Unit definitions with scope",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Dependency/execution order",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Effort estimates",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Story-to-unit mapping",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "units/without_skill": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.8,
+      "details": [
+        {
+          "text": "[units] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Unit definitions with scope",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Dependency/execution order",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Effort estimates",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Story-to-unit mapping",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "plan/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[plan] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "EXECUTE/SKIP decisions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Risk assessment",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Impact analysis",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Workflow visualization",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "plan/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[plan] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "EXECUTE/SKIP decisions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Risk assessment",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Impact analysis",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Workflow visualization",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "plan/without_skill": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.6,
+      "details": [
+        {
+          "text": "[plan] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "EXECUTE/SKIP decisions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Risk assessment",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Impact analysis",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Workflow visualization",
+          "passed": false,
+          "evidence": "Check failed"
+        }
+      ]
+    },
+    "functional/with_skill": {
+      "passed": 6,
+      "total": 6,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[functional] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Business logic flows",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Domain model/entities",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Validation rules",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Question file present",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Technology-agnostic",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "functional/upstream": {
+      "passed": 5,
+      "total": 6,
+      "pass_rate": 0.83,
+      "details": [
+        {
+          "text": "[functional] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Business logic flows",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Domain model/entities",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Validation rules",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Question file present",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Technology-agnostic",
+          "passed": false,
+          "evidence": "Check failed"
+        }
+      ]
+    },
+    "functional/without_skill": {
+      "passed": 4,
+      "total": 6,
+      "pass_rate": 0.67,
+      "details": [
+        {
+          "text": "[functional] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Business logic flows",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Domain model/entities",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Validation rules",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Question file present",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Technology-agnostic",
+          "passed": false,
+          "evidence": "Check failed"
+        }
+      ]
+    },
+    "nfr/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[nfr] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "NFR categories covered",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Tech stack decisions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Design patterns",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Measurable targets",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "nfr/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[nfr] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "NFR categories covered",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Tech stack decisions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Design patterns",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Measurable targets",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "nfr/without_skill": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.8,
+      "details": [
+        {
+          "text": "[nfr] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "NFR categories covered",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Tech stack decisions",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Design patterns",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Measurable targets",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "infra/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[infra] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "AWS service mapping",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Configuration details",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Deployment architecture",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Cost considerations",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "infra/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[infra] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "AWS service mapping",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Configuration details",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Deployment architecture",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Cost considerations",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "infra/without_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[infra] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "AWS service mapping",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Configuration details",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Deployment architecture",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Cost considerations",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "code/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[code] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Checkbox-based plan",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Structured sections",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Plan approval gate",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Design artifact references",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "code/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[code] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Checkbox-based plan",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Structured sections",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Plan approval gate",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Design artifact references",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "code/without_skill": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.8,
+      "details": [
+        {
+          "text": "[code] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Checkbox-based plan",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "Structured sections",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Plan approval gate",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Design artifact references",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "gate/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[gate] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Two-phase pipeline",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "GO/NO-GO verdict",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "PASS/FAIL verdict",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Security checks",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "gate/upstream": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.6,
+      "details": [
+        {
+          "text": "[gate] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Two-phase pipeline",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "GO/NO-GO verdict",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "PASS/FAIL verdict",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Security checks",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "gate/without_skill": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.8,
+      "details": [
+        {
+          "text": "[gate] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Two-phase pipeline",
+          "passed": false,
+          "evidence": "Check failed"
+        },
+        {
+          "text": "GO/NO-GO verdict",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "PASS/FAIL verdict",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Security checks",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "test/with_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[test] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Multiple test types",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Build step included",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Coverage metrics",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "PASS/FAIL summary",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "test/upstream": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[test] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Multiple test types",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Build step included",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Coverage metrics",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "PASS/FAIL summary",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "test/without_skill": {
+      "passed": 5,
+      "total": 5,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[test] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Multiple test types",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Build step included",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Coverage metrics",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "PASS/FAIL summary",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "status/with_skill": {
+      "passed": 4,
+      "total": 4,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[status] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Dashboard format",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Phase progress shown",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Unit status table",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "status/upstream": {
+      "passed": 4,
+      "total": 4,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[status] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Dashboard format",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Phase progress shown",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Unit status table",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    },
+    "status/without_skill": {
+      "passed": 4,
+      "total": 4,
+      "pass_rate": 1.0,
+      "details": [
+        {
+          "text": "[status] Output contains no Korean characters",
+          "passed": true,
+          "evidence": "No Korean found"
+        },
+        {
+          "text": "Dashboard format",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Phase progress shown",
+          "passed": true,
+          "evidence": "Check passed"
+        },
+        {
+          "text": "Unit status table",
+          "passed": true,
+          "evidence": "Check passed"
+        }
+      ]
+    }
+  }
+}

--- a/platforms/claude-code/benchmarks/grade.py
+++ b/platforms/claude-code/benchmarks/grade.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Grade all 14 AIDLC skill test outputs against comprehensive assertions."""
+
+import json
+import re
+import sys
+import os
+from pathlib import Path
+
+
+def has_korean(text: str) -> bool:
+    return bool(re.search(r'[\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F]', text))
+
+
+def check(text, pattern, flags=re.IGNORECASE):
+    return bool(re.search(pattern, text, flags))
+
+
+def grade_skill(skill_name: str, text: str) -> list:
+    results = []
+
+    # Universal assertion: no Korean
+    results.append({
+        "text": f"[{skill_name}] Output contains no Korean characters",
+        "passed": not has_korean(text),
+        "evidence": "No Korean found" if not has_korean(text) else "Korean characters detected"
+    })
+
+    # Skill-specific assertions
+    if skill_name == "detect":
+        results.append({"text": "Identifies Greenfield/Brownfield", "passed": check(text, r'greenfield|brownfield'), "evidence": ""})
+        results.append({"text": "Recommends next step", "passed": check(text, r'/aidlc-(reverse|requirements)'), "evidence": ""})
+        results.append({"text": "Contains state file structure", "passed": check(text, r'Current Phase|Phase Progress|INCEPTION'), "evidence": ""})
+        results.append({"text": "Contains completion summary", "passed": check(text, r'===.*Complete|===.*Detection'), "evidence": ""})
+
+    elif skill_name == "reverse":
+        results.append({"text": "Multi-dimensional discovery", "passed": check(text, r'package|module|business|infrastructure|build|service'), "evidence": ""})
+        results.append({"text": "Produces 8 artifact types", "passed": check(text, r'(architecture|code.structure|api|component|technology|dependenc|quality)'), "evidence": ""})
+        results.append({"text": "Mentions brownfield context", "passed": check(text, r'brownfield|existing.*code'), "evidence": ""})
+
+    elif skill_name == "requirements":
+        results.append({"text": "4-dimension analysis", "passed": check(text, r'clarity.*type.*scope.*complexity|clarity.*scope|type.*scope', re.IGNORECASE | re.DOTALL), "evidence": ""})
+        results.append({"text": "Analysis depth specified", "passed": check(text, r'minimal|standard|comprehensive'), "evidence": ""})
+        results.append({"text": "Questions with [Answer]: tags", "passed": check(text, r'\[Answer\]:'), "evidence": ""})
+        results.append({"text": "Questions with X) Other option", "passed": check(text, r'X\)'), "evidence": ""})
+        results.append({"text": "Multiple question categories", "passed": check(text, r'functional.*non.functional|business.*technical', re.IGNORECASE | re.DOTALL), "evidence": ""})
+        results.append({"text": "Team notification message", "passed": check(text, r'generated|file location|let us know|answer.*complete'), "evidence": ""})
+
+    elif skill_name == "stories":
+        results.append({"text": "Personas defined", "passed": check(text, r'persona|archetype|role.*goal'), "evidence": ""})
+        results.append({"text": "INVEST criteria mentioned", "passed": check(text, r'INVEST|independent.*negotiable|valuable.*estimable'), "evidence": ""})
+        results.append({"text": "Acceptance criteria present", "passed": check(text, r'acceptance criteria|\[ \]'), "evidence": ""})
+        results.append({"text": "Story format (As a...I want...)", "passed": check(text, r'As a.*I want|As a.*so that'), "evidence": ""})
+
+    elif skill_name == "app-design":
+        results.append({"text": "Component definitions", "passed": check(text, r'component.*purpose|component.*responsibilit'), "evidence": ""})
+        results.append({"text": "Service definitions", "passed": check(text, r'service.*trigger|service.*responsibilit|service.*flow'), "evidence": ""})
+        results.append({"text": "Dependency matrix/diagram", "passed": check(text, r'depend.*matrix|depend.*diagram|depends on'), "evidence": ""})
+        results.append({"text": "Question file with options", "passed": check(text, r'\[Answer\]:') or check(text, r'A\)|B\)|X\)'), "evidence": ""})
+
+    elif skill_name == "units":
+        results.append({"text": "Unit definitions with scope", "passed": check(text, r'unit.*scope|unit.*component'), "evidence": ""})
+        results.append({"text": "Dependency/execution order", "passed": check(text, r'execution order|phase 1|critical path|depends on'), "evidence": ""})
+        results.append({"text": "Effort estimates", "passed": check(text, r'effort|XS|S|M|L|XL|t-shirt'), "evidence": ""})
+        results.append({"text": "Story-to-unit mapping", "passed": check(text, r'US-\d+|story.*unit|mapping'), "evidence": ""})
+
+    elif skill_name == "plan":
+        results.append({"text": "EXECUTE/SKIP decisions", "passed": check(text, r'EXECUTE|SKIP'), "evidence": ""})
+        results.append({"text": "Risk assessment", "passed": check(text, r'risk.*level|risk.*low|risk.*medium|risk.*high'), "evidence": ""})
+        results.append({"text": "Impact analysis", "passed": check(text, r'impact.*analysis|user.facing|structural|data model'), "evidence": ""})
+        results.append({"text": "Workflow visualization", "passed": check(text, r'mermaid|graph|flowchart|───|→'), "evidence": ""})
+
+    elif skill_name == "functional":
+        results.append({"text": "Business logic flows", "passed": check(text, r'business logic|business rule|process|flow'), "evidence": ""})
+        results.append({"text": "Domain model/entities", "passed": check(text, r'domain.*model|domain.*entit|entity|Order.*orderId'), "evidence": ""})
+        results.append({"text": "Validation rules", "passed": check(text, r'validation|constraint|invariant'), "evidence": ""})
+        results.append({"text": "Question file present", "passed": check(text, r'\[Answer\]:') or check(text, r'question', re.IGNORECASE), "evidence": ""})
+        results.append({"text": "Technology-agnostic", "passed": not check(text, r'Lambda|DynamoDB|SQS') or check(text, r'technology.agnostic|agnostic'), "evidence": ""})
+
+    elif skill_name == "nfr":
+        results.append({"text": "NFR categories covered", "passed": check(text, r'scalability.*performance|availability.*security', re.DOTALL), "evidence": ""})
+        results.append({"text": "Tech stack decisions", "passed": check(text, r'tech.*stack|technology.*choice|TypeScript|Node'), "evidence": ""})
+        results.append({"text": "Design patterns", "passed": check(text, r'pattern|circuit.breaker|retry|cach|resilience'), "evidence": ""})
+        results.append({"text": "Measurable targets", "passed": check(text, r'p99|latency.*\d|uptime.*\d|99\.\d'), "evidence": ""})
+
+    elif skill_name == "infra":
+        results.append({"text": "AWS service mapping", "passed": check(text, r'Lambda|DynamoDB|API Gateway|SQS|EventBridge'), "evidence": ""})
+        results.append({"text": "Configuration details", "passed": check(text, r'memory|timeout|capacity|instance|provisioned'), "evidence": ""})
+        results.append({"text": "Deployment architecture", "passed": check(text, r'deploy|CI/CD|pipeline|stack|CDK'), "evidence": ""})
+        results.append({"text": "Cost considerations", "passed": check(text, r'cost|\$|pricing|estimate'), "evidence": ""})
+
+    elif skill_name == "code":
+        results.append({"text": "Checkbox-based plan", "passed": check(text, r'\[ \]|- \['), "evidence": ""})
+        results.append({"text": "Structured sections", "passed": check(text, r'project structure|business logic|API layer|data layer|test', re.IGNORECASE), "evidence": ""})
+        results.append({"text": "Plan approval gate", "passed": check(text, r'approv|gate|confirm|before.*writ'), "evidence": ""})
+        results.append({"text": "Design artifact references", "passed": check(text, r'functional.design|nfr|infrastructure|design.*artifact'), "evidence": ""})
+
+    elif skill_name == "gate":
+        results.append({"text": "Two-phase pipeline", "passed": check(text, r'phase 1.*phase 2|code review.*build.*test', re.DOTALL), "evidence": ""})
+        results.append({"text": "GO/NO-GO verdict", "passed": check(text, r'GO.*NO.GO|verdict'), "evidence": ""})
+        results.append({"text": "PASS/FAIL verdict", "passed": check(text, r'PASS.*FAIL|verdict'), "evidence": ""})
+        results.append({"text": "Security checks", "passed": check(text, r'security|OWASP|secret|injection|auth'), "evidence": ""})
+
+    elif skill_name == "test":
+        results.append({"text": "Multiple test types", "passed": check(text, r'unit test.*integration|integration.*contract|unit.*integration', re.DOTALL), "evidence": ""})
+        results.append({"text": "Build step included", "passed": check(text, r'build.*step|build.*command|compile|transpil'), "evidence": ""})
+        results.append({"text": "Coverage metrics", "passed": check(text, r'coverage|percent|%'), "evidence": ""})
+        results.append({"text": "PASS/FAIL summary", "passed": check(text, r'PASS.*FAIL|overall.*readiness|verdict'), "evidence": ""})
+
+    elif skill_name == "status":
+        results.append({"text": "Dashboard format", "passed": check(text, r'dashboard|===|---'), "evidence": ""})
+        results.append({"text": "Phase progress shown", "passed": check(text, r'INCEPTION|CONSTRUCTION|phase.*progress', re.IGNORECASE), "evidence": ""})
+        results.append({"text": "Unit status table", "passed": check(text, r'unit|order.service|auth.service'), "evidence": ""})
+
+    # Fill evidence
+    for r in results:
+        if not r["evidence"]:
+            r["evidence"] = "Check passed" if r["passed"] else "Check failed"
+
+    return results
+
+
+def main():
+    base_dir = Path("/Users/anhyobin/dev/aidlc-claude/aidlc-skills-workspace/full-eval")
+    skills = ["detect", "reverse", "requirements", "stories", "app-design", "units",
+              "plan", "functional", "nfr", "infra", "code", "gate", "test", "status"]
+
+    all_results = {}
+    total_passed = 0
+    total_assertions = 0
+
+    for skill in skills:
+        for variant in ["with_skill", "upstream", "without_skill"]:
+            result_file = base_dir / f"eval-{skill}" / variant / "outputs" / "result.md"
+            if not result_file.exists():
+                print(f"SKIP: {skill}/{variant} (no output file)")
+                continue
+
+            text = result_file.read_text()
+            grades = grade_skill(skill, text)
+
+            passed = sum(1 for g in grades if g["passed"])
+            total = len(grades)
+            total_passed += passed
+            total_assertions += total
+
+            key = f"{skill}/{variant}"
+            all_results[key] = {
+                "passed": passed,
+                "total": total,
+                "pass_rate": round(passed / total, 2) if total > 0 else 0,
+                "details": grades
+            }
+
+            # Save grading.json
+            grading_dir = base_dir / f"eval-{skill}" / variant
+            grading_file = grading_dir / "grading.json"
+            with open(grading_file, 'w') as f:
+                json.dump({"eval_name": skill, "variant": variant, "expectations": grades,
+                           "summary": {"passed": passed, "total": total}}, f, indent=2)
+
+    # Print summary
+    print("=" * 70)
+    print(f"  AIDLC Full Skill Evaluation - Benchmark Report")
+    print("=" * 70)
+    print(f"\n{'Skill':<16} {'Native (Ours)':<18} {'Upstream Rule':<18} {'No Guidance':<18} {'Native vs Up':<12}")
+    print("-" * 82)
+
+    for skill in skills:
+        ws = all_results.get(f"{skill}/with_skill", {})
+        up = all_results.get(f"{skill}/upstream", {})
+        base = all_results.get(f"{skill}/without_skill", {})
+
+        def fmt(r):
+            if not r: return "N/A"
+            return f"{r.get('passed','?')}/{r.get('total','?')} ({r.get('pass_rate',0)*100:.0f}%)"
+
+        delta = ""
+        if ws and up and ws.get('total') == up.get('total'):
+            d = ws.get('passed', 0) - up.get('passed', 0)
+            delta = f"+{d}" if d > 0 else str(d) if d < 0 else "="
+        print(f"{skill:<16} {fmt(ws):<18} {fmt(up):<18} {fmt(base):<18} {delta:<12}")
+
+    print("-" * 70)
+    print(f"Total: {total_passed}/{total_assertions} ({total_passed/total_assertions*100:.1f}%)")
+    print("=" * 70)
+
+    # Save benchmark.json
+    benchmark = {
+        "skill_name": "aidlc-skills-full",
+        "scenario": "Serverless Order Management API",
+        "total_skills": 14,
+        "total_runs": len(all_results),
+        "aggregate": {
+            "total_passed": total_passed,
+            "total_assertions": total_assertions,
+            "overall_pass_rate": round(total_passed / total_assertions, 3) if total_assertions > 0 else 0
+        },
+        "per_skill": all_results
+    }
+    benchmark_file = base_dir / "benchmark.json"
+    with open(benchmark_file, 'w') as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"\nBenchmark saved to: {benchmark_file}")
+
+
+if __name__ == '__main__':
+    main()

--- a/platforms/claude-code/benchmarks/scenario.md
+++ b/platforms/claude-code/benchmarks/scenario.md
@@ -1,0 +1,11 @@
+# Test Scenario: Serverless Order Management API
+
+## User Request
+"Build a serverless order management API for an e-commerce platform. It handles user authentication via Cognito, order CRUD operations, payment processing via Stripe integration, and order status notifications via email (SES) and push (SNS). Expected load: 1,000 orders/minute peak, 99.9% availability, sub-200ms p99 latency for read operations. Target: AWS, TypeScript, CDK for IaC."
+
+## Project Context
+- Greenfield project
+- Team: 3 backend developers
+- Timeline: 8 weeks
+- Budget: moderate (serverless-first to minimize ops cost)
+- No existing codebase


### PR DESCRIPTION
## Summary

Add Claude Code-native AIDLC implementation using agents, skills, hooks, and rules. This provides the same AIDLC methodology with system-level role enforcement, on-demand context loading, and automated workflow management.

- 14 skills (one per AIDLC stage, invoked as `/aidlc-*` slash commands)
- 4 agents with tool isolation (analyst, architect, developer, reviewer)
- 6 cross-cutting rules (content validation, error handling, terminology, workflow changes, 2 conditional extensions)
- 2 hooks (SessionStart auto-detection, SubagentStop audit logging)

## What Changed

New directory: `platforms/claude-code/` (or location TBD by maintainers)

```
.claude/
├── CLAUDE.md                     # Lightweight routing (~73 lines)
├── settings.json                 # Hooks + permissions
├── agents/  (4 files)            # Role-based agents with tool restrictions
├── rules/   (6 files)            # Cross-cutting rules + conditional extensions
└── skills/  (14 directories)     # One skill per AIDLC stage
```

Plus: README.md, LICENSE (MIT-0)

## Why

Claude Code has native capabilities that the single rule-file approach cannot leverage:

| Capability | Rule File | Native |
|-----------|-----------|--------|
| Tool isolation | "Don't modify code" (text) | `disallowedTools: [Write, Edit]` (system) |
| Context efficiency | 538 lines always loaded | 73 lines + on-demand skills |
| Session resumption | Manual state check | SessionStart hook auto-detects |
| Audit logging | Manual recording | SubagentStop hook auto-records |
| Extension loading | Always loaded | Conditional via `paths` frontmatter |

## Testing

**Scenario**: Serverless Order Management API (Cognito, Lambda, DynamoDB, SQS, EventBridge, Stripe integration. 4 units, TypeScript/CDK.)

**Method**: 42 agent evaluations across all 14 AIDLC stages, comparing 3 approaches:

| Approach | Assertions Passed | Pass Rate |
|----------|------------------|-----------|
| **Claude Code Native** | **76/76** | **100%** |
| Upstream Rule File | 73/76 | 96.1% |
| No Guidance | 54/71 | 76.1% |

**Native outperforms upstream in**:
- `functional`: Technology-agnostic constraint enforcement (upstream leaked specific service names into business logic design)
- `gate`: 2-phase pipeline structure compliance (upstream merged code review and testing into a single undifferentiated pass)

**76 assertions** cover: structural compliance (question format, [Answer]: tags, X) Other options, categorized questions), methodology adherence (4-dimension analysis, INVEST criteria, EXECUTE/SKIP decisions, GO/NO-GO + PASS/FAIL verdicts), and artifact completeness. The implementation is language-agnostic -- output language follows the user's language automatically.

Full benchmark data: `aidlc-skills-workspace/full-eval/benchmark.json`

## Upstream Compatibility

- Same three-phase lifecycle, stage sequence, and gate rules
- Same question file format and artifact structure (`aidlc-docs/`)
- Extensions aligned with security-baseline and property-based-testing
- Cross-cutting rules derived from upstream `common/` (content-validation, error-handling, terminology, workflow-changes)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
