### PR TITLE
feat: Add HCLS (Healthcare & Life Sciences) industry lens extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,16 @@ aws-aidlc-rule-details/
     │   └── baseline/
     │       ├── security-baseline.md          # Baseline security rules
     │       └── security-baseline.opt-in.md   # Opt-in prompt
+    ├── hcls/                          # Extension category: Healthcare & Life Sciences
+    │   ├── compliance/
+    │   │   ├── hcls-compliance.md             # HIPAA, HITRUST, GxP, FDA 21 CFR Part 11 rules
+    │   │   └── hcls-compliance.opt-in.md      # Opt-in prompt
+    │   ├── data-handling/
+    │   │   ├── hcls-data-handling.md          # PHI encryption, de-identification, data residency rules
+    │   │   └── hcls-data-handling.opt-in.md   # Opt-in prompt
+    │   └── interoperability/
+    │       ├── hcls-interoperability.md       # FHIR R4, SMART on FHIR, US Core, terminology rules
+    │       └── hcls-interoperability.opt-in.md # Opt-in prompt
     └── testing/                       # Extension category
         └── property-based/
             ├── property-based-testing.md          # Property-based testing rules
@@ -596,6 +606,32 @@ aws-aidlc-rule-details/
 
 > [!IMPORTANT]
 > The security extension rules are provided as a directional reference for building effective security rules within AI-DLC workflows. Each organization should build, customize, and thoroughly test their own security rules before deploying in production workflows.
