### PR TITLE
feat: Make security baseline extension default-enabled (opt-out instead of opt-in)

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/extensions/security/baseline/security-baseline.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/security/baseline/security-baseline.opt-in.md
@@ -1,18 +1,25 @@
-# Security Baseline — Opt-In
+# Security Baseline — Default Enabled (Opt-Out)
 
 **Extension**: Security Baseline
+**Default**: Enabled — rules are enforced unless the user explicitly opts out.
 
-## Opt-In Prompt
+## Opt-Out Prompt
 
 The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
 
 ```markdown
 ## Question: Security Extensions
-Should security extension rules be enforced for this project?
+Security baseline rules (OWASP-based) are **enabled by default** for this project. No action is needed to keep them active.
 
-A) Yes — enforce all SECURITY rules as blocking constraints (recommended for production-grade applications)
-B) No — skip all SECURITY rules (suitable for PoCs, prototypes, and experimental projects)
-X) Other (please describe after [Answer]: tag below)
+If you want to disable security rules (e.g., for a throwaway PoC or experimental prototype), type "disable" below. Otherwise, leave blank or type "keep".
 
 [Answer]: 
 ```
+
+## Loading Behavior
+
+Unlike standard opt-in extensions, this extension's full rules file (`security-baseline.md`) is loaded immediately at workflow start — before the user answers the opt-out question. This ensures security rules are enforced from the earliest stages.
+
+If the user types "disable" during Requirements Analysis, the extension is marked as disabled in `aidlc-docs/aidlc-state.md` and enforcement stops from that point forward.
+
+If the user leaves the answer blank, types "keep", or does not answer the question, enforcement continues unchanged.

--- a/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
+++ b/aidlc-rules/aws-aidlc-rule-details/inception/requirements-analysis.md
@@ -90,21 +90,27 @@ Analyze whatever the user has provided:
 
 **When in doubt, ask questions** - incomplete requirements lead to poor implementations.
 
-### Step 5.1: Extension Opt-In Prompts
+### Step 5.1: Extension Opt-In / Opt-Out Prompts
 
-**MANDATORY**: Scan all loaded `*.opt-in.md` files (loaded at workflow start from `extensions/` subdirectories) for an `## Opt-In Prompt` section. For each extension that declares one, include that question in the clarifying questions file created in Step 6. Present each opt-in question in the same language as the user's conversation.
+**MANDATORY**: Scan all loaded `*.opt-in.md` files (loaded at workflow start from `extensions/` subdirectories) for an `## Opt-In Prompt` or `## Opt-Out Prompt` section. For each extension that declares one, include that question in the clarifying questions file created in Step 6. Present each question in the same language as the user's conversation.
+
+**Default-enabled extensions** (those with `**Default**: Enabled` in their opt-in file) are already loaded and enforced. Their prompt gives the user the choice to disable. **Standard opt-in extensions** are not yet loaded; their prompt gives the user the choice to enable.
 
 After receiving answers:
 1. Record each extension's enablement status in `aidlc-docs/aidlc-state.md` under `## Extension Configuration`:
 
 ```markdown
 ## Extension Configuration
-| Extension | Enabled | Decided At |
-|---|---|---|
-| [Extension Name] | [Yes/No] | Requirements Analysis |
+| Extension | Default | Enabled | Decided At |
+|---|---|---|---|
+| Security Baseline | On | Yes | Requirements Analysis |
+| [Other Extension] | Off | [Yes/No] | Requirements Analysis |
 ```
 
-2. **Deferred Rule Loading**: For each extension the user opted IN, load the full rules file now. The rules file is derived by naming convention: strip `.opt-in.md` from the opt-in filename and append `.md` (e.g., `security-baseline.opt-in.md` → `security-baseline.md`). For extensions the user opted OUT, do NOT load the full rules file.
+2. **Rule Loading**:
+   - **Default-enabled extensions**: Already loaded. If user explicitly opts OUT, mark as disabled in aidlc-state.md and stop enforcement from that point forward.
+   - **Standard opt-in extensions**: If user opts IN, load the full rules file now. The rules file is derived by naming convention: strip `.opt-in.md` from the opt-in filename and append `.md`. If user opts OUT, do NOT load the full rules file.
+   - **No answer provided**: Default-enabled extensions remain enabled. Standard opt-in extensions remain disabled.
 
 ### Step 6: Generate Clarifying Questions (PROACTIVE APPROACH)
    - **ALWAYS** create `aidlc-docs/inception/requirements/requirement-verification-questions.md` unless requirements are exceptionally clear and complete

