### PR TITLE
fix: respect conversation language in generated files

### DIFF
--- a/dist/kiro/.kiro/aidlc-common/conventions/aidlc-question-format.md
+++ b/dist/kiro/.kiro/aidlc-common/conventions/aidlc-question-format.md
@@ -27,3 +27,7 @@ d) Other
 - Wait for the human's answer before presenting the next question.
 - The human may choose to answer in chat or go to the question file and answer all at once.
 - Trade Offs and Recommendation sections are optional per question — include them when the choice has meaningful implications, skip for straightforward questions.
+
+## Language
+
+Always write questions in the same language the human used in their most recent message, unless the human explicitly requests a different language.

--- a/dist/kiro/.kiro/aidlc-common/protocols/aidlc-builder-protocol.md
+++ b/dist/kiro/.kiro/aidlc-common/protocols/aidlc-builder-protocol.md
@@ -103,6 +103,7 @@ Skip this step entirely when the skill's `plan-creation: "false"` — go straigh
 5. **Gap handling.** If you discover a requirement or capability not covered by the inputs, raise it as a follow-up question. Do not silently add functionality beyond what is documented upstream.
 6. **Brownfield context.** When a skill's prerequisites mention brownfield, accept brownfield context from any available source: RE-kb, reverse-engineering artifacts, org-level knowledge base, or LLM analysis of the existing codebase. Do not restate this in the skill's `SKILL.md`.
 7. **Lens application.** When active lens files are provided, read each lens's SKILL.md to understand its principles and definitions. Apply the lens's perspective to the current stage's artifacts — interpret the generic principles in context of whatever you are currently producing. Lens guidance is additive: it does not override the stage skill's instructions but augments them with additional considerations. If a lens principle conflicts with the stage skill's instructions, flag the conflict as a clarification question rather than silently resolving it.
+8. **Language.** Write user-facing files in the same language the human used in their most recent message, unless the human explicitly requests a different language. User-facing files are: question files, plan files, and design artifacts. All other files (state tracking, audit logs, validation results, and any machine-parsed files) remain in English.
 
 ## 4. State File Responsibilities
 

--- a/src/kiro/aidlc-common/conventions/aidlc-question-format.md
+++ b/src/kiro/aidlc-common/conventions/aidlc-question-format.md
@@ -27,3 +27,7 @@ d) Other
 - Wait for the human's answer before presenting the next question.
 - The human may choose to answer in chat or go to the question file and answer all at once.
 - Trade Offs and Recommendation sections are optional per question — include them when the choice has meaningful implications, skip for straightforward questions.
+
+## Language
+
+Always write questions in the same language the human used in their most recent message, unless the human explicitly requests a different language.

--- a/src/kiro/aidlc-common/protocols/aidlc-builder-protocol.md
+++ b/src/kiro/aidlc-common/protocols/aidlc-builder-protocol.md
@@ -103,6 +103,7 @@ Skip this step entirely when the skill's `plan-creation: "false"` — go straigh
 5. **Gap handling.** If you discover a requirement or capability not covered by the inputs, raise it as a follow-up question. Do not silently add functionality beyond what is documented upstream.
 6. **Brownfield context.** When a skill's prerequisites mention brownfield, accept brownfield context from any available source: RE-kb, reverse-engineering artifacts, org-level knowledge base, or LLM analysis of the existing codebase. Do not restate this in the skill's `SKILL.md`.
 7. **Lens application.** When active lens files are provided, read each lens's SKILL.md to understand its principles and definitions. Apply the lens's perspective to the current stage's artifacts — interpret the generic principles in context of whatever you are currently producing. Lens guidance is additive: it does not override the stage skill's instructions but augments them with additional considerations. If a lens principle conflicts with the stage skill's instructions, flag the conflict as a clarification question rather than silently resolving it.
+8. **Language.** Write user-facing files in the same language the human used in their most recent message, unless the human explicitly requests a different language. User-facing files are: question files, plan files, and design artifacts. All other files (state tracking, audit logs, validation results, and any machine-parsed files) remain in English.
 
 ## 4. State File Responsibilities
 


### PR DESCRIPTION
## Summary

Skill-generated files (questions, plans, and design artifacts) were output in English regardless of the user's conversation language. Closes #288

## Changes

- Added a `Language` section to `aidlc-common/conventions/aidlc-question-format.md` directing question files to match the human's conversation language.
- Added Rule 7 (Language) to `aidlc-common/protocols/aidlc-builder-protocol.md` Section 3, extending the language rule to plans and design artifacts. User-facing files are explicitly defined as: question files, plan files, and design artifacts. All other files remain in English.

Note: `*-validation-result.md` is intentionally excluded because `aidlc-process-checker.js` parses its `---PROCESS-CHECK-DATA---` block programmatically.

### Approach

Same approach as the v1 fix (#177): place the language instruction in shared convention/protocol files so all current and future skills automatically inherit the rule without per-skill modification. In v2, the relevant shared files are `aidlc-question-format.md` (for questions) and `aidlc-builder-protocol.md` (for plans and design artifacts).

### Note on dist/

An earlier contributor's commit (`be2b776 feat: adding v2 branch`) updated `src/` but did not include the corresponding `dist/` rebuild. When I ran `make build-kiro` for this PR, those unrelated changes appeared in `dist/` as well. I have excluded them from this PR and only included the `dist/` files corresponding to my own changes. Filed #289 (RFC) to discuss the dist build policy for contributors going forward.

## User experience

**Before:** Question files (e.g., `wireframes-questions.md`) and design artifacts were generated in English even when the conversation was conducted in Japanese.

**After:** User-facing generated files are written in the user's conversation language.

## Checklist

- [x] I have reviewed the [contributing guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

## Test Plan

1. Start AI-DLC v2 with `/aidlc-orchestrator 簡単なTODOアプリを作りたい`
2. Proceed through inception skills (requirements-analysis, user-stories, wireframes)
3. Verify `*-questions.md` files are generated in Japanese

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).