### PR TITLE
feat: propagate build-time discoveries across units (#299)

### DIFF
--- a/aidlc-rules/aws-aidlc-rule-details/common/session-continuity.md
+++ b/aidlc-rules/aws-aidlc-rule-details/common/session-continuity.md
@@ -38,11 +38,15 @@ B) Review a previous stage ([Show available stages])
      `unit-of-work-dependency.md`). The exact files in each subdirectory are enumerated by the
      corresponding construction stage rules.
    - **Code Stages**: Read all code files, plans, AND all previous artifacts
+   - **Cross-Unit Discoveries (Construction resume)**: Also read
+     `aidlc-docs/construction/cross-unit-discoveries.md` if it exists, so a resumed unit reuses prior
+     units' build-time findings rather than re-discovering them. The log's schema and its recording rule
+     are defined in `construction/code-generation.md`.
 4. **Smart Context Loading by Stage**:
    - **Early Stages (Workspace Detection, Reverse Engineering)**: Load workspace analysis
    - **Requirements/Stories**: Load reverse engineering + requirements artifacts
    - **Design Stages**: Load requirements + stories + architecture + design artifacts
-   - **Code Stages**: Load ALL artifacts + existing code files
+   - **Code Stages**: Load ALL artifacts + existing code files + the cross-unit discoveries log (if present)
 5. **Adapt options** based on architectural choice and current phase
 6. **Show specific next steps** rather than generic descriptions
 7. **Log the continuity prompt** in audit.md with timestamp

--- a/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
+++ b/aidlc-rules/aws-aidlc-rule-details/construction/code-generation.md
@@ -19,6 +19,8 @@ This stage generates code for each unit of work through two integrated parts:
 
 ## Step 1: Analyze Unit Context
 - [ ] Read unit design artifacts from Unit Design Generation
+- [ ] If `aidlc-docs/construction/cross-unit-discoveries.md` exists, read it and reuse any finding whose
+      *Affected Resource* this unit also uses (see "Cross-Unit Discoveries Log" in Critical Rules)
 - [ ] Read unit story map to understand assigned stories
 - [ ] Identify unit dependencies and interfaces
 - [ ] Validate unit is ready for code generation
@@ -112,6 +114,14 @@ This stage generates code for each unit of work through two integrated parts:
   - **Build/Config Files**: Workspace root
 - [ ] Follow unit story requirements
 - [ ] Respect dependencies and interfaces
+- [ ] **Record cross-unit discoveries**: if this step uncovers a finding about a **shared resource** —
+      one defined outside this unit's scope, i.e. a third-party API, a cloud/platform service this unit
+      did not provision, or an environment variable/secret this unit only consumes (not the data models
+      or services this unit itself owns) — append a row to
+      `aidlc-docs/construction/cross-unit-discoveries.md`. Typical findings: an undocumented rate limit,
+      an API quirk, or a pivot away from an approach that did not work. Trigger on the *shared-resource*
+      fact, not on a judgement about which future units are affected. The log's schema, lifecycle, and
+      the header to create the file with are defined under "Cross-Unit Discoveries Log" in Critical Rules.
 
 ## Step 12: Update Progress
 - [ ] Mark the completed step as [x] in the unit code generation plan
@@ -207,6 +217,28 @@ When generating UI code (web, mobile, desktop), ensure elements are automation-f
 - Use consistent naming: `{component}-{element-role}` (e.g., `login-form-submit-button`, `user-list-search-input`)
 - Avoid dynamic or auto-generated IDs that change between renders
 - Keep `data-testid` values stable across code changes (only change when element purpose changes)