+
+#### HCLS (Healthcare & Life Sciences) Lens
+
+The HCLS lens adds three independently opt-in-able sub-extensions under `extensions/hcls/` for healthcare-specific projects:
+
+| Sub-Extension | Rules | Covers |
+|---|---|---|
+| **Compliance** (`hcls/compliance/`) | HCLS-COMP-01 → 07 | PHI/PII data classification, audit trails for PHI access, BAA-eligible AWS services, minimum necessary access, data retention & disposal, breach notification design, consent management |
+| **Data Handling** (`hcls/data-handling/`) | HCLS-DATA-01 → 05 | PHI encryption standards (AES-256/KMS CMK), de-identification (HIPAA Safe Harbor / Expert Determination), cross-region data residency, backup & recovery for PHI, log sanitization |
+| **Interoperability** (`hcls/interoperability/`) | HCLS-INTOP-01 → 05 | FHIR R4 compliance, SMART on FHIR authorization, US Core / IPS profile validation, terminology binding (ICD-10, SNOMED CT, LOINC, RxNorm), Bulk Data Export |
+
+Each sub-extension supports three enablement levels during opt-in:
+- **Full** — all rules enforced as blocking constraints
+- **Partial** — a subset of critical rules enforced (see each rules file for details)
+- **Off** — rules not loaded
+
+This allows teams to tailor the lens to their project scope. For example, a FHIR API project might enable only Interoperability, while a full EHR build enables all three.
+
+The HCLS lens follows the same "lens" pattern that can be replicated for other industry verticals (e.g., FSI, Manufacturing) — each lens is a set of sub-extensions under its own category directory.
+
+**Example input documents** for an HCLS project are available in `docs/writing-inputs/`:
+- `example-minimal-vision-hcls-fhir-patient-portal.md` — Vision document for a FHIR-based patient portal
+- `example-minimal-tech-env-hcls-fhir-patient-portal.md` — Technical environment for the same project
+
+> [!IMPORTANT]
+> The HCLS extension rules are provided as a directional reference for building healthcare-compliant workflows within AI-DLC. They cover common HIPAA, FHIR, and data handling requirements but are not exhaustive. Each organization should review, customize, and validate these rules against their specific regulatory obligations, legal counsel guidance, and organizational policies before deploying in production workflows.
 
 ### Adding Your Own Extensions
 

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/compliance/hcls-compliance.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/compliance/hcls-compliance.md
@@ -1,0 +1,186 @@
+# HCLS Compliance Rules
+
+## Overview
+These healthcare compliance rules are cross-cutting constraints that apply across all AI-DLC phases when enabled. They enforce regulatory requirements from HIPAA (Health Insurance Portability and Accountability Act), HITRUST CSF, GxP (Good Practice regulations), and FDA 21 CFR Part 11 where applicable.
+
+**Enforcement**: At each applicable stage, the model MUST verify compliance with these rules before presenting the stage completion message to the user.
+
+**Relationship to Security Baseline**: These rules extend and specialize the Security Baseline extension. If both HCLS Compliance and Security Baseline are enabled, HCLS rules take precedence where they impose stricter requirements. Security Baseline rules still apply for areas not covered by HCLS-specific rules.
+
+### Blocking Compliance Finding Behavior
+A **blocking compliance finding** means:
+1. The finding MUST be listed in the stage completion message under a "HCLS Compliance Findings" section with the rule ID and description
+2. The stage MUST NOT present the "Continue to Next Stage" option until all blocking findings are resolved
+3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
+4. The finding MUST be logged in `aidlc-docs/audit.md` with the HCLS rule ID, description, and stage context
+
+If a rule is not applicable to the current project context (e.g., HCLS-COMP-07 when no patient-facing data sharing exists), mark it as **N/A** in the compliance summary — this is not a blocking finding.
+
+### Default Enforcement
+All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking compliance finding — follow the blocking finding behavior defined above.
+
+### Partial Enablement
+When the user selects **Partial** enablement during opt-in, only the following rules are enforced:
+- HCLS-COMP-01 (PHI/PII Data Classification)
+- HCLS-COMP-02 (Audit Trail for PHI Access)
+
+All other rules are marked as N/A in compliance summaries.
+
+---
+
+## Rule HCLS-COMP-01: PHI/PII Data Classification
+
+**Rule**: Every data model, schema, or data store definition MUST classify each field/attribute into one of three sensitivity categories:
+- **PHI** (Protected Health Information): Any individually identifiable health information as defined by HIPAA §160.103 — includes medical records, diagnoses, treatment information, lab results, insurance information when linked to an individual identifier
+- **PII** (Personally Identifiable Information): Information that can identify an individual but is not health-related — names, addresses, dates of birth, Social Security numbers, contact information
+- **Non-sensitive**: Data that cannot identify an individual and is not health-related
+
+**Requirements**:
+- Data classification MUST be documented in the requirements or design artifacts before any implementation begins
+- PHI fields MUST be tagged/annotated in code (via decorators, annotations, schema metadata, or equivalent mechanism) so that downstream processes (encryption, access control, audit logging) can identify them programmatically
+- Classification decisions MUST be reviewed and approved as part of the Requirements Analysis or Application Design stage
+- When uncertain whether a field constitutes PHI, default to classifying it as PHI
+
+**Verification**:
+- Every data model has a documented classification for each field
+- No data store schema exists without PHI/PII/Non-sensitive annotations
+- Classification is traceable from requirements through to implementation
+- Combined data that could re-identify individuals is classified as PHI even if individual fields are non-sensitive
+
+**Applicable Stages**: Requirements Analysis, Application Design, Functional Design, Code Generation
+
+---
+
+## Rule HCLS-COMP-02: Audit Trail for PHI Access
+
+**Rule**: Every system operation that reads, writes, updates, or deletes PHI MUST generate an immutable audit log entry containing:
+- **Who**: The authenticated user or service principal performing the action
+- **What**: The specific PHI resource accessed (resource type + ID, NOT the PHI data itself)
+- **When**: Timestamp in ISO 8601 format (UTC)
+- **Why**: The purpose/context of the access (API endpoint, business operation, or consent reference)
+- **How**: The access method (API call, direct DB query, batch job, etc.)
+
+**Requirements**:
+- Audit logs MUST be stored in a tamper-evident or append-only store (e.g., AWS CloudTrail with log file integrity validation, Amazon QLDB, S3 with Object Lock)
+- Audit logs MUST be retained for a minimum of 6 years (HIPAA §164.530(j))
+- Audit logs MUST NOT contain the PHI data itself — only references (resource type + ID)
+- Audit log access MUST be restricted to authorized compliance/security personnel
+- Audit logging MUST NOT be bypassable — it must be enforced at the infrastructure or middleware layer, not left to application code to implement per-endpoint
+
+**Verification**:
+- Every API endpoint or data access layer that touches PHI has audit logging
+- Audit log storage is append-only or tamper-evident
+- Audit log entries contain all five required fields (who, what, when, why, how)
+- Audit logs do not contain PHI data values
+- Retention policy is configured for minimum 6 years
+- No code path exists that accesses PHI without generating an audit entry
+
+**Applicable Stages**: Application Design, Infrastructure Design, Functional Design, Code Generation, Build and Test
+
+---
+
+## Rule HCLS-COMP-03: BAA-Eligible Services Only
+
+**Rule**: All AWS services used to store, process, or transmit PHI MUST be covered by the AWS Business Associate Agreement (BAA). This is a non-negotiable HIPAA requirement.
+
+**Requirements**:
+- Infrastructure design MUST reference the current [AWS HIPAA Eligible Services List](https://aws.amazon.com/compliance/hipaa-eligible-services-reference/)
+- Any service selection that involves PHI MUST be validated against the BAA-eligible list
+- If a non-BAA-eligible service is required for a non-PHI function, it MUST be architecturally isolated from PHI data flows — no PHI may transit through or be accessible to the non-BAA service
+- The design document MUST include a "BAA Service Mapping" section that lists each AWS service used, whether it handles PHI, and its BAA eligibility status
+
+**Verification**:
+- Every AWS service in the architecture that handles PHI is on the BAA-eligible list
+- No PHI data flows through non-BAA-eligible services
+- A BAA Service Mapping table exists in the design documentation
+- Non-BAA services used for non-PHI functions are architecturally isolated from PHI
+
+**Applicable Stages**: Application Design, Infrastructure Design, NFR Design
+
+---
+
+## Rule HCLS-COMP-04: Minimum Necessary Access
+
+**Rule**: All access control designs MUST enforce the HIPAA Minimum Necessary Rule (§164.502(b)) — users, roles, and service principals MUST only have access to the minimum PHI necessary to perform their specific function.
+
+**Requirements**:
+- Role definitions MUST specify which PHI data categories each role can access and why
+- No role MUST have blanket "read all patient records" access unless explicitly justified and documented (e.g., system backup role with compensating controls)
+- API endpoints MUST support field-level filtering — responses should only include the PHI fields the requesting role is authorized to see
+- Break-glass procedures MUST be defined for emergency access scenarios, with mandatory post-access review
+- Access reviews MUST be designed into the system — periodic recertification of role assignments
+
+**Verification**:
+- Role-to-PHI-category mapping is documented
+- No role has unrestricted PHI access without documented justification and compensating controls
+- API design includes field-level access control or response filtering
+- Break-glass procedure is defined with audit logging and post-access review
+- Access review/recertification mechanism is included in the design
+
+**Applicable Stages**: Requirements Analysis, Application Design, Functional Design, Code Generation
+
+---
+
+## Rule HCLS-COMP-05: Data Retention and Disposal
+
+**Rule**: The system design MUST define data lifecycle policies for all PHI data categories, including retention periods and secure disposal procedures.
+
+**Requirements**:
+- Retention periods MUST comply with applicable regulations: HIPAA (6 years for administrative records), state laws (which may require longer retention for medical records — up to 10+ years in some jurisdictions), and any customer-specific requirements
+- Automated retention enforcement MUST be designed — data that reaches its retention limit must be flagged or queued for secure disposal
+- Secure disposal MUST use cryptographic erasure (delete encryption keys) or NIST SP 800-88 compliant methods
+- Disposal events MUST be logged in the audit trail with: data category, volume, disposal method, timestamp, and authorizing principal
+- Data in backups MUST be covered by the same retention and disposal policies
+
+**Verification**:
+- Retention policies are documented per data category
+- Automated retention enforcement mechanism is included in the design
+- Disposal method is specified (cryptographic erasure or NIST 800-88)
+- Disposal audit logging is included
+- Backup retention aligns with primary data retention policies
+
+**Applicable Stages**: Requirements Analysis, Application Design, Infrastructure Design
+
+---
+
+## Rule HCLS-COMP-06: Breach Notification Design
+
+**Rule**: The system MUST include a breach detection and notification mechanism to support HIPAA Breach Notification Rule (§164.400-414) requirements.
+
+**Requirements**:
+- Anomaly detection MUST be designed for PHI access patterns — unusual volume, unusual hours, unusual roles, geographic anomalies
+- Automated alerting MUST trigger when potential breach indicators are detected
+- The system MUST support generating a breach impact assessment: which patients were affected, what PHI was exposed, the timeframe of the breach
+- Notification workflow MUST be designed to support the 60-day notification window (HIPAA §164.404) — including affected individuals, HHS, and media (if >500 individuals in a state)
+- Incident response integration MUST be included — the system should provide forensic data to support breach investigation
+
+**Verification**:
+- Anomaly detection for PHI access is included in the design
+- Alerting mechanism is defined for breach indicators
+- Breach impact assessment capability is designed (affected patients, PHI types, timeframe)
+- Notification workflow supports regulatory timelines
+- Forensic data availability is designed (logs, access records, data lineage)
+
+**Applicable Stages**: Application Design, Infrastructure Design, NFR Design
+
+---
+
+## Rule HCLS-COMP-07: Consent Management
+
+**Rule**: The system MUST capture, store, and enforce patient consent preferences before any PHI sharing, disclosure, or secondary use.
+
+**Requirements**:
+- Consent records MUST capture: patient identifier, consent scope (what data, for what purpose, to whom), grant/revoke timestamps, consent method (electronic, paper, verbal with witness), and expiration (if applicable)
+- Consent enforcement MUST be evaluated at the point of data access — before PHI is disclosed to any external party, shared across organizational boundaries, or used for secondary purposes (research, analytics, marketing)
+- Consent revocation MUST be supported and take effect within a defined SLA (document the SLA in requirements)
+- Consent records MUST be included in the audit trail
+- The system MUST support HIPAA minimum consent categories: Treatment, Payment, Healthcare Operations (TPO) and any additional consent categories required by the use case
+
+**Verification**:
+- Consent data model captures all required fields
+- Consent enforcement is evaluated at data access points before disclosure
+- Consent revocation mechanism is designed with a defined SLA
+- Consent events are logged in the audit trail
+- TPO consent categories are supported at minimum
+
+**Applicable Stages**: Requirements Analysis, Application Design, Functional Design, Code Generation

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/compliance/hcls-compliance.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/compliance/hcls-compliance.md
@@ -14,10 +14,10 @@ A **blocking compliance finding** means:
 3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
 4. The finding MUST be logged in `aidlc-docs/audit.md` with the HCLS rule ID, description, and stage context
 
-If a rule is not applicable to the current project context (e.g., HCLS-COMP-07 when no patient-facing data sharing exists), mark it as **N/A** in the compliance summary — this is not a blocking finding.
+If a rule is not applicable to the current project context (e.g., HCLS-COMP-07 when no patient-facing data sharing exists), mark it as **N/A** in the compliance summary. This is not a blocking finding.
 
 ### Default Enforcement
-All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking compliance finding — follow the blocking finding behavior defined above.
+All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking compliance finding. Follow the blocking finding behavior defined above.
 
 ### Partial Enablement
 When the user selects **Partial** enablement during opt-in, only the following rules are enforced:
@@ -31,8 +31,8 @@ All other rules are marked as N/A in compliance summaries.
 ## Rule HCLS-COMP-01: PHI/PII Data Classification
 
 **Rule**: Every data model, schema, or data store definition MUST classify each field/attribute into one of three sensitivity categories:
-- **PHI** (Protected Health Information): Any individually identifiable health information as defined by HIPAA §160.103 — includes medical records, diagnoses, treatment information, lab results, insurance information when linked to an individual identifier
-- **PII** (Personally Identifiable Information): Information that can identify an individual but is not health-related — names, addresses, dates of birth, Social Security numbers, contact information
+- **PHI** (Protected Health Information): Any individually identifiable health information as defined by HIPAA §160.103, including medical records, diagnoses, treatment information, lab results, and insurance information when linked to an individual identifier
+- **PII** (Personally Identifiable Information): Information that can identify an individual but is not health-related: names, addresses, dates of birth, Social Security numbers, contact information
 - **Non-sensitive**: Data that cannot identify an individual and is not health-related
 
 **Requirements**:
@@ -63,9 +63,9 @@ All other rules are marked as N/A in compliance summaries.
 **Requirements**:
 - Audit logs MUST be stored in a tamper-evident or append-only store (e.g., AWS CloudTrail with log file integrity validation, Amazon QLDB, S3 with Object Lock)
 - Audit logs MUST be retained for a minimum of 6 years (HIPAA §164.530(j))
-- Audit logs MUST NOT contain the PHI data itself — only references (resource type + ID)
+- Audit logs MUST NOT contain the PHI data itself, only references (resource type + ID)
 - Audit log access MUST be restricted to authorized compliance/security personnel
-- Audit logging MUST NOT be bypassable — it must be enforced at the infrastructure or middleware layer, not left to application code to implement per-endpoint
+- Audit logging MUST NOT be bypassable. It must be enforced at the infrastructure or middleware layer, not left to application code to implement per-endpoint
 
 **Verification**:
 - Every API endpoint or data access layer that touches PHI has audit logging
@@ -86,7 +86,7 @@ All other rules are marked as N/A in compliance summaries.
 **Requirements**:
 - Infrastructure design MUST reference the current [AWS HIPAA Eligible Services List](https://aws.amazon.com/compliance/hipaa-eligible-services-reference/)
 - Any service selection that involves PHI MUST be validated against the BAA-eligible list
-- If a non-BAA-eligible service is required for a non-PHI function, it MUST be architecturally isolated from PHI data flows — no PHI may transit through or be accessible to the non-BAA service
+- If a non-BAA-eligible service is required for a non-PHI function, it MUST be architecturally isolated from PHI data flows. No PHI may transit through or be accessible to the non-BAA service
 - The design document MUST include a "BAA Service Mapping" section that lists each AWS service used, whether it handles PHI, and its BAA eligibility status
 
 **Verification**:
@@ -101,14 +101,14 @@ All other rules are marked as N/A in compliance summaries.
 
 ## Rule HCLS-COMP-04: Minimum Necessary Access
 
-**Rule**: All access control designs MUST enforce the HIPAA Minimum Necessary Rule (§164.502(b)) — users, roles, and service principals MUST only have access to the minimum PHI necessary to perform their specific function.
+**Rule**: All access control designs MUST enforce the HIPAA Minimum Necessary Rule (§164.502(b)). Users, roles, and service principals MUST only have access to the minimum PHI necessary to perform their specific function.
 
 **Requirements**:
 - Role definitions MUST specify which PHI data categories each role can access and why
 - No role MUST have blanket "read all patient records" access unless explicitly justified and documented (e.g., system backup role with compensating controls)
-- API endpoints MUST support field-level filtering — responses should only include the PHI fields the requesting role is authorized to see
+- API endpoints MUST support field-level filtering so that responses only include the PHI fields the requesting role is authorized to see
 - Break-glass procedures MUST be defined for emergency access scenarios, with mandatory post-access review
-- Access reviews MUST be designed into the system — periodic recertification of role assignments
+- Access reviews MUST be designed into the system, with periodic recertification of role assignments
 
 **Verification**:
 - Role-to-PHI-category mapping is documented
@@ -126,8 +126,8 @@ All other rules are marked as N/A in compliance summaries.
 **Rule**: The system design MUST define data lifecycle policies for all PHI data categories, including retention periods and secure disposal procedures.
 
 **Requirements**:
-- Retention periods MUST comply with applicable regulations: HIPAA (6 years for administrative records), state laws (which may require longer retention for medical records — up to 10+ years in some jurisdictions), and any customer-specific requirements
-- Automated retention enforcement MUST be designed — data that reaches its retention limit must be flagged or queued for secure disposal
+- Retention periods MUST comply with applicable regulations: HIPAA (6 years for administrative records), state laws (which may require longer retention for medical records, up to 10+ years in some jurisdictions), and any customer-specific requirements
+- Automated retention enforcement MUST be designed. Data that reaches its retention limit must be flagged or queued for secure disposal
 - Secure disposal MUST use cryptographic erasure (delete encryption keys) or NIST SP 800-88 compliant methods
 - Disposal events MUST be logged in the audit trail with: data category, volume, disposal method, timestamp, and authorizing principal
 - Data in backups MUST be covered by the same retention and disposal policies
@@ -148,11 +148,11 @@ All other rules are marked as N/A in compliance summaries.
 **Rule**: The system MUST include a breach detection and notification mechanism to support HIPAA Breach Notification Rule (§164.400-414) requirements.
 
 **Requirements**:
-- Anomaly detection MUST be designed for PHI access patterns — unusual volume, unusual hours, unusual roles, geographic anomalies
+- Anomaly detection MUST be designed for PHI access patterns (unusual volume, unusual hours, unusual roles, geographic anomalies)
 - Automated alerting MUST trigger when potential breach indicators are detected
 - The system MUST support generating a breach impact assessment: which patients were affected, what PHI was exposed, the timeframe of the breach
-- Notification workflow MUST be designed to support the 60-day notification window (HIPAA §164.404) — including affected individuals, HHS, and media (if >500 individuals in a state)
-- Incident response integration MUST be included — the system should provide forensic data to support breach investigation
+- Notification workflow MUST be designed to support the 60-day notification window (HIPAA §164.404), including affected individuals, HHS, and media (if >500 individuals in a state)
+- Incident response integration MUST be included. The system should provide forensic data to support breach investigation
 
 **Verification**:
 - Anomaly detection for PHI access is included in the design
@@ -171,7 +171,7 @@ All other rules are marked as N/A in compliance summaries.
 
 **Requirements**:
 - Consent records MUST capture: patient identifier, consent scope (what data, for what purpose, to whom), grant/revoke timestamps, consent method (electronic, paper, verbal with witness), and expiration (if applicable)
-- Consent enforcement MUST be evaluated at the point of data access — before PHI is disclosed to any external party, shared across organizational boundaries, or used for secondary purposes (research, analytics, marketing)
+- Consent enforcement MUST be evaluated at the point of data access, before PHI is disclosed to any external party, shared across organizational boundaries, or used for secondary purposes (research, analytics, marketing)
 - Consent revocation MUST be supported and take effect within a defined SLA (document the SLA in requirements)
 - Consent records MUST be included in the audit trail
 - The system MUST support HIPAA minimum consent categories: Treatment, Payment, Healthcare Operations (TPO) and any additional consent categories required by the use case

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/compliance/hcls-compliance.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/compliance/hcls-compliance.opt-in.md
@@ -1,0 +1,19 @@
+# HCLS Compliance — Opt-In
+
+**Extension**: HCLS Compliance (HIPAA, HITRUST, GxP, FDA 21 CFR Part 11)
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: HCLS Compliance Extension
+Should healthcare compliance rules (HIPAA, HITRUST, GxP) be enforced for this project?
+
+A) Yes — enforce all HCLS compliance rules as blocking constraints (recommended for any system that stores, processes, or transmits Protected Health Information)
+B) Partial — enforce PHI data classification and audit trail rules only (suitable for analytics systems working with de-identified data or limited PHI exposure)
+C) No — skip HCLS compliance rules (suitable for non-healthcare workloads, internal tools with no PHI, or projects where compliance is handled at a different layer)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/data-handling/hcls-data-handling.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/data-handling/hcls-data-handling.md
@@ -14,10 +14,10 @@ A **blocking data handling finding** means:
 3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
 4. The finding MUST be logged in `aidlc-docs/audit.md` with the HCLS-DATA rule ID, description, and stage context
 
