### PR TITLE
docs(setup): add install scripts for clone-based setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ AI-DLC is an intelligent software development workflow that adapts to your needs
 ## Table of Contents
 
 - [Common](#common)
+  - [Option A: Clone this repository](#option-a-clone-this-repository-recommended)
+  - [Option B: Download the release zip](#option-b-download-the-release-zip)
 - [Platform-Specific Setup](#platform-specific-setup)
 - [Usage](#usage)
 - [Three-Phase Adaptive Workflow](#three-phase-adaptive-workflow)
@@ -29,11 +31,46 @@ AI-DLC is an intelligent software development workflow that adapts to your needs
 
 ## Common
 
+Choose how you want to get the AI-DLC rules — clone this repository or download the release zip — then follow the matching steps below.
+
+---
+
+### Option A: Clone this repository (recommended)
+
+If you have cloned this repository, use the included install script to copy the rules to your target project automatically. The script prompts for your coding agent and target project directory, so it works regardless of where you cloned the repo.
+
+**macOS/Linux:**
+
+```bash
+./scripts/install.sh
+```
+
+**Windows PowerShell:**
+
+```powershell
+.\scripts\install.ps1
+```
+
+You can also pass the agent and target project directory as arguments to skip the prompts:
+
+```bash
+# Example: install for Claude Code into ~/my-project
+./scripts/install.sh claude-code ~/my-project
+```
+
+Valid agent names: `kiro` · `amazonq` · `cursor` · `cline` · `claude-code` · `copilot` · `codex`
+
+Once the script completes, jump to the [Usage](#usage) section — you're done.
+
+---
+
+### Option B: Download the release zip
+
 1. Download the latest release zip file named `ai-dlc-rules-v<release-number>.zip` from the [Releases page](../../releases/latest) to a folder **outside** your project directory (e.g., `~/Downloads`).
 2. Extract the zip. It contains an `aidlc-rules/` folder with two subdirectories:
    - `aws-aidlc-rules/` — the core AI-DLC workflow rules
    - `aws-aidlc-rule-details/` — detailed rules conditionally referenced by the core rules
-3. Follow the setup instructions for your coding agent and platform below.
+3. Follow the platform-specific setup instructions below.
 
 ---
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,134 @@
+# AI-DLC Workflow Installer (Windows PowerShell)
+# Sets up AI-DLC rules in your target project from this cloned repository.
+# Usage: .\scripts\install.ps1 [agent] [target-project-dir]
+#   agent: kiro | amazonq | cursor | cline | claude-code | copilot | codex
+#   target-project-dir: path to the project you want to set up (defaults to current directory)
+
+param(
+    [string]$Agent = "",
+    [string]$TargetProject = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = Split-Path -Parent $ScriptDir
+$RulesDir  = Join-Path $RepoRoot "aidlc-rules"
+
+function Write-Success($msg) { Write-Host "✓ $msg" -ForegroundColor Green }
+function Write-Err($msg)     { Write-Host "✗ $msg" -ForegroundColor Red }
+function Write-Info($msg)    { Write-Host "ℹ $msg" -ForegroundColor Cyan }
+
+if (-not (Test-Path $RulesDir)) {
+    Write-Err "Cannot find aidlc-rules\ at: $RulesDir"
+    Write-Err "Run this script from within the cloned aidlc-workflows repository."
+    exit 1
+}
+
+$RulesSrc   = Join-Path $RulesDir "aws-aidlc-rules"
+$DetailsSrc = Join-Path $RulesDir "aws-aidlc-rule-details"
+
+# ── Agent selection ────────────────────────────────────────────────────────────
+
+if (-not $Agent) {
+    Write-Host "AI-DLC Workflow Installer"
+    Write-Host "========================="
+    Write-Host ""
+    Write-Host "Select your coding agent:"
+    Write-Host "  1) Kiro"
+    Write-Host "  2) Amazon Q Developer"
+    Write-Host "  3) Cursor IDE"
+    Write-Host "  4) Cline"
+    Write-Host "  5) Claude Code"
+    Write-Host "  6) GitHub Copilot"
+    Write-Host "  7) OpenAI Codex"
+    Write-Host ""
+    $choice = Read-Host "Enter choice [1-7]"
+    $Agent = switch ($choice) {
+        "1" { "kiro" }
+        "2" { "amazonq" }
+        "3" { "cursor" }
+        "4" { "cline" }
+        "5" { "claude-code" }
+        "6" { "copilot" }
+        "7" { "codex" }
+        default { Write-Err "Invalid choice: $choice"; exit 1 }
+    }
+}
+
+# ── Target project directory ───────────────────────────────────────────────────
+
+if (-not $TargetProject) {
+    $default = (Get-Location).Path
+    $input = Read-Host "Target project directory [$default]"
+    $TargetProject = if ($input -eq "") { $default } else { $input }
+}
+
+if (-not (Test-Path $TargetProject)) {
+    Write-Err "Directory not found: $TargetProject"
+    exit 1
+}
+$TargetProject = (Resolve-Path $TargetProject).Path
+
+Write-Info "Installing AI-DLC rules for agent '$Agent' into: $TargetProject"
+Write-Host ""
+
+# ── Copy rules ─────────────────────────────────────────────────────────────────
+
+switch ($Agent) {
+    "kiro" {
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.kiro\steering" | Out-Null
+        Copy-Item -Recurse -Force $RulesSrc "$TargetProject\.kiro\steering\"
+        Copy-Item -Recurse -Force $DetailsSrc "$TargetProject\.kiro\"
+        Write-Success "Kiro steering files installed"
+    }
+    "amazonq" {
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.amazonq\rules" | Out-Null
+        Copy-Item -Recurse -Force $RulesSrc "$TargetProject\.amazonq\rules\"
+        Copy-Item -Recurse -Force $DetailsSrc "$TargetProject\.amazonq\"
+        Write-Success "Amazon Q Developer rules installed"
+    }
+    "cursor" {
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.cursor\rules" | Out-Null
+        $frontmatter = "---`ndescription: `"AI-DLC (AI-Driven Development Life Cycle) adaptive workflow for software development`"`nalwaysApply: true`n---`n`n"
+        $frontmatter | Out-File -FilePath "$TargetProject\.cursor\rules\ai-dlc-workflow.mdc" -Encoding utf8 -NoNewline
+        Get-Content "$RulesSrc\core-workflow.md" | Add-Content "$TargetProject\.cursor\rules\ai-dlc-workflow.mdc"
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.aidlc-rule-details" | Out-Null
+        Copy-Item -Recurse -Force "$DetailsSrc\*" "$TargetProject\.aidlc-rule-details\"
+        Write-Success "Cursor IDE rules installed"
+    }
+    "cline" {
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.clinerules" | Out-Null
+        Copy-Item -Force "$RulesSrc\core-workflow.md" "$TargetProject\.clinerules\"
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.aidlc-rule-details" | Out-Null
+        Copy-Item -Recurse -Force "$DetailsSrc\*" "$TargetProject\.aidlc-rule-details\"
+        Write-Success "Cline rules installed"
+    }
+    "claude-code" {
+        Copy-Item -Force "$RulesSrc\core-workflow.md" "$TargetProject\CLAUDE.md"
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.aidlc-rule-details" | Out-Null
+        Copy-Item -Recurse -Force "$DetailsSrc\*" "$TargetProject\.aidlc-rule-details\"
+        Write-Success "Claude Code rules installed"
+    }
+    "copilot" {
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.github" | Out-Null
+        Copy-Item -Force "$RulesSrc\core-workflow.md" "$TargetProject\.github\copilot-instructions.md"
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.aidlc-rule-details" | Out-Null
+        Copy-Item -Recurse -Force "$DetailsSrc\*" "$TargetProject\.aidlc-rule-details\"
+        Write-Success "GitHub Copilot rules installed"
+    }
+    "codex" {
+        Copy-Item -Force "$RulesSrc\core-workflow.md" "$TargetProject\AGENTS.md"
+        New-Item -ItemType Directory -Force -Path "$TargetProject\.aidlc-rule-details" | Out-Null
+        Copy-Item -Recurse -Force "$DetailsSrc\*" "$TargetProject\.aidlc-rule-details\"
+        Write-Success "OpenAI Codex rules installed"
+    }
+    default {
+        Write-Err "Unknown agent: $Agent"
+        Write-Host "Valid agents: kiro | amazonq | cursor | cline | claude-code | copilot | codex"
+        exit 1
+    }
+}
+
+Write-Host ""
+Write-Success "Done. Open your project in your coding agent and start with: 'Using AI-DLC, ...'"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# AI-DLC Workflow Installer (macOS/Linux)
+# Sets up AI-DLC rules in your target project from this cloned repository.
+# Usage: ./scripts/install.sh [agent] [target-project-dir]
+#   agent: kiro | amazonq | cursor | cline | claude-code | copilot | codex
+#   target-project-dir: path to the project you want to set up (defaults to current directory)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RULES_DIR="${REPO_ROOT}/aidlc-rules"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}✓${NC} $1"; }
+print_error()   { echo -e "${RED}✗${NC} $1"; }
+print_info()    { echo -e "${BLUE}ℹ${NC} $1"; }
+
+if [ ! -d "$RULES_DIR" ]; then
+    print_error "Cannot find aidlc-rules/ at: $RULES_DIR"
+    print_error "Run this script from within the cloned aidlc-workflows repository."
+    exit 1
+fi
+
+RULES_SRC="${RULES_DIR}/aws-aidlc-rules"
+DETAILS_SRC="${RULES_DIR}/aws-aidlc-rule-details"
+
+# ── Agent selection ────────────────────────────────────────────────────────────
+
+if [ -n "${1:-}" ]; then
+    AGENT="$1"
+else
+    echo "AI-DLC Workflow Installer"
+    echo "========================="
+    echo ""
+    echo "Select your coding agent:"
+    echo "  1) Kiro"
+    echo "  2) Amazon Q Developer"
+    echo "  3) Cursor IDE"
+    echo "  4) Cline"
+    echo "  5) Claude Code"
+    echo "  6) GitHub Copilot"
+    echo "  7) OpenAI Codex"
+    echo ""
+    read -r -p "Enter choice [1-7]: " choice
+    case "$choice" in
+        1) AGENT="kiro" ;;
+        2) AGENT="amazonq" ;;
+        3) AGENT="cursor" ;;
+        4) AGENT="cline" ;;
+        5) AGENT="claude-code" ;;
+        6) AGENT="copilot" ;;
+        7) AGENT="codex" ;;
+        *) print_error "Invalid choice: $choice"; exit 1 ;;
+    esac
+fi
+
+# ── Target project directory ───────────────────────────────────────────────────
+
+if [ -n "${2:-}" ]; then
+    TARGET_PROJECT="$2"
+else
+    read -r -p "Target project directory [$(pwd)]: " TARGET_PROJECT
+    TARGET_PROJECT="${TARGET_PROJECT:-$(pwd)}"
+fi
+
+if [ ! -d "$TARGET_PROJECT" ]; then
+    print_error "Directory not found: $TARGET_PROJECT"
+    exit 1
+fi
+TARGET_PROJECT="$(cd "$TARGET_PROJECT" && pwd)"
+
+print_info "Installing AI-DLC rules for agent '$AGENT' into: $TARGET_PROJECT"
+echo ""
+
+# ── Copy rules ─────────────────────────────────────────────────────────────────
+
+case "$AGENT" in
+    kiro)
+        mkdir -p "${TARGET_PROJECT}/.kiro/steering"
+        cp -R "$RULES_SRC" "${TARGET_PROJECT}/.kiro/steering/"
+        cp -R "$DETAILS_SRC" "${TARGET_PROJECT}/.kiro/"
+        print_success "Kiro steering files installed"
+        ;;
+    amazonq)
+        mkdir -p "${TARGET_PROJECT}/.amazonq/rules"
+        cp -R "$RULES_SRC" "${TARGET_PROJECT}/.amazonq/rules/"
+        cp -R "$DETAILS_SRC" "${TARGET_PROJECT}/.amazonq/"
+        print_success "Amazon Q Developer rules installed"
+        ;;
+    cursor)
+        mkdir -p "${TARGET_PROJECT}/.cursor/rules"
+        {
+            printf -- '---\ndescription: "AI-DLC (AI-Driven Development Life Cycle) adaptive workflow for software development"\nalwaysApply: true\n---\n\n'
+            cat "${RULES_SRC}/core-workflow.md"
+        } > "${TARGET_PROJECT}/.cursor/rules/ai-dlc-workflow.mdc"
+        mkdir -p "${TARGET_PROJECT}/.aidlc-rule-details"
+        cp -R "${DETAILS_SRC}/"* "${TARGET_PROJECT}/.aidlc-rule-details/"
+        print_success "Cursor IDE rules installed"
+        ;;
+    cline)
+        mkdir -p "${TARGET_PROJECT}/.clinerules"
+        cp "${RULES_SRC}/core-workflow.md" "${TARGET_PROJECT}/.clinerules/"
+        mkdir -p "${TARGET_PROJECT}/.aidlc-rule-details"
+        cp -R "${DETAILS_SRC}/"* "${TARGET_PROJECT}/.aidlc-rule-details/"
+        print_success "Cline rules installed"
+        ;;
+    claude-code)
+        cp "${RULES_SRC}/core-workflow.md" "${TARGET_PROJECT}/CLAUDE.md"
+        mkdir -p "${TARGET_PROJECT}/.aidlc-rule-details"
+        cp -R "${DETAILS_SRC}/"* "${TARGET_PROJECT}/.aidlc-rule-details/"
+        print_success "Claude Code rules installed"
+        ;;
+    copilot)
+        mkdir -p "${TARGET_PROJECT}/.github"
+        cp "${RULES_SRC}/core-workflow.md" "${TARGET_PROJECT}/.github/copilot-instructions.md"
+        mkdir -p "${TARGET_PROJECT}/.aidlc-rule-details"
+        cp -R "${DETAILS_SRC}/"* "${TARGET_PROJECT}/.aidlc-rule-details/"
+        print_success "GitHub Copilot rules installed"
+        ;;
+    codex)
+        cp "${RULES_SRC}/core-workflow.md" "${TARGET_PROJECT}/AGENTS.md"
+        mkdir -p "${TARGET_PROJECT}/.aidlc-rule-details"
+        cp -R "${DETAILS_SRC}/"* "${TARGET_PROJECT}/.aidlc-rule-details/"
+        print_success "OpenAI Codex rules installed"
+        ;;
+    *)
+        print_error "Unknown agent: $AGENT"
+        echo "Valid agents: kiro | amazonq | cursor | cline | claude-code | copilot | codex"
+        exit 1
+        ;;
+esac
+
+echo ""
+print_success "Done. Open your project in your coding agent and start with: 'Using AI-DLC, ...'"


### PR DESCRIPTION
Developers who clone this repository instead of downloading the release zip were forced to manually edit hardcoded ~/Downloads paths in every setup command. The new scripts/install.sh (macOS/Linux) and scripts/install.ps1 (Windows) auto-detect the repo root, prompt for the target agent and project directory, and copy the right rule files in one step — regardless of where the repo lives on disk.

The README Common section now leads with the clone-based (script) approach and keeps the download-based instructions as a clearly-labelled alternative.

Fixes #298

# Summary

> replace with your summary...

## Changes

> replace with a description of the changes

## User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

> replace with instructions or a checklist for reviewers to verify

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
