### PR TITLE
docs: add organizational extension strategy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,55 @@ The separation is entirely directory-based. AWS owns their directories, your org
 | Team adds own rules        | Add to `team-extensions/` in their own repo. Completely isolated.                                  |
 | New team onboards          | `git subtree add` + run install. Immediately inherits all org extensions.                          |
 
+### Organizational Complexity
+
+When multiple teams share a single AI-DLC installation, extension management benefits from a layered approach that separates org-wide concerns from team-specific ones.
+
+#### Layer 1 — Org-Wide Extensions
+
+These are extensions that apply across the entire organization (e.g., security baselines, compliance rules). They live alongside the AWS-shipped extensions under `extensions/`:
+
+```
+aws-aidlc-rule-details/
+└── extensions/
+    ├── security/              # AWS-shipped extension
+    └── org-compliance/        # Org-wide extension (your addition)
+        ├── hipaa/
+        └── soc2/
+```
+
+Org-wide extensions follow the same format as any other extension — markdown files with rule IDs, applicability questions, and verification sections.
+
+#### Layer 2 — Team-Specific Extensions
+
+Individual teams can layer their own rules without modifying org-wide or AWS-shipped files. Create separate directories under `extensions/` with a team prefix:
+
+```
+aws-aidlc-rule-details/
+└── extensions/
+    ├── security/              # AWS-shipped
+    ├── org-compliance/        # Org-wide (Layer 1)
+    ├── team-api-standards/    # Team-specific (Layer 2)
+    └── team-data-governance/  # Team-specific (Layer 2)
+```
+
+Each `team-*` directory is owned by its respective team. This naming convention makes ownership clear and avoids merge conflicts between teams.
+
+#### Distribution Approach
+
+Git subtree is the recommended mechanism for distributing AI-DLC rules across repositories. It embeds the rule files directly in each consuming repo (no special tooling required at clone time), avoids the detached-HEAD pitfalls of submodules, and keeps the full file history available locally — making it a pragmatic choice for teams that want simple, self-contained repositories.
+
+The following table summarizes the lifecycle events and who is responsible:
+
+| Event | Who | Action |
+|-------|-----|--------|
+| AWS ships a new release | Central team | Pull latest via `git subtree pull` from the upstream AI-DLC repo; AWS-shipped directories (`security/`, etc.) are overwritten — org and team directories are unaffected |
+| Org rules change | Central team | Commit changes to `org-*` directories and push to the org's internal AI-DLC fork or overlay repo |
+| New team onboards | Team + Central | Team creates a `team-<name>/` directory under `extensions/`; central team adds the repo as a subtree source if distributing centrally |
+| Team adds own rules | Owning team | Commit to their `team-<name>/` directory; changes stay scoped to that team |
+
+> **Note:** The "install script" referenced in some AI-DLC distribution guides is an optional convenience wrapper around `git subtree add` / `git subtree pull` that your organization can provide. If your org doesn't ship one, the raw git subtree commands work directly. See the [Git subtree documentation](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_subtree_merge) for details.
+
 ---
 
 ## Tenets

--- a/README.md
+++ b/README.md
@@ -670,6 +670,66 @@ You can extend an existing category or create an entirely new one.
 3. Add a matching **opt-in file** using the naming convention `<name>.opt-in.md` (e.g., `compliance.opt-in.md`). See `security-baseline.opt-in.md` for the expected format. Omitting this file means the extension is always enforced with no user opt-out.
 4. Rules are blocking by default — if verification criteria are not met, the stage cannot proceed until the finding is resolved.
 
