### PR TITLE
fix: explicitly set tag_name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,13 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
           draft: true
           name: "AI-DLC Workflow v${{ steps.version.outputs.version }}"
           body: |
             Release v${{ steps.version.outputs.version }}
             
-            See [CHANGELOG.md](CHANGELOG.md) for details.
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ steps.version.outputs.tag }}/CHANGELOG.md) for details.
             
             ## Downloads
             - **ai-dlc-rules** - Rules format (Amazon Q, Kiro, etc.)

--- a/.kiro/steering/pr-conventions.md
+++ b/.kiro/steering/pr-conventions.md
@@ -1,0 +1,12 @@
+# Pull Request Conventions
+
+When creating pull requests in this repository, always include the following in the PR body:
+
+1. Use the structure from `.github/pull_request_template.md`
+2. The PR description MUST end with this contributor statement (required by CI):
+
+```
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
+```
+
+Without this statement, the `Require Contributor Statement` CI check will fail.

--- a/.kiro/steering/pr-conventions.md
+++ b/.kiro/steering/pr-conventions.md
@@ -5,7 +5,7 @@ When creating pull requests in this repository, always include the following in 
 1. Use the structure from `.github/pull_request_template.md`
 2. The PR description MUST end with this contributor statement (required by CI):
 
-```
+```text
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
 ```
 


### PR DESCRIPTION
## Summary

Fixes the v0.1.8 draft release being created with an `untagged-*` slug instead of being associated with the `v0.1.8` tag, and adds a Kiro steering file to prevent missing the contributor statement in future PRs.

## Changes

### 1. Fix release workflow tag association

The v0.1.8 draft release was created as `releases/tag/untagged-bfb61f621c7818a82994` instead of `releases/tag/v0.1.8`. This caused the relative `CHANGELOG.md` link to resolve incorrectly.

**Root cause:** `softprops/action-gh-release` without an explicit `tag_name` parameter relies on `GITHUB_REF` being correct at runtime. Race conditions (tag deletion/recreation) or re-runs can cause the release to end up untagged.

**Fix:**
- Add explicit `tag_name` parameter to ensure correct tag association
- Pin `CHANGELOG.md` link to an absolute URL with the tag ref

### 2. Add Kiro steering file for PR conventions

Adds `.kiro/steering/pr-conventions.md` so that Kiro CLI always includes the required contributor statement when creating PRs for this repo.

## Test Plan

- After merging, re-run the release workflow on the `v0.1.8` tag — it should produce a properly tagged draft release
- Future PRs created via Kiro CLI will include the contributor statement automatically

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).