### PR TITLE
feat: add estimation guidance extension

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/extensions/estimation-guidance/estimation-guidance.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/estimation-guidance/estimation-guidance.md
@@ -1,0 +1,54 @@
+# Estimation Guidance Extension
+
+**Extension ID**: `ESTIMATION`
+**Category**: `estimation-guidance`
+**Phase Coverage**: INCEPTION (Units Generation)
+
+---
+
+## Core Principle: AI-DLC Time ≠ Developer Time
+
+AI-DLC execution time is dominated by approval gate throughput — how fast the human reviews and approves artifacts. The AI generates artifacts in minutes; the human review cycle determines elapsed time. Conventional developer-time estimates are useful for stakeholder communication but must never be presented as AI-DLC execution forecasts.
+
+---
+
+## Rule ESTIMATION-001: Structured Estimation in Unit Definitions
+
+**Applies to**: INCEPTION → Units Generation (Step 2: Generate Unit Definitions)
+
+When generating **Estimated Effort** sections in `unit-of-work.md`, include:
+
+### Relative Complexity (Mandatory)
+- Use **story points** or **T-shirt sizing** (XS, S, M, L, XL)
+- Measures problem size independent of who or what builds it
+- Use for comparing units against each other and prioritizing review effort
+- Base on: number of stories, integration complexity, domain complexity, test surface area
+
+### Conventional Team Estimate (Optional)
+- Label clearly: `Reference Only — Conventional Team Estimate`
+- Express as developer-weeks and team size (e.g., "2 developers × 3 weeks")
+- Purpose: stakeholder communication, budget planning, comparison with non-AI approaches
+- **MUST include disclaimer**: "This estimate reflects conventional development effort. AI-DLC execution time depends on approval gate throughput, not generation effort."
+
+---
+
+## Rule ESTIMATION-002: Anti-Confusion Guard
+
+**Applies to**: INCEPTION → Units Generation
+
+- Do NOT present conventional estimates as AI-DLC execution predictions
+- Do NOT calculate total project duration by summing conventional estimates
+- Do NOT create Gantt charts or timelines based on conventional estimates without labeling them as "Reference Only"
+- If a user asks "how long will this take with AI-DLC?", respond that elapsed time depends on review/approval cadence, not generation speed
+
+---
+
+## Extension Compliance Summary Format
+
+When presenting stage completion, include:
+
+```markdown
+### Estimation Guidance Extension Compliance
+- **ESTIMATION-001**: [COMPLIANT — relative complexity + optional conventional estimate included] or [N/A — not Units Generation]
+- **ESTIMATION-002**: [COMPLIANT — no AI-DLC time confusion] or [N/A]
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/estimation-guidance/estimation-guidance.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/estimation-guidance/estimation-guidance.opt-in.md
@@ -1,0 +1,28 @@
+# Estimation Guidance — Opt-In
+
+**Extension**: Estimation Guidance (AI-DLC Estimation Framing)
+
+**Recommended when**: Stakeholders need effort estimates for planning but there is risk of confusing conventional developer-time estimates with AI-DLC execution time.
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: Estimation Guidance Extension
+
+Should Units Generation include structured estimation guidance that
+distinguishes AI-DLC execution time from conventional team estimates?
+
+A) Yes — enable ESTIMATION GUIDANCE. Unit definitions will include
+   relative complexity sizing (story points / T-shirt) for comparing
+   units, and optionally a labeled conventional team estimate for
+   stakeholder communication. Estimates will be clearly framed to
+   prevent confusion with AI-DLC execution time.
+
+B) No — skip structured estimation in unit definitions
+
+X) Other (please describe)
+
+[Answer]:
+```


### PR DESCRIPTION
# Summary

Added new optional extension to the AI-DLC rules to bridge the gap between autonomous AI execution and human project management for both greenfield and brownfield applications.

For full context and discussion, please see the RFC: #218

## Changes

- **Estimation Guidance**: Provides relative complexity sizing (T-shirt sizes/story points) and distinguishes AI-DLC execution time from conventional developer-weeks estimates.

## User experience

This extension is opt-in. When a user is in the Requirements Analysis phase, they will be prompted with an opt-in question to enable estimation guidance during the Units Generation phase.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- Load the extension during the Requirements Analysis phase and verify the opt-in prompt appears.
- All markdown files have passed `markdownlint-cli2`.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).