+### Organizational Complexity
+
+For organizations managing AI-DLC across multiple teams, we recommend a two-layer extension strategy that keeps customizations additive without modifying any shipped AI-DLC files.
+
+#### Layer 1: Org-Wide Extensions
+
+Create new extension categories that apply across all teams. These live in a shared central repo that every project inherits.
+
+```text
+extensions/
+├── security/                  # shipped with AI-DLC (don't touch)
+├── testing/                   # shipped with AI-DLC (don't touch)
+│
+├── org-compliance/            # YOUR org-wide extension
+│   └── baseline/
+│       ├── org-compliance.md          # rules (IDs: ORG-01, ORG-02)
+│       └── org-compliance.opt-in.md   # opt-in prompt
+│
+└── org-observability/         # always enforced (no opt-in file)
+    └── baseline/
+        └── observability.md
+```
+
+#### Layer 2: Team-Specific Extensions
+
+Individual teams add their own extensions in additional subdirectories, stacking on top of org-wide ones.
+
+```text
+extensions/
+├── org-compliance/            # from org central repo
+├── org-observability/         # from org central repo
+│
+├── team-api-standards/        # TEAM-SPECIFIC
+│   └── baseline/
+│       ├── api-standards.md           # IDs: TEAMAPI-01, TEAMAPI-02
+│       └── api-standards.opt-in.md
+│
+└── team-data-governance/      # TEAM-SPECIFIC, always enforced
+    └── baseline/
+        └── data-governance.md
+```
+
+#### Distribution Approach
+
+For managing the two layers in practice:
+
+- **Org template repo**: Contains the AI-DLC core files plus your `org-*` extensions. Teams consume this via `git subtree`.
+- **Team repos**: Add `team-*` extension directories on top. Since everything is additive under `extensions/`, there are no merge conflicts.
+- **Updating AI-DLC**: When a new release drops, update only the AWS-owned directories. Your `org-*` and `team-*` directories are untouched.
+
+The separation is entirely directory-based. AWS owns their directories, your org owns `org-*` directories, and teams own `team-*` directories. Updates flow downstream cleanly because nothing overlaps.
+
+| Event                      | What Happens                                                                                       |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| AWS releases new version   | Central team overwrites `aws-*` directories, commits, pushes. Org extensions untouched.            |
+| Org rules change           | Central team edits `org-*` directories, commits, pushes.                                           |
+| Team pulls updates         | `git subtree pull` + re-run install script. Team extensions layer on top with zero conflicts.      |
+| Team adds own rules        | Add to `team-extensions/` in their own repo. Completely isolated.                                  |
+| New team onboards          | `git subtree add` + run install. Immediately inherits all org extensions.                          |
+
 ---
 
 ## Tenets

--- a/README.md
+++ b/README.md
@@ -672,66 +672,6 @@ You can extend an existing category or create an entirely new one.
 
 ### Organizational Complexity
 
-For organizations managing AI-DLC across multiple teams, we recommend a two-layer extension strategy that keeps customizations additive without modifying any shipped AI-DLC files.
-
-#### Layer 1: Org-Wide Extensions
-
-Create new extension categories that apply across all teams. These live in a shared central repo that every project inherits.
-
-```text
-extensions/
-├── security/                  # shipped with AI-DLC (don't touch)
-├── testing/                   # shipped with AI-DLC (don't touch)
-│
-├── org-compliance/            # YOUR org-wide extension
-│   └── baseline/
-│       ├── org-compliance.md          # rules (IDs: ORG-01, ORG-02)
-│       └── org-compliance.opt-in.md   # opt-in prompt
-│
-└── org-observability/         # always enforced (no opt-in file)
-    └── baseline/
-        └── observability.md
-```
-
-#### Layer 2: Team-Specific Extensions
-
-Individual teams add their own extensions in additional subdirectories, stacking on top of org-wide ones.
-
-```text
-extensions/
-├── org-compliance/            # from org central repo
-├── org-observability/         # from org central repo
-│
-├── team-api-standards/        # TEAM-SPECIFIC
-│   └── baseline/
-│       ├── api-standards.md           # IDs: TEAMAPI-01, TEAMAPI-02
-│       └── api-standards.opt-in.md
-│
-└── team-data-governance/      # TEAM-SPECIFIC, always enforced
-    └── baseline/
-        └── data-governance.md
-```
-
-#### Distribution Approach
-
-For managing the two layers in practice:
-
-- **Org template repo**: Contains the AI-DLC core files plus your `org-*` extensions. Teams consume this via `git subtree`.
-- **Team repos**: Add `team-*` extension directories on top. Since everything is additive under `extensions/`, there are no merge conflicts.
-- **Updating AI-DLC**: When a new release drops, update only the AWS-owned directories. Your `org-*` and `team-*` directories are untouched.
-
-The separation is entirely directory-based. AWS owns their directories, your org owns `org-*` directories, and teams own `team-*` directories. Updates flow downstream cleanly because nothing overlaps.
-
-| Event                      | What Happens                                                                                       |
-| -------------------------- | -------------------------------------------------------------------------------------------------- |
-| AWS releases new version   | Central team overwrites `aws-*` directories, commits, pushes. Org extensions untouched.            |
-| Org rules change           | Central team edits `org-*` directories, commits, pushes.                                           |
-| Team pulls updates         | `git subtree pull` + re-run install script. Team extensions layer on top with zero conflicts.      |
-| Team adds own rules        | Add to `team-extensions/` in their own repo. Completely isolated.                                  |
-| New team onboards          | `git subtree add` + run install. Immediately inherits all org extensions.                          |
-
-### Organizational Complexity
-
 When multiple teams share a single AI-DLC installation, extension management benefits from a layered approach that separates org-wide concerns from team-specific ones.
 
 #### Layer 1 — Org-Wide Extensions

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ When multiple teams share a single AI-DLC installation, extension management ben
 
 These are extensions that apply across the entire organization (e.g., security baselines, compliance rules). They live alongside the AWS-shipped extensions under `extensions/`:
 
