### PR TITLE
fix: scope per-unit artifact loading to unit directories in session-continuity

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/common/session-continuity.md
+++ b/aidlc-rules/aws-aidlc-rule-details/common/session-continuity.md
@@ -30,7 +30,12 @@ B) Review a previous stage ([Show available stages])
    - **User Stories**: Read stories.md, personas.md, story-generation-plan.md
    - **Application Design**: Read application-design artifacts (components.md, component-methods.md, services.md)
    - **Design (Units)**: Read unit-of-work.md, unit-of-work-dependency.md, unit-of-work-story-map.md
-   - **Per-Unit Design**: Read functional-design.md, nfr-requirements.md, nfr-design.md, infrastructure-design.md
+   - **Per-Unit Design**: Per-unit artifacts live under `aidlc-docs/construction/{unit-name}/` in
+     `functional-design/`, `nfr-requirements/`, `nfr-design/`, and `infrastructure-design/`
+     subdirectories. On resume, determine the in-progress unit from `aidlc-state.md` and load that
+     unit's design artifacts, plus the design artifacts of any units it depends on (per
+     `unit-of-work-dependency.md`). The exact files in each subdirectory are enumerated by the
+     corresponding construction stage rules.
    - **Code Stages**: Read all code files, plans, AND all previous artifacts
 4. **Smart Context Loading by Stage**:
    - **Early Stages (Workspace Detection, Reverse Engineering)**: Load workspace analysis


### PR DESCRIPTION
## Summary

Closes #275.

The "Per-Unit Design" artifact-loading instruction in `session-continuity.md` did not reflect the actual per-unit directory structure of the Construction phase. A resumed, zero-context session had no way to know which unit's artifacts to load or where they live.

## Problem

`session-continuity.md` line 33 read:

```
- **Per-Unit Design**: Read functional-design.md, nfr-requirements.md, nfr-design.md, infrastructure-design.md
```

This is inaccurate in three ways (verified against the current rule files):

1. **Missing the `{unit-name}` directory level.** Every Construction stage writes to `aidlc-docs/construction/{unit-name}/{stage}/` (e.g. `functional-design.md` lines 68-71). The line listed bare filenames with no path.
2. **No unit selection for multi-unit projects.** Construction runs a per-unit loop; an N-unit project has N copies of these directories. The line gave no guidance on which unit(s) to load.
3. **Filenames did not match the real artifacts.** There is no single `functional-design.md` — the stage produces `functional-design/business-logic-model.md`, `business-rules.md`, `domain-entities.md`; similarly for `nfr-design` and `nfr-requirements`.

The other lines in the same list are fine because those stages are not unit-scoped — only Per-Unit Design has artifacts under a `{unit-name}` directory.

## Change

Rewrites the Per-Unit Design line to:

- Use the real path shape `aidlc-docs/construction/{unit-name}/{functional-design,nfr-requirements,nfr-design,infrastructure-design}/`.
- State unit selection explicitly: determine the in-progress unit from `aidlc-state.md`, load that unit plus its dependencies (per `unit-of-work-dependency.md`).
- Defer exact filenames to the construction stage rules (single source of truth) instead of repeating a stale, inaccurate list.

## Test Plan

- Observed during a multi-unit (6-unit) greenfield Construction run: on a mid-Construction resume, the instruction pointed at filenames that do not exist and are not unit-qualified.
- The changed file passes `markdownlint-cli2` (0 errors).

## Checklist

- [x] Reviewed the contributing guidelines
- [x] Performed a self-review
- [x] Changes tested (multi-unit Construction run described above)
- [x] Changes documented (#275 has full context)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).