+
+### Cross-Unit Discoveries Log
+
+`aidlc-docs/construction/cross-unit-discoveries.md` is an append-only log shared across the per-unit
+loop (read in Step 1, written in Step 11). It propagates build-time findings about external resources
+to later units regardless of the declared dependency graph; the dependency matrix in
+`unit-of-work-dependency.md` stays unchanged as a design-time artifact. *Affected Resource* must
+identify the resource concretely (service name, API + version, or env variable) so a later unit can
+match it at Step 1 — e.g. a rate limit one unit records against an email API applies to any later unit
+that calls that same API, even with no declared dependency between them. The log is cycle-scoped:
+archive or reset it with other cycle-specific documents when a new cycle begins (a cycle is one
+end-to-end pass of the workflow tracked in `aidlc-state.md`). Create the file with this header on first
+use:
+
+```markdown
+# Cross-Unit Discoveries
+<!-- Append-only, one row per discovery (newest last). Build-time findings about external
+     resources that cross unit boundaries, independent of unit-of-work-dependency.md.
+     Cycle-scoped: archive/reset with other cycle-specific docs when a new cycle begins. -->
+| Affected Resource | Finding | Scope of Impact | Action Taken | Rationale | Originating Unit |
+|---|---|---|---|---|---|
+```
 
 ## Completion Criteria
 - Complete unit code generation plan created and approved


### PR DESCRIPTION
> **Companion to #299.** Opened so the proposed mechanism is concrete and reviewable. This touches the shared `common/` file, so per CONTRIBUTING ("align on scope before you invest time writing code") I'd still like the approach settled in #299 — happy to revise the mechanism (or close this) based on where that discussion lands. Putting it up for review rather than leaving it as a draft so it's easy to comment on inline.

See #299 for the problem statement and discussion.

## What this changes

Construction runs a per-unit loop. Today, cross-unit context is shared only by following the *statically declared* dependency matrix (`unit-of-work-dependency.md`). Build-time discoveries — undocumented rate limits, API quirks, pivots that weren't foreseeable at design time — don't appear in that matrix, so a later unit touching the same external resource re-discovers (and re-pays for) the same lesson, and may even pivot inconsistently.

This adds an **orthogonal build-time layer** on top of the dependency matrix — the matrix itself is unchanged.

| File | Change |
|------|--------|
| `common/session-continuity.md` | New **Cross-Unit Discoveries** loading rule: read `aidlc-docs/construction/cross-unit-discoveries.md` during Construction stages (also covers resumed sessions, the same section #276 just fixed). |
| `construction/code-generation.md` | **Step 1** reads the log and reuses prior findings (referencing the session-continuity rule, not duplicating it). **Step 11** appends an entry when a build-time discovery crosses a unit boundary. |

The log is append-only, one entry = *finding · scope of impact · action taken · rationale · originating unit*. The file is created on first discovery and only when relevant, so projects with no cross-cutting findings produce nothing.

## Example (from @mayakost, #299)

Unit 1 (Notification) discovers email API v2 is rate-limited to 10 req/s (undocumented) and pivots to batching with API v1. With this change, that pivot is recorded once; Unit 2 (User Onboarding), which also sends email but has no declared dependency on Unit 1, reads the log at Step 1 and reuses the v1 batching approach instead of re-hitting the same wall.

## Design notes / open questions for review

- **Single source of truth**: the loading rule lives in `common/session-continuity.md`; `code-generation.md` references it rather than restating it. Recording is a distinct responsibility, so it's defined where it happens (Step 11).
- **Where should the log live / who owns the schema?** Open to feedback on the file location, the entry shape, or whether loading belongs in the per-unit loop vs. the smart-context rule.
- **RFC?** If maintainers consider this design-level rather than a small enhancement, happy to move the discussion to the RFC template.

## Testing

These are rule (documentation) changes, not code. I verified:
- The new path `aidlc-docs/construction/cross-unit-discoveries.md` is referenced consistently across both files (no typos / no divergent paths).
- The cross-reference from `code-generation.md` Step 1 to the `common/session-continuity.md` rule resolves to the section added here.
- No directory names under `aidlc-rules/` were renamed or moved (public-contract paths intact).
- Walked the email-API scenario above against the edited rules to confirm the load → reuse → record loop is coherent for an agent driving the per-unit Construction loop.

Platform: reviewed against the Claude Code rule-loading flow (rule-details path resolution under `aidlc-rules/aws-aidlc-rule-details/`).

