### PR TITLE
feat(data-engineering): add data-engineering extension family

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/baseline/data-engineering-baseline.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/baseline/data-engineering-baseline.md
@@ -1,0 +1,296 @@
+# Data Engineering Baseline Extension
+
+## Overview
+
+These rules apply to any data pipeline regardless of compute or storage platform. Stack platform-specific extensions (`s3-lakehouse`, `redshift`, `postgresql`, `databricks`, `snowflake`) and capability extensions (`orchestration`, `cicd`, `catalog`) on top of this baseline.
+
+**Enforcement**: At each applicable AIDLC stage, the model MUST verify compliance with these rules before presenting the stage completion message to the user. Findings are surfaced according to their severity tier (see below).
+
+## Severity Tiers
+
+Unlike most extensions where every rule is blocking, data engineering rules are assigned one of three severity tiers based on whether non-compliance is a correctness issue, a production-readiness issue, or a recommendation. The same model applies to all extensions in the `data-engineering/` family.
+
+| Tier | Label | Enforcement |
+|------|-------|-------------|
+| **P0** | Blocking | Must be resolved before the stage completes. Non-compliance is a hard finding that blocks stage sign-off. |
+| **P1** | Warning | Must be resolved before production go-live. Non-compliance is flagged but does not block stage completion; it becomes a hard finding at the Build and Test gate. |
+| **P2** | Advisory | Good practice; record as a recommendation. Non-compliance is noted in the compliance summary but does not block any stage. |
+
+### Blocking Finding Behavior (P0)
+
+A **P0 finding** means:
+1. The finding MUST be listed in the stage completion message under a "Data Engineering Findings" section with the rule ID, severity, and description
+2. The stage MUST NOT present the "Continue to Next Stage" option until all P0 findings are resolved
+3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
+4. The finding MUST be logged in `aidlc-docs/audit.md` with the rule ID, severity, description, and stage context
+
+### Warning Finding Behavior (P1)
+
+A **P1 finding** means:
+1. The finding MUST be listed in the stage completion message under "Data Engineering Findings" with the rule ID, severity P1, and description
+2. The stage MAY present "Continue to Next Stage" — P1 does not block stage sign-off
+3. P1 findings carry forward and become P0 (blocking) at the Build and Test stage gate; unresolved P1 findings at Build and Test block production promotion
+4. The finding MUST be logged in `aidlc-docs/audit.md`
+
+### Advisory Finding Behavior (P2)
+
+A **P2 finding** means:
+1. The finding is noted in the stage compliance summary as a recommendation
+2. No stage gate is affected
+3. The finding SHOULD be logged in `aidlc-docs/audit.md` for traceability but does not require resolution
+
+### N/A Handling
+
+If a rule is not applicable to the current project (e.g., DATAENG-05 lateness handling when no event ingestion is in scope), mark it as **N/A** in the compliance summary with a one-line rationale. This is not a finding at any tier.
+
+### Verification Criteria Format
+
+Verification items in this document are plain bullet points describing compliance checks. They are distinct from the `- [ ]` / `- [x]` progress-tracking checkboxes used in stage plan files. Each item should be evaluated as compliant, non-compliant, or N/A during review.
+
+### Precedence
+
+When a platform-specific extension rule conflicts with a baseline rule, the stricter rule wins. The `security/baseline` extension follows the same precedence: if a SECURITY-* rule is stricter than a DATAENG-* rule, the SECURITY-* rule governs.
+
+---
+
+## Rule DATAENG-01: Explicit Data Contract Between Producer and Consumer
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every dataset that crosses a process or team boundary MUST have a machine-readable data contract stored in version control. A free-text document does not satisfy this rule. The contract MUST specify all of the following fields; any omission is a blocking finding:
+
+| Field | Requirement |
+|-------|-------------|
+| `schema` | Column name, data type, nullability, and semantic description for every column |
+| `primary_key` | Column(s) that uniquely identify a row; `none` if append-only with explicit rationale |
+| `partitioning` | Partition key(s) and grain, or `none` with rationale |
+| `freshness_sla` | Maximum acceptable age of data at the consumption layer (e.g., `T+4h`, `daily by 08:00 UTC`) |
+| `volume_expectation` | Expected row count range per partition or per day; used to set DATAENG-09 volume monitors |
+| `value_constraints` | Allowed enums, ranges, or regex patterns for critical columns; at least one per non-free-text critical column |
+| `classification` | Sensitivity per column per DATAENG-06 (`public`, `internal`, `confidential`, `pii`, `phi`, `pci`) |
+| `version` | Semantic version (`MAJOR.MINOR.PATCH`); breaking changes increment MAJOR per DATAENG-02 |
+| `owner` | Owning team identifier per CAT-01 |
+| `consumers` | Named downstream pipelines, services, or teams; used for breaking-change notification per DATAENG-02 and deprecation notice per CAT-04 |
+| `contract_enforcement` | Tool and mode used to validate the contract at runtime (see tooling guidance below) |
+
+Implicit contracts ("whatever the upstream table looks like today") are prohibited for any dataset consumed by another pipeline, service, or analytical workload.
+
+**Contract Format**: The contract MUST be expressed in one of the following machine-readable formats. Free-text Markdown or Word documents do not qualify:
+- **dbt model contract** (`models/<name>.yml` with `contract: {enforced: true}` and `columns:` block) — preferred for dbt projects
+- **Soda contract** (`contracts/<name>.yml` using the Soda Contract specification) — preferred when dbt is not the transformation layer
+- **OpenAPI/JSON Schema** (`data-contracts/<name>.json` or `.yaml`) — acceptable for API-style datasets
+- **AsyncAPI + Schema Registry subject** — required for streaming sources (see tooling guidance below); a schema registry subject name MUST be recorded in the contract file
+
+**Contract Enforcement Tooling**:
+
+*Batch and SQL pipelines*:
+- `dbt model contracts` — enforces schema shape at model materialization time; `contract: {enforced: true}` causes dbt to fail if the produced relation does not match the declared columns and types
+- `Soda Contracts` — enforces column presence, type, nullability, and value constraints as a post-write check; integrates with CI and orchestration
+- Custom assertion libraries (Great Expectations, Deequ) are acceptable for constraint validation but MUST be paired with a machine-readable schema definition file (JSON Schema or equivalent) for the schema fields
+
+*Streaming pipelines*:
+- **AWS Glue Schema Registry** — required when the streaming transport is Amazon Kinesis, Amazon MSK, or AWS Glue Streaming ETL; schema subject name and registry ARN MUST be recorded in the contract file; compatibility mode MUST be set to `BACKWARD` or `FULL` per DATAENG-02
+- **Confluent Schema Registry** — required when the streaming transport is Confluent Cloud Kafka or self-managed Kafka; subject naming strategy (TopicNameStrategy, RecordNameStrategy) MUST be documented; compatibility mode MUST be set to `BACKWARD` or `FULL`
+- Schema registry enforcement mode MUST be `FULL` for any topic with multiple consumer groups — `BACKWARD`-only does not protect producers from breaking consumers with older schemas
+
+**Verification**:
+- Requirements Analysis includes a `data-contracts/` directory in the repository containing one contract file per dataset produced or consumed across the unit boundary, in one of the approved formats above.
+- A free-text document, diagram, or Confluence page alone does not constitute a contract — a machine-readable file MUST exist.
+- Functional Design references the contract file path for each dataset; the column list in the design is derived from the contract, not independently authored.
+- Code Generation wires the declared `contract_enforcement` tool into the pipeline execution path: dbt contract enforcement at model run, Soda check at post-write step, schema registry serializer/deserializer at producer and consumer.
+- For streaming sources: Code Generation configures the producer serializer to register schemas against the named registry subject; consumer deserializer is configured to validate on read.
+- Build and Test includes a deliberate contract violation test: a column is removed or a type is narrowed in a test fixture and the enforcement tool is asserted to fail the run.
+- A contract is versioned; the MAJOR version in the contract file matches the major version of the deployed schema.
+
+---
+
+## Rule DATAENG-02: Backward-Compatible Schema Evolution
+
+**Severity**: P0 — Blocking
+
+**Rule**: Schema changes to existing datasets MUST be backward compatible by default. Adding a nullable column is allowed; removing a column, renaming a column, narrowing a type, or changing nullability from nullable to non-nullable is a breaking change that requires either (a) a major version bump of the data contract with a coexistence window where both versions are produced, or (b) explicit consumer sign-off captured in the requirements artifact.
+
+**Verification**:
+- Brownfield reverse engineering captures the current schema for every persisted dataset.
+- Any proposed schema change is classified in the design as "additive" or "breaking" with rationale.
+- Breaking changes have an entry in the requirements artifact naming each downstream consumer and the coexistence plan.
+- Code Generation produces migration scripts (DDL or table-format schema evolution operations) rather than implicit type coercion.
+
+---
+
+## Rule DATAENG-03: Idempotent and Re-runnable Transformations
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every batch or micro-batch transformation MUST be safely re-runnable for any given input partition or time window without producing duplicates, leaving the target in a corrupted state, or requiring manual cleanup. Append-only patterns without dedup keys, INSERT without UPSERT/MERGE semantics on tables with declared primary keys, and "delete-then-insert" patterns without transactional guarantees are prohibited.
+
+**Verification**:
+- Functional Design names the dedup key or merge condition for each write.
+- Code Generation uses MERGE/UPSERT, transactional overwrites of partitions, or table-format snapshot replacement — never naive INSERT into a keyed table.
+- Build and Test includes a test case that runs the same partition twice and asserts row counts and content are stable.
+- Streaming pipelines document at-least-once vs exactly-once semantics and the downstream deduplication mechanism if at-least-once.
+
+---
+
+## Rule DATAENG-04: Deterministic Partitioning Strategy
+
+**Severity**: P1 — Warning
+
+**Rule**: Every persisted dataset larger than 10 GB or expected to grow past it MUST have an explicit partitioning strategy chosen against the actual query and write patterns. High-cardinality natural keys (user_id, order_id, uuid) MUST NOT be used as partition keys. Partition keys are derived from columns present in the data; partition-pruning predicates MUST be expressible by typical consumers.
+
+**Verification**:
+- Functional Design specifies partition keys and rationale (read patterns, write patterns, file count targets).
+- Estimated partition count over a one-year horizon is within platform-appropriate limits (no more than ~10,000 partitions for Hive-style; Iceberg/Delta hidden partitioning preferred where supported).
+- Code Generation produces partition writes aligned to the design — no accidental over-partitioning by including timestamps with second-level resolution.
+- For time-based partitioning, the grain (day/hour) is justified by query SLA and ingestion volume.
+
+---
+
+## Rule DATAENG-05: Late-Arriving and Out-of-Order Data Handling
+
+**Severity**: P1 — Warning
+
+**Rule**: Every pipeline that ingests event data MUST define a policy for late-arriving records, including: maximum acceptable lateness, how late records are merged into existing partitions, whether they trigger downstream reprocessing, and how watermarks or processing-time vs event-time semantics are handled.
+
+**Verification**:
+- Requirements Analysis captures the lateness SLA (e.g., "events up to 7 days late are processed in place; older records are routed to a quarantine table").
+- Functional Design specifies the merge mechanism (partition rewrite, MERGE on event_time + key, etc.).
+- Code Generation implements quarantine routing and writes a count of late records to an observability sink.
+- Tests include a late-record scenario.
+
+---
+
+## Rule DATAENG-06: PII and Sensitive Data Classification
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every column containing personally identifiable information, payment data, protected health information, or other regulated content MUST be classified in the data contract. Classified columns MUST be protected via at-rest encryption with customer-managed keys, masked or tokenized at the consumption layer for non-authorized roles, excluded from non-production environments unless synthetic, and logged in an access audit trail.
+
+**Verification**:
+- The data contract has a `classification` field per column (e.g., `public`, `internal`, `confidential`, `pii`, `phi`, `pci`).
+- NFR Design includes a key management and masking strategy for classified columns.
+- Code Generation does not log values of classified columns; column-level grants or masking policies are applied.
+- Test fixtures use synthetic values for classified columns or are explicitly marked as anonymized.
+- This rule composes with the `security/baseline` extension; if SECURITY-* rules conflict, the stricter rule wins.
+
+---
+
+## Rule DATAENG-07: Data Quality Gates with Explicit Expectations
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every pipeline MUST run data quality checks against produced datasets and either fail the pipeline, quarantine bad records, or emit an alert on violation — never silently produce bad data downstream. Minimum expectations: row count within tolerance band, primary key uniqueness, non-null on contract-required columns, referential integrity on declared foreign keys, and at least one domain check per critical column.
+
+**Verification**:
+- Functional Design lists expectations per dataset with action-on-failure (fail/quarantine/alert).
+- Code Generation uses a declarative framework (e.g., Great Expectations, Deequ, DLT expectations, dbt tests, custom assertions) rather than ad-hoc IF statements.
+- Tests cover both pass and fail paths for at least one expectation per critical dataset.
+- Quality results are persisted to a queryable location for trend analysis.
+
+---
+
+## Rule DATAENG-08: Column-Level Lineage Captured End-to-End
+
+**Severity**: P1 — Warning
+
+**Rule**: For every produced dataset, the pipeline MUST emit lineage metadata capturing: source tables and columns, transformations applied, the producing job and run identifier, and the timestamp of production. Lineage MUST be queryable without re-reading source code.
+
+**Verification**:
+- Infrastructure Design names the lineage capture mechanism (OpenLineage, Marquez, Unity Catalog, Snowflake ACCESS_HISTORY, Glue Crawler + Lake Formation, dbt artifacts, etc.).
+- Code Generation emits lineage events at write boundaries or relies on a platform feature that does so automatically.
+- Build and Test verifies at least one end-to-end lineage trace from a leaf source through to a published mart.
+
+---
+
+## Rule DATAENG-09: Pipeline Observability — Monitors Exist and Alert
+
+**Severity**: P1 — Warning
+
+**Rule**: Every production dataset MUST have active monitors on four pillars: freshness (time since last successful write), volume (row count and byte count deviation from expected band), schema (drift vs the contract), and quality (DATAENG-07 results). Each monitor MUST be wired to a notification or paging mechanism with a defined owner. Silent dashboards — monitors that display but never alert — do not satisfy this rule. SLA targets that the monitors measure against are defined separately in DATAENG-12.
+
+**Verification**:
+- Infrastructure Design names the monitoring stack (Monte Carlo, Soda, custom CloudWatch/Datadog, etc.), the four pillars covered per dataset, and the on-call routing for each alert.
+- Code Generation or IaC provisions monitors alongside the pipeline — not as a separate post-launch manual step.
+- Build and Test includes a synthetic violation (e.g., write suppressed to trigger a freshness alert) that fires and resolves a monitor, confirming the alerting path is wired end-to-end.
+
+---
+
+## Rule DATAENG-10: Backfill Strategy Separate From Incremental
+
+**Severity**: P1 — Warning
+
+**Rule**: Pipelines MUST distinguish between incremental processing and backfill, with separate parameterization, separate resource sizing, and a documented backfill procedure. A backfill MUST NOT block ongoing incremental processing, and MUST be safely re-runnable per DATAENG-03.
+
+**Verification**:
+- Functional Design includes a backfill section: parameter shape (date range, partition list), resource profile, expected duration, isolation from incremental runs.
+- Code Generation produces parameterized entry points for both modes; no hard-coded "last 1 day" filters in code that also needs to backfill years.
+- Build and Test includes a backfill scenario over multiple partitions.
+
+---
+
+## Rule DATAENG-11: Cost Controls and Resource Caps
+
+**Severity**: P1 — Warning
+
+**Rule**: Every pipeline MUST have explicit upper bounds on resource consumption: maximum concurrent compute, maximum runtime, maximum bytes scanned or processed per run, and a credit/dollar budget where the platform supports it. Unbounded autoscaling is prohibited for production workloads.
+
+**Verification**:
+- NFR Requirements names per-pipeline budgets in compute units (DBU, credit, slot-hours, DPU-hours) and dollars.
+- Infrastructure Design configures resource monitors, query timeouts, max cluster size, or warehouse auto-suspend per platform conventions.
+- Code Generation includes guardrails (query timeout, max records, LIMIT on exploratory reads, partition pruning predicates).
+- Cost attribution metadata (cost center, project, environment tags) is applied to every compute resource.
+
+---
+
+## Rule DATAENG-12: Explicit SLA, SLO, and SLI Per Pipeline
+
+**Severity**: P1 — Warning
+
+**Rule**: Every production pipeline MUST have written SLAs (the consumer-facing commitments), SLOs (the internal measurable targets derived from SLAs), and SLIs (the specific metric or query that measures each SLO) defined before go-live. Required SLA dimensions: freshness (P50 and P99 delivery time), completeness (minimum acceptable row fraction), and accuracy (acceptable error rate per DATAENG-07). An SLA without a corresponding SLI query that can be evaluated from existing telemetry is not acceptable. Monitoring that enforces these targets is defined separately in DATAENG-09; this rule governs that the targets themselves are written down and computable.
+
+**Verification**:
+- Requirements Analysis captures the consumer-facing SLA per dataset (what the producing team promises).
+- NFR Requirements translates each SLA dimension into a measurable SLO with a numeric target (e.g., "data available by 08:00 UTC on 99.5% of days").
+- NFR Requirements defines the SLI for each SLO: the specific metric, query, or monitor output used to evaluate it (e.g., `max(load_timestamp) < now() - interval '26 hours'` evaluated against the freshness monitor).
+- Build and Test verifies each SLI can be evaluated from existing telemetry and produces a pass/fail result against its SLO threshold.
+
+---
+
+## Rule DATAENG-13: Failure Semantics Documented and Tested
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every pipeline MUST declare its failure semantics: what happens on a transient error (retry policy with backoff and max attempts), what happens on a permanent error (dead-letter behavior, partial commit policy), and what guarantees the consumer receives (at-most-once, at-least-once, exactly-once and the mechanism). Silent retries that hide data loss are prohibited.
+
+**Verification**:
+- Functional Design includes a "failure modes" section per pipeline.
+- Code Generation implements explicit retry with bounded attempts and dead-letter routing for permanent failures.
+- Tests include induced-failure scenarios for at least one transient and one permanent failure mode.
+
+---
+
+## Rule DATAENG-14: Reproducibility — Deterministic Outputs and Pinned Dependencies
+
+**Severity**: P1 — Warning
+
+**Rule**: A pipeline re-run against the same input data MUST produce byte-identical or semantically identical output, modulo declared non-deterministic columns (e.g., load_timestamp). Dependencies (libraries, container images, model weights, reference data versions) MUST be pinned. Re-runs of historical periods MUST be possible without "the dataset I had in March no longer exists" failures.
+
+**Verification**:
+- Code Generation pins all runtime dependencies (lockfile, image digest, library versions).
+- Reference data snapshots are taken at known-good points and addressable by version.
+- Non-deterministic columns are enumerated in the data contract.
+- Build and Test includes a determinism check: re-run produces the same row hashes.
+
+---
+
+## Rule DATAENG-15: Secrets and Connection Credentials Never in Code
+
+**Severity**: P0 — Blocking
+
+**Rule**: Database connection strings, API tokens, cloud credentials, service principals, and any secret used by the pipeline MUST be sourced at runtime from a managed secret store (AWS Secrets Manager, AWS Systems Manager Parameter Store, HashiCorp Vault, Azure Key Vault, GCP Secret Manager, Databricks secret scopes, Snowflake EXTERNAL ACCESS integrations). Secrets MUST NOT appear in code, config files committed to git, notebooks, environment files, container images, audit logs, error messages, stack traces, or DAG definitions. Rotation MUST be possible without redeploying the pipeline.
+
+**Verification**:
+- Code Generation reads secrets via the secret store SDK; no string literals or env-from-file patterns for production secrets.
+- Infrastructure Design specifies IAM/role-based access to secrets and rotation cadence.
+- Repository scanning (pre-commit, secret detection) is mandated in the build instructions.
+- This rule composes with `security/baseline`; secret-handling rules from SECURITY-* take precedence where stricter.

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/baseline/data-engineering-baseline.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/baseline/data-engineering-baseline.opt-in.md
@@ -1,0 +1,18 @@
+# Data Engineering Baseline — Opt-In
+
+**Extension**: Data Engineering Baseline
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: Data Engineering Baseline Extension
+Should data engineering baseline rules be enforced for this project?
+
+A) Yes — enforce all DATAENG rules per their P0/P1/P2 severity tiers (recommended for any pipeline producing a dataset consumed by another team, service, or analytical workload, or any pipeline running in production)
+B) No — skip all DATAENG rules (suitable only for one-off exploratory analyses with no downstream consumers)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/catalog/catalog.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/catalog/catalog.md
@@ -1,0 +1,137 @@
+# Data Catalog and Ownership Extension
+
+Rules for ensuring every production dataset is discoverable, has a declared owner, and carries the metadata needed for consumers to find, evaluate, and trust it without reading source code or asking the producing team. Applies to any pipeline producing a dataset consumed by another team, service, or analytical workload.
+
+This extension layers on top of `data-engineering/baseline`. It composes with `s3-lakehouse` (Glue Catalog as the technical metastore), `databricks` (Unity Catalog), `snowflake` (Snowflake Information Schema and data sharing), `redshift` (Glue Catalog + Redshift Serverless catalog), and `cicd` (catalog registration as part of deployment).
+
+## Severity Tiers
+
+Severity tiers are defined in `data-engineering/baseline`. The same P0/P1/P2 model applies here:
+
+| Tier | Enforcement |
+|------|-------------|
+| **P0** | Blocking — must be resolved before stage sign-off. |
+| **P1** | Warning — must be resolved before production go-live; flagged but does not block individual stages. |
+| **P2** | Advisory — good practice; noted in compliance summary but non-blocking at all stages. |
+
+---
+
+## Rule CAT-01: Every Production Dataset Has a Declared Owner
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every dataset produced for consumption by another team, service, or analytical workload MUST have a declared owner: a named team (not an individual) responsible for schema stability, SLA adherence, quality, and incident response. Ownership MUST be recorded in two places: the data contract (DATAENG-01) and the catalog entry (CAT-02). A dataset with no owner is an unowned liability — consumers have no escalation path and the pipeline can be silently abandoned. Individual-person ownership is prohibited because it creates a single point of failure.
+
+**Verification**:
+- Requirements Analysis names the owning team per dataset alongside the data contract.
+- The catalog entry for each dataset carries an `owner` field referencing a team identifier (email alias, Slack channel, PagerDuty service, or equivalent).
+- Functional Design identifies any dataset changing ownership and captures the handoff procedure.
+- Build and Test includes a post-deploy check asserting the `owner` field is non-empty on every registered dataset.
+
+---
+
+## Rule CAT-02: Every Production Dataset Has a Catalog Entry Before Go-Live
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every dataset promoted to production MUST have a catalog entry registered before or at the time of first production write. A catalog entry is not optional documentation — it is the mechanism by which consumers discover the dataset, evaluate its fitness, and find its owner. Registration MUST occur as part of the deployment pipeline, not as a post-launch manual step. Acceptable catalog targets: AWS Glue Data Catalog, Unity Catalog, Apache Atlas, DataHub, Collibra, Alation, or any catalog that supports programmatic registration and is queryable without reading source code.
+
+**Verification**:
+- Infrastructure Design names the catalog target and the registration mechanism (Glue Crawler, Unity Catalog DDL, DataHub ingestion source, etc.).
+- Code Generation or IaC includes catalog registration as a deployment step, not a separate manual runbook.
+- Build and Test asserts the catalog entry exists and is populated after a staging deployment.
+- The catalog entry references the data contract artifact (DATAENG-01) by URI or version identifier.
+
+---
+
+## Rule CAT-03: Catalog Entry Carries a Minimum Required Metadata Set
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every catalog entry MUST carry the following fields at registration time. Missing fields are a blocking finding at the Build and Test gate:
+
+| Field | Requirement |
+|-------|-------------|
+| `display_name` | Human-readable name, distinct from the technical table name |
+| `description` | Plain-language summary of what the dataset contains and its intended use |
+| `owner` | Team identifier per CAT-01 |
+| `classification` | Data sensitivity level per DATAENG-06 (`public`, `internal`, `confidential`, `pii`, `phi`, `pci`) |
+| `freshness_sla` | How current the data is expected to be (e.g., "updated daily by 08:00 UTC") |
+| `schema_version` | Semantic version of the data contract (per DATAENG-01) |
+| `data_contract_uri` | Link or path to the full data contract artifact |
+| `status` | Lifecycle state: `experimental`, `stable`, `deprecated`, `sunset_date` |
+| `producing_pipeline` | Name or ARN of the job or DAG that writes the dataset |
+
+**Verification**:
+- Functional Design includes a catalog metadata template populated for each dataset.
+- Code Generation or IaC writes these fields to the catalog at deploy time.
+- Build and Test runs a metadata completeness check against the catalog API after staging deployment; any missing required field fails the gate.
+- `status = experimental` is acceptable for initial launch but must be upgraded to `stable` before the dataset is referenced by any downstream production pipeline.
+
+---
+
+## Rule CAT-04: Deprecated Datasets Are Cataloged With a Sunset Date
+
+**Severity**: P1 — Warning
+
+**Rule**: When a dataset is scheduled for retirement, its catalog entry MUST be updated to `status = deprecated` with a `sunset_date` field set at least 30 days in the future. Consumers listed in the data contract (DATAENG-01) MUST be notified at deprecation time. Silent deletion of a production dataset — removing the table or stopping the pipeline without a catalog deprecation notice — is prohibited. After the sunset date, the entry transitions to `status = removed` and is retained for 90 days before deletion to preserve lineage history.
+
+**Verification**:
+- Requirements Analysis captures the sunset plan whenever a dataset is being retired.
+- The catalog entry is updated to `deprecated` with `sunset_date` before any pipeline change is deployed.
+- Downstream consumers named in the data contract receive a deprecation notice (email, Slack, Jira ticket, or equivalent) captured in audit.md.
+- Build and Test includes a check that no pipeline in staging or production reads from a dataset with `status = removed`.
+
+---
+
+## Rule CAT-05: Catalog Entries Updated Automatically on Schema Change
+
+**Severity**: P1 — Warning
+
+**Rule**: Schema changes deployed via the migration pipeline (CICD-04) MUST trigger an automated catalog update. Catalog entries that lag behind the deployed schema are misleading — consumers make decisions based on stale metadata. The update MUST occur in the same deployment pipeline run as the migration apply, not as a separate manual step. This composes with CICD-09: the catalog update is a deployable artifact with the same provenance tagging as the migration.
+
+**Verification**:
+- Infrastructure Design names the mechanism that keeps the catalog in sync with deployed schema (e.g., post-migration hook, Glue Crawler schedule tight enough to reflect changes within one deployment cycle, Unity Catalog DDL auto-updates, DataHub ingestion triggered by CI).
+- Build and Test asserts that after a migration apply, the catalog reflects the new schema within the deployment pipeline run.
+- A deliberately lagging catalog (e.g., a weekly crawler on a daily-changing schema) is flagged as a finding.
+
+---
+
+## Rule CAT-06: Ownership Review Cadence Defined
+
+**Severity**: P2 — Advisory
+
+**Rule**: Dataset ownership MUST be reviewed on a defined cadence (recommended: quarterly) to catch orphaned datasets whose owning team has been reorganized or disbanded. The review process MUST produce one of three outcomes per dataset: ownership confirmed, ownership transferred to a new team, or dataset deprecated per CAT-04. Datasets that have not been reviewed within two cadence periods are flagged as ownership-unknown and blocked from new consumer onboarding until reviewed.
+
+**Verification**:
+- Infrastructure Design or operational runbooks document the review cadence and responsible party.
+- The catalog supports a `last_ownership_reviewed` timestamp field; it is updated after each review.
+- A catalog query surfacing datasets with `last_ownership_reviewed` older than two cadence periods is documented as an operational monitor.
+
+---
+
+## Rule CAT-07: Sensitive Dataset Discovery Is Access-Controlled
+
+**Severity**: P0 — Blocking
+
+**Rule**: Catalog entries for datasets classified as `pii`, `phi`, or `pci` (per DATAENG-06) MUST be visible in search results only to principals with a legitimate access need. The existence of a PII dataset MUST NOT be discoverable by all employees — catalog-level visibility must mirror data-level access controls. This does not mean classified datasets are invisible; it means the catalog enforces the same access model as the underlying data. This composes with S3LH-08 (Lake Formation), DBX-01 (Unity Catalog column masks), and SF-08 (Snowflake masking policies).
+
+**Verification**:
+- Infrastructure Design specifies catalog access tiers: which roles can discover `pii`/`phi`/`pci` entries vs `internal` vs `public` entries.
+- Catalog access controls are provisioned in the same IaC as data access controls — they are not managed separately.
+- Build and Test includes a check that a principal without data access cannot retrieve the catalog entry for a classified dataset.
+- `classification` field (CAT-03) drives the access tier assignment; no manual per-entry override without documented justification.
+
+---
+
+## Rule CAT-08: Lineage Links Are Populated in the Catalog
+
+**Severity**: P1 — Warning
+
+**Rule**: The catalog entry for every produced dataset MUST reference its upstream sources and the transformation that produced it, queryable from the catalog without reading pipeline code. Lineage in the catalog need not be column-level (that is governed by DATAENG-08) but MUST capture dataset-level lineage: which datasets feed this one, and which datasets consume it. This makes impact analysis — "what breaks if I change dataset X?" — answerable from the catalog alone.
+
+**Verification**:
+- Infrastructure Design names the lineage integration between the catalog and the lineage mechanism named in DATAENG-08 (OpenLineage, Unity Catalog lineage, Snowflake ACCESS_HISTORY, dbt artifacts, etc.).
+- Catalog entries for produced datasets include at least one upstream source reference and at least one downstream consumer reference where consumers are known.
+- Build and Test verifies at least one dataset's catalog entry contains a populated lineage graph after a staging deployment.
+- Lineage entries are updated by the same automated mechanism as schema updates (CAT-05) — not maintained manually.

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/catalog/catalog.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/catalog/catalog.opt-in.md
@@ -1,0 +1,18 @@
+# Data Catalog and Ownership — Opt-In
+
+**Extension**: Data Catalog and Ownership
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: Data Catalog and Ownership Extension
+Should data catalog and ownership rules be enforced for this project?
+
+A) Yes — enforce all CAT rules per their P0/P1/P2 severity tiers (recommended for any project producing datasets consumed by another team, service, or analytical workload)
+B) No — skip all CAT rules (suitable only for fully self-contained pipelines whose outputs are never shared outside the producing team and have no external consumers)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/cicd/cicd.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/cicd/cicd.md
@@ -1,0 +1,154 @@
+# CI/CD for Data Assets Extension
+
+Rules for applying software engineering delivery practices to data assets — including schema change review, breaking change detection, pipeline deployment promotion, secret scanning, and environment parity. Applies to any project that produces data pipelines, schemas, dbt models, Glue jobs, or orchestration definitions deployed to a production environment.
+
+This extension layers on top of `data-engineering/baseline`. It composes with `orchestration` (deployment targets), `s3-lakehouse` (table format migrations), `databricks` (DABs / Asset Bundles), `redshift`, `snowflake`, and `postgresql` (DDL migration tooling).
+
+## Severity Tiers
+
+Severity tiers are defined in `data-engineering/baseline`. The same P0/P1/P2 model applies here:
+
+| Tier | Enforcement |
+|------|-------------|
+| **P0** | Blocking — must be resolved before stage sign-off. |
+| **P1** | Warning — must be resolved before production go-live; flagged but does not block individual stages. |
+| **P2** | Advisory — good practice; noted in compliance summary but non-blocking at all stages. |
+
+---
+
+## Rule CICD-01: All Data Assets Managed in Version Control
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every artifact that defines the shape or behavior of a production data asset MUST be committed to version control: DDL migration scripts, schema definitions, dbt models, Glue job scripts, DAG files, State Machine ASL definitions, IaC (CloudFormation, CDK, Terraform), and data contracts. Assets that exist only in a UI, console, or metastore and cannot be reproduced from the repository are prohibited in production. This rule enables all downstream CI/CD, review, and audit rules.
+
+**Verification**:
+- Code Generation places all pipeline code, DDL, and IaC in the repository under documented paths.
+- No production asset is created exclusively via a cloud console, Airflow UI, or notebook run.
+- Build and Test includes a `git status` / drift-detection check confirming deployed state matches repository HEAD.
+- Brownfield reverse engineering captures any existing assets not yet in version control and creates a remediation plan.
+
+---
+
+## Rule CICD-02: Schema Changes Require a Pull Request with Reviewer Sign-Off
+
+**Severity**: P0 — Blocking
+
+**Rule**: Any change to a published schema — adding, removing, or modifying columns; changing types, nullability, or partitioning; altering primary or foreign key constraints — MUST be made via a pull request and approved by at least one designated data owner or schema reviewer before merge to the default branch. Direct commits to the default branch that modify schema artifacts are prohibited. This ensures breaking change classification (DATAENG-02) is reviewed by a human before the change lands.
+
+**Verification**:
+- Infrastructure Design or build instructions document the branch protection rule: required reviewers on paths matching schema artifacts (`migrations/`, `models/`, `schemas/`, `dags/`, `*.sql`, `*.yaml` schema files, etc.).
+- Code Generation places schema changes in discrete migration files, not inline with unrelated code changes.
+- Build and Test confirms branch protection is configured (e.g., via `gh api` check or repository settings audit step).
+- Reviewer sign-off is captured in the PR; the merge commit SHA is recorded in audit.md.
+
+---
+
+## Rule CICD-03: Breaking Change Detection Runs Automatically in CI
+
+**Severity**: P0 — Blocking
+
+**Rule**: The CI pipeline MUST automatically detect breaking schema changes on every pull request that touches schema artifacts and surface the result before merge. A breaking change detected in CI is a hard blocker: the PR cannot merge until either the design is made additive, or the breaking change is explicitly classified and a consumer coexistence plan is approved (per DATAENG-02). Acceptable detection mechanisms include: schema diff tools (buf breaking, schemathesis, dbt schema diff), Glue Schema Registry compatibility checks, Iceberg/Delta schema evolution validation, or a custom migration linter.
+
+**Verification**:
+- Infrastructure Design or build instructions name the breaking change detection tool and the CI step it runs in.
+- CI configuration (e.g., `.github/workflows/`, `buildspec.yml`, `Jenkinsfile`) includes the schema diff step on the paths that trigger it.
+- Build and Test documents a test case where a deliberately breaking change (column removal, type narrowing) causes the CI step to fail.
+- A breaking change that bypasses detection (e.g., renaming a file to avoid path matching) is itself a CI defect — path matching covers all schema artifact patterns.
+
+---
+
+## Rule CICD-04: Migration Scripts Are Forward-Only and Sequenced
+
+**Severity**: P0 — Blocking
+
+**Rule**: Schema changes MUST be expressed as versioned, forward-only migration scripts (Flyway, Liquibase, Alembic, custom numbered SQL files). In-place edits to previously applied migration files are prohibited — once a migration is merged and applied to any environment it is immutable. Each migration file MUST have a unique monotonically increasing version or timestamp prefix. Rollback scripts are permitted as a separate forward migration (e.g., `V003__revert_column_rename.sql`) but MUST NOT be applied automatically.
+
+**Verification**:
+- Code Generation produces migration files following the project's chosen versioning scheme.
+- CI includes a lint step that detects modifications to already-merged migration files (e.g., `git diff origin/main -- migrations/` checks for edits to existing files rather than new additions).
+- Build and Test applies migrations to a clean schema and verifies the target state matches the contract.
+- No migration file is deleted or modified after merging to the default branch.
+
+---
+
+## Rule CICD-05: CI Pipeline Applies Migrations to an Isolated Test Schema
+
+**Severity**: P1 — Warning
+
+**Rule**: The CI pipeline MUST apply all pending migrations against an isolated, ephemeral test schema or database before the pull request can merge. Testing migrations only in staging or production is prohibited. The test schema MUST be spun up fresh for each CI run to catch ordering dependencies and cumulative state issues that a diff-only review misses.
+
+**Verification**:
+- Build instructions include a step: spin up ephemeral schema, apply all migrations from V0, run validation queries, tear down.
+- CI uses a real database engine matching production (not a SQLite substitute for a PostgreSQL target, not a local Spark session for a Redshift target).
+- Test schema is isolated per PR run (unique name derived from PR number or commit SHA) to prevent concurrent CI runs from interfering.
+- Migration apply step fails the CI run on any error; partial applies are not accepted.
+
+---
+
+## Rule CICD-06: Environment Promotion Is Sequential and Gated
+
+**Severity**: P0 — Blocking
+
+**Rule**: Pipeline and schema artifacts MUST promote through environments in a fixed sequence (e.g., dev → staging → production) with an explicit gate at each boundary. Deploying directly to production without a prior successful staging deployment is prohibited except during declared incidents with documented approval. Each promotion gate MUST require: CI passing on the source branch, migration apply success in the target environment's test schema, and a human approval step for the production gate.
+
+**Verification**:
+- Infrastructure Design diagrams the promotion sequence and gate requirements per environment.
+- The CI/CD pipeline configuration enforces the sequence (no production deploy job unless staging succeeded).
+- The production gate requires manual approval (GitHub Actions environment protection, CodePipeline approval action, or equivalent).
+- Incident-exception deployments are logged in audit.md with approver identity and timestamp.
+
+---
+
+## Rule CICD-07: Secret Scanning Blocks Merge on Detection
+
+**Severity**: P0 — Blocking
+
+**Rule**: Secret scanning MUST run on every pull request and block merge if a secret pattern is detected. Scanning MUST cover: AWS access keys, Snowflake connection strings, database passwords, API tokens, private keys, and generic high-entropy strings. Approved scanning tools include: GitHub Advanced Security secret scanning, GitLeaks, Trufflehog, detect-secrets, or AWS CodeGuru. A finding that is suppressed without review is itself a policy violation. This composes with DATAENG-15.
+
+**Verification**:
+- Build instructions include the secret scanning tool and the CI step it runs on.
+- A false-positive suppression requires a documented review comment on the suppression entry (e.g., `.secrets.baseline` entry with justification).
+- Build and Test documents a test case where a synthetic secret pattern (e.g., a clearly fake `AKIA`-prefixed key) causes the scan to fail.
+- Pre-commit hooks for secret scanning are recommended for developer workstations (P2 advisory) but CI gate is the enforced control.
+
+---
+
+## Rule CICD-08: Pipeline Code Is Tested Before Deployment
+
+**Severity**: P1 — Warning
+
+**Rule**: Data pipeline code MUST have automated tests that run in CI before deployment: unit tests for transformation logic, DAG import tests for MWAA DAGs (per ORCH-02), ASL schema validation for Step Functions definitions, and contract tests asserting that the pipeline's output schema matches the declared data contract. Integration tests against a real compute target are required before staging promotion. Code with no tests cannot be deployed to staging or production.
+
+**Verification**:
+- Build and Test includes: unit test step, DAG import test or ASL validation step, and at least one contract test per produced dataset.
+- CI configuration runs tests before any deploy step.
+- Code coverage is reported; a floor (recommended: 70% for transformation logic) is documented even if not enforced as a hard gate.
+- Brownfield projects document existing test gaps and a remediation timeline.
+
+---
+
+## Rule CICD-09: Deployed Artifact Versions Are Tagged and Traceable
+
+**Severity**: P1 — Warning
+
+**Rule**: Every artifact deployed to staging or production MUST be tagged with its originating commit SHA, CI run ID, and deployment timestamp. Deployed Lambda functions, Glue job scripts, DAG S3 objects, Step Functions State Machine revisions, dbt manifest files, and container images MUST all carry this provenance. Untagged production deployments make incident root-cause analysis impractical. This composes with ORCH-14.
+
+**Verification**:
+- Infrastructure Design specifies the tagging strategy and which resources carry provenance tags.
+- CI/CD pipeline sets tags at deploy time (AWS resource tags, S3 object metadata, image labels).
+- Build and Test includes a post-deploy step that asserts the deployed artifact's provenance tags match the current CI run.
+- dbt manifest.json or equivalent artifact version file is stored in S3 or an artifact store alongside each production deployment.
+
+---
+
+## Rule CICD-10: Data Contract Changes Follow the Same PR Process as Schema Changes
+
+**Severity**: P1 — Warning
+
+**Rule**: Changes to data contract files (per DATAENG-01) MUST follow the same PR and reviewer sign-off process as schema migration scripts (CICD-02). A data contract change that is not reflected in a corresponding schema migration is a finding. A schema migration that is not reflected in a corresponding data contract update is a finding. Contracts and migrations MUST remain in sync; CI MUST detect divergence.
+
+**Verification**:
+- CI includes a sync-check step: if a migration file changes, the corresponding contract file must also change in the same PR (and vice versa), unless the change is explicitly classified as contract-only (e.g., documentation update) or migration-only (e.g., index addition with no schema change).
+- Functional Design or Code Generation co-locates contract files with the migration or model they describe, making divergence visible in diffs.
+- Build and Test validates that the applied migration's resulting schema matches the contract's column list, types, and nullability for each affected dataset.

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/cicd/cicd.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/cicd/cicd.opt-in.md
@@ -1,0 +1,18 @@
+# CI/CD for Data Assets — Opt-In
+
+**Extension**: CI/CD for Data Assets
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: CI/CD for Data Assets Extension
+Should CI/CD rules for data assets be enforced for this project?
+
+A) Yes — enforce all CICD rules per their P0/P1/P2 severity tiers (recommended for any project deploying data pipelines, schemas, or orchestration definitions to a production environment)
+B) No — skip all CICD rules (suitable only for purely exploratory or sandbox work with no production consumers)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/glue-etl/glue-etl.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/glue-etl/glue-etl.md
@@ -1,0 +1,301 @@
+# AWS Glue ETL Extension
+
+Rules for data engineering workloads that use AWS Glue as a compute surface — Spark ETL jobs, Spark Streaming ETL jobs, Ray jobs, Python shell jobs, interactive sessions, and visually authored jobs (Glue Studio, DataBrew). Applies whenever Glue is the runtime for transformation, ingestion, or movement of data, regardless of source or destination.
+
+This extension layers on top of `data-engineering/baseline`. It composes with `data-engineering/catalog` (which mandates Glue Data Catalog as a registration target), `data-engineering/s3-lakehouse` (which mandates Glue Data Catalog as the lakehouse metastore in S3LH-02), `data-engineering/cicd` (which mandates Glue job scripts in version control in CICD-01 and provenance tagging in CICD-09), `data-engineering/orchestration` (which governs Step Functions and MWAA invocation of Glue), and `data-engineering/redshift` (which mandates JDBC for Glue ETL → Redshift in RSHIFT-11).
+
+## Severity Tiers
+
+Severity tiers are defined in `data-engineering/baseline`. The same P0/P1/P2 model applies here:
+
+| Tier | Enforcement |
+|------|-------------|
+| **P0** | Blocking — must be resolved before stage sign-off. |
+| **P1** | Warning — must be resolved before production go-live; flagged but does not block individual stages. |
+| **P2** | Advisory — good practice; noted in compliance summary but non-blocking at all stages. |
+
+---
+
+## Rule GLUE-01: Job Type and Glue Version Chosen Deliberately
+
+**Severity**: P1 — Warning
+
+**Rule**: Every Glue job MUST declare its job type and Glue version with documented rationale. The job type — Spark, Spark Streaming, Ray, or Python shell — fundamentally determines runtime cost, parallelism model, and available APIs. Defaulting to Spark for everything wastes money on workloads that fit in a Python shell; defaulting to Python shell starves jobs that need a distributed engine.
+
+**Job type selection criteria**:
+
+| Job type | Use when | Avoid when |
+|----------|----------|------------|
+| **Spark (Glue ETL)** | Batch transforms over >10 GB per run, joins across distributed datasets, writes to Iceberg/Delta tables | Source/sink fits in memory of a single worker; the work is sequential and not partitionable |
+| **Spark Streaming** | True streaming sources (Kinesis Data Streams, MSK, self-managed Kafka) with continuous ingestion | Micro-batch over an hourly schedule — that's a Spark batch job triggered hourly, not streaming |
+| **Ray** | Distributed Python workloads that are model-training-adjacent or require fine-grained Python parallelism rather than Spark's bulk-synchronous model | General ETL — Spark is the better fit and has more mature catalog, bookmark, and connector integration |
+| **Python shell** | Small jobs under 1 DPU: orchestration glue, single-file landings, sub-GB transformations, calls to external APIs | Anything that needs distributed compute or reads more than tens of millions of rows |
+
+**Glue version pinning**:
+
+- Glue version (4.0, 5.0, etc.) MUST be pinned explicitly per job — not left to "latest." Glue versions bundle a specific Spark, Python, and connector matrix; an unpinned job picks up new versions at AWS's discretion and breaks reproducibility.
+- End-of-support windows for older Glue versions MUST be tracked. A Glue 3.0 job still in production after the documented end-of-support date is a P0 finding at the next review — schedule the upgrade before the deadline, not after the runtime stops.
+- When upgrading Glue versions, the upgrade MUST be tested on a non-production job run with representative data volume; behavior changes between Glue versions (Spark API deprecations, connector defaults, Python library versions) are routine and assumed-compatible upgrades have failed silently in production.
+
+**Verification**:
+- Functional Design names the job type per Glue job with rationale tied to the data volume, parallelism need, and source/sink characteristics.
+- Infrastructure Design lists the pinned Glue version per job and the end-of-support date for that version.
+- Code Generation sets `GlueVersion` explicitly in the job definition; no job uses an unset or wildcard version.
+- Build and Test for any Glue version upgrade includes a parallel run on a representative dataset comparing output row counts and a sample of values against the prior version.
+
+---
+
+## Rule GLUE-02: Spark DataFrame Is the Default — DynamicFrame Only With Cause
+
+**Severity**: P2 — Advisory
+
+**Rule**: Spark DataFrame is the default API for Glue Spark jobs. DynamicFrame MUST be used only when its specific capabilities are needed: schema inference from heterogeneous sources, `resolveChoice` to handle columns with mixed types across files, `relationalize` to unnest JSON, or reading from a catalog table whose schema is genuinely unknown at job-author time. Code that converts DynamicFrame to DataFrame on the first line and never uses DynamicFrame methods is a code smell — start with the DataFrame API instead.
+
+**Why DataFrame by default**:
+
+- DataFrame is the dominant Spark API; it has more documentation, more community examples, more performance tuning guidance, and more compatibility with non-Glue Spark environments. Code written against DataFrame ports to EMR, Databricks, and self-managed Spark; code written against DynamicFrame is Glue-specific.
+- DynamicFrame's schema flexibility carries CPU cost. Every record passes through Glue's choice-resolution machinery even when the schema is in fact uniform. For uniform-schema datasets, DataFrame is faster and produces cleaner Spark plans.
+- Catalyst optimization is more thoroughly applied to DataFrame operations. Several DynamicFrame operations are opaque to Catalyst and force whole-stage codegen to bail out.
+
+**When DynamicFrame is the right choice**:
+
+- Reading semi-structured data (JSON, log lines) where individual records have different shapes and column types vary across files. `resolveChoice` consolidates these without failing the job.
+- Reading from a catalog table whose underlying files have evolved through multiple schema versions and whose Spark-inferred schema would conflict.
+- One-time data exploration and profiling jobs where author time is more valuable than runtime cost.
+
+**Verification**:
+- Functional Design states the chosen API per job (DataFrame or DynamicFrame) with rationale.
+- Code Generation reviews flag any job that imports `awsglue.dynamicframe` but immediately calls `toDF()` without invoking a DynamicFrame-specific method — convert it to a DataFrame-native job.
+- Mixed-type columns or schema inconsistencies that justified DynamicFrame are documented in the design as the source data's known shape, not as defensive coding.
+
+---
+
+## Rule GLUE-03: Job Bookmarks Used for Incremental Sources
+
+**Severity**: P0 — Blocking
+
+**Rule**: Glue jobs reading from incremental sources (S3 prefixes that grow over time, JDBC tables with monotonic columns, catalog tables backed by partitioned data) MUST use Glue job bookmarks to track processed data. Re-processing the entire source on every run is acceptable only for jobs explicitly designed as full-snapshot pipelines, and that design choice MUST be documented. Disabling bookmarks (`--job-bookmark-option job-bookmark-disable`) in production for an incremental source is prohibited.
+
+**Bookmark requirements**:
+
+- The job script MUST call `job.init(args['JOB_NAME'], args)` at start and `job.commit()` at end. A job that omits `job.commit()` reads the same data every run because the bookmark never advances. This is the single most common Glue job defect and is not caught by any AWS-side guardrail.
+- The bookmark option MUST be set per job: `job-bookmark-enable` for incremental, `job-bookmark-disable` for full-snapshot (with documented rationale), `job-bookmark-pause` for one-off reprocessing windows. `pause` MUST be reverted to `enable` after the reprocessing window — leaving a job in `pause` indefinitely silently disables bookmarks.
+- Bookmark behavior depends on source type. For S3 sources, bookmarks track which files have been read; for JDBC, they track the maximum value of the bookmark key column. The chosen bookmark key for JDBC sources MUST be monotonically increasing and indexed at the source.
+- DynamicFrame-only feature: bookmarks work natively on DynamicFrame reads from catalog tables and from `from_options`. DataFrame reads from S3 do NOT participate in Glue bookmarks unless the read is wrapped through `glueContext.create_dynamic_frame.from_catalog` or equivalent. Jobs using pure DataFrame APIs against incremental sources MUST implement watermark tracking explicitly (e.g., maximum processed timestamp written to a control table) — this is a design decision that MUST be made and documented, not discovered when re-runs duplicate data.
+
+**Bookmark reset procedure**:
+
+- Resetting a bookmark (e.g., to reprocess a backfill window) MUST follow a documented runbook: stop downstream consumers or write to a side branch, run with `--job-bookmark-option job-bookmark-pause` to test, then `--job-bookmark-option job-bookmark-from-time <RFC3339>` for the reprocessing run, then restore to `job-bookmark-enable`. Resetting in production without this sequence has caused duplicate writes to downstream tables.
+- The reset event MUST be logged in audit.md with the reset reason, the time window reprocessed, and the operator who ran it.
+
+**Verification**:
+- Functional Design states per source whether the read is incremental or full-snapshot, and the bookmark key column for JDBC sources.
+- Code Generation reviews confirm `job.init` and `job.commit` are present in every Glue Spark job; the absence of either is a P0 finding.
+- For DataFrame-based jobs reading incremental sources, the design specifies the explicit watermark tracking mechanism (control table, max-timestamp file in S3, etc.).
+- Build and Test includes a re-run test: invoke the job twice on the same incremental source and assert the second run processes zero or only newly-added rows.
+- The bookmark reset runbook is included in the build-and-test runbook section.
+
+---
+
+## Rule GLUE-04: Worker Type, DPU Count, and Auto Scaling Sized to Measured Workload
+
+**Severity**: P1 — Warning
+
+**Rule**: Worker type, number of workers, and Auto Scaling configuration MUST be chosen against measured data volume, partition count, and shuffle behavior — not picked from a default. The wrong worker type is the single biggest contributor to Glue job cost overruns: undersized G.1X workers spill to disk and run for hours; oversized G.4X workers sit idle and bill at premium rates.
+
+**Worker type selection**:
+
+| Worker type | DPUs | Memory per worker | Use when |
+|-------------|------|-------------------|----------|
+| **G.025X** | 0.25 | 4 GB | Streaming jobs with very low throughput; small Python shell-equivalent loads where Spark is still preferred for catalog integration |
+| **G.1X** | 1 | 16 GB | Default for most batch ETL — covers the broad middle of workloads |
+| **G.2X** | 2 | 32 GB | Heavy joins, large shuffles, jobs that spill on G.1X. Verify spill before upgrading; a slow G.1X job is not always memory-bound |
+| **G.4X** | 4 | 64 GB | Memory-intensive transforms (large broadcast joins, wide aggregations on TB-scale data). Required only when G.2X demonstrably spills |
+| **G.8X** | 8 | 128 GB | Reserved for documented memory-pressure cases. Unjustified G.8X selection is the most common cost finding in Glue reviews |
+| **R-series (R.1X, R.2X, R.4X, R.8X)** | Memory-optimized variants of G-series | Use when measured spill is heavy but CPU is underutilized; rare |
+
+**DPU and Auto Scaling**:
+
+- Number of workers MUST be set as a function of input partition count and target task parallelism — not picked as a round number. Rule of thumb: target 2–4 Spark tasks per executor core. A job reading 200 input partitions with G.1X workers (4 cores each) is well-served by 13–25 workers; running 50 workers leaves most idle.
+- Auto Scaling MUST be enabled for jobs with variable input volume; the maximum worker count MUST be capped to bound cost runaway (composes with DATAENG-11). Leaving Auto Scaling at the account-default maximum is not a sizing decision.
+- Streaming jobs MUST set the worker count statically — Auto Scaling on streaming ETL is not supported as of Glue 4.0 and producing a job definition that assumes it will scale is a defect.
+- The DPU-hour budget per job run MUST be projected before the job goes to production. A job that consumes 80 DPU-hours per run multiplied by hourly schedules is several thousand dollars per month — and is invisible until the bill arrives.
+
+**Verification**:
+- NFR Requirements captures expected input volume, partition count, and run frequency per job.
+- Infrastructure Design specifies worker type, baseline worker count, Auto Scaling enabled/disabled, and max workers — with rationale referencing the volume estimate.
+- Build and Test runs the job at representative volume and captures actual DPU-seconds consumed; if actual usage diverges from the projection by more than 50%, the worker count or type is reassessed before production.
+- Cost projection covers steady-state monthly DPU-hour cost per job and is signed off as part of NFR Requirements.
+
+---
+
+## Rule GLUE-05: Job Parameters and Secrets Bound Through Defined Mechanisms
+
+**Severity**: P0 — Blocking
+
+**Rule**: Glue job arguments MUST follow defined patterns for configuration, secrets, and Glue-managed flags. Plaintext credentials in Default Arguments are prohibited. Required Glue feature flags MUST be set explicitly. Tuning parameters carried as job arguments MUST be parameterized — not hardcoded inside the job script.
+
+**Required Glue feature flags**:
+
+The following arguments MUST be set on every applicable job. Omission is a P0 finding because each flag enables a feature that downstream rules depend on:
+
+- `--enable-glue-datacatalog`: Required for any job that reads from or writes to a catalog table. Without it, Spark uses its own in-memory metastore and silently bypasses the Glue Data Catalog (defeats S3LH-02 and CAT-02).
+- `--enable-continuous-cloudwatch-log`: Required for all production Spark jobs (composes with GLUE-08).
+- `--enable-metrics`: Required for all production Spark jobs (composes with GLUE-08).
+- `--enable-job-insights`: Required for all production Spark jobs (composes with GLUE-08).
+- `--job-bookmark-option`: Required to be set explicitly to `enable`, `disable`, or `pause` per GLUE-03; an unset value defaults to `disable` silently.
+- `--enable-spark-ui` and `--spark-event-logs-path`: Required for jobs expected to run more than 5 minutes; the Spark UI history is the primary post-incident debugging surface (composes with GLUE-08).
+
+**Secrets**:
+
+- Database passwords, API keys, and any other credential MUST resolve through Secrets Manager — not be passed as job arguments and not be embedded in the job script (composes with DATAENG-15).
+- The job's IAM role MUST have `secretsmanager:GetSecretValue` scoped to specific secret ARNs — not `secretsmanager:*` on `*`. Cross-account secret access MUST be explicitly justified.
+- Connection objects (the Glue Connection resource type) that bundle credentials with network configuration MUST reference Secrets Manager rather than storing the password in the connection definition itself. Older Glue Connection objects with embedded passwords MUST be migrated.
+
+**Tuning parameters**:
+
+- Spark configuration overrides (`--conf spark.sql.shuffle.partitions=...`) MUST be passed as job arguments rather than hardcoded with `spark.conf.set` inside the script. This makes tuning visible in the job definition and CI-reviewable.
+- Job-specific input paths, output paths, and run dates MUST be passed as job arguments — not hardcoded. Hardcoded paths defeat reuse across environments and force per-environment script copies (composes with CICD-01).
+
+**Verification**:
+- Code Generation reviews list the job arguments per job; the required Glue feature flags above are present and any omission is justified in writing.
+- Infrastructure Design specifies the IAM role for each job with `secretsmanager:GetSecretValue` scoped to specific ARNs and lists the secret ARNs the job consumes.
+- No Glue Connection object in the design has an inline password.
+- Static analysis or grep checks confirm no `spark.conf.set("spark.sql.*")` or hardcoded credential string in committed job scripts.
+
+---
+
+## Rule GLUE-06: Pushdown Predicates and Partition Pruning Enforced
+
+**Severity**: P1 — Warning
+
+**Rule**: Glue jobs reading from catalog tables backed by partitioned data MUST use pushdown predicates so the job reads only the partitions it needs. Reading an entire partitioned table when the job filters to a single date partition wastes runtime and S3 GET cost. Pushdown failures are not always visible from the job script — they manifest as long read times and high DPU-second consumption that look like compute problems but are actually I/O problems.
+
+**Mechanisms**:
+
+- For DynamicFrame reads via `glueContext.create_dynamic_frame.from_catalog`, partition pruning uses the `push_down_predicate` argument. The predicate is a SQL expression evaluated against partition columns. Without it, all partitions are listed.
+- For partitions that are themselves the result of an expensive partition discovery (high-cardinality date or hour partitions), `catalogPartitionPredicate` is preferred over `push_down_predicate` — it is evaluated server-side by the Glue Data Catalog before partition metadata is fetched, avoiding the listing cost entirely.
+- For DataFrame reads via Spark SQL or `spark.read.format(...).table(...)`, partition pruning happens through Catalyst when the WHERE clause references partition columns directly. Joins and subqueries that obscure the partition column from the planner defeat pruning; the design MUST verify the plan, not assume Catalyst will figure it out.
+- For Iceberg tables (composes with S3LH-04), partition transforms (`bucket`, `truncate`, `days`) work correctly only when the query references the underlying column; predicates on derived columns will not prune. Iceberg table designs MUST document which query predicates align with which partition transforms.
+
+**Verification**:
+- Functional Design lists per source the partition columns and the expected query predicate per job run.
+- Code Generation reviews show `push_down_predicate` or `catalogPartitionPredicate` set on every DynamicFrame read from a partitioned catalog table; jobs without one are flagged.
+- Build and Test captures a Spark plan (`EXPLAIN`) for representative jobs and confirms partition filters appear in the scan node — not as a post-scan filter.
+- Glue job metrics MUST show partition reads bounded to the expected count; a job that reads 365 partitions when filtering to one day is a finding regardless of correctness.
+
+---
+
+## Rule GLUE-07: Retry, Timeout, and Concurrent Run Controls Set Explicitly
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every Glue job MUST set explicit values for `Timeout`, `MaxRetries`, and `MaxConcurrentRuns`. The defaults — 2880-minute timeout, 0 retries, 1 concurrent run — are not safe defaults for most workloads: 48 hours is far too long for cost protection on a misbehaving job; zero retries gives no resilience to transient failures; and 1 concurrent run will silently queue overlapping invocations from upstream orchestrators.
+
+**Settings**:
+
+- **Timeout**: MUST be set to a value tied to the expected run duration plus a safety multiplier. A job that runs in 20 minutes at p99 should have a timeout of 60–90 minutes, not 2880. An over-long timeout is a cost-runaway risk: a stuck job consumes DPU-hours until the timeout fires.
+- **MaxRetries**: MUST be set considering job idempotency. For a fully idempotent job (composes with DATAENG-04), 1–2 retries is reasonable. For a non-idempotent job, retries MUST be 0 and orchestration must handle re-invocation through a designed-for-rerun path (composes with ORCH-07). A retry-loop on a non-idempotent job that writes side effects creates duplicates.
+- **MaxConcurrentRuns**: MUST be set deliberately. Setting it to 1 prevents concurrent overruns but causes upstream orchestrators to queue jobs. Setting it >1 allows concurrent runs but the job MUST be designed for it (different bookmark scope per run, partitioned output paths, no shared mutable state).
+- Job runs invoked from Step Functions MUST check for an already-running execution before retrying (composes with ORCH-07). The design MUST specify whether the orchestrator or Glue itself owns retry semantics — not both.
+
+**Verification**:
+- NFR Requirements captures the expected job duration distribution (p50, p99) and the SLO-based timeout target.
+- Infrastructure Design specifies `Timeout`, `MaxRetries`, and `MaxConcurrentRuns` per job with rationale.
+- Code Generation reviews confirm the values are set in the job definition; a job using defaults is a P0 finding.
+- For non-idempotent jobs, the retry path is designed end-to-end across orchestrator and job and documented; ad-hoc retry-on-orchestrator + retry-on-Glue is flagged.
+
+---
+
+## Rule GLUE-08: Continuous Logging, Metrics, and Job Run Insights Enabled
+
+**Severity**: P1 — Warning
+
+**Rule**: Production Glue Spark jobs MUST emit continuous CloudWatch logs, Glue job metrics, and Glue Job Run Insights. Spark UI event logs MUST be persisted to S3 for jobs expected to run more than 5 minutes. The default Glue logging configuration — driver and executor logs only on completion, no metrics, no insights — does not provide enough signal to debug a failed or slow production run; teams that ship with defaults are then surprised when the post-incident review has no usable data.
+
+**Required configuration**:
+
+- `--enable-continuous-cloudwatch-log true` and `--continuous-log-logGroup` set to a project-specific log group with a documented retention. Continuous logging streams driver and executor stdout/stderr in near-real-time, allowing live troubleshooting of running jobs.
+- `--enable-metrics true` emits Glue's job-level CloudWatch metrics (DPU usage, executor count, memory pressure) — required for capacity dashboards and Auto Scaling tuning.
+- `--enable-job-insights true` produces Glue's automated diagnostic reports for failed runs (skewed partitions, executor OOM, common Spark anti-patterns). For any non-trivial job this saves hours of post-failure analysis.
+- `--enable-spark-ui true` and `--spark-event-logs-path` pointed to a project-controlled S3 path. The Spark UI history server is the primary diagnostic for slow stages and skewed shuffles. Event logs MUST land in a path that is not deleted by lifecycle policies sooner than the operational review cadence (e.g., 30 days minimum).
+- Log group retention MUST be set explicitly. The Glue-default 14-day retention is too short for weekly on-call rotations and quarterly audits; 90 days is a reasonable baseline.
+
+**CloudWatch dashboards and alerts**:
+
+- Each production job MUST have at least one CloudWatch alarm: job failure (one or more failed runs in a rolling window) or job duration breach (p99 duration exceeds SLO).
+- A central dashboard listing DPU-hours per job over the last 30 days MUST exist; cost regressions show up here before they show up on the bill (composes with DATAENG-11).
+
+**Verification**:
+- Infrastructure Design specifies log group name, retention, S3 event log path, and the CloudWatch alarms per job.
+- Code Generation reviews confirm `--enable-continuous-cloudwatch-log`, `--enable-metrics`, `--enable-job-insights`, and (where applicable) `--enable-spark-ui` are present in every production job's arguments.
+- Build and Test confirms the job's log group and event log path are reachable and contain entries after a test run.
+- The runbook (composes with RSHIFT-12 pattern of named diagnostic surfaces) lists Glue Job Run Insights and Spark UI as the first stops for slow or failed runs.
+
+---
+
+## Rule GLUE-09: Streaming ETL Discipline — Checkpoints, Watermarks, Schema Registry
+
+**Severity**: P1 — Warning
+
+**Rule**: Glue Streaming ETL jobs MUST set an explicit checkpoint location, configure a micro-batch window appropriate to the source rate, define watermarks for late-arriving data, and bind to a schema registry for any structured streaming source. Streaming jobs left at defaults exhibit silent data loss on operator restarts, unbounded state accumulation, and schema drift that corrupts downstream tables.
+
+**Checkpoint requirements**:
+
+- `checkpointLocation` MUST be set to a project-controlled S3 path scoped per job and per job version. Re-using a checkpoint location across job versions causes Spark to refuse to start with a state-incompatibility error; using a single shared checkpoint across multiple jobs causes silent state corruption.
+- The checkpoint location MUST have an S3 lifecycle policy that does NOT expire current checkpoint data. Lifecycle expiration on a checkpoint location is a recurring incident pattern — the job appears healthy until the operator restart, at which point the missing checkpoint forces a restart from earliest offsets and re-emits hours of already-processed data.
+- A checkpoint reset procedure MUST be documented (analogous to the bookmark reset procedure in GLUE-03): when intentional state reset is needed, the runbook specifies the steps to drain downstream consumers, clear the checkpoint, and restart with a defined start position.
+
+**Micro-batch window**:
+
+- `windowSize` MUST be set deliberately. The Glue default of 100 seconds is reasonable for many workloads but is not universal. Sub-30-second windows for low-rate sources cause excess Spark scheduling overhead and high empty-batch counts; multi-minute windows on high-rate sources accumulate excess in-memory state and increase end-to-end latency.
+- The chosen window MUST be justified in NFR Requirements against the source's measured event rate and the downstream latency SLO.
+
+**Watermarks and late data**:
+
+- Streaming jobs that aggregate or join MUST define an event-time watermark. Without one, state grows unboundedly and the job fails after hours or days with executor OOM.
+- The watermark delay MUST be chosen against the measured 99th-percentile late-arrival distribution of the source — not a round number. A 10-minute watermark on a source where 1% of events arrive 30 minutes late silently drops 1% of events.
+- The job MUST emit a metric for late-data drop count; a streaming job that drops late data without telemetry has a silent data-loss bug waiting to be discovered downstream (composes with DATAENG-09 backfill).
+
+**Schema registry binding**:
+
+- Streaming ETL jobs reading from Kinesis, MSK, or self-managed Kafka MUST bind to AWS Glue Schema Registry (composes with DATAENG-01). The job arguments specify the registry name, schema name, and compatibility mode. Reading streaming data without a schema registry contract is a P0 finding for any production source feeding a contracted downstream table.
+- Schema evolution events on the source registry MUST not deploy automatically to a running streaming job. Streaming jobs MUST be restarted on a controlled schedule when the source schema changes, with the new schema version pinned in the job arguments.
+
+**Verification**:
+- Infrastructure Design specifies the checkpoint S3 path per streaming job, lifecycle policy on that path, and the documented checkpoint reset runbook.
+- NFR Requirements documents the source event rate, target end-to-end latency, late-arrival distribution, and the chosen `windowSize` and watermark delay with rationale.
+- Code Generation reviews confirm `checkpointLocation`, `windowSize`, watermark configuration, schema registry binding, and late-data metric emission are present.
+- Build and Test includes a checkpoint-recovery test: kill the job mid-batch and confirm restart resumes from the checkpoint without re-emitting committed records.
+
+---
+
+## Rule GLUE-10: Interactive Sessions and Visual Authoring Governed Separately From Production
+
+**Severity**: P1 — Warning
+
+**Rule**: Glue interactive sessions, Glue Studio (visual authoring), and Glue DataBrew are development and exploration surfaces. They MUST NOT bypass the controls that apply to production jobs: IAM scope, cost controls, and code-in-version-control discipline. The most common pattern of Glue cost runaway and untracked production code traces back to interactive sessions left running and Studio jobs deployed straight from the console.
+
+**Interactive Sessions**:
+
+- Interactive Sessions MUST run under a dedicated dev/exploration IAM role — separate from any production job role. The dev role MUST NOT have write permission to production catalog databases, production S3 prefixes, or production Redshift schemas.
+- Every interactive session MUST have an idle timeout (`idle_timeout`) and a maximum session lifetime (`max_capacity`-bound or time-bound) set deliberately. The default — sessions live until manually stopped — has produced multi-week running sessions billing continuously. A default idle timeout of 30 minutes and a max session lifetime of 8 hours is a reasonable starting point.
+- Sessions MUST carry cost allocation tags identifying the user and the project (composes with DATAENG-11). Untagged sessions are routinely the largest single line items in unexpected Glue bills.
+- Notebook code that becomes production code MUST go through the same Code Generation and review path as any other Glue job. Promoting a notebook directly to a scheduled Glue job by exporting and uploading the script bypasses CI entirely — prohibited (composes with CICD-01, CICD-04).
+
+**Glue Studio (visual authoring)**:
+
+- Glue Studio jobs MUST be exported to script form and committed to version control. Visual-only jobs that exist only in the Glue console are prohibited in production — they cannot be reviewed in PRs, cannot be diffed across versions, and cannot be redeployed reproducibly (composes with CICD-01).
+- The Studio-generated script MAY be the canonical artifact (with the visual graph regenerated from the script on console open), or the visual graph MAY be the canonical artifact (with the script regenerated on save) — but the design MUST pick one and document it. Maintaining both as canonical leads to drift.
+- Studio jobs deployed from the console without going through the project's CI pipeline are a P0 finding regardless of how trivial the change appears (composes with CICD-06).
+
+**Glue DataBrew**:
+
+- DataBrew recipes MUST be versioned and exported to the project repository. A recipe authored in the DataBrew UI and never exported is identical in governance terms to an unversioned production script.
+- DataBrew profile jobs and projects MUST carry the same IAM scoping, cost tagging, and S3 path discipline as Glue ETL jobs. The DataBrew console exposes a different UI, not a different governance regime.
+
+**Verification**:
+- Infrastructure Design specifies the dev IAM role for interactive sessions, the idle and max-lifetime defaults, and the cost allocation tagging convention.
+- Build and Test (or operational runbook) includes a weekly review process surfacing long-running interactive sessions and untagged sessions for shutdown.
+- Code Generation reviews confirm every Glue Studio job in production has a corresponding committed script and that the project's canonical-form choice (script or visual graph) is documented.
+- DataBrew recipes used in production are listed in the project repository alongside the Glue ETL job inventory.

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/glue-etl/glue-etl.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/glue-etl/glue-etl.opt-in.md
@@ -1,0 +1,18 @@
+# AWS Glue ETL — Opt-In
+
+**Extension**: AWS Glue ETL
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: AWS Glue ETL Extension
+Should AWS Glue ETL rules be enforced for this project?
+
+A) Yes — enforce all GLUE rules per their P0/P1/P2 severity tiers (recommended if Glue Spark, Spark Streaming, Ray, Python shell, interactive sessions, Glue Studio, or DataBrew is a compute target)
+B) No — skip all GLUE rules (suitable when Glue is not used as a compute surface; note this does not exempt Glue Data Catalog usage governed by `data-engineering/catalog` and `data-engineering/s3-lakehouse`)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/orchestration/orchestration.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/orchestration/orchestration.md
@@ -1,0 +1,217 @@
+# Orchestration Extension
+
+Rules for data pipeline orchestration on AWS using Amazon Managed Workflows for Apache Airflow (MWAA) and AWS Step Functions. Covers DAG design, environment configuration, IAM, error handling, scheduling, and observability for both orchestrators.
+
+This extension layers on top of `data-engineering/baseline`. It composes with all compute and storage extensions (`s3-lakehouse`, `databricks`, `redshift`, `snowflake`, `postgresql`) — orchestration rules govern the control plane regardless of what the pipelines execute.
+
+## Severity Tiers
+
+Severity tiers are defined in `data-engineering/baseline`. The same P0/P1/P2 model applies here:
+
+| Tier | Enforcement |
+|------|-------------|
+| **P0** | Blocking — must be resolved before stage sign-off. |
+| **P1** | Warning — must be resolved before production go-live; flagged but does not block individual stages. |
+| **P2** | Advisory — good practice; noted in compliance summary but non-blocking at all stages. |
+
+---
+
+## Rule ORCH-01: Orchestrator Choice Documented Per Pipeline
+
+**Severity**: P1 — Warning
+
+**Rule**: The orchestrator for every production pipeline MUST be explicitly chosen and documented with rationale. MWAA is preferred when: pipelines have complex conditional branching, dynamic task generation, sensor-based waits, or require rich cross-pipeline dependency tracking. Step Functions is preferred when: pipelines are serverless-native, integration with AWS SDK services is the primary workload, or minimal operational overhead is required. Mixed use of both orchestrators within a single logical workflow is prohibited unless the boundary and handoff mechanism are explicitly designed.
+
+**Verification**:
+- Functional Design or Workflow Planning names the orchestrator per pipeline with rationale.
+- Pipelines that span both MWAA and Step Functions document the exact handoff (e.g., MWAA Task invoking a State Machine via `StepFunctionExecuteTrigger`, or EventBridge routing).
+- No pipeline uses both orchestrators to do the same work (e.g., retry logic in MWAA and Step Functions for the same task).
+
+---
+
+## Rule ORCH-02: DAG Design — No Business Logic in DAG Files (MWAA)
+
+**Severity**: P0 — Blocking
+
+**Rule**: MWAA DAG files MUST contain only orchestration logic (task definitions, dependencies, schedule, callbacks). Business logic, data transformations, SQL, and API calls MUST be implemented in external modules, operators, or compute targets (EMR, Glue, ECS, Lambda, Databricks). DAG files that import and execute transformation code directly are prohibited. This prevents DAG parse failures from corrupting the entire Airflow scheduler and keeps compute logic testable independently.
+
+**Verification**:
+- Code Generation places DAG files in a `dags/` directory containing only orchestration constructs.
+- Business logic resides in a separate module, container, or compute service called via an operator.
+- Build and Test includes a DAG import test (all DAGs load without error in an isolated Airflow environment).
+- No SQL strings longer than a single-line identifier or templated reference appear directly in the DAG file.
+
+---
+
+## Rule ORCH-03: DAG Idempotency and Catchup Behavior Explicitly Set (MWAA)
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every DAG MUST have `catchup` set explicitly (`catchup=True` or `catchup=False`) — relying on the Airflow global default is prohibited. DAGs with `catchup=True` MUST produce idempotent runs (per DATAENG-03) because catchup triggers multiple historical runs simultaneously. DAGs with `catchup=False` MUST document why historical backfill is not needed. `max_active_runs` MUST be set to prevent unbounded concurrent DAG runs.
+
+**Verification**:
+- Every DAG definition includes explicit `catchup=` and `max_active_runs=` parameters.
+- DAGs with `catchup=True` have idempotency verified in Build and Test (per DATAENG-03).
+- DAGs with `catchup=False` include a comment or design note explaining why backfill is not needed.
+
+---
+
+## Rule ORCH-04: Sensor and Trigger Design — No Indefinite Poke Loops (MWAA)
+
+**Severity**: P1 — Warning
+
+**Rule**: Sensors MUST use `mode="reschedule"` rather than `mode="poke"` for any wait exceeding 5 minutes to avoid holding a worker slot indefinitely. `timeout` MUST be set on every sensor; a sensor without a timeout can block a DAG run permanently. External task sensors MUST define `execution_timeout` and `failed_states` to detect upstream failures rather than hanging.
+
+**Verification**:
+- Code Generation sets `mode="reschedule"` and `timeout` on every sensor with expected wait > 5 minutes.
+- No sensor omits a `timeout` value.
+- `ExternalTaskSensor` definitions include `failed_states` and `execution_timeout`.
+
+---
+
+## Rule ORCH-05: MWAA Environment Sizing and Worker Autoscaling Configured
+
+**Severity**: P1 — Warning
+
+**Rule**: MWAA environment class and worker autoscaling bounds MUST be explicitly chosen and documented. Environment class (mw1.small through mw1.2xlarge) MUST be justified against the DAG parse time budget and concurrent task count. `min_workers` and `max_workers` MUST be set with a documented basis. The default `max_workers=10` is not an acceptable substitute for a deliberate sizing decision for production environments.
+
+**Verification**:
+- Infrastructure Design specifies environment class, `min_workers`, `max_workers`, and scheduler count with rationale.
+- DAG parse time budget is evaluated (target < 30 seconds total; Airflow drops DAGs that parse too slowly).
+- Airflow configuration overrides (`core.parallelism`, `scheduler.max_dagruns_to_create_tis_per_loop`, etc.) are set deliberately, not left at defaults.
+
+---
+
+## Rule ORCH-06: MWAA Secrets via AWS Secrets Manager Backend
+
+**Severity**: P0 — Blocking
+
+**Rule**: MWAA connections and variables that contain credentials MUST be stored in AWS Secrets Manager using the MWAA Secrets Manager backend, not in the Airflow metastore UI. Connection URIs and variable values stored in the metastore are accessible to any user with UI access and are not rotatable independently of Airflow. This rule composes with DATAENG-15.
+
+**Verification**:
+- Infrastructure Design enables the Secrets Manager backend (`secrets.backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend`).
+- Code Generation references connections by `aws_default` or named connection IDs that resolve from Secrets Manager.
+- No production connection URI or password appears in the Airflow UI connection store or in DAG code.
+- Rotation of any secret requires no DAG or environment change.
+
+---
+
+## Rule ORCH-07: State Machine Design — Each State Is Idempotent (Step Functions)
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every Task state in a Step Functions State Machine MUST be idempotent — a re-execution of the state with the same input MUST produce the same outcome without side effects or duplicated side effects. Lambda functions invoked from Step Functions MUST use the `clientToken` or idempotency key pattern. AWS SDK integrations (Glue, EMR, ECS, Batch) MUST check for an already-running or already-completed execution before starting a new one when the state is retried. This composes with DATAENG-03.
+
+**Verification**:
+- Functional Design documents the idempotency mechanism per Task state (clientToken, existence check, UPSERT target, etc.).
+- Code Generation implements idempotency checks in Lambda handlers and SDK integration states.
+- Build and Test includes a scenario where the State Machine is re-executed from a mid-workflow failure and asserts no duplicate side effects.
+
+---
+
+## Rule ORCH-08: Step Functions Retry and Catch Blocks on Every Task State
+
+**Severity**: P0 — Blocking
+
+**Rule**: Every Task state in a production State Machine MUST have an explicit `Retry` block and a `Catch` block. States without `Retry` propagate transient AWS SDK errors (throttling, eventual-consistency races) as permanent failures. States without `Catch` leave executions stuck in a terminal `Failed` state with no routing to dead-letter or alerting paths. This composes with DATAENG-13.
+
+**Verification**:
+- Every Task state in the ASL definition has at least one `Retry` entry covering `States.TaskFailed` and `States.Timeout`.
+- Retry `IntervalSeconds`, `MaxAttempts`, and `BackoffRate` are set deliberately (not defaulted to MaxAttempts=3 without review).
+- Every Task state has a `Catch` block routing permanent failures to a failure state that notifies via SNS or EventBridge (composes with DATAENG-09).
+- Build and Test includes an induced-failure scenario that exercises the Catch path and verifies notification delivery.
+
+---
+
+## Rule ORCH-09: Step Functions Express vs Standard Workflow Decision Documented
+
+**Severity**: P1 — Warning
+
+**Rule**: The workflow type (Standard or Express) MUST be chosen explicitly and documented with rationale. Standard Workflows are required when: execution history must be auditable via the console or `GetExecutionHistory`, executions may run longer than 5 minutes, or exactly-once execution semantics are required. Express Workflows are appropriate for high-volume, short-duration (< 5 minutes), at-least-once workloads. Mixing workflow types within a logical pipeline requires documented handoff.
+
+**Verification**:
+- Infrastructure Design specifies Standard or Express for each State Machine with rationale aligned to duration, volume, and auditability requirements.
+- Express Workflows have execution logs routed to CloudWatch Logs (the only audit mechanism; console history is not available).
+- Standard Workflows that run longer than 1 hour document the expected execution duration and verify it is within the 1-year limit.
+
+---
+
+## Rule ORCH-10: Execution Input and Output Payload Size Managed (Step Functions)
+
+**Severity**: P1 — Warning
+
+**Rule**: State Machine execution input, state output, and inter-state payload MUST stay within AWS limits (256 KB per state input/output for Standard; same for Express). Large datasets MUST be passed by reference (S3 URI, DynamoDB key, SSM Parameter ARN) rather than by value. Workflows that inline dataset contents in the execution payload are prohibited.
+
+**Verification**:
+- Functional Design identifies states with potentially large outputs and documents the pass-by-reference pattern.
+- Code Generation uses S3 URIs or DynamoDB references for payloads expected to exceed 32 KB (conservative threshold to allow headroom).
+- Build and Test includes a payload-size assertion for states with variable-size outputs.
+
+---
+
+## Rule ORCH-11: Orchestrator IAM Roles Follow Least Privilege
+
+**Severity**: P0 — Blocking
+
+**Rule**: The IAM execution role for MWAA (the environment role) and for each Step Functions State Machine MUST follow least privilege. MWAA environment roles MUST NOT use `arn:aws:iam::aws:policy/AdministratorAccess` or wildcard resource policies. Step Functions roles MUST scope permissions to the specific Lambda functions, Glue jobs, EMR clusters, or ECS tasks the State Machine invokes — not to `*` resources. Service-level wildcards (e.g., `glue:*` on `*`) are prohibited unless justified and time-bounded.
+
+**Verification**:
+- Infrastructure Design lists the IAM role per orchestrator with a permission inventory: action, resource ARN or ARN pattern, and justification.
+- No wildcard resource (`"Resource": "*"`) in production roles except where AWS requires it (e.g., `cloudwatch:PutMetricData`).
+- MWAA environment role is scoped to the specific S3 bucket, KMS key, Secrets Manager paths, and CloudWatch log groups for the environment.
+- Build and Test includes an IAM policy linting step (e.g., AWS IAM Access Analyzer, cfn-python-lint, or Checkov).
+
+---
+
+## Rule ORCH-12: Schedule and Trigger Source Documented Per Pipeline
+
+**Severity**: P1 — Warning
+
+**Rule**: Every pipeline MUST have a documented trigger source: cron schedule, event-driven trigger (S3 event → EventBridge → MWAA REST API or Step Functions, SNS, SQS), or manual-only. Pipelines triggered by multiple sources MUST document concurrency behavior — what happens if a scheduled run and an event-driven run overlap. "Triggered ad hoc" is not an acceptable production trigger definition.
+
+**Verification**:
+- Requirements Analysis or Functional Design lists the trigger source per pipeline with timing guarantees.
+- Event-driven pipelines document the EventBridge rule or S3 notification configuration.
+- Pipelines with multiple trigger sources document `max_active_runs` (MWAA) or a concurrency-check state (Step Functions) that prevents overlapping executions from conflicting.
+
+---
+
+## Rule ORCH-13: Pipeline Observability — SLA Miss Alerting Required
+
+**Severity**: P1 — Warning
+
+**Rule**: Every production pipeline MUST have an SLA miss alert: a notification fires if the pipeline has not completed successfully by its SLA deadline. For MWAA, this is an SLA callback or an external CloudWatch alarm on `TaskInstanceDuration` / `DagRunDurationSuccess`. For Step Functions, this is a CloudWatch alarm on `ExecutionsFailed` or `ExecutionTime` exceeding a threshold, routed to SNS. Dashboards without alerting are not sufficient. This composes with DATAENG-09 and DATAENG-12.
+
+**Verification**:
+- Infrastructure Design provisions an SLA alarm per production pipeline.
+- MWAA DAGs with consumer-facing SLAs use Airflow SLA callbacks or equivalent external alerting.
+- Step Functions pipelines have CloudWatch alarms on `ExecutionsFailed` and `ExecutionThrottled` routed to SNS.
+- Build and Test includes a synthetic SLA breach that triggers and resolves the alarm.
+
+---
+
+## Rule ORCH-14: DAG and State Machine Versioning and Promotion Process
+
+**Severity**: P1 — Warning
+
+**Rule**: DAG files and State Machine definitions MUST be version-controlled and deployed via a CI/CD pipeline — no manual edits to DAG files in the S3 DAGs bucket or direct updates to State Machine definitions in the console in production. Deployments MUST be gated on DAG import tests (MWAA) or ASL schema validation (Step Functions). Environment promotion (dev → staging → prod) MUST follow the same process as application code.
+
+**Verification**:
+- Infrastructure Design names the CI/CD mechanism (CodePipeline, GitHub Actions, etc.) and the promotion gates.
+- Build and Test documents the DAG import test (MWAA) or the ASL validation step (Step Functions).
+- Production DAGs bucket has an S3 bucket policy or IAM boundary that prevents direct human writes outside the CI/CD role.
+- State Machine ARNs in production are tagged with the deploying pipeline and commit SHA.
+
+---
+
+## Rule ORCH-15: Dead-Letter and Failed-Execution Retention Policy
+
+**Severity**: P1 — Warning
+
+**Rule**: Failed MWAA DAG runs and failed Step Functions executions MUST be retained long enough to diagnose and replay. For MWAA: task logs in CloudWatch MUST have a retention policy of at least 30 days. For Step Functions Standard Workflows: execution history is retained for 90 days by AWS; Express Workflow logs in CloudWatch MUST have a retention policy set (default = never expire, which incurs unbounded cost). Failed executions MUST route to an alert or dead-letter mechanism so they are not silently abandoned.
+
+**Verification**:
+- Infrastructure Design sets CloudWatch log group retention for MWAA task logs (minimum 30 days).
+- Express Workflow log groups have explicit retention set (30–90 days recommended; cost model justifies longer).
+- Failed Step Functions executions trigger an SNS notification or EventBridge rule per ORCH-08.
+- Failed MWAA DAG runs trigger an on-failure callback or alerting DAG.

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/orchestration/orchestration.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/orchestration/orchestration.opt-in.md
@@ -1,0 +1,18 @@
+# Orchestration — Opt-In
+
+**Extension**: Orchestration (MWAA + Step Functions)
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: Orchestration Extension
+Should orchestration rules be enforced for this project?
+
+A) Yes — enforce all ORCH rules per their P0/P1/P2 severity tiers (recommended if any production pipeline uses Amazon MWAA or AWS Step Functions for orchestration)
+B) No — skip all ORCH rules (suitable when pipelines are triggered exclusively by native platform schedulers — Databricks Workflows, dbt Cloud, Snowflake Tasks — with no MWAA or Step Functions involvement)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/redshift/redshift.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/redshift/redshift.md
@@ -1,0 +1,302 @@
+# Amazon Redshift Extension
+
+Rules for data engineering workloads using Amazon Redshift as a warehouse — both provisioned (RA3) and Serverless. Covers Redshift native tables, materialized views, Spectrum external tables, and data sharing.
+
+This extension layers on top of `data-engineering/baseline`.
+
+## Severity Tiers
+
+Severity tiers are defined in `data-engineering/baseline`. The same P0/P1/P2 model applies here:
+
+| Tier | Enforcement |
+|------|-------------|
+| **P0** | Blocking — must be resolved before stage sign-off. |
+| **P1** | Warning — must be resolved before production go-live; flagged but does not block individual stages. |
+| **P2** | Advisory — good practice; noted in compliance summary but non-blocking at all stages. |
+
+---
+
+## Rule RSHIFT-01: Distribution Style Chosen and Documented Per Table
+
+**Severity**: P1 — Warning
+
+**Rule**: Every Redshift native table MUST have an explicitly chosen distribution style (KEY, ALL, EVEN, or AUTO) with documented rationale. Defaulting to AUTO is acceptable only for tables under 10 GB or where workload patterns are not yet known; tables above 10 GB with stable workload MUST have a deliberate choice. KEY distribution on the join column is required for fact-to-dimension joins that scan large volumes.
+
+**Verification**:
+- Functional Design includes a table-level matrix: table name, expected size, primary join pattern, chosen distribution style, rationale.
+- DDL in Code Generation matches the design.
+- KEY distribution is chosen on join columns for declared fact-dimension relationships.
+- ALL is reserved for dimension tables under approximately 3 million rows or 2–3 GB.
+
+---
+
+## Rule RSHIFT-02: Sort Key Strategy Justified Against Query Predicates
+
+**Severity**: P1 — Warning
+
+**Rule**: Every table MUST have a sort key chosen against the actual filter predicates in the most expensive queries. Compound sort keys are the default; interleaved sort keys are used only when multiple equally weighted filter columns are queried and the cost of VACUUM REINDEX is acceptable. Sort key columns MUST be present in WHERE clauses of the workload's top-10 queries by cost.
+
+**Verification**:
+- Functional Design lists sort key columns per table with example WHERE predicates that benefit.
+- For interleaved sort keys: VACUUM REINDEX schedule is in Infrastructure Design.
+- Tables without a sort key are flagged as findings unless explicitly documented as low-volume or fully-scanned tables.
+
+---
+
+## Rule RSHIFT-03: Workload Concurrency and Queue Management Designed for Deployment Type
+
+**Severity**: P1 — Warning
+
+**Rule**: Workload management configuration MUST be explicitly designed for the chosen deployment type. The mechanisms differ fundamentally between provisioned and Serverless, and applying provisioned WLM concepts to Serverless (or ignoring Serverless-specific controls) is a design defect.
+
+**Redshift Provisioned (RA3)**:
+- WLM MUST be configured for the workload mix. Automatic WLM with query priorities is the default and covers most cases; manual WLM queues are used only when hard queue isolation (separate memory, concurrency slots, timeout) is required for a specific workload class.
+- Concurrency Scaling MUST be enabled for clusters with read-heavy or burst workloads unless a cost analysis explicitly excludes it; usage limits MUST be set per queue to bound Concurrency Scaling credit consumption.
+- Short Query Acceleration (SQA) MUST be evaluated; it reduces latency for short queries without requiring a separate manual WLM queue and should be preferred over a dedicated short-query queue for most provisioned configurations.
+- Query monitoring rules (QMR) MUST be defined for the superuser queue to detect and abort runaway queries that would otherwise starve other queues.
+
+**Redshift Serverless**:
+- Redshift Serverless has no WLM — queue management is automatic and not user-configurable. Rules about WLM queues, queue slots, and queue memory allocation do not apply to Serverless deployments and MUST be marked N/A.
+- The primary concurrency and throughput lever for Serverless is the RPU (Redshift Processing Unit) range: `base RPU` sets the minimum compute available at all times and `max RPU` caps peak autoscaling. Both MUST be set with a documented basis — leaving `max RPU` at the account default is not an acceptable substitute for a sizing decision.
+- Usage limits MUST be configured on the Serverless namespace to cap credit consumption and prevent cost runaway (composes with DATAENG-11). At minimum: a daily or weekly RPU-hour limit with a `LOG` action and a hard `STOP` action at a higher threshold.
+- Query priority within Serverless is controlled by query groups and associated priorities (`CRITICAL`, `HIGH`, `NORMAL`, `LOW`, `LOWEST`) set via `SET query_group`. Workloads with differentiated SLAs MUST use query groups to signal priority to the Serverless scheduler; an undifferentiated workload where all queries compete equally is acceptable only when all consumers have identical SLA requirements.
+
+**Verification**:
+- NFR Requirements identifies the workload mix (ETL writes, BI reads, ad-hoc queries), their priorities, and the deployment type (provisioned or Serverless). Rules inapplicable to the chosen deployment type are marked N/A in the compliance summary.
+- **Provisioned**: Infrastructure Design specifies WLM mode (automatic or manual), queue definitions with memory and concurrency allocations, SQA enabled/disabled with rationale, Concurrency Scaling usage limits per queue, and at least one QMR rule on the superuser queue.
+- **Serverless**: Infrastructure Design specifies base RPU, max RPU with sizing rationale (peak query concurrency, expected query duration, and data volume scanned per query), namespace usage limits with both LOG and STOP thresholds, and query group priority assignments for differentiated workloads.
+- Build and Test benchmarks representative queries from each workload class under concurrent load and asserts latency targets are met without one workload class starving another.
+
+---
+
+## Rule RSHIFT-04: Materialized Views Use Incremental Refresh Where Possible
+
+**Severity**: P2 — Advisory
+
+**Rule**: Materialized views MUST be evaluated for incremental refresh eligibility (Redshift documents specific SQL constructs supported). MVs that fall back to full recompute are acceptable only for small base tables or low refresh frequency. Auto Refresh is preferred over scheduled refresh when query patterns benefit.
+
+**Verification**:
+- Functional Design notes each MV as incremental-eligible or full-recompute, with refresh strategy.
+- Code Generation creates MVs with AUTO REFRESH where appropriate.
+- Disqualifying SQL constructs (outer joins to non-PK columns, certain window functions, etc.) are avoided in incremental-eligible MVs or the MV is reclassified.
+
+---
+
+## Rule RSHIFT-05: Spectrum vs Native Decision Documented Per Dataset
+
+**Severity**: P1 — Warning
+
+**Rule**: For every dataset accessed through Redshift, the design MUST state whether it lives as a native Redshift table or as a Spectrum external table on S3, with rationale. Spectrum is preferred for datasets that are infrequently joined to native tables, are owned by a separate pipeline that already lands them in S3, or exceed cost-effective native storage. Joining a large Spectrum table to a large native table without distribution key alignment is a performance anti-pattern.
+
+**Verification**:
+- Functional Design includes a per-dataset native-vs-Spectrum matrix with rationale.
+- For Spectrum tables: external schema and table definitions reference Glue Catalog (composes with S3LH-02 if `s3-lakehouse` is enabled).
+- Spectrum queries scan partitioned data; full table scans across partitions are flagged unless justified.
+
+---
+
+## Rule RSHIFT-06: VACUUM and ANALYZE Cadence Defined
+
+**Severity**: P1 — Warning
+
+**Rule**: Tables with significant update or delete activity MUST have a VACUUM cadence (Auto Vacuum is acceptable for most patterns; explicit VACUUM SORT/DELETE is used when Auto Vacuum cannot keep up). Statistics MUST be refreshed via ANALYZE after material data changes; AUTO ANALYZE is acceptable when staleness is bounded. The design MUST acknowledge each Auto setting as a deliberate choice.
+
+**Verification**:
+- Infrastructure Design lists tables with material update/delete activity and their maintenance approach.
+- For high-velocity tables, explicit maintenance scheduling is in place rather than relying on Auto.
+- ANALYZE runs after large loads (post-COPY ANALYZE pattern).
+
+---
+
+## Rule RSHIFT-07: Column Compression Encodings Set Explicitly on Wide Tables
+
+**Severity**: P2 — Advisory
+
+**Rule**: Tables with more than 20 columns or expected size over 50 GB MUST have column compression encodings explicitly set. Leaving encodings to Redshift's automatic selection (RAW default on `CREATE TABLE`, or `COMPUPDATE ON` during COPY without review) is prohibited for tables of this size because the automatic choice is made per-batch and may not reflect the full value distribution.
+
+**ANALYZE COMPRESSION sampling**:
+- `ANALYZE COMPRESSION` MUST be run against a representative data sample before DDL is finalised. "Representative" means at minimum 10–20% of expected steady-state row count, covering the same value distributions (cardinality, skew, seasonal patterns) that production data will have. Running `ANALYZE COMPRESSION` on an empty table or a trivially small seed dataset produces misleading encoding recommendations and is prohibited.
+- The output of `ANALYZE COMPRESSION` MUST be captured as a design artifact (screenshot, table, or script output) and retained alongside the DDL. This creates an audit trail for future re-encoding decisions and prevents the sample step from being silently skipped.
+- Recommendations from `ANALYZE COMPRESSION` are a starting point, not an instruction to accept blindly. The design MUST apply the following overrides where the tool's recommendation conflicts with known best practice:
+  - AZ64 is preferred over LZO for numeric (`INT`, `BIGINT`, `DECIMAL`) and date/time columns — AZ64 compresses and decompresses faster on modern hardware.
+  - ZSTD is preferred over LZO or BYTEDICT for variable-length strings with low-to-moderate cardinality — better compression ratio with acceptable CPU cost.
+  - RAW is appropriate for single-byte boolean-equivalent columns and very-high-cardinality columns (e.g., UUID surrogate keys) where any encoding adds CPU overhead without compressing effectively.
+  - DELTA or DELTA32K is appropriate for monotonically increasing numeric sequences (e.g., auto-increment IDs, unix epoch timestamps) — `ANALYZE COMPRESSION` often misses this because it inspects value distributions, not sequence patterns.
+
+**Re-encoding and the VACUUM FULL interaction**:
+- Changing a column's compression encoding on an existing populated table **requires a full table rewrite** — there is no in-place re-encoding operation in Redshift. The options are: (a) `CREATE TABLE new AS SELECT ... FROM old` with the corrected DDL followed by a rename, (b) `ALTER TABLE ... ALTER COLUMN ... ENCODE` (available in newer Redshift versions) which internally triggers the same full rewrite, or (c) `VACUUM FULL` — which does NOT re-encode columns. `VACUUM FULL` reorganises physical storage and sorts data but preserves the existing encoding on each block; it cannot change encodings.
+- This cost MUST be acknowledged in the design before DDL is committed to production. A table that requires re-encoding after initial load imposes a maintenance window proportional to table size and cannot be done transparently under load.
+- For tables where encodings are initially uncertain (e.g., a new table whose production value distributions are not yet known), the design MUST document this explicitly and schedule a post-launch `ANALYZE COMPRESSION` run on a representative production sample followed by a planned re-encoding window. Deferring indefinitely is not acceptable.
+- `COPY` with `COMPUPDATE PRESET` is acceptable as an initial loading strategy when the encoding choice is deferred, but the DDL produced by PRESET MUST be reviewed and locked before the table exceeds 10 GB — beyond that point, re-encoding carries a meaningful operational cost.
+
+**Verification**:
+- Functional Design includes the encoding strategy per column for in-scope tables: column name, chosen encoding, and rationale referencing the `ANALYZE COMPRESSION` output or the override reason above.
+- The `ANALYZE COMPRESSION` sample artifact is attached to or referenced from the design document.
+- DDL specifies `ENCODE <encoding>` per column; no in-scope table relies on implicit defaults or unreviewed COMPUPDATE output.
+- Infrastructure Design acknowledges the re-encoding cost for any table where encodings are deferred post-launch, including the planned re-encoding window and the trigger condition (e.g., "after 30 days of production load, re-run ANALYZE COMPRESSION and schedule re-encoding if recommendations differ from initial DDL").
+- LISTAGG and other wide-row-producing patterns are flagged for review — wide intermediate rows can exceed the 4 MB per-row limit and are not mitigated by column encoding alone.
+
+---
+
+## Rule RSHIFT-08: Data Sharing and Federated Query Security Model Documented
+
+**Severity**: P0 — Blocking
+
+**Rule**: When using Redshift Data Sharing (across clusters, across accounts) or Federated Queries (to RDS PostgreSQL, Aurora, etc.), the design MUST specify: which datashares exist, who consumes them, IAM/role bindings, and column-level visibility. Federated queries MUST use Secrets Manager-backed credentials.
+
+**Verification**:
+- Infrastructure Design lists datashares: name, producer cluster, consumer accounts/namespaces, included schemas/tables.
+- Federated query secrets resolve through Secrets Manager (composes with DATAENG-15).
+- Cross-region or cross-account shares have explicit network and IAM justification.
+
+---
+
+## Rule RSHIFT-09: Cluster Sizing — Provisioned vs Serverless Decision Documented
+
+**Severity**: P1 — Warning
+
+**Rule**: The choice between provisioned RA3 and Redshift Serverless MUST be a documented decision based on workload predictability, concurrency profile, and cost analysis. Serverless is preferred for unpredictable or intermittent workloads; provisioned RA3 with reserved instances is preferred for steady, high-utilization workloads. Mixing should be deliberate (e.g., Serverless dev/test + Provisioned prod).
+
+**Verification**:
+- NFR Requirements captures workload predictability and concurrency targets.
+- Infrastructure Design names the cluster type, node type or base RPU, and reservation strategy.
+- Cost projection covers both peak and steady-state.
+
+---
+
+## Rule RSHIFT-10: Result Caching Is a Bonus, Not a Performance Strategy
+
+**Severity**: P1 — Warning
+
+**Rule**: Result caching MUST NOT be relied on for SLA-meeting query performance. Every query that has a stated latency SLA MUST be benchmarked with caching disabled (`SET enable_result_cache_for_session = OFF`). Caching is a real benefit but disappears on the first run after DDL changes, statistics refresh, or cache eviction.
+
+**Verification**:
+- NFR Requirements lists queries with latency SLAs.
+- Build and Test benchmarks each SLA-bound query with result cache disabled and asserts the SLA holds.
+- Performance test instructions include the cache-disabled run as the primary metric.
+
+---
+
+## Rule RSHIFT-11: Redshift Data API vs JDBC/ODBC Connection Method Documented
+
+**Severity**: P1 — Warning
+
+**Rule**: Pick a connection method per caller type and document the choice. JDBC/ODBC as the default for everything is wrong — Lambda functions and other short-lived callers can't hold persistent connections, so each invocation opens and closes a new one. Under concurrent load that exhausts the cluster's connection limit fast.
+
+**Decision criteria**:
+
+| Caller type | Method | Why |
+|-------------|--------|-----|
+| Lambda, short-lived ECS task, Step Functions Task state | **Data API** | Can't hold a persistent connection; JDBC here causes connection storms |
+| AppSync, API Gateway + Lambda backend | **Data API** | Same reason; async execution model fits the Data API naturally |
+| Long-running app server, pooled container | **JDBC/ODBC + pool** | Persistent connections amortise auth overhead; Data API latency and per-call cost add up here |
+| BI tools (QuickSight, Tableau, Looker) | **JDBC/ODBC** | Most don't support the Data API; they manage their own pools |
+| Glue ETL, EMR, Spark | **JDBC** | Distributed engines handle their own parallelism; the Data API's sequential model doesn't fit |
+| Ad-hoc scripts, one-off migrations | Either | Data API if no driver available; JDBC otherwise |
+
+**Using the Data API**:
+
+`execute-statement` is asynchronous — it hands back an `Id` immediately, not results. The caller polls `describe-statement` until status is `FINISHED` or `FAILED`, then calls `get-statement-result`. Skip the poll loop and you get nothing back, with no error to show for it.
+
+A few other sharp edges worth knowing:
+
+- **24-hour execution limit.** Anything expected to run longer needs JDBC instead; the Data API will not accept it.
+- **Results are paginated at 100 rows.** Use `NextToken` on `get-statement-result` or silently truncate. This is a data correctness bug, not a performance issue.
+- **Polling is billed.** A tight polling loop burns API calls and will get throttled. Use exponential backoff.
+- **Auth is IAM only.** No database username/password. The calling role needs `redshift-data:ExecuteStatement`, `redshift-data:DescribeStatement`, and `redshift-data:GetStatementResult` scoped to the specific cluster or Serverless workgroup ARN — not `redshift-data:*` on `*` (composes with DATAENG-15 and RSHIFT-08).
+
+**Using JDBC/ODBC**:
+
+- Credentials come from Secrets Manager or IAM — no hardcoded passwords (composes with DATAENG-15).
+- On Serverless, IAM-based JDBC auth requires a database user created from the IAM role. Document how that user is provisioned.
+- Pool size must be set against the cluster's `max_connections` (provisioned) or the Serverless connection limit. Multiple teams each sizing pools to their own peak will collectively exceed the limit and block each other.
+
+**Verification**:
+- NFR Requirements lists every caller type (Lambda functions, application servers, BI tools, ETL jobs) with its assigned connection method.
+- Infrastructure Design covers IAM permissions for Data API callers and pool sizing for JDBC/ODBC callers.
+- Code Generation implements the async poll-and-paginate loop for every Data API caller — no caller assumes one `get-statement-result` call is enough.
+- Build and Test includes a Data API test that fetches a multi-page result set and asserts all pages are retrieved.
+- Any Lambda or Step Functions Task state using JDBC/ODBC has a written justification explaining why a persistent connection works in that context.
+
+---
+
+## Rule RSHIFT-12: STL/SVL System Tables Used as the Standard Debugging Toolkit
+
+**Severity**: P2 — Advisory
+
+**Rule**: Teams running production Redshift workloads MUST know which system tables answer which operational questions. Redshift's STL/SVL/STV/SVV views are the primary diagnostic surface — not the console, not CloudWatch alone. Incidents that take hours to diagnose because no one knew which table to query are an operational maturity failure, not a Redshift limitation.
+
+The following views are the minimum set every engineer touching production should be able to use without looking them up:
+
+**Query performance**
+
+- `SVL_QUERY_SUMMARY` — per-step execution breakdown for a completed query: rows processed, bytes, execution time, and whether a step was skipped. Start here when a query is slower than expected. Filter on `query` (query ID) and sort by `maxtime` to find the expensive steps.
+- `SVL_QLOG` — lightweight log of recent queries with elapsed time, queue time, and user. Useful for a quick scan of what ran recently and how long it took before pulling the full plan.
+- `STL_QUERY` — full query text and timing. Join to `SVL_QUERY_SUMMARY` on `query` when you need the SQL alongside the execution breakdown.
+
+**Alerts and bad query patterns**
+
+- `STL_ALERT_EVENT_LOG` — Redshift's own assessment of query problems: missing statistics, nested loops, hash loops, very selective filters that should be sort-key-aligned, and distribution mismatches causing cross-node data movement. This is the fastest way to find structural problems. A query with multiple alert events is a design finding, not just a slow query.
+- `SVL_QUERY_REPORT` — per-slice, per-step execution detail. Use this when `SVL_QUERY_SUMMARY` shows an expensive step and you need to know whether the work is balanced across slices or skewed to one.
+
+**Locks and concurrency**
+
+- `STV_LOCKS` — currently held table locks. When a query hangs, check here first before assuming it's a performance issue. A `DROP TABLE` or `ALTER TABLE` waiting on a lock from a long-running transaction is a common cause of apparent hangs.
+- `STL_TR_CONFLICT` — lock conflict history. Helps identify which queries are repeatedly blocking each other so the scheduling or transaction design can be fixed.
+
+**WLM and queuing (provisioned only)**
+
+- `STV_WLM_QUERY_STATE` — live view of queries currently in WLM queues: which queue, what state (queuing, running), and how long they've been waiting. The first place to check when SLA-bound queries are slow due to queue saturation rather than execution time.
+- `STL_WLM_QUERY` — completed WLM records with queue wait time vs execution time. If a query consistently spends more time queuing than executing, the WLM queue configuration or concurrency limit needs revisiting.
+
+**Data loads**
+
+- `STL_LOAD_ERRORS` — COPY command errors with file name, line number, and error message. Required first stop after a failed or partial COPY before checking S3 logs.
+- `STL_LOAD_COMMITS` — successful COPY completions with row counts. Cross-reference against expected volume per DATAENG-07 after any bulk load.
+
+**Usage on Serverless**: `STL_*` and `STV_*` views are not available on Redshift Serverless — they are provisioned-cluster-only. On Serverless, equivalent diagnostics come from the `SYS_*` views (`SYS_QUERY_HISTORY`, `SYS_QUERY_DETAIL`, `SYS_LOAD_ERROR_DETAIL`, `SYS_ALERT_EVENT_LOG`). Runbooks targeting provisioned system tables will silently return no rows on Serverless; teams MUST maintain separate runbook paths per deployment type.
+
+**Verification**:
+- Build and Test documentation includes a runbook section listing the system table queries used to diagnose the three most common failure modes for this pipeline: slow query, failed load, and lock contention.
+- The runbook distinguishes provisioned (`STL_*`/`SVL_*`) from Serverless (`SYS_*`) paths where the pipeline may run on either.
+- Infrastructure Design enables `pg_stat_statements` or equivalent query history retention settings so system table data survives long enough to be useful during post-incident review (Redshift retains STL data for approximately 2–5 days by default; workloads with weekly on-call rotations should confirm this is sufficient or supplement with CloudWatch Logs export).
+
+---
+
+## Rule RSHIFT-13: Redshift ML Model Governance (Conditional — ML in Scope Only)
+
+**Severity**: P1 — Warning
+
+**Applicability**: This rule applies only when `CREATE MODEL` is used in the project. Mark as N/A otherwise.
+
+**Rule**: Redshift ML (`CREATE MODEL`) trains a SageMaker Autopilot model from a SQL query and exposes it as a SQL function. It looks like a database operation but it isn't — it launches SageMaker training jobs, writes data to S3, and incurs SageMaker compute costs independently of Redshift costs. Treating it as just another SQL statement leads to ungoverned training runs, untracked model versions, PII leaking into training data, and surprise bills.
+
+**Training data**
+
+- The SELECT query passed to `CREATE MODEL` defines the training dataset. Any column included in that query is exported to S3 in plaintext for SageMaker to read. Columns classified as `pii`, `phi`, or `pci` (per DATAENG-06) MUST NOT appear in the training query unless the model's purpose explicitly requires them and a privacy review has been completed and captured in the requirements artifact.
+- The S3 bucket Redshift uses for training data export MUST be the project-controlled bucket specified in the `MODEL_PARAMETERS` clause — not the Redshift-managed default. Using the default means training data lands in an AWS-managed location outside the project's KMS and access control boundary (composes with S3LH-07).
+- Training data selection must be reproducible. The query MUST reference a versioned snapshot or a time-bounded filter so the same training run can be replicated. Open-ended queries against live tables produce a different model every time they run.
+
+**IAM and cost**
+
+- `CREATE MODEL` requires the Redshift cluster's IAM role to have `sagemaker:CreateAutoMLJob`, `s3:PutObject` on the training bucket, and `iam:PassRole` to a SageMaker execution role. These permissions MUST be scoped to specific resource ARNs — not wildcards — and documented in Infrastructure Design (composes with DATAENG-15 and RSHIFT-08).
+- SageMaker Autopilot training costs are separate from Redshift costs and are not covered by Redshift resource monitors (RSHIFT-04 / DATAENG-11). A dedicated SageMaker budget or AWS Budgets alert MUST be configured before any `CREATE MODEL` runs in production. An accidental retraining run on a large dataset can cost hundreds of dollars and will not be caught by Redshift WLM limits.
+- `MAX_CELLS` and `MAX_RUNTIME` parameters MUST be set on every `CREATE MODEL` call to bound training time and dataset size. Omitting them allows Autopilot to run to its own defaults, which can be hours and millions of rows.
+
+**Model versioning and promotion**
+
+- Each `CREATE MODEL` call produces a new model version. Model versions MUST follow the same promotion process as pipeline code (composes with CICD-06): train in dev/staging, evaluate against a held-out test set, promote to production only after explicit approval.
+- The model function name in production MUST be versioned or use a stable alias (`predict_churn_v2`, not `predict_churn`) so callers are never silently upgraded to a new model without a deployment event. Replacing a model function in-place without a version bump is prohibited.
+- Model evaluation metrics (accuracy, F1, AUC, or domain-appropriate equivalents) MUST be captured as a design artifact at promotion time. Deploying a model without recorded evaluation metrics makes it impossible to detect degradation later.
+
+**Model drift and refresh**
+
+- Production models MUST have a defined refresh cadence or a drift detection trigger — the appropriate choice depends on how fast the underlying data distribution changes. A model trained once and never refreshed is a reliability risk; Redshift ML does not monitor drift automatically.
+- When a model is retrained, the previous version MUST be retained (not dropped) for at least one SLA cycle so callers can roll back without a full retrain if the new model behaves unexpectedly in production.
+
+**Verification**:
+- Requirements Analysis flags ML-in-scope and captures the privacy review outcome for any training query touching classified columns.
+- Infrastructure Design specifies the training S3 bucket ARN, KMS key, SageMaker execution role, IAM permissions scoped to specific ARNs, SageMaker budget alert, and the `MAX_CELLS` / `MAX_RUNTIME` values used for each model.
+- Code Generation sets `MAX_CELLS`, `MAX_RUNTIME`, and the explicit S3 bucket in every `CREATE MODEL` call; no call omits these parameters.
+- Build and Test includes: model evaluation metrics captured against a held-out test set; confirmation that the training query is reproducible against a fixed snapshot; and a check that no classified columns appear in the training query without a recorded privacy review.
+- The model promotion record in audit.md includes: model function name and version, training data snapshot identifier, evaluation metrics, approver, and deployment timestamp.

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/redshift/redshift.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/redshift/redshift.opt-in.md
@@ -1,0 +1,18 @@
+# Amazon Redshift — Opt-In
+
+**Extension**: Amazon Redshift
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: Amazon Redshift Extension
+Should Amazon Redshift rules be enforced for this project?
+
+A) Yes — enforce all RSHIFT rules per their P0/P1/P2 severity tiers (recommended if Redshift provisioned or Serverless is a compute target)
+B) No — skip all RSHIFT rules (suitable when Redshift is not used)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/s3-lakehouse/s3-lakehouse.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/s3-lakehouse/s3-lakehouse.md
@@ -1,0 +1,238 @@
+# S3 Lakehouse Extension
+
+Rules for data engineering workloads using Amazon S3 as the storage layer with open table formats (Apache Iceberg or Delta Lake), AWS Glue Data Catalog as the metastore, and optionally AWS Lake Formation for fine-grained access control.
+
+This extension layers on top of `data-engineering/baseline`. Enable both when building a lakehouse on AWS.
+
+## Severity Tiers
+
+Severity tiers are defined in `data-engineering/baseline`. The same P0/P1/P2 model applies here:
+
+| Tier | Enforcement |
+|------|-------------|
+| **P0** | Blocking — must be resolved before stage sign-off. |
+| **P1** | Warning — must be resolved before production go-live; flagged but does not block individual stages. |
+| **P2** | Advisory — good practice; noted in compliance summary but non-blocking at all stages. |
+
+---
+
+## Rule S3LH-01: Open Table Format Required for Persisted Tables
+
+**Severity**: P0 — Blocking
+
+**Rule**: Any S3 dataset that is registered as a table, queried by name through a SQL engine, or modified after initial write MUST use an open table format (Apache Iceberg or Delta Lake). Raw Parquet, Avro, or ORC directories registered as Hive tables are not acceptable for new work because they cannot provide ACID guarantees, schema evolution, or safe concurrent writes. Raw object layouts are allowed only for landing-zone ingestion that is immediately promoted into a table-format dataset.
+
+**Verification**:
+- Functional Design names the table format (Iceberg or Delta) for every persisted dataset.
+- Code Generation produces CREATE TABLE statements using the chosen format and writes via the format's APIs.
+- Hive-style append-only directory writes are flagged as findings unless documented as landing-zone only.
+
+---
+
+## Rule S3LH-02: Glue Data Catalog as the Sole Metastore for Production Tables
+
+**Severity**: P0 — Blocking
+
+**Rule**: Production tables MUST be registered in AWS Glue Data Catalog (or a Glue-compatible catalog such as S3 Tables, which is built on it). Engine-local metastores (Spark in-memory metastore, Trino file-based metastore) are not acceptable for production. Cross-engine access (Athena, EMR, Redshift Spectrum, Glue ETL, SageMaker) is a design requirement.
+
+**Verification**:
+- Infrastructure Design specifies the catalog (Glue Catalog, S3 Tables, REST catalog backed by Glue).
+- Code Generation creates tables through the catalog, not as engine-local externals.
+- Build and Test verifies the table is queryable from at least two engines if cross-engine access is in scope.
+
+---
+
+## Rule S3LH-03: Partition Strategy Validated Against File Size Targets
+
+**Severity**: P1 — Warning
+
+**Rule**: Partitioning MUST be designed against a target file size of 128 MB to 1 GB per file post-compaction. A combination of partition column cardinality and ingestion volume that produces files smaller than 64 MB or larger than 2 GB at steady state is a design defect. For Iceberg, hidden partitioning with bucket/truncate transforms is preferred over exposing partition columns to consumers.
+
+**Verification**:
+- Functional Design estimates files per partition per day based on ingestion volume.
+- File size projection is within target range or a compaction job is specified.
+- Iceberg tables use partition transforms (`bucket`, `truncate`, `days`, `hours`) rather than synthetic partition columns where possible.
+
+---
+
+## Rule S3LH-04: Table Maintenance Jobs Required and Scheduled
+
+**Severity**: P1 — Warning
+
+**Rule**: Every Iceberg or Delta table MUST have associated maintenance jobs: compaction (rewrite_data_files / OPTIMIZE), snapshot expiration (expire_snapshots / VACUUM), and orphan file cleanup (remove_orphan_files). Maintenance MUST be scheduled, not manual. Tables left without maintenance accumulate small files, manifest bloat, and S3 storage cost from retained snapshots.
+
+**Verification**:
+- Infrastructure Design schedules maintenance for every managed table (frequency justified by write rate).
+- Code Generation or IaC includes the maintenance job definitions.
+- Retention policy for snapshots is set (default Iceberg 5 days is acceptable; Delta default 7 days is acceptable) and aligned with time-travel requirements in the data contract.
+
+---
+
+## Rule S3LH-05: Concurrent Writers Use Optimistic Concurrency
+
+**Severity**: P0 — Blocking
+
+**Rule**: When more than one writer can target the same table (multiple jobs, batch + streaming, backfill + incremental), the table format's optimistic concurrency mechanism MUST be configured and writers MUST retry on commit conflict. Naive parallel writers without conflict resolution corrupt manifests and cause silent data loss in some engines.
+
+**Verification**:
+- Functional Design identifies all writers per table.
+- For tables with multiple writers: Iceberg `commit.retry.num-retries` and related properties are set, or Delta `txn.appId` and retry logic is implemented.
+- Tests include a concurrent-writer scenario for any table with multiple producers.
+
+---
+
+## Rule S3LH-06: Bronze-Silver-Gold (or Equivalent) Zone Separation
+
+**Severity**: P1 — Warning
+
+**Rule**: The S3 layout MUST separate ingestion zones from curated zones — naming convention is not prescribed (raw/bronze/silver/gold, landing/staging/curated, etc.) but separation is mandatory. Raw data MUST be retained in its source form (or close to it) so transformations can be replayed. Direct writes from a producer into a curated zone are prohibited.
+
+**Verification**:
+- Functional Design includes a zone diagram with arrows showing only valid promotions.
+- Bucket and prefix naming distinguishes zones.
+- IAM and Lake Formation grants align with zones (producers write to landing, transformations write across zones, consumers read from curated).
+
+---
+
+## Rule S3LH-07: SSE-KMS Encryption with Customer-Managed Keys
+
+**Severity**: P0 — Blocking
+
+**Rule**: Production buckets containing data classified as `internal`, `confidential`, `pii`, `phi`, or `pci` (per DATAENG-06) MUST use SSE-KMS with a customer-managed KMS key (CMK), not SSE-S3 or an AWS-managed key. Key policies MUST restrict decrypt access to specific IAM roles. S3 Bucket Keys SHOULD be enabled to control KMS request costs.
+
+**Verification**:
+- Infrastructure Design specifies CMK ARN, key policy, and rotation policy per bucket.
+- Bucket default encryption is set to SSE-KMS with the CMK.
+- S3 Bucket Keys are enabled on buckets with significant write volume (justification documented if disabled).
+- Cross-account access patterns explicitly grant kms:Decrypt to the consuming principal.
+
+---
+
+## Rule S3LH-08: Lake Formation for Fine-Grained Access Control on Shared Tables
+
+**Severity**: P1 — Warning
+
+**Rule**: Tables that need column-level or row-level access control, or that are shared across AWS accounts, MUST be managed by AWS Lake Formation. IAM-only access (bucket policy + role permissions) is acceptable only for tables where every reader needs all columns and all rows.
+
+**Verification**:
+- Infrastructure Design names tables under Lake Formation governance.
+- Column-level filters, row-level filters, and data filters are specified per persona/role for governed tables.
+- Cross-account sharing uses LF-Tags or named resource grants, not bucket policies.
+- IAMAllowedPrincipals is removed from Lake Formation settings on Glue databases and tables that are governed.
+
+---
+
+## Rule S3LH-09: Parquet as Default Format with Explicit Compression
+
+**Severity**: P2 — Advisory
+
+**Rule**: Parquet is the default columnar format for new tables unless a specific reason exists to choose otherwise. Compression codec MUST be explicitly set (ZSTD recommended for analytical workloads; SNAPPY acceptable for write-throughput-critical workloads). Row group size and page size MUST be tuned for the expected query pattern when defaults are not appropriate.
+
+**Verification**:
+- Functional Design names the file format, compression codec, and any non-default row group / page size settings with justification.
+- Code Generation writes Parquet with explicit codec configuration.
+- ORC or other formats require explicit justification.
+
+---
+
+## Rule S3LH-10: Time Travel Retention Aligned to Recovery and Audit Requirements
+
+**Severity**: P1 — Warning
+
+**Rule**: Snapshot retention (Iceberg) or version retention (Delta) MUST be sized intentionally against two requirements: how far back a consumer needs to query historical state (time travel), and how much restore-from-corruption headroom the operations team needs. The default (5–7 days) is acceptable for most workloads but MUST be a deliberate choice, not an accepted default. Retention beyond 30 days has material storage cost implications.
+
+**Verification**:
+- Data contract or NFR Requirements states the time-travel SLA per table.
+- Infrastructure Design sets snapshot/version retention properties to match.
+- Cost model accounts for retained data file storage at the chosen retention.
+
+---
+
+## Rule S3LH-11: Column Statistics Configured for Query-Critical Tables
+
+**Severity**: P1 — Warning
+
+**Rule**: Every table with a declared query latency SLA (per DATAENG-12) MUST have column statistics explicitly configured and kept current. Query engines use column-level statistics — stored in Iceberg manifest files or the Delta log — to skip data files whose min/max bounds exclude a predicate, reducing bytes scanned without changing query results. Tables where statistics are absent, stale, or misconfigured silently degrade to full scans and will miss their SLA targets under production load.
+
+Statistics configuration MUST be deliberate rather than defaulted:
+
+**Iceberg**:
+- `write.metadata.metrics.default` controls the metric mode for all columns. Acceptable values: `truncate(N)` (default; collects truncated bounds — acceptable for most string columns), `full` (exact bounds — preferred for numeric, date, and timestamp filter columns), `counts` (null and NaN counts only — use for columns never used in range predicates), `none` (disables statistics — use only for high-cardinality free-text columns such as `description` or `json_payload` where bounds have no pruning value).
+- Per-column overrides via `write.metadata.metrics.column.<col_name>` MUST be used when the default mode is wrong for a specific column (e.g., set `full` on a `event_timestamp` column while leaving string columns at `truncate(16)`).
+- Tables wider than 100 columns MUST explicitly set `none` on columns that are never used in filter predicates to prevent manifest bloat.
+
+**Delta Lake**:
+- `delta.dataSkippingNumIndexedCols` controls how many leftmost columns are included in per-file statistics written to the Delta log. The default (32) is not always appropriate — it silently skips statistics for filter columns that fall beyond position 32, and wastes log space collecting statistics on columns that are never filtered.
+- This property MUST be set to cover at minimum every column that appears in a `WHERE` clause in any SLA-bound query, regardless of column position.
+- `ANALYZE TABLE <table> COMPUTE STATISTICS FOR COLUMNS <col1>, <col2>, ...` MUST be run after initial load and after any backfill that materially changes value distributions. For incrementally written tables, statistics refresh MUST be scheduled as part of the maintenance cadence defined in S3LH-04.
+
+**Verification**:
+- Functional Design lists, per SLA-bound table: the columns used in WHERE clauses and JOIN predicates of the top queries, the chosen metric mode per column (Iceberg) or the `dataSkippingNumIndexedCols` value and covered columns (Delta), and the statistics refresh cadence.
+- Code Generation sets `write.metadata.metrics.*` properties in Iceberg table DDL and sets `delta.dataSkippingNumIndexedCols` in Delta table properties where the default is insufficient.
+- Infrastructure Design includes `ANALYZE TABLE` execution in the maintenance schedule (S3LH-04) for Delta tables and for Iceberg tables where `rewrite_manifests` is needed to refresh statistics after bulk rewrites.
+- Build and Test executes each SLA-bound query with statistics in place and asserts that the query engine reports skipped files (via `EXPLAIN` output, query profile, or engine scan metrics) — a full scan on a filtered table with statistics configured is a test failure.
+
+---
+
+## Rule S3LH-12: Iceberg Branches and Tags Used for CI/CD Isolation and Audit Snapshots
+
+**Severity**: P1 — Warning
+
+**Rule**: Projects using Apache Iceberg MUST use Iceberg's branch and tag primitives to isolate in-flight changes from production readers and to preserve point-in-time audit snapshots. Writing speculatively to the `main` branch while CI validation is in progress exposes partially-validated data to downstream consumers and is prohibited for any table with a declared SLA or downstream consumers listed in the data contract.
+
+**Branch workflow**:
+- Every pull request that modifies transformation logic, schema, or seed data for an Iceberg table MUST write to a named Iceberg branch scoped to that PR (e.g., `pr-<number>` or `ci-<commit-sha>`), not to the `main` branch.
+- CI validation — data quality checks (DATAENG-07), schema contract enforcement (DATAENG-01), and statistics verification (S3LH-11) — runs against the PR branch. Only a clean CI run unblocks promotion.
+- On PR merge, the PR branch is fast-forward merged into `main` via `ALTER TABLE ... SET CURRENT SNAPSHOT` or the engine's branch merge API. The PR branch is deleted after successful promotion.
+- The `main` branch is the only branch read by downstream production consumers. Production queries MUST NOT reference PR or CI branches.
+
+**Tag workflow**:
+- A named Iceberg tag MUST be created at every production deployment boundary (e.g., `deploy-<YYYY-MM-DD>-<commit-sha>`) immediately before any schema migration or bulk write is applied to `main`. Tags are immutable snapshot references — they preserve a restore point without retaining live data files beyond the configured retention.
+- Tags used for regulatory audit snapshots MUST have an explicit `max-ref-age-ms` set to match the audit retention requirement (e.g., 7 years for financial data) and MUST NOT rely on the table's default snapshot expiration policy, which would silently delete them.
+- Tags MUST NOT be used as write targets; they are read-only snapshot pointers.
+
+**Branch and tag retention**:
+- Merged PR branches MUST be deleted within one maintenance cycle (S3LH-04) to prevent manifest accumulation.
+- Long-lived audit tags are exempt from snapshot expiration — `expire_snapshots` procedures MUST be configured to retain snapshots referenced by named tags. Iceberg's `expire_snapshots` does not expire snapshots pinned by a tag by default; this behaviour MUST be verified in Build and Test.
+- The number of concurrent live PR branches on a single table MUST be bounded (recommended maximum: 10) to prevent metadata file growth; the CI/CD system MUST enforce this limit by deleting stale branches from abandoned PRs.
+
+**Verification**:
+- Infrastructure Design documents the branch naming convention, the promotion procedure (merge API call or `SET CURRENT SNAPSHOT`), and the tag naming convention with retention overrides for audit tags.
+- Code Generation configures the pipeline's write target as the PR branch reference, not `main`, for CI runs; promotion to `main` is a separate explicit step in the CI/CD pipeline (per CICD-06).
+- Build and Test includes: (a) a CI run that writes to a PR branch and asserts `main` is unchanged; (b) a promotion step that merges the PR branch and asserts `main` reflects the new snapshot; (c) a verification that `expire_snapshots` does not remove a snapshot pinned by a named tag.
+- Brownfield projects that currently write directly to `main` without branch isolation document a migration plan to adopt the branch workflow; direct-to-main writes are accepted as a P1 finding with a remediation timeline, not silently grandfathered.
+
+---
+
+## Rule S3LH-13: S3 Lifecycle Policies for Cold Partition Cost Management
+
+**Severity**: P1 — Warning
+
+**Rule**: Every S3 bucket used as a lakehouse storage layer MUST have explicit S3 lifecycle policies that transition or expire objects based on age and access pattern. Storing all partitions indefinitely in S3 Standard is a cost defect for any table whose historical partitions are accessed infrequently. Lifecycle configuration MUST be a deliberate design decision per bucket and per partition age tier — not an omission.
+
+**Storage class selection**:
+
+| Use case | Recommended class | Rationale |
+|----------|-------------------|-----------|
+| Active partitions (last 30–90 days), queried frequently | S3 Standard | No retrieval cost; lowest latency |
+| Warm partitions (90 days–1 year), queried occasionally | S3 Intelligent-Tiering | Automatic movement between Frequent and Infrequent Access tiers based on observed access patterns; no retrieval fee for objects that move back to Frequent Access |
+| Cold partitions (1–3 years), queried rarely but must remain queryable | S3 Intelligent-Tiering (Archive Instant Access tier enabled) | Sub-millisecond retrieval like Standard-IA but lower storage cost; no minimum retrieval fee |
+| Archive partitions (>3 years), queried only for compliance or audits | S3 Glacier Instant Retrieval or S3 Glacier Flexible Retrieval | Lowest storage cost; retrieval fee and latency are acceptable when access frequency is near-zero |
+| Objects past retention requirement | Expire and delete | Retaining objects beyond the retention requirement defined in the data contract (DATAENG-01) and time-travel policy (S3LH-10) is a compliance and cost liability |
+
+**S3 Intelligent-Tiering specifics**:
+- The monitoring and automation fee (per-object charge) makes Intelligent-Tiering cost-ineffective for objects smaller than 128 KB. Lifecycle rules MUST NOT apply Intelligent-Tiering to small-file objects; this is a direct consequence of the file size discipline in S3LH-03 — properly compacted tables naturally satisfy the 128 KB floor.
+- The Archive Access and Deep Archive Access tiers within Intelligent-Tiering introduce retrieval latency (hours) and MUST only be enabled on buckets where that latency is acceptable to all consumers. When enabled, the activation thresholds (90 days for Archive Access, 180 days for Deep Archive Access) MUST be documented alongside the consumer SLA to confirm compatibility.
+- Intelligent-Tiering does not suit landing-zone buckets with high object churn (objects written and deleted within days) — Standard with a short expiration rule is cheaper there.
+
+**Iceberg and Delta interaction**:
+- Data files (Parquet) are candidates for tiering based on partition age. Metadata files (Iceberg manifests, manifest lists, `version-hint.text`; Delta `_delta_log/` JSON and checkpoint files) MUST remain in S3 Standard or S3 Standard-IA — transitioning metadata files to Glacier breaks table reads without warning.
+- Lifecycle rules MUST use prefix or tag conditions to exclude metadata paths from tiering transitions. For Iceberg: exclude `<table-prefix>/metadata/`. For Delta: exclude `<table-prefix>/_delta_log/`.
+- Orphan data files cleaned by `remove_orphan_files` (S3LH-04) are deleted explicitly by the maintenance job; lifecycle expiration is a safety net for files the maintenance job misses, not the primary deletion mechanism.
+
+**Verification**:
+- Infrastructure Design includes a lifecycle policy matrix per bucket: prefix or tag scope, age threshold per transition tier, storage class target, and a note on whether Intelligent-Tiering archive tiers are enabled and why.
+- Metadata prefixes are explicitly excluded from tiering transitions in the lifecycle rule configuration.
+- The lifecycle age thresholds are reconciled against the time-travel retention from S3LH-10 — a lifecycle rule that expires data files before the snapshot retention window closes is a blocking finding.
+- Infrastructure as Code (CDK, Terraform, CloudFormation) provisions lifecycle rules alongside bucket creation; lifecycle configuration is not applied manually after deployment.
+- Build and Test documents a cost model: estimated monthly S3 cost before and after lifecycle policy at projected steady-state data volume, demonstrating the policy is sized to the actual access pattern rather than copied from a template.

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/s3-lakehouse/s3-lakehouse.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/s3-lakehouse/s3-lakehouse.opt-in.md
@@ -1,0 +1,18 @@
+# S3 Lakehouse — Opt-In
+
+**Extension**: S3 Lakehouse
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: S3 Lakehouse Extension
+Should S3 Lakehouse rules be enforced for this project?
+
+A) Yes — enforce all S3LH rules per their P0/P1/P2 severity tiers (recommended if any persisted dataset lives on Amazon S3 and is queried by name through Athena, EMR, Glue, Spark, Trino, Redshift Spectrum, or any SQL engine)
+B) No — skip all S3LH rules (suitable when S3 is used only as a passthrough or staging buffer with no SQL-queryable tables)
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```


### PR DESCRIPTION
## Summary
- Introduces an opt-in data-engineering extension family under `aidlc-rules/aws-aidlc-rule-details/extensions/data-engineering/` with seven extensions: `baseline`, `catalog`, `cicd`, `orchestration`, `redshift`, `s3-lakehouse`, and `glue-etl`.
- Each extension follows the established pattern: a rule file (`<name>.md`) plus an opt-in prompt file (`<name>.opt-in.md`) with A/B/X format and `[Answer]:` tag.
- Rules carry P0 (blocking) / P1 (warning) / P2 (advisory) severity tiers defined in `baseline`, and verification bullets keyed to AIDLC stages (Requirements Analysis, Functional Design, Infrastructure Design, Code Generation, Build and Test, NFR Requirements).
- `glue-etl` covers Glue as a compute surface (Spark, Spark Streaming, Ray, Python shell, interactive sessions, Studio, DataBrew) — complementing existing catalog/lakehouse extensions that govern Glue Data Catalog and Lake Formation.

## Test plan
- [ ] Verify each `*.opt-in.md` file is discovered by the extensions loader at workflow start
- [ ] Confirm that opting IN for an extension loads the corresponding rules file on demand
- [ ] Confirm that opting OUT skips loading the full rules file
- [ ] Run a sample inception flow that opts into `baseline` plus `glue-etl` and validates the rules surface in Requirements Analysis
- [ ] Confirm composition references between extensions (e.g., `s3-lakehouse` S3LH-02 referenced by `glue-etl` GLUE-05) resolve as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).