-If a rule is not applicable to the current project context (e.g., HCLS-DATA-02 when no analytics or ML pipelines exist), mark it as **N/A** in the compliance summary — this is not a blocking finding.
+If a rule is not applicable to the current project context (e.g., HCLS-DATA-02 when no analytics or ML pipelines exist), mark it as **N/A** in the compliance summary. This is not a blocking finding.
 
 ### Default Enforcement
-All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking data handling finding — follow the blocking finding behavior defined above.
+All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking data handling finding. Follow the blocking finding behavior defined above.
 
 ### Partial Enablement
 When the user selects **Partial** enablement during opt-in, only the following rules are enforced:
@@ -32,15 +32,15 @@ All other rules are marked as N/A in compliance summaries.
 
 **Rule**: All PHI data MUST be encrypted using healthcare-grade encryption standards that meet or exceed HIPAA Security Rule requirements (§164.312(a)(2)(iv) and §164.312(e)(1)).
 
-**Requirements — Encryption at Rest**:
+**Requirements (Encryption at Rest)**:
 - PHI at rest MUST be encrypted using AES-256 (or equivalent) via AWS KMS with Customer Managed Keys (CMKs)
 - KMS key policies MUST restrict key usage to authorized services and principals only
 - Key rotation MUST be enabled (annual automatic rotation for KMS CMKs, or more frequent per organizational policy)
-- Envelope encryption MUST be used for large data objects (e.g., S3 objects, database fields) — data encrypted with a data key, data key encrypted with the CMK
+- Envelope encryption MUST be used for large data objects (e.g., S3 objects, database fields): data encrypted with a data key, data key encrypted with the CMK
 - Different PHI data categories SHOULD use separate CMKs to limit blast radius of a key compromise
 
-**Requirements — Encryption in Transit**:
-- All PHI in transit MUST use TLS 1.2 or higher — TLS 1.0 and 1.1 MUST be explicitly disabled
+**Requirements (Encryption in Transit)**:
+- All PHI in transit MUST use TLS 1.2 or higher. TLS 1.0 and 1.1 MUST be explicitly disabled
 - Internal service-to-service communication carrying PHI MUST also be encrypted (mTLS recommended for service mesh architectures)
 - API Gateway and Load Balancer TLS policies MUST enforce minimum TLS 1.2 with strong cipher suites (no RC4, no 3DES, no export ciphers)
 - Certificate management MUST use AWS Certificate Manager (ACM) or equivalent automated certificate lifecycle management
@@ -67,8 +67,8 @@ All other rules are marked as N/A in compliance summaries.
   - **Safe Harbor** (§164.514(b)): Remove all 18 HIPAA identifiers (names, geographic data smaller than state, dates except year, phone/fax numbers, email addresses, SSN, MRN, health plan numbers, account numbers, certificate/license numbers, vehicle identifiers, device identifiers, URLs, IP addresses, biometric identifiers, full-face photos, any other unique identifier)
   - **Expert Determination** (§164.514(a)): A qualified statistical expert certifies that the risk of re-identification is very small
 - The de-identification method used MUST be documented in the design artifacts
-- De-identification MUST be applied as close to the data source as possible — preferably during data extraction, not downstream
-- Re-identification risk MUST be assessed when combining de-identified datasets — quasi-identifiers (age, zip code, gender) can enable re-identification when combined
+- De-identification MUST be applied as close to the data source as possible, preferably during data extraction, not downstream
+- Re-identification risk MUST be assessed when combining de-identified datasets. Quasi-identifiers (age, zip code, gender) can enable re-identification when combined
 - A re-identification key (if maintained) MUST be stored separately from the de-identified data, with access restricted to authorized personnel
 
 **Verification**:
@@ -113,13 +113,13 @@ All other rules are marked as N/A in compliance summaries.
 
 **Requirements**:
 - Backups MUST be encrypted using the same (or equivalent) encryption standards as the primary data (AES-256 with KMS CMKs)
-- Backup frequency MUST meet the Recovery Point Objective (RPO) defined in requirements — document the RPO explicitly
-- Recovery procedures MUST meet the Recovery Time Objective (RTO) defined in requirements — document the RTO explicitly
+- Backup frequency MUST meet the Recovery Point Objective (RPO) defined in requirements. Document the RPO explicitly
+- Recovery procedures MUST meet the Recovery Time Objective (RTO) defined in requirements. Document the RTO explicitly
 - Backup restoration MUST be tested at least annually (design for automated restoration testing where possible)
 - Backups MUST be stored in a separate AWS account or with cross-account access controls to protect against ransomware or account compromise
 - Backup retention MUST align with data retention policies defined in HCLS-COMP-05 (if HCLS Compliance is also enabled) or customer-specified retention periods
 - Point-in-time recovery (PITR) MUST be enabled for databases containing PHI where the service supports it (e.g., RDS, DynamoDB)
-- Backup access MUST be audited — any backup restoration event must be logged
+- Backup access MUST be audited. Any backup restoration event must be logged
 
 **Verification**:
 - RPO and RTO are documented in requirements
@@ -140,11 +140,11 @@ All other rules are marked as N/A in compliance summaries.
 **Rule**: Application logs, debug output, error messages, and monitoring data MUST NOT contain PHI. Logging infrastructure MUST enforce sanitization before write.
 
 **Requirements**:
-- A PHI sanitization layer MUST be implemented in the logging pipeline — this may be a logging middleware, a custom log formatter, or a structured logging configuration that explicitly excludes PHI fields
+- A PHI sanitization layer MUST be implemented in the logging pipeline. This may be a logging middleware, a custom log formatter, or a structured logging configuration that explicitly excludes PHI fields
 - PHI fields identified in HCLS-COMP-01 (data classification) MUST be filtered, masked, or replaced with opaque references (e.g., patient ID → hash or token) before log output
-- Error messages and exception stack traces MUST be reviewed for PHI leakage — caught exceptions involving PHI must sanitize the error context before logging
+- Error messages and exception stack traces MUST be reviewed for PHI leakage. Caught exceptions involving PHI must sanitize the error context before logging
 - Log aggregation services (CloudWatch Logs, OpenSearch, third-party SIEM) MUST NOT receive raw PHI
