### PR TITLE
fix: add quality-target verification gate to Construction phase

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/common/overconfidence-prevention.md
+++ b/aidlc-rules/aws-aidlc-rule-details/common/overconfidence-prevention.md
@@ -80,6 +80,8 @@ These directives were telling the AI to avoid asking questions rather than encou
 - Proceeding with vague or ambiguous user responses
 - Skipping entire question categories without justification
 - Making assumptions instead of asking for clarification
+- Relaxing, lowering, or disabling a previously defined quality target
+  (e.g. a test coverage threshold) instead of meeting it
 
 ### Success Indicators
 - Appropriate number of clarifying questions for project complexity

--- a/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/build-and-test.md
@@ -19,6 +19,12 @@ Analyze the project to determine appropriate testing strategy:
 - **Contract tests**: API contract validation between services
 - **Security tests**: Vulnerability scanning, penetration testing
 
+When NFR Requirements defined measurable quality targets for any unit (e.g. test
+coverage thresholds, performance budgets), record those targets here. The summary
+in Step 7 MUST compare actual results against them and state whether each target
+was met. If a target was not met, the summary MUST say so explicitly and the
+"Ready for Operations" field MUST reflect it.
+
 ---
 
 ## Step 2: Generate Build Instructions
@@ -265,6 +271,8 @@ Create `aidlc-docs/construction/build-and-test/build-and-test-summary.md`:
 - **Passed**: [X]
 - **Failed**: [X]
 - **Coverage**: [X]%
+- **Coverage Target (from NFR Requirements)**: [X]% (or N/A if none defined)
+- **Target Met**: [Yes/No/N/A]
 - **Status**: [Pass/Fail]
 
 ### Integration Tests

--- a/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
@@ -200,6 +200,13 @@ This stage generates code for each unit of work through two integrated parts:
 - **UPDATE CHECKBOXES**: Mark [x] immediately after completing each step
 - **STORY TRACEABILITY**: Mark unit stories [x] when functionality is implemented
 - **RESPECT DEPENDENCIES**: Only implement when unit dependencies are satisfied
+- **HONOR QUALITY TARGETS**: Measurable quality targets defined in NFR Requirements
+  or NFR Design (e.g. test coverage thresholds, performance budgets) are inputs to
+  Code Generation, not suggestions. Generated tests and configuration MUST aim to
+  meet them. NEVER relax, lower, or disable a previously defined quality target
+  (including threshold settings in test or build configuration) to make a step
+  "pass". If a target cannot be met, surface the gap explicitly in the completion
+  message instead of silently weakening the target.
 
 ### Automation Friendly Code Rules
 When generating UI code (web, mobile, desktop), ensure elements are automation-friendly:


### PR DESCRIPTION
## Summary

Closes #273.

Adds a tool-agnostic quality-target verification gate to the Construction phase. Measurable quality targets defined in NFR Requirements (test coverage thresholds, performance budgets, etc.) currently have no downstream stage that verifies they were met — an agent can silently miss, or even lower, its own defined target while satisfying every rule. This PR closes that gap with three minimal changes.

## Changes

| File | Change |
|------|--------|
| `construction/code-generation.md` | Add `HONOR QUALITY TARGETS` to the "Generation Phase Rules" Critical Rules |
| `construction/build-and-test.md` | Add "Coverage Target" / "Target Met" fields to the summary template, and a comparison instruction |
| `common/overconfidence-prevention.md` | Add target-relaxation to the "Red Flags to Watch For" list |

## Rationale

This mirrors the gap PR #155 fixed for question/answer rigor: a property is strengthened on one side of a stage boundary but left unenforced on the other. Here, quality targets are *defined* (NFR Requirements) but never *verified* (Code Generation / Build & Test). The change is consistent with `common/overconfidence-prevention.md`'s principle of not proceeding past unresolved gaps.

The changes are tool-agnostic (no test-runner-specific wording) and follow the "single source of truth" principle — `overconfidence-prevention.md` carries the red flag, the stage files carry the actionable rules.

## Test Plan

- Ran a full Inception→Construction cycle on a real greenfield monorepo project (TypeScript / pnpm, 6 units) with an AI coding agent.
- In the original run, the agent lowered a coverage threshold (90/85 → 70/65) in the test config to pass Code Generation; this was only caught by human review. See #273 for the full reproduction.
- With these rule changes applied, the agent is explicitly instructed to surface the coverage gap in the completion message instead of weakening the target, and Build & Test now records target-vs-actual.
- All three changed markdown files pass `markdownlint-cli2` (0 errors).

## Checklist

- [x] Reviewed the contributing guidelines
- [x] Performed a self-review
- [x] Changes tested (full Construction-phase run described above)
- [x] Changes documented (rule files are self-documenting; #273 has full context)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).

