### PR TITLE
fix: Clarify zip download file name in Quick Start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AI-DLC is an intelligent software development workflow that adapts to your needs
 
 ## Quick Start
 
-1. Download the latest release zip from the [Releases page](../../releases/latest) to a folder **outside** your project directory (e.g., `~/Downloads`).
+1. Download the latest release zip file named `ai-dlc-rules-v<release-number>.zip` from the [Releases page](../../releases/latest) to a folder **outside** your project directory (e.g., `~/Downloads`).
 2. Extract the zip. It contains an `aidlc-rules/` folder with two subdirectories:
    - `aws-aidlc-rules/` — the core AI-DLC workflow rules
    - `aws-aidlc-rule-details/` — detailed rules conditionally referenced by the core rules


### PR DESCRIPTION
# Summary

Clarify zip download file name in Quick Start instructions

## Changes

Updates the README Quick Start section to explicitly mention the expected zip file name (ai-dlc-rules-v<release-number>.zip) when downloading from the Releases page. Previously, the instruction just said "download the latest release zip," which was ambiguous as the release page multiple assets.

## User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [*] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [*] I have performed a self-review of this change
* [*] Changes have been tested
* [*] Changes are documented

## Test Plan

Ensured the instruction is correct and matches the file name

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
