### PR TITLE
feat: add NFR compensation extension

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/extensions/nfr-compensation/nfr-compensation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/nfr-compensation/nfr-compensation.md
@@ -1,0 +1,57 @@
+# NFR Compensation Extension
+
+**Extension ID**: `NFR-COMP`
+**Category**: `nfr-compensation`
+**Phase Coverage**: CONSTRUCTION (Functional Design)
+
+---
+
+## Core Principle: Domain-Specific NFR Concerns Belong in Domain Design
+
+A global NFR pass covers system-wide concerns (database choice, caching layer, retry framework). It cannot anticipate unit-specific performance characteristics — how a particular unit handles slow dependencies, what its latency budget is, or what happens at its specific system boundaries. This extension ensures those concerns are captured where they are best understood: during the functional design of each domain unit.
+
+---
+
+## Rule NFR-COMP-001: Mandatory Performance Section in Functional Design
+
+**Applies to**: CONSTRUCTION → Functional Design (per-unit)
+**Trigger**: This unit's NFR Requirements / NFR Design / Infrastructure Design stages are being SKIPPED (e.g., because NFR was handled globally during a foundation unit)
+
+When Functional Design executes for a unit whose NFR stages are skipped, each Functional Design artifact MUST include a section titled:
+
+**"## Performance & Behavioral Considerations"**
+
+This section (2-5 paragraphs) covers unit-specific non-functional concerns that a global NFR pass cannot anticipate. Include:
+
+- **Latency budgets**: Expected response time for critical operations in this unit (e.g., multi-hop forwarding chain resolution, parallel Lambda invocation timeout)
+- **Timeout strategies**: How this unit handles slow dependencies (partial results vs full failure, retry behavior, graceful degradation)
+- **Resource constraints**: File size limits, concurrent operation limits, presigned URL TTLs, cache TTLs specific to this unit
+- **Edge-case behavior**: What happens at system boundaries (expired tokens during playback, circular references, one dependency returns while another times out)
+- **Testable acceptance criteria**: Specific, measurable NFR thresholds for this unit that QA can validate (e.g., "forwarding chain evaluation ≤ 200ms for ≤ 5 hops")
+
+This is NOT a full NFR stage — it is a lightweight addendum ensuring domain-specific performance concerns are captured where they are best understood: during the functional design of that domain.
+
+---
+
+## Rule NFR-COMP-002: Cross-Reference with Global NFR
+
+**Applies to**: CONSTRUCTION → Functional Design (per-unit)
+**Trigger**: Same as NFR-COMP-001
+
+When writing the Performance & Behavioral Considerations section:
+
+- **Reference the global NFR artifacts**: Cite specific decisions from the foundation unit's NFR Design that this unit inherits (e.g., "Uses the retry framework from foundation NFR Design — 3 retries with exponential backoff")
+- **Identify gaps**: Note any area where the global NFR does not cover this unit's specific needs (e.g., "Global NFR specifies 5s timeout; this unit's forwarding chain may need 10s for deep chains")
+- **Flag conflicts**: If this unit's performance needs conflict with global NFR decisions, flag for resolution before Code Generation
+
+---
+
+## Extension Compliance Summary Format
+
+When presenting stage completion, include:
+
+```markdown
+### NFR Compensation Extension Compliance
+- **NFR-COMP-001**: [COMPLIANT — Performance section included] or [N/A — NFR stages executed for this unit]
+- **NFR-COMP-002**: [COMPLIANT — global NFR cross-referenced] or [N/A — NFR stages executed for this unit]
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/nfr-compensation/nfr-compensation.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/nfr-compensation/nfr-compensation.opt-in.md
@@ -1,0 +1,30 @@
+# NFR Compensation — Opt-In
+
+**Extension**: NFR Compensation (Lightweight NFR in Functional Design)
+
+**Recommended when**: The project uses a global/foundation-unit NFR strategy where NFR Requirements, NFR Design, and Infrastructure Design are done once and subsequent units skip those stages. Without this extension, unit-specific performance concerns may be lost.
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: NFR Compensation Extension
+
+Should units that skip NFR stages include a lightweight Performance &
+Behavioral Considerations section in their Functional Design?
+
+A) Yes — enable NFR COMPENSATION. When a unit's NFR Requirements / NFR
+   Design / Infrastructure Design stages are skipped (e.g., handled
+   globally), its Functional Design will include a mandatory section
+   covering latency budgets, timeout strategies, resource constraints,
+   edge-case behavior, and testable acceptance criteria specific to that
+   unit.
+
+B) No — units that skip NFR stages will not include additional
+   performance considerations in their Functional Design
+
+X) Other (please describe)
+
+[Answer]:
+```


### PR DESCRIPTION
# Summary

Added new optional extension to the AI-DLC rules that ensures domain-specific, unit-level non-functional requirements are captured during Functional Design — particularly for units whose global NFR stages are skipped.

For full context and discussion, please see the RFC: #218

## Changes

- **NFR Compensation**: Adds two rules that inject lightweight, domain-specific NFR coverage into the Functional Design phase:
  - **NFR-COMP-001 (Mandatory Performance Section)**: When a unit's NFR stages are skipped (e.g., handled by a foundation unit), its Functional Design must include a "Performance & Behavioral Considerations" section covering latency budgets, timeout strategies, resource constraints, edge-case behavior at system boundaries, and testable acceptance criteria specific to that unit.
  - **NFR-COMP-002 (Cross-Reference with Global NFR)**: Requires the unit's performance section to explicitly reference inherited global NFR decisions, identify gaps where global NFR doesn't cover this unit's specific needs, and flag conflicts for resolution before Code Generation.

## Core Principle

A global NFR pass covers system-wide concerns (database choice, caching layer, retry framework). It cannot anticipate unit-specific performance characteristics — how a particular unit handles slow dependencies, what its latency budget is, or what happens at its specific system boundaries. This extension ensures those concerns are captured where they are best understood: during the functional design of each domain unit.

## User experience

This extension is opt-in. When a user is in the Requirements Analysis phase, they will be prompted with an opt-in question to enable NFR compensation for units that skip dedicated NFR stages.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- Load the extension during the Requirements Analysis phase and verify the opt-in prompt appears.
- Verify that when NFR stages are skipped for a unit, the Functional Design output includes the mandatory Performance & Behavioral Considerations section.
- All markdown files have passed `markdownlint-cli2`.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).