-- Developers MUST NOT use `console.log`, `print`, or equivalent statements that output PHI during debugging — enforce via linting rules or code review checklists
+- Developers MUST NOT use `console.log`, `print`, or equivalent statements that output PHI during debugging. Enforce via linting rules or code review checklists
 - Monitoring dashboards and alerting systems MUST NOT display PHI in alert messages, metric labels, or dashboard widgets
 
 **Verification**:

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/data-handling/hcls-data-handling.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/data-handling/hcls-data-handling.md
@@ -1,0 +1,158 @@
+# HCLS Data Handling Rules
+
+## Overview
+These healthcare data handling rules govern how Protected Health Information (PHI) and electronic PHI (ePHI) are encrypted, de-identified, stored, backed up, and logged. They apply across all AI-DLC phases when enabled and ensure that PHI is protected at every layer of the technology stack.
+
+**Enforcement**: At each applicable stage, the model MUST verify compliance with these rules before presenting the stage completion message to the user.
+
+**Relationship to Security Baseline**: These rules extend SECURITY-01 (Encryption at Rest and in Transit) with healthcare-specific encryption requirements. If both extensions are enabled, HCLS Data Handling rules take precedence for PHI data. Security Baseline rules still govern non-PHI data.
+
+### Blocking Data Handling Finding Behavior
+A **blocking data handling finding** means:
+1. The finding MUST be listed in the stage completion message under a "HCLS Data Handling Findings" section with the rule ID and description
+2. The stage MUST NOT present the "Continue to Next Stage" option until all blocking findings are resolved
+3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
+4. The finding MUST be logged in `aidlc-docs/audit.md` with the HCLS-DATA rule ID, description, and stage context
+
+If a rule is not applicable to the current project context (e.g., HCLS-DATA-02 when no analytics or ML pipelines exist), mark it as **N/A** in the compliance summary — this is not a blocking finding.
+
+### Default Enforcement
+All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking data handling finding — follow the blocking finding behavior defined above.
+
+### Partial Enablement
+When the user selects **Partial** enablement during opt-in, only the following rules are enforced:
+- HCLS-DATA-01 (PHI Encryption Standards)
+- HCLS-DATA-05 (Log Sanitization)
+
+All other rules are marked as N/A in compliance summaries.
+
+---
+
+## Rule HCLS-DATA-01: PHI Encryption Standards
+
+**Rule**: All PHI data MUST be encrypted using healthcare-grade encryption standards that meet or exceed HIPAA Security Rule requirements (§164.312(a)(2)(iv) and §164.312(e)(1)).
+
+**Requirements — Encryption at Rest**:
+- PHI at rest MUST be encrypted using AES-256 (or equivalent) via AWS KMS with Customer Managed Keys (CMKs)
+- KMS key policies MUST restrict key usage to authorized services and principals only
+- Key rotation MUST be enabled (annual automatic rotation for KMS CMKs, or more frequent per organizational policy)
+- Envelope encryption MUST be used for large data objects (e.g., S3 objects, database fields) — data encrypted with a data key, data key encrypted with the CMK
+- Different PHI data categories SHOULD use separate CMKs to limit blast radius of a key compromise
+
+**Requirements — Encryption in Transit**:
+- All PHI in transit MUST use TLS 1.2 or higher — TLS 1.0 and 1.1 MUST be explicitly disabled
+- Internal service-to-service communication carrying PHI MUST also be encrypted (mTLS recommended for service mesh architectures)
+- API Gateway and Load Balancer TLS policies MUST enforce minimum TLS 1.2 with strong cipher suites (no RC4, no 3DES, no export ciphers)
+- Certificate management MUST use AWS Certificate Manager (ACM) or equivalent automated certificate lifecycle management
+
+**Verification**:
+- Every data store containing PHI uses AES-256 encryption with KMS CMKs
+- KMS key policies are scoped to authorized principals
+- Key rotation is enabled
+- TLS 1.2+ is enforced on all endpoints handling PHI
+- TLS 1.0/1.1 are explicitly disabled
+- Internal service communication carrying PHI is encrypted
+- No PHI is transmitted over unencrypted channels
+
+**Applicable Stages**: Application Design, Infrastructure Design, NFR Design, Code Generation
+
+---
+
+## Rule HCLS-DATA-02: De-identification Methods
+
+**Rule**: Any analytics, machine learning, research, or reporting pipeline that uses PHI MUST apply HIPAA-compliant de-identification before processing, unless a valid authorization or exception applies.
+
+**Requirements**:
+- De-identification MUST follow one of two HIPAA-approved methods:
+  - **Safe Harbor** (§164.514(b)): Remove all 18 HIPAA identifiers (names, geographic data smaller than state, dates except year, phone/fax numbers, email addresses, SSN, MRN, health plan numbers, account numbers, certificate/license numbers, vehicle identifiers, device identifiers, URLs, IP addresses, biometric identifiers, full-face photos, any other unique identifier)
+  - **Expert Determination** (§164.514(a)): A qualified statistical expert certifies that the risk of re-identification is very small
+- The de-identification method used MUST be documented in the design artifacts
+- De-identification MUST be applied as close to the data source as possible — preferably during data extraction, not downstream
+- Re-identification risk MUST be assessed when combining de-identified datasets — quasi-identifiers (age, zip code, gender) can enable re-identification when combined
+- A re-identification key (if maintained) MUST be stored separately from the de-identified data, with access restricted to authorized personnel
+
+**Verification**:
+- De-identification method is documented (Safe Harbor or Expert Determination)
+- All 18 HIPAA identifiers are addressed in the de-identification pipeline (for Safe Harbor)
+- De-identification is applied at or near the data source
+- Re-identification risk assessment is documented for combined datasets
+- Re-identification keys (if any) are stored separately with restricted access
+
+**Applicable Stages**: Requirements Analysis, Application Design, Functional Design, Code Generation
+
+---
+
+## Rule HCLS-DATA-03: Cross-Region Data Residency
+
+**Rule**: PHI MUST NOT leave the designated AWS region unless explicitly approved and documented, with appropriate safeguards.
+
+**Requirements**:
+- The primary AWS region for PHI storage MUST be documented in the requirements
+- Cross-region replication of PHI (for DR or availability) MUST be explicitly approved and limited to approved regions
+- PHI MUST NOT be replicated to or processed in regions outside the jurisdiction specified by the customer or applicable regulations (e.g., US PHI should generally stay within US regions unless approved)
+- AWS service configurations MUST enforce region-locking:
+  - S3 bucket policies MUST deny cross-region replication unless explicitly configured for approved DR regions
+  - DynamoDB global tables MUST only include approved regions
+  - Lambda@Edge and CloudFront MUST NOT cache or process PHI at edge locations outside approved regions
+- SCP (Service Control Policies) or IAM policies SHOULD restrict resource creation to approved regions
+
+**Verification**:
+- Primary PHI region is documented
+- Cross-region replication (if any) is limited to approved regions and documented
+- No PHI data flows to unapproved regions
+- Region-locking is enforced at the infrastructure level (SCPs, bucket policies, service configurations)
+- Edge computing configurations do not expose PHI outside approved regions
+
+**Applicable Stages**: Requirements Analysis, Infrastructure Design, NFR Design
+
+---
+
+## Rule HCLS-DATA-04: Backup and Recovery for PHI
+
+**Rule**: All PHI data stores MUST have automated, encrypted backup procedures with tested recovery capabilities.
+
+**Requirements**:
+- Backups MUST be encrypted using the same (or equivalent) encryption standards as the primary data (AES-256 with KMS CMKs)
+- Backup frequency MUST meet the Recovery Point Objective (RPO) defined in requirements — document the RPO explicitly
+- Recovery procedures MUST meet the Recovery Time Objective (RTO) defined in requirements — document the RTO explicitly
+- Backup restoration MUST be tested at least annually (design for automated restoration testing where possible)
+- Backups MUST be stored in a separate AWS account or with cross-account access controls to protect against ransomware or account compromise
+- Backup retention MUST align with data retention policies defined in HCLS-COMP-05 (if HCLS Compliance is also enabled) or customer-specified retention periods
+- Point-in-time recovery (PITR) MUST be enabled for databases containing PHI where the service supports it (e.g., RDS, DynamoDB)
+- Backup access MUST be audited — any backup restoration event must be logged
+
+**Verification**:
+- RPO and RTO are documented in requirements
+- Automated backup is configured for all PHI data stores
+- Backups are encrypted with KMS CMKs
+- Backup storage is isolated (separate account or cross-account controls)
+- PITR is enabled where supported
+- Backup restoration testing is included in operational design
+- Backup retention aligns with data retention policies
+- Backup access is audited
+
+**Applicable Stages**: Requirements Analysis, Infrastructure Design, NFR Design, Build and Test
+
+---
+
+## Rule HCLS-DATA-05: Log Sanitization
+
+**Rule**: Application logs, debug output, error messages, and monitoring data MUST NOT contain PHI. Logging infrastructure MUST enforce sanitization before write.
+
+**Requirements**:
+- A PHI sanitization layer MUST be implemented in the logging pipeline — this may be a logging middleware, a custom log formatter, or a structured logging configuration that explicitly excludes PHI fields
+- PHI fields identified in HCLS-COMP-01 (data classification) MUST be filtered, masked, or replaced with opaque references (e.g., patient ID → hash or token) before log output
+- Error messages and exception stack traces MUST be reviewed for PHI leakage — caught exceptions involving PHI must sanitize the error context before logging
+- Log aggregation services (CloudWatch Logs, OpenSearch, third-party SIEM) MUST NOT receive raw PHI
+- Developers MUST NOT use `console.log`, `print`, or equivalent statements that output PHI during debugging — enforce via linting rules or code review checklists
+- Monitoring dashboards and alerting systems MUST NOT display PHI in alert messages, metric labels, or dashboard widgets
+
+**Verification**:
+- A PHI sanitization mechanism exists in the logging pipeline
+- PHI fields from the data classification are explicitly filtered/masked in log output
+- Error handling code sanitizes PHI before logging exceptions
+- Log aggregation destinations do not receive raw PHI
+- Linting rules or code review checklists address PHI in debug statements
+- Monitoring and alerting configurations do not expose PHI
+
+**Applicable Stages**: Application Design, Functional Design, Code Generation, Build and Test

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/data-handling/hcls-data-handling.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/data-handling/hcls-data-handling.opt-in.md
@@ -1,0 +1,19 @@
+# HCLS Data Handling — Opt-In
+
+**Extension**: HCLS Data Handling (PHI Encryption, De-identification, Data Residency)
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: HCLS Data Handling Extension
+Should healthcare data handling rules (PHI encryption, de-identification, data residency) be enforced for this project?
+
+A) Yes — enforce all HCLS data handling rules as blocking constraints (recommended for any system that persists or processes PHI/ePHI)
+B) Partial — enforce PHI encryption and log sanitization only (suitable for systems that handle PHI in transit but do not perform analytics or de-identification)
+C) No — skip HCLS data handling rules (suitable for projects with no PHI exposure or where data handling is governed by an external platform layer)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/interoperability/hcls-interoperability.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/interoperability/hcls-interoperability.md
@@ -14,10 +14,10 @@ A **blocking interoperability finding** means:
 3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
 4. The finding MUST be logged in `aidlc-docs/audit.md` with the HCLS-INTOP rule ID, description, and stage context
 
-If a rule is not applicable to the current project context (e.g., HCLS-INTOP-05 when the system manages fewer than 1000 patient records), mark it as **N/A** in the compliance summary — this is not a blocking finding.
+If a rule is not applicable to the current project context (e.g., HCLS-INTOP-05 when the system manages fewer than 1000 patient records), mark it as **N/A** in the compliance summary. This is not a blocking finding.
 
 ### Default Enforcement