--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -31,13 +31,21 @@ All subsequent rule detail file references (e.g., `common/process-overview.md`, 
 
 **Loading process**:
 1. List all subdirectories under `extensions/` (e.g., `extensions/security/`, `extensions/compliance/`)
-2. In each subdirectory, load ONLY `*.opt-in.md` files — these contain the extension's opt-in prompt. The corresponding rules file is derived by convention: strip the `.opt-in.md` suffix and append `.md` (e.g., `security-baseline.opt-in.md` → `security-baseline.md`)
-3. Do NOT load full rule files (e.g., `security-baseline.md`) at this stage
+2. In each subdirectory, load ONLY `*.opt-in.md` files — these contain the extension's prompt. The corresponding rules file is derived by convention: strip the `.opt-in.md` suffix and append `.md` (e.g., `security-baseline.opt-in.md` → `security-baseline.md`)
+3. Check each `*.opt-in.md` file for `**Default**: Enabled`:
+   - If present: this is a **default-enabled** extension — load its full rules file immediately at workflow start. The opt-in file's prompt becomes an opt-out question during Requirements Analysis.
+   - If not present: this is a standard **opt-in** extension — do NOT load the full rules file yet.
 
-**Deferred Rule Loading**:
-- During Requirements Analysis, opt-in prompts from the loaded `*.opt-in.md` files are presented to the user
-- When the user opts IN for an extension, load the corresponding rules file (derived by naming convention) at that point
+**Deferred Rule Loading** (standard opt-in extensions only):
+- During Requirements Analysis, opt-in prompts are presented to the user
+- When the user opts IN, load the corresponding rules file at that point
 - When the user opts OUT, the full rules file is never loaded — saving context
+
+**Default-Enabled Extensions**:
+- Rules are loaded and enforced from workflow start (no deferral)
+- During Requirements Analysis, the opt-out prompt is presented to give the user explicit choice to disable
+- If the user opts OUT, mark the extension as disabled in `aidlc-docs/aidlc-state.md` and stop enforcement from that point forward
+- If the user does not answer or keeps enabled, enforcement continues unchanged
 - Extensions without a matching `*.opt-in.md` file are always enforced — load their rule files immediately at workflow start
 
 **Enforcement** (applies only to loaded/enabled extensions):


### PR DESCRIPTION
## Summary

Changes the security baseline extension from opt-in to default-enabled (opt-out). Security rules are now loaded and enforced from workflow start. Users can explicitly disable them during Requirements Analysis if needed (e.g., for throwaway PoCs).

## Motivation

Security should be on by default — requiring users to opt in means most projects run without security rules unless someone actively remembers to enable them. This change flips the default so the path of least resistance is the secure path.

## Changes

### `security-baseline.opt-in.md`
- Added `**Default**: Enabled` metadata flag
- Changed prompt from opt-in multiple choice (A=Yes, B=No) to opt-out informational (type disable to turn off, otherwise leave blank)
- Added Loading Behavior section documenting immediate load at workflow start

### `core-workflow.md` (Extensions Loading section)
- Added step 3: check each `*.opt-in.md` for `**Default**: Enabled`
- If present: load full rules file immediately (default-enabled behavior)
- If not present: existing deferred opt-in behavior unchanged
- Added Default-Enabled Extensions subsection documenting the opt-out flow
- No-answer behavior: default-enabled extensions stay enabled

### `requirements-analysis.md` (Step 5.1)
- Renamed from Extension Opt-In Prompts to Extension Opt-In / Opt-Out Prompts
- Now handles both flows: opt-out for default-enabled, opt-in for standard
- State tracking table includes Default column (On/Off)
- Documented no-answer behavior for both extension types

## Backward Compatibility

- Property-based testing extension is unchanged (still opt-in)
- Any existing extension without `**Default**: Enabled` in its opt-in file behaves exactly as before
- The `**Default**: Enabled` flag is additive — only extensions that declare it get the new behavior

## Testing

Validated end-to-end in Kiro IDE:

**Test 1: Default behavior (keep enabled)**
1. Workflow starts → security rules loaded immediately ✅
2. Requirements Analysis presents opt-out question ✅
3. User leaves answer blank → security stays enabled ✅
4. Requirements document includes security rule applicability mapping ✅

**Test 2: Explicit opt-out (disable)**
1. Workflow starts → security rules loaded immediately ✅
2. Requirements Analysis presents opt-out question ✅
3. User types "disable" → extension marked as disabled in aidlc-state.md ✅
4. Subsequent stages do not enforce security rules ✅
5. Audit log records the opt-out decision ✅

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).