### PR TITLE
feat: detect and flag infrastructure failures in trend reports

### DIFF
--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/__init__.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/__init__.py
@@ -19,6 +19,8 @@ from trend_reports.gate import check_regressions
 from trend_reports.models import (
     BaselineMetrics,
     GateResult,
+    InfraFailure,
+    InfraFailureReason,
     RunData,
     RunType,
     SemVer,
@@ -33,6 +35,8 @@ from trend_reports.render_yaml import render_trend_yaml
 __all__ = [
     "BaselineMetrics",
     "GateResult",
+    "InfraFailure",
+    "InfraFailureReason",
     "RunData",
     "RunType",
     "SemVer",

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/__main__.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/__main__.py
@@ -217,6 +217,11 @@ def cmd_trend(
         # 5. Gate
         if gate:
             result = check_regressions(trend)
+            if result.infra_failure_detected:
+                print(
+                    f"Gate WARNING: {result.infra_failure_summary}",
+                    file=sys.stderr,
+                )
             if result.passed:
                 print(
                     f"Gate PASSED: {result.latest_label} vs {result.comparison_label} "

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/collector.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/collector.py
@@ -18,6 +18,8 @@ from .models import (
     ContractTestResults,
     DocumentScore,
     HandoffMetrics,
+    InfraFailure,
+    InfraFailureReason,
     QualitativeComparison,
     RunConfig,
     RunData,
@@ -147,14 +149,20 @@ def parse_run_metrics(yaml_path: Path) -> RunMetrics:
 
     hp = raw.get("handoff_patterns", {})
     errors = raw.get("errors", {})
+    throttle_events = errors.get("throttle_events", 0)
+    timeout_events = errors.get("timeout_events", 0)
+    failed_tool_calls = errors.get("failed_tool_calls", 0)
+    model_error_events = errors.get("model_error_events", 0)
+    service_unavailable_events = errors.get("service_unavailable_events", 0)
+    validation_error_events = errors.get("validation_error_events", 0)
     error_count = sum(
         [
-            errors.get("throttle_events", 0),
-            errors.get("timeout_events", 0),
-            errors.get("failed_tool_calls", 0),
-            errors.get("model_error_events", 0),
-            errors.get("service_unavailable_events", 0),
-            errors.get("validation_error_events", 0),
+            throttle_events,
+            timeout_events,
+            failed_tool_calls,
+            model_error_events,
+            service_unavailable_events,
+            validation_error_events,
         ]
     )
 
@@ -175,6 +183,12 @@ def parse_run_metrics(yaml_path: Path) -> RunMetrics:
         handoffs=handoffs,
         server_startup_success=True,
         error_count=error_count,
+        throttle_events=throttle_events,
+        service_unavailable_events=service_unavailable_events,
+        model_error_events=model_error_events,
+        timeout_events=timeout_events,
+        failed_tool_calls=failed_tool_calls,
+        validation_error_events=validation_error_events,
     )
 
 
@@ -215,12 +229,17 @@ def parse_contract_tests(yaml_path: Path) -> ContractTestResults:
                 )
             )
 
+    server_started = raw.get("server_started", True)
+    server_error = raw.get("server_error") or ""
+
     return ContractTestResults(
         total=total,
         passed=passed,
         failed=failed,
         pass_rate=pass_rate,
         failures=failures,
+        server_started=server_started,
+        server_error=server_error,
     )
 
 
@@ -302,6 +321,59 @@ def classify_run(rules_ref: str) -> tuple[RunType, str, SemVer | None, int | Non
 
 
 # ---------------------------------------------------------------------------
+# Infrastructure failure detection
+# ---------------------------------------------------------------------------
+
+
+def detect_infra_failure(
+    meta: RunMeta,
+    metrics: RunMetrics,
+    contract_tests: ContractTestResults,
+    has_metrics_file: bool,
+) -> InfraFailure:
+    """Detect infrastructure failures from run signals.
+
+    Conservative: only flags clear infra issues, not ambiguous cases.
+    """
+    reasons: list[InfraFailureReason] = []
+
+    # Signal 1: Bedrock infra errors in run-metrics.yaml
+    if metrics.throttle_events > 0:
+        reasons.append(InfraFailureReason.THROTTLED)
+    if metrics.service_unavailable_events > 0:
+        reasons.append(InfraFailureReason.SERVICE_UNAVAILABLE)
+    if metrics.model_error_events > 0:
+        reasons.append(InfraFailureReason.MODEL_ERROR)
+
+    # Signal 2: run-meta.yaml status indicates failure/crash
+    status_lower = meta.status.lower() if meta.status else ""
+    if "failed" in status_lower:
+        reasons.append(InfraFailureReason.RUN_FAILED)
+    elif not meta.status or meta.status.strip() == "":
+        reasons.append(InfraFailureReason.RUN_CRASHED)
+
+    # Signal 3: run-metrics.yaml missing entirely (swarm crashed before writing)
+    if not has_metrics_file:
+        reasons.append(InfraFailureReason.METRICS_MISSING)
+
+    # Signal 4: Server failed to start (from contract-test-results.yaml)
+    if not contract_tests.server_started:
+        reasons.append(InfraFailureReason.SERVER_START_FAILED)
+
+    if not reasons:
+        return InfraFailure(is_infra_failure=False)
+
+    reason_strs = [r.value for r in reasons]
+    summary = f"Infrastructure failure detected: {', '.join(reason_strs)}"
+
+    return InfraFailure(
+        is_infra_failure=True,
+        reasons=reasons,
+        summary=summary,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Collection pipeline
 # ---------------------------------------------------------------------------
 
@@ -319,11 +391,8 @@ def _collect_from_run_dir(run_dir: Path, source_label: str) -> RunData:
     meta = parse_run_meta(yaml_files["run-meta"])
     run_type, label, semver, pr_number = classify_run(meta.config.rules_ref)
 
-    metrics = (
-        parse_run_metrics(yaml_files["run-metrics"])
-        if "run-metrics" in yaml_files
-        else RunMetrics()
-    )
+    has_metrics_file = "run-metrics" in yaml_files
+    metrics = parse_run_metrics(yaml_files["run-metrics"]) if has_metrics_file else RunMetrics()
     unit_tests = (
         parse_test_results(yaml_files["test-results"])
         if "test-results" in yaml_files
@@ -334,6 +403,10 @@ def _collect_from_run_dir(run_dir: Path, source_label: str) -> RunData:
         if "contract-test-results" in yaml_files
         else ContractTestResults()
     )
+
+    # Propagate actual server_started to metrics
+    metrics.server_startup_success = contract_tests.server_started
+
     code_quality = (
         parse_quality_report(yaml_files["quality-report"])
         if "quality-report" in yaml_files
@@ -346,12 +419,17 @@ def _collect_from_run_dir(run_dir: Path, source_label: str) -> RunData:
     )
 
     # Backfill artifact counts from run-metrics if available
-    if "run-metrics" in yaml_files:
+    if has_metrics_file:
         raw_metrics = _load_yaml(yaml_files["run-metrics"])
         workspace = raw_metrics.get("artifacts", {}).get("workspace", {})
         code_quality.source_file_count = workspace.get("source_files", 0)
         code_quality.test_file_count = workspace.get("test_files", 0)
         code_quality.total_lines_of_code = workspace.get("total_lines_of_code", 0)
+
+    # Detect infrastructure failures
+    infra_failure = detect_infra_failure(meta, metrics, contract_tests, has_metrics_file)
+    if infra_failure.is_infra_failure:
+        logger.warning("Infra failure detected in %s: %s", source_label, infra_failure.summary)
 
     return RunData(
         label=label,
@@ -364,6 +442,7 @@ def _collect_from_run_dir(run_dir: Path, source_label: str) -> RunData:
         contract_tests=contract_tests,
         code_quality=code_quality,
         qualitative=qualitative,
+        infra_failure=infra_failure,
     )
 
 

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/gate.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/gate.py
@@ -12,6 +12,9 @@ def check_regressions(trend: TrendData) -> GateResult:
     - Contract test pass rate decreased
     - Unit test failures appeared (> 0 when previous had 0)
     - Qualitative overall score decreased by more than 0.02
+
+    If the latest run is an infrastructure failure, the gate passes with
+    an annotation — results from infra-failed runs are unreliable.
     """
     latest, previous = find_latest_and_previous(trend)
     if latest is None or previous is None:
@@ -21,6 +24,36 @@ def check_regressions(trend: TrendData) -> GateResult:
             latest_label=latest.label if latest else "",
             comparison_label=previous.label if previous else "",
         )
+
+    # If the latest run is an infra failure, skip regression checks
+    if latest.infra_failure.is_infra_failure:
+        return GateResult(
+            passed=True,
+            regressions=[],
+            latest_label=latest.label,
+            comparison_label=previous.label,
+            infra_failure_detected=True,
+            infra_failure_summary=(
+                f"Latest run ({latest.label}) was an infrastructure failure: "
+                f"{latest.infra_failure.summary}. "
+                "Regression check skipped — results are unreliable."
+            ),
+        )
+
+    # If the comparison run is an infra failure, find a non-infra alternative
+    if previous.infra_failure.is_infra_failure:
+        previous = _find_non_infra_previous(trend, latest)
+        if previous is None:
+            return GateResult(
+                passed=True,
+                regressions=[],
+                latest_label=latest.label,
+                comparison_label="",
+                infra_failure_detected=True,
+                infra_failure_summary=(
+                    "No non-infra-failure comparison run available. Regression check skipped."
+                ),
+            )
 
     regressions: list[str] = []
 
@@ -50,6 +83,27 @@ def check_regressions(trend: TrendData) -> GateResult:
         latest_label=latest.label,
         comparison_label=previous.label,
     )
+
+
+def _find_non_infra_previous(trend: TrendData, latest: RunData) -> RunData | None:
+    """Find the most recent non-infra-failure run suitable for comparison."""
+    candidates = [r for r in trend.runs if r is not latest]
+
+    if latest.run_type == RunType.RELEASE:
+        for run in reversed(candidates):
+            if run.run_type == RunType.RELEASE and not run.infra_failure.is_infra_failure:
+                return run
+    else:
+        for run in reversed(candidates):
+            if run.run_type == RunType.RELEASE and not run.infra_failure.is_infra_failure:
+                return run
+
+    # Fallback: any non-infra run
+    for run in reversed(candidates):
+        if not run.infra_failure.is_infra_failure:
+            return run
+
+    return None
 
 
 def find_latest_and_previous(

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/models.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/models.py
@@ -34,6 +34,27 @@ class RunType(Enum):
     PR = "pr"
 
 
+class InfraFailureReason(Enum):
+    """Reasons why a run is classified as an infrastructure failure."""
+
+    THROTTLED = "bedrock_throttled"
+    SERVICE_UNAVAILABLE = "bedrock_service_unavailable"
+    MODEL_ERROR = "bedrock_model_error"
+    RUN_FAILED = "run_failed"
+    RUN_CRASHED = "run_crashed"
+    SERVER_START_FAILED = "server_start_failed"
+    METRICS_MISSING = "metrics_missing"
+
+
+@dataclass
+class InfraFailure:
+    """Details about an infrastructure failure detected in a run."""
+
+    is_infra_failure: bool = False
+    reasons: list[InfraFailureReason] = field(default_factory=list)
+    summary: str = ""
+
+
 @dataclass(frozen=True, order=True)
 class SemVer:
     """Semantic version, comparable via tuple ordering."""
@@ -119,6 +140,12 @@ class RunMetrics:
     handoffs: list[HandoffMetrics] = field(default_factory=list)
     server_startup_success: bool = True
     error_count: int = 0
+    throttle_events: int = 0
+    service_unavailable_events: int = 0
+    model_error_events: int = 0
+    timeout_events: int = 0
+    failed_tool_calls: int = 0
+    validation_error_events: int = 0
 
 
 @dataclass
@@ -152,6 +179,8 @@ class ContractTestResults:
     failed: int = 0
     pass_rate: float = 0.0
     failures: list[ContractTestFailure] = field(default_factory=list)
+    server_started: bool = True
+    server_error: str = ""
 
 
 @dataclass
@@ -210,6 +239,7 @@ class RunData:
     contract_tests: ContractTestResults
     code_quality: CodeQualityMetrics
     qualitative: QualitativeComparison
+    infra_failure: InfraFailure = field(default_factory=InfraFailure)
 
 
 @dataclass
@@ -258,3 +288,5 @@ class GateResult:
     regressions: list[str] = field(default_factory=list)
     latest_label: str = ""
     comparison_label: str = ""
+    infra_failure_detected: bool = False
+    infra_failure_summary: str = ""

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_html.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_html.py
@@ -19,6 +19,7 @@ def render_trend_html(trend: TrendData) -> str:
     parts = [
         _html_header("AIDLC Rules Trend Report"),
         _render_html_hero(trend),
+        _render_infra_failure_banner_html(trend),
         _render_nav(),
         _render_html_section_a(trend),
         _render_html_section_b(trend),
@@ -168,6 +169,16 @@ td:first-child { font-weight: 500; }
 /* Section description */
 .section-desc { color: var(--gray-500); font-size: 14px; margin: 0 0 12px 0; }
 
+/* Infra failure banner */
+.infra-banner {
+    padding: 16px 20px; margin: 0 0 24px 0;
+    background: var(--red-bg); border: 2px solid var(--red-border);
+    border-radius: var(--radius); color: var(--red-text);
+}
+.infra-banner h3 { margin: 0 0 8px 0; color: var(--red-text); font-size: 16px; }
+.infra-banner ul { margin: 4px 0 0 0; padding-left: 20px; }
+.badge-infra { background: var(--red-bg); color: var(--red-text); border: 1px solid var(--red-border); }
+
 /* Responsive */
 @media (max-width: 768px) {
     body { padding: 12px; }
@@ -224,6 +235,27 @@ def _render_nav() -> str:
     return f'<nav class="nav">{items}</nav>\n'
 
 
+def _render_infra_failure_banner_html(trend: TrendData) -> str:
+    """Render a prominent warning banner if any runs have infra failures."""
+    infra_runs = [r for r in trend.runs if r.infra_failure.is_infra_failure]
+    if not infra_runs:
+        return ""
+
+    items = []
+    for r in infra_runs:
+        reasons = ", ".join(reason.value for reason in r.infra_failure.reasons)
+        items.append(f"<li><strong>{escape(r.label)}</strong>: {escape(reasons)}</li>")
+
+    return (
+        '<div class="infra-banner">\n'
+        "  <h3>Infrastructure Failure Detected</h3>\n"
+        "  <p>The following runs experienced infrastructure failures. "
+        "Their results are unreliable and have been excluded from regression checks.</p>\n"
+        f"  <ul>{''.join(items)}</ul>\n"
+        "</div>\n"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Section A — Executive Summary
 # ---------------------------------------------------------------------------
@@ -248,14 +280,10 @@ def _render_html_section_a(trend: TrendData) -> str:
         else ("warn" if latest.contract_tests.pass_rate >= 0.95 else "bad")
     )
     unit_pass_rate = (
-        latest.unit_tests.passed / latest.unit_tests.total
-        if latest.unit_tests.total > 0
-        else 0.0
+        latest.unit_tests.passed / latest.unit_tests.total if latest.unit_tests.total > 0 else 0.0
     )
     bl_unit_pass_rate = (
-        bl.unit_tests_passed / bl.unit_tests_total
-        if bl.unit_tests_total > 0
-        else 0.0
+        bl.unit_tests_passed / bl.unit_tests_total if bl.unit_tests_total > 0 else 0.0
     )
     test_status = "good" if unit_pass_rate >= 1.0 else ("warn" if unit_pass_rate >= 0.95 else "bad")
     lint_status = "good" if latest.code_quality.lint_findings == 0 else "warn"
@@ -354,7 +382,9 @@ def _render_html_section_a(trend: TrendData) -> str:
         table_rows.append([label, golden, latest_val, vs])
         # Color the delta column based on metric direction
         delta_cls = ""
-        if vs not in ("=", "—") and (vs.startswith("+") or vs.startswith("-") or vs.startswith("−")):
+        if vs not in ("=", "—") and (
+            vs.startswith("+") or vs.startswith("-") or vs.startswith("−")
+        ):
             is_negative = vs.startswith("-") or vs.startswith("−")
             if label.lower() in lower_is_better:
                 delta_cls = "d-pos" if is_negative else "d-neg"
@@ -499,9 +529,7 @@ def _render_html_section_c(trend: TrendData) -> str:
     )
     bl_score = trend.baseline.qualitative_overall
     if bl_score:
-        parts.append(
-            f"<p>Golden baseline: <strong>{bl_score:.3f}</strong></p>\n"
-        )
+        parts.append(f"<p>Golden baseline: <strong>{bl_score:.3f}</strong></p>\n")
     parts.append("</div>\n<div>\n")
 
     rows = []
@@ -659,7 +687,14 @@ def _render_html_section_d(trend: TrendData) -> str:
             f"H{h.handoff_number}: {format_seconds_as_minutes(h.duration_seconds)}"
             for h in r.metrics.handoffs
         ]
-        rows.append([r.label, bar_html, format_seconds_as_minutes(r.metrics.execution_time_seconds), " · ".join(handoff_strs) if handoff_strs else "—"])
+        rows.append(
+            [
+                r.label,
+                bar_html,
+                format_seconds_as_minutes(r.metrics.execution_time_seconds),
+                " · ".join(handoff_strs) if handoff_strs else "—",
+            ]
+        )
         styles.append(["", "bar-cell", "", ""])
     parts.append(_html_table(["Version", "", "Wall Clock", "Handoff Breakdown"], rows, styles))
     parts.append("</div>\n</div>\n")
@@ -736,25 +771,61 @@ def _render_html_section_f(trend: TrendData) -> str:
     parts.append(
         '<p class="section-desc">Tracks whether the evaluation pipeline itself ran smoothly, independent of output quality.</p>\n'
         "<table>\n<thead>\n<tr>\n  <th>Metric</th>\n  <th>What it measures</th>\n</tr>\n</thead>\n<tbody>\n"
-        "<tr><td><strong>Error Events</strong></td><td>Runtime errors logged during the run (exceptions, timeouts, API failures). 0 = clean run.</td></tr>\n"
-        "<tr><td><strong>Handoffs</strong></td><td>Number of sequential pipeline phases completed. Typically 3 (generate, build/test, report). A different count may indicate an early abort or retry.</td></tr>\n"
-        "<tr><td><strong>Server Startup</strong></td><td>Whether the generated application server started successfully. A failure here means the generated code couldn&rsquo;t even boot, preventing contract tests from running.</td></tr>\n"
+        "<tr><td><strong>Infra Failure</strong></td><td>Whether infrastructure issues (Bedrock outage, throttling) invalidated the run.</td></tr>\n"
+        "<tr><td><strong>Total Errors</strong></td><td>Sum of all runtime error events. 0 = clean run.</td></tr>\n"
+        "<tr><td><strong>Throttle</strong></td><td>Bedrock API throttle (rate limit) events.</td></tr>\n"
+        "<tr><td><strong>Svc Unavail</strong></td><td>Bedrock service unavailable events.</td></tr>\n"
+        "<tr><td><strong>Model Error</strong></td><td>Bedrock model error events.</td></tr>\n"
+        "<tr><td><strong>Handoffs</strong></td><td>Number of sequential pipeline phases completed. Typically 3.</td></tr>\n"
+        "<tr><td><strong>Server Startup</strong></td><td>Whether the generated application server started successfully.</td></tr>\n"
         "</tbody>\n</table>\n"
     )
     rows = []
     styles = []
     for r in trend.runs:
         ok = r.metrics.server_startup_success
+        infra_html = (
+            '<span class="badge badge-infra">INFRA FAIL</span>'
+            if r.infra_failure.is_infra_failure
+            else '<span class="badge badge-pass">OK</span>'
+        )
         err_cls = "d-neg" if r.metrics.error_count > 0 else ""
+        throttle_cls = "d-neg" if r.metrics.throttle_events > 0 else ""
+        svc_cls = "d-neg" if r.metrics.service_unavailable_events > 0 else ""
+        model_cls = "d-neg" if r.metrics.model_error_events > 0 else ""
         ok_html = (
             '<span class="badge badge-pass">PASS</span>'
             if ok
             else '<span class="badge badge-fail">FAIL</span>'
         )
-        rows.append([r.label, str(r.metrics.error_count), str(r.metrics.num_handoffs), ok_html])
-        styles.append(["", err_cls, "", ""])
+        rows.append(
+            [
+                r.label,
+                infra_html,
+                str(r.metrics.error_count),
+                str(r.metrics.throttle_events),
+                str(r.metrics.service_unavailable_events),
+                str(r.metrics.model_error_events),
+                str(r.metrics.num_handoffs),
+                ok_html,
+            ]
+        )
+        styles.append(["", "", err_cls, throttle_cls, svc_cls, model_cls, "", ""])
     parts.append(
-        _html_table(["Version", "Error Events", "Handoffs", "Server Startup"], rows, styles)
+        _html_table(
+            [
+                "Version",
+                "Infra Status",
+                "Total Errors",
+                "Throttle",
+                "Svc Unavail",
+                "Model Error",
+                "Handoffs",
+                "Server Startup",
+            ],
+            rows,
+            styles,
+        )
     )
     return "".join(parts)
 

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_md.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_md.py
@@ -18,6 +18,7 @@ def render_trend_markdown(trend: TrendData) -> str:
     """Render the full trend report as Markdown."""
     sections = [
         _render_header(trend),
+        _render_infra_failure_banner(trend),
         _render_toc(),
         _render_section_a(trend),
         _render_section_b(trend),
@@ -46,6 +47,26 @@ def _render_header(trend: TrendData) -> str:
         f"> **Repository:** `{trend.repo}`  \n"
         f"> **Generated:** {trend.generated_at}\n"
     )
+
+
+def _render_infra_failure_banner(trend: TrendData) -> str:
+    """Render a prominent warning banner if any runs have infra failures."""
+    infra_runs = [r for r in trend.runs if r.infra_failure.is_infra_failure]
+    if not infra_runs:
+        return ""
+
+    lines = [
+        "> **WARNING: Infrastructure Failure Detected**",
+        ">",
+        "> The following runs experienced infrastructure failures. "
+        "Their results are unreliable and have been excluded from regression checks.",
+        ">",
+    ]
+    for r in infra_runs:
+        reasons = ", ".join(reason.value for reason in r.infra_failure.reasons)
+        lines.append(f"> - **{r.label}**: {reasons}")
+    lines.append("")
+    return "\n".join(lines) + "\n"
 
 
 def _render_toc() -> str:
@@ -449,20 +470,42 @@ def _render_section_f(trend: TrendData) -> str:
         "Tracks whether the evaluation pipeline itself ran smoothly, independent of output quality.\n\n"
         "| Metric | What it measures |\n"
         "| --- | --- |\n"
-        "| **Error Events** | Runtime errors logged during the run (exceptions, timeouts, API failures). 0 = clean run. |\n"
+        "| **Infra Failure** | Whether infrastructure issues (Bedrock outage, throttling) invalidated the run. |\n"
+        "| **Total Errors** | Sum of all runtime error events. |\n"
+        "| **Throttle** | Bedrock API throttle (rate limit) events. |\n"
+        "| **Svc Unavail** | Bedrock service unavailable events. |\n"
+        "| **Model Error** | Bedrock model error events. |\n"
         "| **Handoffs** | Number of sequential pipeline phases completed. Typically 3 (generate, build/test, report). A different count may indicate an early abort or retry. |\n"
         "| **Server Startup** | Whether the generated application server started successfully. A failure here means the generated code couldn't even boot, preventing contract tests from running. |\n\n"
     )
     rows = [
         [
             r.label,
+            "**YES**" if r.infra_failure.is_infra_failure else "No",
             str(r.metrics.error_count),
+            str(r.metrics.throttle_events),
+            str(r.metrics.service_unavailable_events),
+            str(r.metrics.model_error_events),
             str(r.metrics.num_handoffs),
             "Yes" if r.metrics.server_startup_success else "**No**",
         ]
         for r in trend.runs
     ]
-    parts.append(_md_table(["Version", "Error Events", "Handoffs", "Server Startup"], rows))
+    parts.append(
+        _md_table(
+            [
+                "Version",
+                "Infra Failure",
+                "Total Errors",
+                "Throttle",
+                "Svc Unavail",
+                "Model Error",
+                "Handoffs",
+                "Server Startup",
+            ],
+            rows,
+        )
+    )
     return "\n".join(parts)
 
 

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_md.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_md.py
@@ -58,8 +58,10 @@ def _render_infra_failure_banner(trend: TrendData) -> str:
     lines = [
         "> **WARNING: Infrastructure Failure Detected**",
         ">",
-        "> The following runs experienced infrastructure failures. "
-        "Their results are unreliable and have been excluded from regression checks.",
+        (
+            "> The following runs experienced infrastructure failures. "
+            "Their results are unreliable and have been excluded from regression checks."
+        ),
         ">",
     ]
     for r in infra_runs:

--- a/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_yaml.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/src/trend_reports/render_yaml.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import dataclasses
+from enum import Enum
 
 import yaml
 
-from .models import RunType, SemVer, TrendData
+from .models import SemVer, TrendData
 
 
 def render_trend_yaml(trend: TrendData) -> str:
@@ -19,13 +20,10 @@ def _serialize(obj: object) -> object:
     """Recursively convert dataclasses, enums, and custom types to plain dicts."""
     if isinstance(obj, SemVer):
         return str(obj)
-    if isinstance(obj, RunType):
+    if isinstance(obj, Enum):
         return obj.value
     if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
-        return {
-            f.name: _serialize(getattr(obj, f.name))
-            for f in dataclasses.fields(obj)
-        }
+        return {f.name: _serialize(getattr(obj, f.name)) for f in dataclasses.fields(obj)}
     if isinstance(obj, list):
         return [_serialize(item) for item in obj]
     if isinstance(obj, dict):

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/conftest.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/conftest.py
@@ -7,6 +7,7 @@ from trend_reports.models import (
     CodeQualityMetrics,
     ContractTestResults,
     DocumentScore,
+    InfraFailure,
     QualitativeComparison,
     RunConfig,
     RunData,
@@ -34,6 +35,7 @@ def make_run(
     document_scores: list[DocumentScore] | None = None,
     inception_score: float = 0.0,
     construction_score: float = 0.0,
+    infra_failure: InfraFailure | None = None,
 ) -> RunData:
     """Create a RunData instance for testing."""
     if semver is None and run_type == RunType.RELEASE:
@@ -65,6 +67,7 @@ def make_run(
             construction_score=construction_score,
             document_scores=document_scores or [],
         ),
+        infra_failure=infra_failure or InfraFailure(),
     )
 
 

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_collector.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_collector.py
@@ -642,7 +642,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics()
         contract = ContractTestResults(server_started=True)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is False
+        assert not result.is_infra_failure
         assert result.reasons == []
 
     def test_throttle_events_flagged(self):
@@ -650,7 +650,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics(throttle_events=5)
         contract = ContractTestResults(server_started=True)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert InfraFailureReason.THROTTLED in result.reasons
 
     def test_service_unavailable_flagged(self):
@@ -658,7 +658,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics(service_unavailable_events=3)
         contract = ContractTestResults(server_started=True)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert InfraFailureReason.SERVICE_UNAVAILABLE in result.reasons
 
     def test_model_error_flagged(self):
@@ -666,7 +666,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics(model_error_events=1)
         contract = ContractTestResults(server_started=True)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert InfraFailureReason.MODEL_ERROR in result.reasons
 
     def test_run_failed_status(self):
@@ -674,7 +674,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics()
         contract = ContractTestResults(server_started=True)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert InfraFailureReason.RUN_FAILED in result.reasons
 
     def test_missing_status_means_crash(self):
@@ -682,7 +682,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics()
         contract = ContractTestResults(server_started=True)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert InfraFailureReason.RUN_CRASHED in result.reasons
 
     def test_metrics_missing(self):
@@ -690,7 +690,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics()
         contract = ContractTestResults(server_started=True)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=False)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert InfraFailureReason.METRICS_MISSING in result.reasons
 
     def test_server_start_failed(self):
@@ -698,7 +698,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics()
         contract = ContractTestResults(server_started=False, server_error="Connection refused")
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert InfraFailureReason.SERVER_START_FAILED in result.reasons
 
     def test_multiple_reasons(self):
@@ -706,7 +706,7 @@ class TestDetectInfraFailure:
         metrics = RunMetrics(throttle_events=10, service_unavailable_events=5)
         contract = ContractTestResults(server_started=False)
         result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
-        assert result.is_infra_failure is True
+        assert result.is_infra_failure
         assert len(result.reasons) >= 3
         assert "Infrastructure failure detected" in result.summary
 

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_collector.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_collector.py
@@ -17,6 +17,7 @@ from trend_reports.collector import (
     collect_from_zip,
     collect_trend_data,
     compute_deltas,
+    detect_infra_failure,
     extract_zip,
     find_yaml_files,
     load_baseline,
@@ -30,6 +31,11 @@ from trend_reports.collector import (
 )
 from trend_reports.models import (
     CollectorError,
+    ContractTestResults,
+    InfraFailureReason,
+    RunConfig,
+    RunMeta,
+    RunMetrics,
     RunType,
     SemVer,
 )
@@ -482,26 +488,48 @@ class TestCollectFromDirectory:
     def test_full_directory(self, tmp_path):
         run_dir = tmp_path / "run-001"
         run_dir.mkdir()
-        _write_yaml(run_dir / "run-meta.yaml", {
-            "run_folder": "run-001",
-            "config": {"rules_ref": "v0.1.5"},
-        })
-        _write_yaml(run_dir / "run-metrics.yaml", {
-            "tokens": {"total": {"total_tokens": 9000000}},
-            "timing": {"total_wall_clock_ms": 600000},
-        })
-        _write_yaml(run_dir / "test-results.yaml", {
-            "test": {"parsed_results": {"passed": 175, "failed": 0, "total": 175}},
-        })
-        _write_yaml(run_dir / "contract-test-results.yaml", {
-            "total": 88, "passed": 88, "failed": 0,
-        })
-        _write_yaml(run_dir / "quality-report.yaml", {
-            "lint": {}, "summary": {"lint_total": 0},
-        })
-        _write_yaml(run_dir / "qualitative-comparison.yaml", {
-            "overall_score": 0.898, "phases": [],
-        })
+        _write_yaml(
+            run_dir / "run-meta.yaml",
+            {
+                "run_folder": "run-001",
+                "config": {"rules_ref": "v0.1.5"},
+            },
+        )
+        _write_yaml(
+            run_dir / "run-metrics.yaml",
+            {
+                "tokens": {"total": {"total_tokens": 9000000}},
+                "timing": {"total_wall_clock_ms": 600000},
+            },
+        )
+        _write_yaml(
+            run_dir / "test-results.yaml",
+            {
+                "test": {"parsed_results": {"passed": 175, "failed": 0, "total": 175}},
+            },
+        )
+        _write_yaml(
+            run_dir / "contract-test-results.yaml",
+            {
+                "total": 88,
+                "passed": 88,
+                "failed": 0,
+            },
+        )
+        _write_yaml(
+            run_dir / "quality-report.yaml",
+            {
+                "lint": {},
+                "summary": {"lint_total": 0},
+            },
+        )
+        _write_yaml(
+            run_dir / "qualitative-comparison.yaml",
+            {
+                "overall_score": 0.898,
+                "phases": [],
+            },
+        )
 
         run = collect_from_directory(run_dir)
         assert run.label == "v0.1.5"
@@ -529,10 +557,13 @@ class TestCollectFromDirectory:
     def test_missing_optional_files_use_defaults(self, tmp_path):
         run_dir = tmp_path / "run-minimal"
         run_dir.mkdir()
-        _write_yaml(run_dir / "run-meta.yaml", {
-            "run_folder": "run-002",
-            "config": {"rules_ref": "v0.1.0"},
-        })
+        _write_yaml(
+            run_dir / "run-meta.yaml",
+            {
+                "run_folder": "run-002",
+                "config": {"rules_ref": "v0.1.0"},
+            },
+        )
         run = collect_from_directory(run_dir)
         assert run.unit_tests.passed == 0
         assert run.contract_tests.total == 0
@@ -549,33 +580,203 @@ class TestCollectTrendDataDirectoryDispatch:
         # Create a directory bundle
         run_dir = tmp_path / "dir-bundle"
         run_dir.mkdir()
-        _write_yaml(run_dir / "run-meta.yaml", {
-            "run_folder": "run-dir", "config": {"rules_ref": "pr-42"},
-        })
+        _write_yaml(
+            run_dir / "run-meta.yaml",
+            {
+                "run_folder": "run-dir",
+                "config": {"rules_ref": "pr-42"},
+            },
+        )
         _write_yaml(run_dir / "run-metrics.yaml", {"tokens": {"total": {}}, "timing": {}})
         _write_yaml(run_dir / "test-results.yaml", {"test": {"parsed_results": {}}})
-        _write_yaml(run_dir / "contract-test-results.yaml", {
-            "total": 0, "passed": 0, "failed": 0,
-        })
+        _write_yaml(
+            run_dir / "contract-test-results.yaml",
+            {
+                "total": 0,
+                "passed": 0,
+                "failed": 0,
+            },
+        )
         _write_yaml(run_dir / "quality-report.yaml", {"lint": {}, "summary": {}})
-        _write_yaml(run_dir / "qualitative-comparison.yaml", {
-            "overall_score": 0.5, "phases": [],
-        })
+        _write_yaml(
+            run_dir / "qualitative-comparison.yaml",
+            {
+                "overall_score": 0.5,
+                "phases": [],
+            },
+        )
 
         # Create a zip bundle
-        zip_path = _make_report_zip(tmp_path, {
-            "run-meta.yaml": {"run_folder": "run-zip", "config": {"rules_ref": "v0.1.0"}},
-            "run-metrics.yaml": {"tokens": {"total": {}}, "timing": {}},
-            "test-results.yaml": {"test": {"parsed_results": {}}},
-            "contract-test-results.yaml": {"total": 0, "passed": 0, "failed": 0},
-            "quality-report.yaml": {"lint": {}, "summary": {}},
-            "qualitative-comparison.yaml": {"overall_score": 0.6, "phases": []},
-        })
+        zip_path = _make_report_zip(
+            tmp_path,
+            {
+                "run-meta.yaml": {"run_folder": "run-zip", "config": {"rules_ref": "v0.1.0"}},
+                "run-metrics.yaml": {"tokens": {"total": {}}, "timing": {}},
+                "test-results.yaml": {"test": {"parsed_results": {}}},
+                "contract-test-results.yaml": {"total": 0, "passed": 0, "failed": 0},
+                "quality-report.yaml": {"lint": {}, "summary": {}},
+                "qualitative-comparison.yaml": {"overall_score": 0.6, "phases": []},
+            },
+        )
 
         baseline_path = tmp_path / "golden.yaml"
         _write_yaml(baseline_path, {})
 
         trend = collect_trend_data(
-            [zip_path, run_dir], baseline_path, "test/repo", tmp_path / "work",
+            [zip_path, run_dir],
+            baseline_path,
+            "test/repo",
+            tmp_path / "work",
         )
         assert len(trend.runs) == 2
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure failure detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectInfraFailure:
+    def test_clean_run_no_failure(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.COMPLETED")
+        metrics = RunMetrics()
+        contract = ContractTestResults(server_started=True)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is False
+        assert result.reasons == []
+
+    def test_throttle_events_flagged(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.COMPLETED")
+        metrics = RunMetrics(throttle_events=5)
+        contract = ContractTestResults(server_started=True)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is True
+        assert InfraFailureReason.THROTTLED in result.reasons
+
+    def test_service_unavailable_flagged(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.COMPLETED")
+        metrics = RunMetrics(service_unavailable_events=3)
+        contract = ContractTestResults(server_started=True)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is True
+        assert InfraFailureReason.SERVICE_UNAVAILABLE in result.reasons
+
+    def test_model_error_flagged(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.COMPLETED")
+        metrics = RunMetrics(model_error_events=1)
+        contract = ContractTestResults(server_started=True)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is True
+        assert InfraFailureReason.MODEL_ERROR in result.reasons
+
+    def test_run_failed_status(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.FAILED")
+        metrics = RunMetrics()
+        contract = ContractTestResults(server_started=True)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is True
+        assert InfraFailureReason.RUN_FAILED in result.reasons
+
+    def test_missing_status_means_crash(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="")
+        metrics = RunMetrics()
+        contract = ContractTestResults(server_started=True)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is True
+        assert InfraFailureReason.RUN_CRASHED in result.reasons
+
+    def test_metrics_missing(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.COMPLETED")
+        metrics = RunMetrics()
+        contract = ContractTestResults(server_started=True)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=False)
+        assert result.is_infra_failure is True
+        assert InfraFailureReason.METRICS_MISSING in result.reasons
+
+    def test_server_start_failed(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.COMPLETED")
+        metrics = RunMetrics()
+        contract = ContractTestResults(server_started=False, server_error="Connection refused")
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is True
+        assert InfraFailureReason.SERVER_START_FAILED in result.reasons
+
+    def test_multiple_reasons(self):
+        meta = RunMeta(run_id="r1", config=RunConfig(rules_ref="v0.1.0"), status="Status.FAILED")
+        metrics = RunMetrics(throttle_events=10, service_unavailable_events=5)
+        contract = ContractTestResults(server_started=False)
+        result = detect_infra_failure(meta, metrics, contract, has_metrics_file=True)
+        assert result.is_infra_failure is True
+        assert len(result.reasons) >= 3
+        assert "Infrastructure failure detected" in result.summary
+
+
+class TestParseRunMetricsIndividualErrors:
+    def test_individual_error_fields_populated(self, tmp_path):
+        path = tmp_path / "run-metrics.yaml"
+        _write_yaml(
+            path,
+            {
+                "tokens": {"total": {"total_tokens": 100}},
+                "timing": {"total_wall_clock_ms": 1000},
+                "errors": {
+                    "throttle_events": 3,
+                    "service_unavailable_events": 2,
+                    "model_error_events": 1,
+                    "timeout_events": 4,
+                    "failed_tool_calls": 5,
+                    "validation_error_events": 6,
+                },
+            },
+        )
+        metrics = parse_run_metrics(path)
+        assert metrics.throttle_events == 3
+        assert metrics.service_unavailable_events == 2
+        assert metrics.model_error_events == 1
+        assert metrics.timeout_events == 4
+        assert metrics.failed_tool_calls == 5
+        assert metrics.validation_error_events == 6
+        assert metrics.error_count == 21
+
+    def test_missing_errors_default_to_zero(self, tmp_path):
+        path = tmp_path / "run-metrics.yaml"
+        _write_yaml(path, {"tokens": {"total": {}}, "timing": {}})
+        metrics = parse_run_metrics(path)
+        assert metrics.throttle_events == 0
+        assert metrics.service_unavailable_events == 0
+        assert metrics.error_count == 0
+
+
+class TestParseContractTestsServerStarted:
+    def test_server_started_true(self, tmp_path):
+        path = tmp_path / "contract-test-results.yaml"
+        _write_yaml(
+            path,
+            {"total": 88, "passed": 88, "failed": 0, "server_started": True, "server_error": None},
+        )
+        result = parse_contract_tests(path)
+        assert result.server_started is True
+        assert result.server_error == ""
+
+    def test_server_started_false(self, tmp_path):
+        path = tmp_path / "contract-test-results.yaml"
+        _write_yaml(
+            path,
+            {
+                "total": 0,
+                "passed": 0,
+                "failed": 0,
+                "server_started": False,
+                "server_error": "Connection refused",
+            },
+        )
+        result = parse_contract_tests(path)
+        assert result.server_started is False
+        assert result.server_error == "Connection refused"
+
+    def test_server_started_missing_defaults_true(self, tmp_path):
+        path = tmp_path / "contract-test-results.yaml"
+        _write_yaml(path, {"total": 88, "passed": 88, "failed": 0})
+        result = parse_contract_tests(path)
+        assert result.server_started is True
+        assert result.server_error == ""

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_gate.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_gate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from conftest import make_run, make_trend
 from trend_reports.gate import check_regressions, find_latest_and_previous
-from trend_reports.models import RunType
+from trend_reports.models import InfraFailure, InfraFailureReason, RunType
 
 
 class TestCheckRegressions:
@@ -93,3 +93,64 @@ class TestFindLatestAndPrevious:
         latest, prev = find_latest_and_previous(make_trend(r1, r_pr))
         assert latest is r_pr
         assert prev is r1
+
+
+class TestCheckRegressionsInfraFailure:
+    def test_latest_infra_failure_skips_regression(self):
+        """If latest run is an infra failure, gate passes with annotation."""
+        r1 = make_run("v0.1.0", qualitative_score=0.90)
+        r2 = make_run(
+            "v0.1.1",
+            qualitative_score=0.0,
+            contract_passed=0,
+            contract_total=88,
+            infra_failure=InfraFailure(
+                is_infra_failure=True,
+                reasons=[InfraFailureReason.THROTTLED],
+                summary="Infrastructure failure detected: bedrock_throttled",
+            ),
+        )
+        result = check_regressions(make_trend(r1, r2))
+        assert result.passed is True
+        assert result.infra_failure_detected is True
+        assert result.regressions == []
+        assert "infrastructure" in result.infra_failure_summary.lower()
+
+    def test_previous_infra_failure_finds_older_comparison(self):
+        """If comparison run is infra failure, gate should find an older non-infra run."""
+        r1 = make_run("v0.1.0", qualitative_score=0.90)
+        r2 = make_run(
+            "v0.1.1",
+            qualitative_score=0.0,
+            infra_failure=InfraFailure(
+                is_infra_failure=True,
+                reasons=[InfraFailureReason.SERVICE_UNAVAILABLE],
+                summary="test",
+            ),
+        )
+        r3 = make_run("v0.1.2", qualitative_score=0.91)
+        result = check_regressions(make_trend(r1, r2, r3))
+        assert result.passed is True
+        assert result.comparison_label == "v0.1.0"
+
+    def test_non_infra_failure_still_detects_regression(self):
+        """Normal runs should still trigger regressions as before."""
+        r1 = make_run("v0.1.0", qualitative_score=0.90)
+        r2 = make_run("v0.1.1", qualitative_score=0.85)
+        result = check_regressions(make_trend(r1, r2))
+        assert result.passed is False
+        assert result.infra_failure_detected is False
+
+    def test_all_runs_infra_failure_gate_passes(self):
+        """If all comparison candidates are infra failures, gate passes with annotation."""
+        infra = InfraFailure(
+            is_infra_failure=True,
+            reasons=[InfraFailureReason.THROTTLED],
+            summary="test",
+        )
+        r1 = make_run("v0.1.0", infra_failure=infra)
+        r2 = make_run("v0.1.1", qualitative_score=0.90)
+        result = check_regressions(make_trend(r1, r2))
+        # Latest is not infra, but comparison is; should skip with annotation
+        assert result.passed is True
+        assert result.infra_failure_detected is True

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_models.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_models.py
@@ -8,6 +8,8 @@ from trend_reports.models import (
     CollectorError,
     FetchError,
     GateResult,
+    InfraFailure,
+    InfraFailureReason,
     RunType,
     SemVer,
     TrendReportError,
@@ -82,3 +84,33 @@ class TestDataclassDefaults:
         gr = GateResult(passed=True)
         assert gr.regressions == []
         assert gr.latest_label == ""
+        assert gr.infra_failure_detected is False
+        assert gr.infra_failure_summary == ""
+
+
+class TestInfraFailure:
+    def test_defaults_no_failure(self):
+        inf = InfraFailure()
+        assert inf.is_infra_failure is False
+        assert inf.reasons == []
+        assert inf.summary == ""
+
+    def test_with_reasons(self):
+        inf = InfraFailure(
+            is_infra_failure=True,
+            reasons=[InfraFailureReason.THROTTLED, InfraFailureReason.SERVICE_UNAVAILABLE],
+            summary="test summary",
+        )
+        assert inf.is_infra_failure is True
+        assert len(inf.reasons) == 2
+
+
+class TestInfraFailureReason:
+    def test_values(self):
+        assert InfraFailureReason.THROTTLED.value == "bedrock_throttled"
+        assert InfraFailureReason.SERVICE_UNAVAILABLE.value == "bedrock_service_unavailable"
+        assert InfraFailureReason.MODEL_ERROR.value == "bedrock_model_error"
+        assert InfraFailureReason.RUN_FAILED.value == "run_failed"
+        assert InfraFailureReason.RUN_CRASHED.value == "run_crashed"
+        assert InfraFailureReason.SERVER_START_FAILED.value == "server_start_failed"
+        assert InfraFailureReason.METRICS_MISSING.value == "metrics_missing"

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_models.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_models.py
@@ -91,7 +91,7 @@ class TestDataclassDefaults:
 class TestInfraFailure:
     def test_defaults_no_failure(self):
         inf = InfraFailure()
-        assert inf.is_infra_failure is False
+        assert not inf.is_infra_failure
         assert inf.reasons == []
         assert inf.summary == ""
 
@@ -101,7 +101,7 @@ class TestInfraFailure:
             reasons=[InfraFailureReason.THROTTLED, InfraFailureReason.SERVICE_UNAVAILABLE],
             summary="test summary",
         )
-        assert inf.is_infra_failure is True
+        assert inf.is_infra_failure
         assert len(inf.reasons) == 2
 
 

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_render_html.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_render_html.py
@@ -5,19 +5,18 @@ Smoke tests verify the output is valid HTML with expected sections.
 
 from __future__ import annotations
 
-from conftest import make_run
+from conftest import make_run, make_trend
 from trend_reports.models import (
     BaselineMetrics,
+    InfraFailure,
+    InfraFailureReason,
     TrendData,
 )
 from trend_reports.render_html import render_trend_html
 
 
 def _make_trend(*labels: str) -> TrendData:
-    runs = [
-        make_run(label, qualitative_score=0.85 + i * 0.02)
-        for i, label in enumerate(labels)
-    ]
+    runs = [make_run(label, qualitative_score=0.85 + i * 0.02) for i, label in enumerate(labels)]
     return TrendData(
         runs=runs,
         baseline=BaselineMetrics(
@@ -74,3 +73,40 @@ class TestRenderTrendHtml:
         trend = _make_trend("v0.1.0")
         result = render_trend_html(trend)
         assert "<style>" in result
+
+
+class TestInfraFailureBannerHtml:
+    def test_no_banner_when_no_infra_failure(self):
+        trend = _make_trend("v0.1.0", "v0.1.1")
+        result = render_trend_html(trend)
+        assert '<div class="infra-banner">' not in result
+
+    def test_banner_when_infra_failure(self):
+        r1 = make_run("v0.1.0")
+        r2 = make_run(
+            "v0.1.1",
+            infra_failure=InfraFailure(
+                is_infra_failure=True,
+                reasons=[InfraFailureReason.THROTTLED],
+                summary="bedrock_throttled",
+            ),
+        )
+        trend = make_trend(r1, r2)
+        result = render_trend_html(trend)
+        assert "infra-banner" in result
+        assert "v0.1.1" in result
+
+    def test_section_f_shows_infra_badge(self):
+        r1 = make_run("v0.1.0")
+        r2 = make_run(
+            "v0.1.1",
+            infra_failure=InfraFailure(
+                is_infra_failure=True,
+                reasons=[InfraFailureReason.THROTTLED],
+                summary="test",
+            ),
+        )
+        trend = make_trend(r1, r2)
+        result = render_trend_html(trend)
+        assert "badge-infra" in result
+        assert "INFRA FAIL" in result

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_render_md.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_render_md.py
@@ -6,19 +6,18 @@ various inputs. Does not validate exact Markdown formatting.
 
 from __future__ import annotations
 
-from conftest import make_run
+from conftest import make_run, make_trend
 from trend_reports.models import (
     BaselineMetrics,
+    InfraFailure,
+    InfraFailureReason,
     TrendData,
 )
 from trend_reports.render_md import render_trend_markdown
 
 
 def _make_trend(*labels: str) -> TrendData:
-    runs = [
-        make_run(label, qualitative_score=0.85 + i * 0.02)
-        for i, label in enumerate(labels)
-    ]
+    runs = [make_run(label, qualitative_score=0.85 + i * 0.02) for i, label in enumerate(labels)]
     return TrendData(
         runs=runs,
         baseline=BaselineMetrics(
@@ -73,3 +72,41 @@ class TestRenderTrendMarkdown:
         trend = _make_trend("v0.1.0")
         result = render_trend_markdown(trend)
         assert "v0.1.0" in result
+
+
+class TestInfraFailureBannerMd:
+    def test_no_banner_when_no_infra_failure(self):
+        trend = _make_trend("v0.1.0", "v0.1.1")
+        result = render_trend_markdown(trend)
+        assert "Infrastructure Failure" not in result
+
+    def test_banner_when_infra_failure(self):
+        r1 = make_run("v0.1.0")
+        r2 = make_run(
+            "v0.1.1",
+            infra_failure=InfraFailure(
+                is_infra_failure=True,
+                reasons=[InfraFailureReason.THROTTLED],
+                summary="bedrock_throttled",
+            ),
+        )
+        trend = make_trend(r1, r2)
+        result = render_trend_markdown(trend)
+        assert "Infrastructure Failure" in result
+        assert "v0.1.1" in result
+        assert "bedrock_throttled" in result
+
+    def test_section_f_shows_infra_failure_column(self):
+        r1 = make_run("v0.1.0")
+        r2 = make_run(
+            "v0.1.1",
+            infra_failure=InfraFailure(
+                is_infra_failure=True,
+                reasons=[InfraFailureReason.THROTTLED],
+                summary="test",
+            ),
+        )
+        trend = make_trend(r1, r2)
+        result = render_trend_markdown(trend)
+        assert "Infra Failure" in result
+        assert "**YES**" in result

--- a/scripts/aidlc-evaluator/packages/trend-reports/tests/test_render_yaml.py
+++ b/scripts/aidlc-evaluator/packages/trend-reports/tests/test_render_yaml.py
@@ -7,6 +7,8 @@ from trend_reports.models import (
     BaselineMetrics,
     CodeQualityMetrics,
     ContractTestResults,
+    InfraFailure,
+    InfraFailureReason,
     QualitativeComparison,
     RunConfig,
     RunData,
@@ -72,3 +74,29 @@ class TestRenderTrendYaml:
         trend = _make_trend()
         result = render_trend_yaml(trend)
         assert isinstance(result, str)
+
+    def test_infra_failure_serialized(self):
+        trend = _make_trend()
+        trend.runs[0].infra_failure = InfraFailure(
+            is_infra_failure=True,
+            reasons=[InfraFailureReason.THROTTLED],
+            summary="test",
+        )
+        yaml_str = render_trend_yaml(trend)
+        parsed = yaml.safe_load(yaml_str)
+        infra = parsed["runs"][0]["infra_failure"]
+        assert infra["is_infra_failure"] is True
+        assert "bedrock_throttled" in infra["reasons"]
+        assert infra["summary"] == "test"
+
+    def test_infra_failure_reason_serialized_as_value(self):
+        trend = _make_trend()
+        trend.runs[0].infra_failure = InfraFailure(
+            is_infra_failure=True,
+            reasons=[InfraFailureReason.SERVICE_UNAVAILABLE, InfraFailureReason.RUN_FAILED],
+            summary="test",
+        )
+        yaml_str = render_trend_yaml(trend)
+        parsed = yaml.safe_load(yaml_str)
+        reasons = parsed["runs"][0]["infra_failure"]["reasons"]
+        assert reasons == ["bedrock_service_unavailable", "run_failed"]


### PR DESCRIPTION
## Summary

- When Bedrock is unavailable during evaluation (throttling, service outages), runs produce 0 test passes and the trend report incorrectly signals a regression. This change adds infrastructure failure detection so the gate skips unreliable runs instead of firing false regressions.
- Adds `InfraFailureReason` enum and `InfraFailure` dataclass with conservative detection logic covering: Bedrock throttling, service unavailable, model errors, run failures/crashes, missing metrics, and server start failures.
- The regression gate now passes with an annotation when the latest run is an infra failure, and falls back to an older clean run when the comparison run is an infra failure.
- Both MD and HTML renderers show a prominent warning banner at the top of the report, and Section F is expanded with per-error-type columns (throttle, svc unavail, model error) and an infra failure flag.

## Test plan

- [x] All 174 existing + new unit tests pass (`uv run pytest packages/trend-reports/tests/ -v`)
- [x] Smoke tested with synthetic infra failure bundle — detection, gate skip, and report rendering all work correctly
- [ ] Verify trend report renders correctly in CodeBuild pipeline when Bedrock is healthy (no false positives)
- [ ] Verify trend report correctly flags infra failure when Bedrock is degraded

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).