-All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking interoperability finding — follow the blocking finding behavior defined above.
+All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking interoperability finding. Follow the blocking finding behavior defined above.
 
 ### Partial Enablement
 When the user selects **Partial** enablement during opt-in, only the following rules are enforced:
@@ -34,8 +34,8 @@ All other rules are marked as N/A in compliance summaries.
 
 **Requirements**:
 - API endpoints MUST expose FHIR R4 resources (Patient, Observation, Condition, MedicationRequest, etc.) using standard FHIR RESTful interactions (read, search, create, update, delete)
-- FHIR resources MUST validate against the base FHIR R4 specification — invalid resources MUST be rejected with appropriate OperationOutcome responses
-- Custom data elements MUST use the FHIR extensibility framework (Extension elements with defined StructureDefinitions) — do NOT add non-FHIR fields to standard resources
+- FHIR resources MUST validate against the base FHIR R4 specification. Invalid resources MUST be rejected with appropriate OperationOutcome responses
+- Custom data elements MUST use the FHIR extensibility framework (Extension elements with defined StructureDefinitions). Do NOT add non-FHIR fields to standard resources
 - The FHIR CapabilityStatement resource MUST be served at the `/metadata` endpoint, accurately reflecting the server's supported resources, interactions, and search parameters
 - FHIR search MUST support at minimum the required search parameters defined by the applicable profiles (US Core, IPS, or base FHIR)
 - FHIR Bundle resources MUST be used for batch operations and transaction processing
@@ -63,11 +63,11 @@ All other rules are marked as N/A in compliance summaries.
   - **EHR Launch**: Application launched from within an EHR context (receives launch context parameters)
   - **Standalone Launch**: Application launches independently and requests authorization
 - FHIR access scopes MUST follow the SMART scope syntax:
-  - `patient/{ResourceType}.{read|write|*}` — patient-context scopes
-  - `user/{ResourceType}.{read|write|*}` — user-context scopes
-  - `system/{ResourceType}.{read|write|*}` — system-level (backend service) scopes
+  - `patient/{ResourceType}.{read|write|*}` (patient-context scopes)
+  - `user/{ResourceType}.{read|write|*}` (user-context scopes)
+  - `system/{ResourceType}.{read|write|*}` (system-level / backend service scopes)
 - The `.well-known/smart-configuration` endpoint MUST be served, documenting the authorization endpoints, supported scopes, and capabilities
-- Token introspection or validation MUST occur on every FHIR request — not just at session initiation
+- Token introspection or validation MUST occur on every FHIR request, not just at session initiation
 - Refresh token support MUST be implemented for long-running sessions
 - Backend service authorization (system-to-system) MUST use the SMART Backend Services specification (JWT assertion for client authentication)
 