-```
+```text
 aws-aidlc-rule-details/
 └── extensions/
     ├── security/              # AWS-shipped extension
@@ -693,7 +693,7 @@ Org-wide extensions follow the same format as any other extension — markdown f
 
 Individual teams can layer their own rules without modifying org-wide or AWS-shipped files. Create separate directories under `extensions/` with a team prefix:
 
-```
+```text
 aws-aidlc-rule-details/
 └── extensions/
     ├── security/              # AWS-shipped
@@ -710,12 +710,12 @@ Git subtree is the recommended mechanism for distributing AI-DLC rules across re
 
 The following table summarizes the lifecycle events and who is responsible:
 
-| Event | Who | Action |
-|-------|-----|--------|
-| AWS ships a new release | Central team | Pull latest via `git subtree pull` from the upstream AI-DLC repo; AWS-shipped directories (`security/`, etc.) are overwritten — org and team directories are unaffected |
-| Org rules change | Central team | Commit changes to `org-*` directories and push to the org's internal AI-DLC fork or overlay repo |
-| New team onboards | Team + Central | Team creates a `team-<name>/` directory under `extensions/`; central team adds the repo as a subtree source if distributing centrally |
-| Team adds own rules | Owning team | Commit to their `team-<name>/` directory; changes stay scoped to that team |
+| Event                      | What Happens                                                                                                                     |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| AWS ships a new release    | Central team pulls latest via `git subtree pull`. AWS-shipped dirs (`security/`, etc.) overwritten; org/team dirs unaffected.    |
+| Org rules change           | Central team commits changes to `org-*` directories and pushes to the org's internal AI-DLC fork or overlay repo.                |
+| New team onboards          | Team creates a `team-<name>/` dir under `extensions/`; central team adds repo as a subtree source if distributing centrally.     |
+| Team adds own rules        | Owning team commits to their `team-<name>/` directory. Changes stay scoped to that team.                                         |
 
 > **Note:** The "install script" referenced in some AI-DLC distribution guides is an optional convenience wrapper around `git subtree add` / `git subtree pull` that your organization can provide. If your org doesn't ship one, the raw git subtree commands work directly. See the [Git subtree documentation](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging#_subtree_merge) for details.
 


### PR DESCRIPTION
# Summary

Adds organizational extension strategy guidance (two-layer approach and distribution model) to the Extensions section of the README.

## Changes

- Added a new "Organizational Complexity" subsection under Extensions in README.md
- Covers Layer 1 (Org-Wide Extensions) and Layer 2 (Team-Specific Extensions) with directory structure examples
- Includes a Distribution Approach section with a lifecycle event table covering AWS updates, org rule changes, team onboarding, and team-specific additions
- Content sourced from the AI-DLC Customer Extensions guide (sections 4 and 6)

## User experience

**Before:** The Extensions section explains how extensions work, lists built-in extensions, and describes how to add your own. There is no guidance on managing extensions across multiple teams or organizations.

**After:** The Extensions section now includes an "Organizational Complexity" subsection that provides a clear two-layer strategy for org-wide and team-specific extensions, along with a practical distribution approach using git subtree. Organizations can follow this guidance to scale AI-DLC extensions without merge conflicts or modifying shipped files.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- Open the README.md and verify the "Organizational Complexity" subsection appears under Extensions, after "Adding Your Own Extensions" and before "Tenets"
- Confirm heading levels are consistent: `###` for the subsection, `####` for sub-parts
- Verify the two directory structure code blocks render correctly
- Verify the distribution lifecycle table renders correctly
- Confirm no existing content was modified — the addition is purely additive

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
