### PR TITLE
feat: add unit context to audit log format (#72)

### DIFF
--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -482,6 +482,7 @@ The Operations stage will eventually include:
 - **CRITICAL**: NEVER use file writing tools and commands that overwrite the entire contents of audit.md, as this causes duplication
 - Use ISO 8601 format for timestamps (YYYY-MM-DDTHH:MM:SSZ)
 - Include stage context for each entry
+- **For Construction phase per-unit stages**: Include unit name in Context field (e.g., "CONSTRUCTION - Code Generation - Unit: user-service")
 
 ### Audit Log Format:
 ```markdown
@@ -490,6 +491,17 @@ The Operations stage will eventually include:
 **User Input**: "[Complete raw user input - never summarized]"
 **AI Response**: "[AI's response or action taken]"
 **Context**: [Stage, action, or decision made]
+
+---
+```
+
+**Example with unit context:**
+```markdown
+## Code Generation
+**Timestamp**: 2024-02-09T14:30:00Z
+**User Input**: "Approve code generation plan"
+**AI Response**: "Code generation plan approved"
+**Context**: CONSTRUCTION - Code Generation - Unit: user-service
 
 ---
 ```


### PR DESCRIPTION
# Summary

Adds unit-specific context to the audit.md logging format to improve traceability in multi-unit Construction phase workflows. Closes #72.

## Changes

Two additive changes to `aidlc-rules/aws-aidlc-rules/core-workflow.md`:

1. Added a bullet to "Prompts Logging Requirements" specifying that Construction phase per-unit stages should include the unit name in the Context field.
2. Added an example block after the existing Audit Log Format template showing what a unit-context entry looks like.

## User experience

**Before**: Audit log entries during multi-unit Construction lack unit identification, making it hard to trace which interactions belong to which unit.

**After**: Clear guidance and an example ensure unit names appear in the Context field (e.g., `CONSTRUCTION - Code Generation - Unit: user-service`).

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

## Test Plan

- Run a multi-unit AI-DLC workflow and verify audit.md entries include unit names in the Context field during Construction phase stages.
- Verify single-unit workflows are unaffected.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).