@@ -93,7 +93,7 @@ All other rules are marked as N/A in compliance summaries.
   - Patient, AllergyIntolerance, Condition, DiagnosticReport, DocumentReference, Encounter, Immunization, MedicationRequest, Observation (vital signs, lab results, social history, smoking status), Procedure, CarePlan, CareTeam, Goal
 - **International/Cross-border**: Resources MUST validate against the [International Patient Summary (IPS)](http://hl7.org/fhir/uv/ips/) profiles
 - **Must Support elements**: All elements marked as `mustSupport` in the applicable profile MUST be populated when data is available and MUST be accepted when received
-- Profile validation MUST be automated — use a FHIR validation library (e.g., HAPI FHIR Validator, Firely .NET SDK, or AWS HealthLake built-in validation) as part of the API pipeline or CI/CD
+- Profile validation MUST be automated. Use a FHIR validation library (e.g., HAPI FHIR Validator, Firely .NET SDK, or AWS HealthLake built-in validation) as part of the API pipeline or CI/CD
 - Non-compliant resources MUST be rejected with OperationOutcome detailing which profile constraints failed
 
 **Verification**:
@@ -125,8 +125,8 @@ All other rules are marked as N/A in compliance summaries.
   - `system`: The canonical URL for the terminology (e.g., `http://snomed.info/sct`, `http://loinc.org`)
   - `code`: The specific code from that system
   - `display`: The human-readable display text
-- ValueSet bindings defined in the applicable profiles (US Core, IPS) MUST be respected — required bindings are blocking, extensible bindings should use the defined ValueSet when a suitable code exists
-- Terminology validation MUST be implemented — codes must be valid within their declared CodeSystem
+- ValueSet bindings defined in the applicable profiles (US Core, IPS) MUST be respected. Required bindings are blocking, extensible bindings should use the defined ValueSet when a suitable code exists
+- Terminology validation MUST be implemented. Codes must be valid within their declared CodeSystem
 - When local/proprietary codes are necessary, they MUST be included as an additional coding alongside the standard terminology code (never as a replacement)
 
 **Verification**:
@@ -147,15 +147,15 @@ All other rules are marked as N/A in compliance summaries.
 **Requirements**:
 - The system MUST implement the [FHIR Bulk Data Access IG](http://hl7.org/fhir/uv/bulkdata/) (v2.0 preferred)
 - Supported export operations:
-  - `GET [fhir-base]/$export` — system-level export (all data)
-  - `GET [fhir-base]/Group/[id]/$export` — group-level export (specific patient cohort)
-  - `GET [fhir-base]/Patient/$export` — all patient data
+  - `GET [fhir-base]/$export`: system-level export (all data)
+  - `GET [fhir-base]/Group/[id]/$export`: group-level export (specific patient cohort)
+  - `GET [fhir-base]/Patient/$export`: all patient data
 - Export format MUST be NDJSON (Newline Delimited JSON) with one FHIR resource per line
 - Export MUST support the `_since` parameter for incremental exports (only resources modified since a given timestamp)
 - Export MUST support the `_type` parameter to filter by resource type
 - Export status MUST be trackable via the async request pattern (202 Accepted → polling URL → completed with download links)
 - Export files MUST be served from a secure, time-limited download URL (pre-signed S3 URL or equivalent)
-- Bulk data export MUST respect the same access controls and consent rules as individual FHIR requests — no bypass of authorization for bulk operations
+- Bulk data export MUST respect the same access controls and consent rules as individual FHIR requests. No bypass of authorization for bulk operations
 - Export operations MUST be logged in the audit trail (if HCLS Compliance is enabled)
 
 **Verification**:

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/interoperability/hcls-interoperability.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/interoperability/hcls-interoperability.md
@@ -1,0 +1,170 @@
+# HCLS Interoperability Rules
+
+## Overview
+These healthcare interoperability rules ensure that systems exchanging clinical data follow industry standards for data format, transport, authorization, and terminology. They promote compliance with the ONC 21st Century Cures Act, CMS Interoperability and Patient Access rules, and international interoperability frameworks.
+
+**Enforcement**: At each applicable stage, the model MUST verify compliance with these rules before presenting the stage completion message to the user.
+
+**Relationship to Other Extensions**: These rules are independent of HCLS Compliance and HCLS Data Handling. They can be enabled standalone (e.g., for a FHIR API project that handles only de-identified data) or alongside the other HCLS extensions for a complete healthcare solution.
+
+### Blocking Interoperability Finding Behavior
+A **blocking interoperability finding** means:
+1. The finding MUST be listed in the stage completion message under a "HCLS Interoperability Findings" section with the rule ID and description
+2. The stage MUST NOT present the "Continue to Next Stage" option until all blocking findings are resolved
+3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
+4. The finding MUST be logged in `aidlc-docs/audit.md` with the HCLS-INTOP rule ID, description, and stage context
+
+If a rule is not applicable to the current project context (e.g., HCLS-INTOP-05 when the system manages fewer than 1000 patient records), mark it as **N/A** in the compliance summary — this is not a blocking finding.
+
+### Default Enforcement
+All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking interoperability finding — follow the blocking finding behavior defined above.
+
+### Partial Enablement
+When the user selects **Partial** enablement during opt-in, only the following rules are enforced:
+- HCLS-INTOP-01 (FHIR R4 Compliance)
+- HCLS-INTOP-04 (Terminology Binding)
+
+All other rules are marked as N/A in compliance summaries.
+
+---
+
+## Rule HCLS-INTOP-01: FHIR R4 Compliance
+
+**Rule**: All healthcare API endpoints that exchange clinical data MUST use HL7 FHIR R4 (v4.0.1) as the primary data format and interaction model.
+
+**Requirements**:
+- API endpoints MUST expose FHIR R4 resources (Patient, Observation, Condition, MedicationRequest, etc.) using standard FHIR RESTful interactions (read, search, create, update, delete)
+- FHIR resources MUST validate against the base FHIR R4 specification — invalid resources MUST be rejected with appropriate OperationOutcome responses
+- Custom data elements MUST use the FHIR extensibility framework (Extension elements with defined StructureDefinitions) — do NOT add non-FHIR fields to standard resources
+- The FHIR CapabilityStatement resource MUST be served at the `/metadata` endpoint, accurately reflecting the server's supported resources, interactions, and search parameters
+- FHIR search MUST support at minimum the required search parameters defined by the applicable profiles (US Core, IPS, or base FHIR)
+- FHIR Bundle resources MUST be used for batch operations and transaction processing
+- Content negotiation MUST support both `application/fhir+json` and `application/fhir+xml` (JSON is the primary format; XML support may be deferred to a later phase if documented)
+
+**Verification**:
+- API endpoints use FHIR R4 resource types
+- Resource validation is implemented (accept valid, reject invalid with OperationOutcome)
+- Custom data uses FHIR extensions, not ad-hoc fields
+- `/metadata` endpoint returns a valid CapabilityStatement
+- Required search parameters are supported per applicable profiles
+- Content-Type headers use `application/fhir+json` or `application/fhir+xml`
+
+**Applicable Stages**: Requirements Analysis, Application Design, Functional Design, Code Generation, Build and Test
+
+---
+
+## Rule HCLS-INTOP-02: SMART on FHIR Authorization
+
+**Rule**: FHIR endpoints MUST support SMART on FHIR (Substitutable Medical Applications, Reusable Technologies) authorization to enable secure third-party application access.
+
+**Requirements**:
+- The FHIR server MUST implement the SMART App Launch Framework (v2.0 preferred, v1.0 acceptable) for OAuth 2.0 based authorization
+- Supported launch modes MUST include:
+  - **EHR Launch**: Application launched from within an EHR context (receives launch context parameters)
+  - **Standalone Launch**: Application launches independently and requests authorization
+- FHIR access scopes MUST follow the SMART scope syntax:
+  - `patient/{ResourceType}.{read|write|*}` — patient-context scopes
+  - `user/{ResourceType}.{read|write|*}` — user-context scopes
+  - `system/{ResourceType}.{read|write|*}` — system-level (backend service) scopes
+- The `.well-known/smart-configuration` endpoint MUST be served, documenting the authorization endpoints, supported scopes, and capabilities
+- Token introspection or validation MUST occur on every FHIR request — not just at session initiation
+- Refresh token support MUST be implemented for long-running sessions
+- Backend service authorization (system-to-system) MUST use the SMART Backend Services specification (JWT assertion for client authentication)
+
+**Verification**:
+- SMART App Launch is implemented (v1.0 or v2.0)
+- Both EHR Launch and Standalone Launch modes are supported (or documented as future phase)
+- SMART scopes follow the standard syntax and are enforced
+- `.well-known/smart-configuration` endpoint is served and accurate
+- Token validation occurs per-request
+- Backend service authorization uses JWT assertion
+- Refresh token flow is implemented
+
+**Applicable Stages**: Application Design, Functional Design, Code Generation, Build and Test
+
+---
+
+## Rule HCLS-INTOP-03: US Core and IPS Profile Compliance
+
+**Rule**: FHIR resources MUST validate against the appropriate implementation guide profiles based on the target market and use case.
+
+**Requirements**:
+- **US Market**: Resources MUST validate against [US Core Implementation Guide](http://hl7.org/fhir/us/core/) (latest published version). At minimum, the following US Core profiles MUST be supported:
+  - Patient, AllergyIntolerance, Condition, DiagnosticReport, DocumentReference, Encounter, Immunization, MedicationRequest, Observation (vital signs, lab results, social history, smoking status), Procedure, CarePlan, CareTeam, Goal
+- **International/Cross-border**: Resources MUST validate against the [International Patient Summary (IPS)](http://hl7.org/fhir/uv/ips/) profiles
+- **Must Support elements**: All elements marked as `mustSupport` in the applicable profile MUST be populated when data is available and MUST be accepted when received
+- Profile validation MUST be automated — use a FHIR validation library (e.g., HAPI FHIR Validator, Firely .NET SDK, or AWS HealthLake built-in validation) as part of the API pipeline or CI/CD
+- Non-compliant resources MUST be rejected with OperationOutcome detailing which profile constraints failed
+
+**Verification**:
+- Target market profiles are identified (US Core, IPS, or both)
+- Required resource profiles are implemented per the applicable IG
+- mustSupport elements are handled correctly (populated when available, accepted when received)
+- Automated profile validation is integrated into the API pipeline or CI/CD
+- Non-compliant resources return OperationOutcome with profile violation details
+
+**Applicable Stages**: Requirements Analysis, Application Design, Functional Design, Code Generation, Build and Test
+
+---
+
+## Rule HCLS-INTOP-04: Terminology Binding
+
+**Rule**: Clinical data fields MUST use standard healthcare terminologies with proper CodeSystem and ValueSet bindings as defined by FHIR and applicable implementation guides.
+
+**Requirements**:
+- The following standard terminologies MUST be used where applicable:
+  - **ICD-10-CM/PCS**: Diagnoses and procedures (US)
+  - **ICD-11**: Diagnoses (international, where adopted)
+  - **SNOMED CT**: Clinical findings, procedures, body structures, substances
+  - **LOINC**: Laboratory tests and observations, vital signs, document types
+  - **RxNorm**: Medications (US)
+  - **CPT/HCPCS**: Procedures and services (US billing)
+  - **CVX**: Vaccines
+  - **NUCC**: Provider taxonomy/specialty
+- CodeableConcept fields MUST include:
+  - `system`: The canonical URL for the terminology (e.g., `http://snomed.info/sct`, `http://loinc.org`)
+  - `code`: The specific code from that system
+  - `display`: The human-readable display text
+- ValueSet bindings defined in the applicable profiles (US Core, IPS) MUST be respected — required bindings are blocking, extensible bindings should use the defined ValueSet when a suitable code exists
+- Terminology validation MUST be implemented — codes must be valid within their declared CodeSystem
+- When local/proprietary codes are necessary, they MUST be included as an additional coding alongside the standard terminology code (never as a replacement)
+
+**Verification**:
+- Standard terminologies are used for clinical data fields
+- CodeableConcept fields include system, code, and display
+- ValueSet bindings from applicable profiles are respected
+- Terminology validation is implemented (codes are valid within their CodeSystem)
+- Local codes supplement (not replace) standard terminology codes
+
+**Applicable Stages**: Application Design, Functional Design, Code Generation, Build and Test
+
+---
+
+## Rule HCLS-INTOP-05: Bulk Data Export
+
+**Rule**: Systems managing clinical data for more than 1,000 patients MUST support the FHIR Bulk Data Access specification (Flat FHIR) for population-level data export.
+
+**Requirements**:
+- The system MUST implement the [FHIR Bulk Data Access IG](http://hl7.org/fhir/uv/bulkdata/) (v2.0 preferred)
+- Supported export operations:
+  - `GET [fhir-base]/$export` — system-level export (all data)
+  - `GET [fhir-base]/Group/[id]/$export` — group-level export (specific patient cohort)
+  - `GET [fhir-base]/Patient/$export` — all patient data
+- Export format MUST be NDJSON (Newline Delimited JSON) with one FHIR resource per line
+- Export MUST support the `_since` parameter for incremental exports (only resources modified since a given timestamp)
+- Export MUST support the `_type` parameter to filter by resource type
+- Export status MUST be trackable via the async request pattern (202 Accepted → polling URL → completed with download links)
+- Export files MUST be served from a secure, time-limited download URL (pre-signed S3 URL or equivalent)
+- Bulk data export MUST respect the same access controls and consent rules as individual FHIR requests — no bypass of authorization for bulk operations
+- Export operations MUST be logged in the audit trail (if HCLS Compliance is enabled)
+
+**Verification**:
+- Bulk Data Access endpoints are implemented (system, group, and/or patient level)
+- Export format is NDJSON
+- `_since` and `_type` parameters are supported
+- Async request pattern is implemented (202 → polling → download)
+- Download URLs are secure and time-limited
+- Bulk export respects access controls and consent
+- Export operations are audited (if HCLS Compliance is enabled)
+
+**Applicable Stages**: Requirements Analysis, Application Design, Functional Design, Code Generation, Build and Test

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/interoperability/hcls-interoperability.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/interoperability/hcls-interoperability.opt-in.md
@@ -1,0 +1,19 @@
+# HCLS Interoperability — Opt-In
+
+**Extension**: HCLS Interoperability (FHIR R4, HL7, SMART on FHIR, US Core)
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: HCLS Interoperability Extension
+Should healthcare interoperability rules (FHIR R4, SMART on FHIR, clinical terminologies) be enforced for this project?
+
+A) Yes — enforce all HCLS interoperability rules as blocking constraints (recommended for any system that exchanges clinical data with EHRs, HIEs, or other healthcare systems)
+B) Partial — enforce FHIR R4 resource compliance and terminology binding only (suitable for internal clinical data APIs that do not require SMART on FHIR or Bulk Data Access)
+C) No — skip HCLS interoperability rules (suitable for non-clinical systems, back-office healthcare applications, or projects where interoperability is handled by an integration layer)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/lens-descriptor.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/hcls/lens-descriptor.md
@@ -1,0 +1,56 @@
+# HCLS Lens Descriptor
+
+**Lens**: Healthcare & Life Sciences (HCLS)
+
+**Purpose**: Adds healthcare-specific compliance, data handling, and interoperability rules for projects that store, process, or transmit Protected Health Information (PHI) or interact with clinical systems.
+
+## Detection Signals
+
+When analyzing the user's vision document, requirements, or initial request, look for the presence of these signals to determine whether the HCLS lens is relevant:
+
+**Strong signals** (any one of these suggests HCLS lens is relevant):
+- PHI, ePHI, Protected Health Information
+- HIPAA, HITRUST, GxP, FDA 21 CFR Part 11
+- FHIR, HL7, CDA, CCD-A
+- EHR, EMR, Electronic Health Record, Electronic Medical Record
+- Patient data, patient records, patient portal
+- Clinical data, clinical trials, clinical decision support
+- SMART on FHIR
+- BAA, Business Associate Agreement
+- De-identification, Safe Harbor method
+- US Core profiles, International Patient Summary
+
+**Supporting signals** (multiple together suggest HCLS lens):
+- Healthcare, health system, hospital, provider, payer
+- Life sciences, pharma, pharmaceutical, biotech
+- Medical devices, medical imaging, diagnostics
+- SNOMED CT, LOINC, ICD-10, RxNorm, CVX, NUCC
+- Consent management (in a healthcare context)
+- Health Information Exchange, HIE
+- ONC, CMS Interoperability
+- Bulk Data Access, population health
+- Audit trail for data access (in a healthcare context)
+
+## Sub-Extensions
+
+When the HCLS lens is enabled, present opt-in prompts for these sub-extensions:
+- `compliance/hcls-compliance.opt-in.md`
+- `data-handling/hcls-data-handling.opt-in.md`
+- `interoperability/hcls-interoperability.opt-in.md`
+
+## Lens Confirmation Prompt
+
+When detection signals are found, present this confirmation to the user:
+
+```markdown
+## Question: Industry Lens
+Based on your requirements, this project involves healthcare data and systems. The HCLS (Healthcare & Life Sciences) lens adds rules for regulatory compliance, PHI data handling, and clinical interoperability.
+
+A) Enable HCLS lens (recommended based on project context). You will be asked which specific HCLS sub-extensions to enable next.
+B) Skip. No industry-specific lens needed for this project.
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]:
+```
+
+When NO detection signals are found, do NOT present this question. Skip the lens entirely.

--- a/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
@@ -92,7 +92,19 @@ Analyze whatever the user has provided:
 
 ### Step 5.1: Extension Opt-In Prompts
 
-**MANDATORY**: Scan all loaded `*.opt-in.md` files (loaded at workflow start from `extensions/` subdirectories) for an `## Opt-In Prompt` section. For each extension that declares one, include that question in the clarifying questions file created in Step 6.
+**MANDATORY**: Present extension opt-in prompts in the clarifying questions file created in Step 6.
+
+**Non-lens extensions** (loaded at workflow start): Scan all loaded `*.opt-in.md` files for an `## Opt-In Prompt` section. For each extension that declares one, include that question in the clarifying questions file.
+
+**Lens-gated extensions** (deferred from workflow start): For each loaded `lens-descriptor.md`:
+1. Analyze the user's vision document, requirements, and initial request against the descriptor's **Detection Signals** section
+2. If one or more **strong signals** are found, OR if multiple **supporting signals** are found together, the lens is relevant:
+   - Include the lens confirmation prompt (from the descriptor's `## Lens Confirmation Prompt` section) in the clarifying questions file
+   - If the user confirms the lens (answers A/Yes), load all `*.opt-in.md` files from the lens's sub-directories and include their opt-in prompts in a follow-up question file (or append to the same file if answers have not yet been collected)
+   - If the user declines the lens (answers B/No), skip all sub-extensions under that lens. Record the lens as disabled in `aidlc-docs/aidlc-state.md`
+3. If no detection signals are found, skip the lens entirely. Do not present the lens confirmation prompt. The lens's sub-extension opt-in prompts are never shown.
+
+This ensures that only industry-relevant extensions are presented to the user. A non-healthcare project will never see HCLS opt-in questions; a non-financial project will never see FSI opt-in questions.
 
 After receiving answers:
 1. Record each extension's enablement status in `aidlc-docs/aidlc-state.md` under `## Extension Configuration`:

--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -30,14 +30,21 @@ All subsequent rule detail file references (e.g., `common/process-overview.md`, 
 
 **Loading process**:
 1. List all subdirectories under `extensions/` (e.g., `extensions/security/`, `extensions/compliance/`)
-2. In each subdirectory, load ONLY `*.opt-in.md` files — these contain the extension's opt-in prompt. The corresponding rules file is derived by convention: strip the `.opt-in.md` suffix and append `.md` (e.g., `security-baseline.opt-in.md` → `security-baseline.md`)
-3. Do NOT load full rule files (e.g., `security-baseline.md`) at this stage
+2. Check for `lens-descriptor.md` files in top-level extension category directories (e.g., `extensions/hcls/lens-descriptor.md`). If found, load only the descriptor (lightweight). Do NOT load the lens's `*.opt-in.md` files yet. These are deferred to Requirements Analysis where the model evaluates whether the lens is relevant based on the project context and the descriptor's detection signals.
+3. For extensions NOT inside a lens directory (i.e., no sibling or parent `lens-descriptor.md`), load `*.opt-in.md` files as usual. The corresponding rules file is derived by convention: strip the `.opt-in.md` suffix and append `.md` (e.g., `security-baseline.opt-in.md` → `security-baseline.md`)
+4. Do NOT load full rule files (e.g., `security-baseline.md`) at this stage
 
 **Deferred Rule Loading**:
 - During Requirements Analysis, opt-in prompts from the loaded `*.opt-in.md` files are presented to the user
 - When the user opts IN for an extension, load the corresponding rules file (derived by naming convention) at that point
 - When the user opts OUT, the full rules file is never loaded — saving context
 - Extensions without a matching `*.opt-in.md` file are always enforced — load their rule files immediately at workflow start
+
+**Lens-Gated Extensions**:
+- Extensions organized under a lens (identified by a `lens-descriptor.md` in their parent directory) are context-gated. During Requirements Analysis, the model analyzes the user's requirements against the lens descriptor's detection signals.
+- If strong signals are detected, the model presents the lens confirmation prompt from the descriptor. If the user confirms, the lens's `*.opt-in.md` files are loaded and its sub-extension opt-in prompts are included in the clarifying questions.
+- If no detection signals are found, the lens is skipped entirely. Its opt-in prompts are never presented, saving context and avoiding irrelevant questions.
+- This mechanism allows multiple industry lenses (HCLS, FSI, Manufacturing, etc.) to coexist under `extensions/` without every project being asked about every industry.
 
 **Enforcement** (applies only to loaded/enabled extensions):
 - Extension rules are hard constraints, not optional guidance

--- a/docs/writing-inputs/example-minimal-tech-env-hcls-fhir-patient-portal.md
+++ b/docs/writing-inputs/example-minimal-tech-env-hcls-fhir-patient-portal.md
@@ -1,0 +1,145 @@
+# Technical Environment: HealthBridge FHIR Patient Portal API
+
+## Language and Package Manager
+
+- **Java 21** (LTS) with **Spring Boot 3.3+**
+- **Gradle 8.x** with Kotlin DSL (`build.gradle.kts`)
+- **HAPI FHIR 7.x** for FHIR R4 resource handling, validation, and parsing
+
+## FHIR Framework
+
+- **HAPI FHIR Server** as the FHIR facade (not a full HAPI JPA Server — we use it as a framework, not a data store)
+- **HAPI FHIR Validation** for US Core profile validation using the official IG package
+- **HAPI FHIR Client** for upstream EHR integrations (Epic, Cerner, Athenahealth)
+- Content types: `application/fhir+json` primary, `application/fhir+xml` supported
+
+## Cloud and Deployment
+
+- **AWS**, multi-account strategy:
+  - **Workload account**: Application services, API Gateway, compute
+  - **Data account**: PHI data stores, encryption keys
+  - **Audit account**: CloudTrail logs, compliance audit trail
+- **Primary region**: `us-east-1`, **DR region**: `us-west-2`
+- **Compute**: ECS Fargate (containerized Spring Boot) — not Lambda (HAPI FHIR cold starts are too slow for Lambda)
+- **API Gateway**: Amazon API Gateway (REST API type) with custom authorizer for SMART on FHIR token validation
+- **Data stores**:
+  - **Amazon HealthLake** for FHIR resource storage and search (BAA-eligible, FHIR-native)
+  - **Amazon DynamoDB** for tenant configuration, consent records, and session management
+  - **Amazon S3** for Bulk Data Export output (NDJSON files), clinical documents (CCD-A, discharge summaries)
+- **Encryption**: AWS KMS with Customer Managed Keys (CMKs) — separate CMK per tenant, separate CMK for audit logs
+- **Networking**: Private subnets for all compute and data, VPC endpoints for AWS services, no public internet access for data-plane components
+- **Infrastructure as Code**: AWS CDK (TypeScript) for all infrastructure — no manual console changes
+- **Container registry**: Amazon ECR with image scanning enabled
+
+## Authentication and Authorization
+
+- **SMART on FHIR** via Spring Security OAuth2 Resource Server
+- **Token issuer**: Amazon Cognito (or customer's existing IdP via OIDC federation)
+- Scope enforcement: `patient/*.read`, `user/*.read`, `system/*.read`, `system/*.write`
+- Backend service auth: SMART Backend Services (JWT assertion with `client_credentials` grant)
+- Break-glass: Time-limited admin token with mandatory post-access review logged in audit trail
+
+## Data Handling
+
+- **PHI encryption at rest**: AES-256 via KMS CMK (per-tenant keys), envelope encryption for S3 objects
+- **PHI encryption in transit**: TLS 1.2+ enforced everywhere, mTLS between ECS services
+- **De-identification**: Safe Harbor method implemented as a streaming transform — runs at export time before writing to the analytics S3 bucket
+- **Data residency**: PHI locked to `us-east-1` and `us-west-2` only, enforced via SCPs
+- **Backup**: HealthLake automated backups (daily), DynamoDB PITR enabled, S3 versioning + cross-account replication to audit account
+- **Log sanitization**: Custom Logback filter strips PHI fields before writing to CloudWatch Logs
+
+## Terminology
+
+- **ICD-10-CM**: Diagnoses (Condition resource)
+- **SNOMED CT**: Clinical findings, body structures (Condition, Observation)
+- **LOINC**: Lab tests, vital signs, document types (Observation, DocumentReference)
+- **RxNorm**: Medications (MedicationRequest)
+- **CVX**: Vaccines (Immunization)
+- **NUCC**: Provider taxonomy (Practitioner)
+- Terminology server: **HAPI FHIR terminology service** backed by ValueSet/CodeSystem resources loaded from the official FHIR package registry
+
+## Testing
+
+- **JUnit 5** with Spring Boot Test
+- **HAPI FHIR Validator** for automated US Core profile validation in integration tests
+- **Testcontainers** for local DynamoDB and ECS integration testing
+- **Touchstone** (HL7 FHIR testing platform) for ONC certification testing
+- **JaCoCo** for code coverage (85% line coverage minimum)
+- **OWASP Dependency Check** for vulnerability scanning
+- **Trivy** for container image scanning
+
+## Monitoring and Observability
+
+- **Amazon CloudWatch** for metrics, logs, and alarms
+- **AWS X-Ray** for distributed tracing (FHIR request → ECS → HealthLake → response)
+- **Amazon CloudWatch Anomaly Detection** for PHI access pattern monitoring
+- **AWS CloudTrail** for API-level audit (data events enabled for HealthLake, S3, DynamoDB)
+- **Custom compliance dashboard**: CloudWatch dashboard showing audit log metrics, consent enforcement stats, de-identification pipeline throughput
+
+## Do NOT Use
+
+| Prohibited | Reason | Use Instead |
+|---|---|---|
+| Lambda for FHIR server | HAPI FHIR cold start too slow (>10s) | ECS Fargate |
+| RDS/Aurora for FHIR data | Not FHIR-native, requires manual mapping | Amazon HealthLake |
+| Self-managed HAPI JPA Server | Operational overhead for persistence layer | HealthLake + HAPI facade |
+| Non-BAA-eligible AWS services for PHI | HIPAA violation | Only BAA-eligible services |
+| `System.out.println` for logging | No sanitization, no structured format | SLF4J + Logback with PHI filter |
+| Storing PHI in environment variables | Secrets exposure risk | AWS Secrets Manager or SSM Parameter Store (SecureString) |
+| Public S3 buckets | PHI exposure risk | Private buckets + pre-signed URLs |
+| TLS < 1.2 | Does not meet HIPAA Security Rule | TLS 1.2+ enforced via security policies |
+
+## Example Code Patterns
+
+### FHIR Resource Endpoint
+
+```java
+@RestController
+@RequestMapping("/fhir/r4")
+public class PatientController {
+
+    private final PatientService patientService;
+    private final AuditService auditService;
+    private final ConsentService consentService;
+
+    @GetMapping("/Patient/{id}")
+    public ResponseEntity<String> getPatient(
+            @PathVariable String id,
+            @AuthenticationPrincipal SmartOnFhirToken token) {
+
+        // Consent check before PHI access
+        consentService.assertAccessAllowed(token.getPatientId(), id, "read", "Patient");
+
+        Patient patient = patientService.findById(id, token.getTenantId());
+
+        // Audit log — resource ref only, no PHI in log
+        auditService.logAccess(token.getSubject(), "Patient", id, "read",
+                "GET /fhir/r4/Patient/" + id);
+
+        String fhirJson = FhirContext.forR4().newJsonParser()
+                .encodeResourceToString(patient);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.valueOf("application/fhir+json"))
+                .body(fhirJson);
+    }
+}
+```
+
+### PHI Log Sanitization Filter
+
+```java
+public class PhiSanitizingFilter extends Filter<ILoggingEvent> {
+    private static final Set<String> PHI_PATTERNS = Set.of(
+        "ssn", "mrn", "patientName", "dateOfBirth", "address",
+        "phoneNumber", "email", "insuranceId"
+    );
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        // Replace PHI field values with [REDACTED] before log output
+        // Implementation: scan structured arguments, mask matching keys
+        return FilterReply.NEUTRAL;
+    }
+}
+```

--- a/docs/writing-inputs/example-minimal-vision-hcls-fhir-patient-portal.md
+++ b/docs/writing-inputs/example-minimal-vision-hcls-fhir-patient-portal.md
@@ -1,0 +1,62 @@
+# Vision: HealthBridge FHIR Patient Portal API
+
+## Executive Summary
+
+HealthBridge is a FHIR R4-compliant API layer that gives patients secure access to their health records from multiple provider systems. Instead of every hospital building their own patient portal backend, they integrate with HealthBridge. We deploy it as a managed service on AWS, fully HIPAA-compliant, and sell it to healthcare provider organizations as a SaaS subscription.
+
+## Features In Scope (MVP)
+
+- **Patient record aggregation**: Ingest and normalize patient data from multiple EHR systems via FHIR R4 interfaces (Epic, Cerner, Athenahealth)
+- **FHIR R4 API**: Expose Patient, Condition, Observation (vitals + lab results), MedicationRequest, AllergyIntolerance, Immunization, Encounter, and DocumentReference resources
+- **SMART on FHIR authorization**: Support EHR Launch and Standalone Launch for third-party patient apps
+- **Patient consent management**: Capture and enforce patient consent preferences for data sharing — treatment, payment, healthcare operations (TPO) and granular research opt-in/out
+- **Clinical document access**: Serve CCD-A and discharge summary documents via DocumentReference with binary download
+- **Provider directory**: Expose Practitioner and Organization resources for the care team view
+- **Audit trail**: Immutable audit log for every PHI access event (who, what, when, why, how) — queryable by compliance team
+- **US Core compliance**: All resources validate against US Core Implementation Guide profiles
+- **Terminology support**: ICD-10, SNOMED CT, LOINC, RxNorm, CVX — proper CodeSystem/ValueSet bindings on all CodeableConcept fields
+- **Bulk Data Export**: FHIR Bulk Data Access (Flat FHIR) for population health analytics and quality reporting — NDJSON export with `_since` and `_type` filtering
+- **PHI de-identification pipeline**: Safe Harbor method de-identification for research/analytics data exports — strips all 18 HIPAA identifiers
+- **Multi-tenant**: Each provider organization is an isolated tenant with its own encryption keys, data partition, and access policies
+
+## Features Explicitly Out of Scope (MVP)
+
+- Real-time clinical decision support / CDS Hooks (Phase 2)
+- Patient messaging / secure chat (Phase 2)
+- Appointment scheduling via FHIR Scheduling resources (Phase 2)
+- Claims and billing integration — ExplanationOfBenefit, Coverage resources (Phase 2)
+- Patient-reported outcomes (Questionnaire/QuestionnaireResponse) (Phase 2)
+- International Patient Summary (IPS) profile support (Phase 3 — US market first)
+- On-premises / hybrid deployment (Phase 3)
+- FHIR Subscriptions for real-time event notifications (Phase 3)
+
+## Target Users
+
+- **Healthcare provider organizations** (hospitals, health systems, clinics) that need a patient-facing API without building one from scratch
+- **Digital health startups** building patient engagement apps that need a FHIR-compliant backend
+- **Health Information Exchanges (HIEs)** that need a standards-compliant aggregation layer
+- **Life sciences / pharma companies** that need de-identified patient data for research (via Bulk Data Export + de-identification)
+
+## Key Success Metrics
+
+- 5 provider organization tenants onboarded within 6 months
+- FHIR R4 validation: 100% of resources pass US Core profile validation
+- API uptime: 99.95%
+- Response time: p50 under 200ms for single-resource reads, p99 under 2s
+- HIPAA compliance: zero audit findings on PHI access controls
+- Bulk Data Export: process 100K patient records in under 30 minutes
+- Consent enforcement: 100% of data sharing requests checked against patient consent
+
+## Regulatory and Compliance Context
+
+- **HIPAA**: Full compliance with Privacy Rule, Security Rule, and Breach Notification Rule
+- **ONC 21st Century Cures Act**: Support information blocking prevention — patients must be able to access all their EHI without delay
+- **CMS Interoperability Rules**: FHIR R4 API required for patient access
+- **State regulations**: Design for extensible retention policies (state medical record retention varies from 5 to 10+ years)
+
+## Open Questions
+
+- Should we support FHIR R5 resources alongside R4, or strictly R4 for MVP?
+- What is the target SLA for consent revocation taking effect — immediate vs. within 24 hours?
+- Should Bulk Data Export support Group-level exports (specific patient cohorts) in MVP, or only system-level and Patient-level?
+- How should we handle EHR systems that only support FHIR DSTU2 — transform to R4 at ingestion or reject?


### PR DESCRIPTION
---

# Summary

Adds a modular Healthcare & Life Sciences (HCLS) lens to AI-DLC as the first industry-vertical extension. The lens introduces 17 blocking rules across three independently opt-in-able sub-extensions (Compliance, Data Handling, Interoperability) and a context-aware auto-detection mechanism so that only healthcare projects are prompted with HCLS-specific questions.

## Changes

**New: HCLS lens extension** (`extensions/hcls/`) — 7 files:
- `lens-descriptor.md` — Detection signals (strong + supporting) for the model to auto-detect healthcare context from project requirements
- `compliance/hcls-compliance.opt-in.md` + `hcls-compliance.md` — 7 rules (HCLS-COMP-01→07): PHI/PII data classification, audit trails for PHI access, BAA-eligible AWS services only, minimum necessary access, data retention and disposal, breach notification design, consent management
- `data-handling/hcls-data-handling.opt-in.md` + `hcls-data-handling.md` — 5 rules (HCLS-DATA-01→05): PHI encryption standards (AES-256/KMS CMK), HIPAA Safe Harbor / Expert Determination de-identification, cross-region data residency, backup and recovery for PHI, log sanitization
- `interoperability/hcls-interoperability.opt-in.md` + `hcls-interoperability.md` — 5 rules (HCLS-INTOP-01→05): FHIR R4 compliance, SMART on FHIR authorization, US Core / IPS profile validation, terminology binding (ICD-10, SNOMED CT, LOINC, RxNorm), Bulk Data Export

**Modified: Core workflow** (`aws-aidlc-rules/core-workflow.md`):
- Extensions Loading section updated to support lens-gated extension loading via `lens-descriptor.md` files. Non-lens extensions (security, testing) continue to load as before. Lens-gated extensions are deferred to Requirements Analysis where the model evaluates project context.

**Modified: Requirements Analysis** (`inception/requirements-analysis.md`):
- Step 5.1 updated with lens auto-detection logic. The model analyzes the user's requirements against detection signals in the lens descriptor, presents a single lens confirmation prompt only if relevant, then loads the lens's sub-extension opt-ins upon user confirmation.

**New: Example input documents** (`docs/writing-inputs/`):
- `example-minimal-vision-hcls-fhir-patient-portal.md` — Vision document for a FHIR R4 patient portal (HealthBridge)
- `example-minimal-tech-env-hcls-fhir-patient-portal.md` — Technical environment (Java/Spring Boot, HAPI FHIR, Amazon HealthLake, multi-account AWS)

**Modified: README.md**:
- HCLS lens added to extensions directory tree
- HCLS lens documentation section with rule summary table, enablement levels, and disclaimer

## User experience

**Before:** All projects see all extension opt-in prompts regardless of industry relevance. No healthcare-specific rules exist.

**After:**
- **HCLS project** (vision mentions PHI, FHIR, HIPAA, etc.): Model auto-detects healthcare context → presents a single "Enable HCLS lens?" confirmation → if confirmed, presents 3 sub-extension opt-ins (Compliance, Data Handling, Interoperability) with full/partial/off options → enabled rules are enforced as blocking constraints throughout all subsequent stages
- **Non-HCLS project** (e.g., a calculator API): No healthcare signals detected → HCLS lens is skipped entirely → user never sees any HCLS-related questions
- **Future lenses** (FSI, Manufacturing): Follow the same pattern — add a `lens-descriptor.md` + sub-extension files under `extensions/<industry>/`. No further core workflow changes needed.

## Checklist

* [x] I have reviewed the [[contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

1. **Generic project (negative test):** Open `test-generic-project/` in Kiro (CalcEngine Scientific Calculator API). Run AI-DLC workflow. Verify:
   - No HCLS lens confirmation prompt appears
   - Only Security Baseline and Property-Based Testing opt-ins are shown
   - Workflow proceeds as before with no HCLS rules enforced

2. **HCLS project (positive test):** Open `test-hcls-project/` in Kiro (HealthBridge FHIR Patient Portal). Run AI-DLC workflow. Verify:
   - Model detects healthcare signals from `docs/vision.md` (PHI, FHIR, HIPAA, patient data, EHR)
   - HCLS lens confirmation prompt is presented ("Enable HCLS lens?")
   - Upon confirming, 3 sub-extension opt-ins appear (Compliance, Data Handling, Interoperability)
   - Opted-in rules are enforced as blocking constraints in subsequent stages
   - Stage completion messages include HCLS rule compliance summaries (HCLS-COMP-xx, HCLS-DATA-xx, HCLS-INTOP-xx)

3. **Partial enablement:** In the HCLS project, select "Partial" for one sub-extension. Verify only the partial rule subset is enforced (e.g., HCLS-COMP-01 and HCLS-COMP-02 only for Compliance partial).

4. **Non-lens extensions unaffected:** Verify Security Baseline and Property-Based Testing continue to work identically in both projects.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).