### PR TITLE
fix: forks skip codebuild

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -122,9 +122,13 @@ jobs:
           fi
 
   build:
+    # Fork PRs are skipped because they cannot access the repository secrets
+    # or OIDC credentials needed for AWS CodeBuild.
     if: >-
-      github.event_name != 'pull_request'
-      || contains(github.event.pull_request.labels.*.name, 'rules')
+      (github.event_name != 'pull_request'
+      || contains(github.event.pull_request.labels.*.name, 'rules'))
+      && (github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository)
     environment: codebuild
 
     permissions:

--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -152,6 +152,7 @@ jobs:
           lookup-only: true
 
       - name: Configure AWS credentials
+        # env.ACT is set by the 'act' CLI tool for local testing
         if: ${{ !env.ACT && steps.cache-check.outputs.cache-hit != 'true' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -405,6 +406,7 @@ jobs:
           key: ${{ env.CODEBUILD_PROJECT_NAME }}-${{ github.ref_name }}-${{ github.sha }}
 
       - name: Upload CodeBuild primary artifact
+        # env.ACT is set by the 'act' CLI tool for local testing
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -414,6 +416,7 @@ jobs:
           archive: false
 
       - name: Upload Evaluation Report
+        # env.ACT is set by the 'act' CLI tool for local testing
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -423,6 +426,7 @@ jobs:
           archive: false
 
       - name: Upload Trend Report
+        # env.ACT is set by the 'act' CLI tool for local testing
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -459,6 +463,7 @@ jobs:
           fi
 
       - name: Upload Report Bundle
+        # env.ACT is set by the 'act' CLI tool for local testing
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
# Summary

Forks shall not access secrets, so skip the "build".

## Changes

* Add logic when there are forks to skip running Code Build.
* Add comment on the purpose of the `env.ACT`

## User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

## Test Plan

> replace with instructions or a checklist for reviewers to verify

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
