### PR TITLE
feat: add automated setup scripts for platform-specific installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ AI-DLC is an intelligent software development workflow that adapts to your needs
 
 ## Platform-Specific Setup
 
+> [!TIP]
+> **Prefer automated setup?** Run the one-liner below from your project root and follow the prompts — it downloads the rules and installs them for your chosen agent automatically.
+>
+> macOS / Linux:
+>
+> ```bash
+> bash <(curl -sL https://raw.githubusercontent.com/awslabs/aidlc-workflows/main/scripts/setup/setup.sh)
+> ```
+>
+> Windows (PowerShell):
+>
+> ```powershell
+> irm https://raw.githubusercontent.com/awslabs/aidlc-workflows/main/scripts/setup/setup.ps1 | iex
+> ```
+>
+> **Offline / air-gapped networks:** If GitHub is not accessible, transfer the release zip (`ai-dlc-rules-v*.zip`) and the setup script (`setup.sh` or `setup.ps1`) to your machine via USB, internal mirror, or file share. Extract the zip, then run the script — it will detect that GitHub is unreachable and prompt you for the local path to the extracted `aidlc-rules/` folder. See [`scripts/setup/README.md`](scripts/setup/README.md) for details.
+
+### Manual Setup
+
 - [Kiro](#kiro)
 - [Amazon Q Developer IDE Plugin](#amazon-q-developer-ide-pluginextension)
 - [Cursor IDE](#cursor-ide)

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -1,0 +1,111 @@
+# AI-DLC Automated Setup Scripts
+
+One-command setup for AI-DLC rules across all supported coding agents.
+
+## What These Scripts Do
+
+1. **Download** the latest AI-DLC rules from GitHub releases (or use a local path if GitHub is blocked)
+2. **Auto-detect** common locations where the rules might already be extracted
+3. **Ask** which coding agent you want to configure
+4. **Install** the rules in the correct directory structure for your chosen agent
+
+## Quick Start
+
+### macOS / Linux
+
+```bash
+# Navigate to your project root
+cd /path/to/your/project
+
+# Run the setup script (one of these):
+bash <(curl -sL https://raw.githubusercontent.com/awslabs/aidlc-workflows/main/scripts/setup/setup.sh)
+
+# Or if you have the repo cloned:
+bash /path/to/aidlc-workflows/scripts/setup/setup.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+# Navigate to your project root
+cd C:\path\to\your\project
+
+# Run the setup script:
+powershell -ExecutionPolicy Bypass -File C:\path\to\aidlc-workflows\scripts\setup\setup.ps1
+```
+
+### Windows (CMD)
+
+```cmd
+REM Navigate to your project root
+cd C:\path\to\your\project
+
+REM Run the setup script:
+C:\path\to\aidlc-workflows\scripts\setup\setup.bat
+```
+
+## Supported Agents
+
+| #   | Agent              | Rules Location                                      |
+| --- | ------------------ | --------------------------------------------------- |
+| 1   | Kiro               | `.kiro/steering/aws-aidlc-rules/`                   |
+| 2   | Amazon Q Developer | `.amazonq/rules/aws-aidlc-rules/`                   |
+| 3   | Cursor IDE         | `.cursor/rules/ai-dlc-workflow.mdc` or `AGENTS.md`  |
+| 4   | Cline              | `.clinerules/core-workflow.md` or `AGENTS.md`       |
+| 5   | Claude Code        | `CLAUDE.md` or `.claude/CLAUDE.md`                  |
+| 6   | GitHub Copilot     | `.github/copilot-instructions.md`                   |
+| 7   | OpenAI Codex       | `AGENTS.md`                                         |
+| 8   | All agents         | Installs for all of the above                       |
+
+## How It Works
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  Step 1: Obtain Rules                               │
+│  ┌───────────────┐    ┌──────────────────────────┐  │
+│  │ Try GitHub    │───▶│ Download & extract latest │  │
+│  │ API download  │    │ release zip              │  │
+│  └───────┬───────┘    └──────────────────────────┘  │
+│          │ (if blocked)                             │
+│          ▼                                          │
+│  ┌───────────────┐    ┌──────────────────────────┐  │
+│  │ Auto-detect   │───▶│ ~/Downloads/aidlc-rules  │  │
+│  │ common paths  │    │ ~/Desktop/aidlc-rules    │  │
+│  └───────┬───────┘    └──────────────────────────┘  │
+│          │ (if not found)                           │
+│          ▼                                          │
+│  ┌───────────────────────────────────────────────┐  │
+│  │ Ask user for path                             │  │
+│  └───────────────────────────────────────────────┘  │
+├─────────────────────────────────────────────────────┤
+│  Step 2: Select Agent (interactive menu)            │
+├─────────────────────────────────────────────────────┤
+│  Step 3: Install rules to correct locations         │
+└─────────────────────────────────────────────────────┘
+```
+
+## Offline / Air-Gapped Usage
+
+If GitHub is not accessible from your network:
+
+1. Download the release zip from another machine
+2. Transfer it to your target machine and extract it
+3. Run the setup script — it will ask for the local path to the `aidlc-rules` folder
+
+## Requirements
+
+### macOS / Linux
+
+- `bash` (pre-installed)
+- `curl` or `wget` (for GitHub download; optional if using local path)
+- `unzip` (for extracting the release; optional if using local path)
+
+### Windows (PowerShell)
+
+- PowerShell 5.1+ (pre-installed on Windows 10+)
+- Internet access (optional, for GitHub download)
+
+### Windows (CMD)
+
+- Windows 10+ (uses built-in `curl` and `powershell` for JSON parsing)
+- Internet access (optional, for GitHub download)

--- a/scripts/setup/setup.bat
+++ b/scripts/setup/setup.bat
@@ -1,0 +1,324 @@
+@echo off
+REM =============================================================================
+REM AI-DLC Setup Script (Windows CMD)
+REM =============================================================================
+REM Automates the platform-specific setup of AI-DLC rules for supported coding
+REM agents. Downloads the latest release from GitHub or uses a local path if
+REM GitHub is unreachable.
+REM =============================================================================
+REM Usage: setup.bat
+REM =============================================================================
+
+setlocal enabledelayedexpansion
+
+set "REPO=awslabs/aidlc-workflows"
+set "PROJECT_ROOT=%CD%"
+set "AIDLC_RULES_PATH="
+set "TMP_DIR="
+
+echo.
+echo   ================================================================
+echo            AI-DLC Setup - Automated Installer (CMD)
+echo   ================================================================
+echo.
+echo   [i] This script sets up AI-DLC rules for your coding agent.
+echo   [i] Run this from your project root directory.
+echo   [i] Project root: %PROJECT_ROOT%
+echo.
+
+REM --- Step 1: Obtain Rules ---
+echo.
+echo   === Step 1: Obtaining AI-DLC Rules ===
+echo.
+echo   [i] Attempting to download latest release from GitHub...
+
+REM Check if curl is available (Windows 10+ has curl)
+where curl >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo   [!] curl not found. Cannot download from GitHub.
+    goto :get_local_path
+)
+
+REM Try to download - use PowerShell for JSON parsing since CMD can't do it
+set "TMP_DIR=%TEMP%\aidlc-setup-%RANDOM%"
+mkdir "%TMP_DIR%" 2>nul
+
+REM Use PowerShell to get the download URL (available on all modern Windows)
+where powershell >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+    echo   [!] PowerShell not found. Cannot parse GitHub API.
+    echo   [!] Consider using setup.ps1 instead for a better experience.
+    goto :get_local_path
+)
+
+echo   [i] Checking for latest release...
+for /f "delims=" %%u in ('powershell -NoProfile -Command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/%REPO%/releases/latest' -TimeoutSec 10; $a = $r.assets | Where-Object { $_.name -like '*.zip' } | Select-Object -First 1; if ($a) { Write-Output $a.browser_download_url } } catch { }"') do set "DOWNLOAD_URL=%%u"
+
+for /f "delims=" %%v in ('powershell -NoProfile -Command "try { $r = Invoke-RestMethod -Uri 'https://api.github.com/repos/%REPO%/releases/latest' -TimeoutSec 10; Write-Output $r.tag_name } catch { }"') do set "VERSION=%%v"
+
+if not defined DOWNLOAD_URL (
+    echo   [!] Could not reach GitHub or find a release.
+    goto :get_local_path
+)
+
+echo.
+echo   [i] Found latest release: %VERSION%
+set /p "DL_CHOICE=  Download from GitHub? [Y/n]: "
+if not defined DL_CHOICE set "DL_CHOICE=Y"
+if /i not "%DL_CHOICE:~0,1%"=="Y" goto :get_local_path
+
+echo   [i] Downloading...
+curl -sL -o "%TMP_DIR%\aidlc-rules.zip" "%DOWNLOAD_URL%"
+if %ERRORLEVEL% neq 0 (
+    echo   [x] Download failed.
+    goto :get_local_path
+)
+
+echo   [i] Extracting...
+powershell -NoProfile -Command "Expand-Archive -Path '%TMP_DIR%\aidlc-rules.zip' -DestinationPath '%TMP_DIR%' -Force"
+
+REM Find the aidlc-rules directory
+for /f "delims=" %%d in ('powershell -NoProfile -Command "$d = Get-ChildItem -Path '%TMP_DIR%' -Recurse -Directory -Filter 'aws-aidlc-rules' | Select-Object -First 1; if ($d) { Write-Output $d.Parent.FullName }"') do set "AIDLC_RULES_PATH=%%d"
+
+if not defined AIDLC_RULES_PATH (
+    echo   [x] Could not find aidlc-rules in the downloaded archive.
+    echo   [!] Falling back to local path...
+    goto :get_local_path
+)
+
+if not exist "%AIDLC_RULES_PATH%\aws-aidlc-rules" (
+    echo   [x] Could not find aws-aidlc-rules in extracted content.
+    goto :get_local_path
+)
+
+echo   [+] Downloaded and extracted successfully.
+goto :select_agent
+
+:get_local_path
+echo.
+echo   [i] Please provide the path to the extracted 'aidlc-rules' folder.
+echo   [i] This folder should contain 'aws-aidlc-rules\' and 'aws-aidlc-rule-details\'.
+echo.
+
+REM Try common locations
+if exist "%USERPROFILE%\Downloads\aidlc-rules\aws-aidlc-rules" (
+    if exist "%USERPROFILE%\Downloads\aidlc-rules\aws-aidlc-rule-details" (
+        echo   [i] Auto-detected: %USERPROFILE%\Downloads\aidlc-rules
+        set /p "USE_DETECTED=  Use this path? [Y/n]: "
+        if not defined USE_DETECTED set "USE_DETECTED=Y"
+        if /i "!USE_DETECTED:~0,1!"=="Y" (
+            set "AIDLC_RULES_PATH=%USERPROFILE%\Downloads\aidlc-rules"
+            goto :select_agent
+        )
+    )
+)
+
+if exist "%USERPROFILE%\Desktop\aidlc-rules\aws-aidlc-rules" (
+    if exist "%USERPROFILE%\Desktop\aidlc-rules\aws-aidlc-rule-details" (
+        echo   [i] Auto-detected: %USERPROFILE%\Desktop\aidlc-rules
+        set /p "USE_DETECTED=  Use this path? [Y/n]: "
+        if not defined USE_DETECTED set "USE_DETECTED=Y"
+        if /i "!USE_DETECTED:~0,1!"=="Y" (
+            set "AIDLC_RULES_PATH=%USERPROFILE%\Desktop\aidlc-rules"
+            goto :select_agent
+        )
+    )
+)
+
+:ask_path
+set /p "USER_PATH=  Path to aidlc-rules folder: "
+if not exist "%USER_PATH%\aws-aidlc-rules" (
+    echo   [x] Invalid path. Expected to find 'aws-aidlc-rules\' and 'aws-aidlc-rule-details\' inside.
+    set /p "RETRY=  Try again? [Y/n]: "
+    if not defined RETRY set "RETRY=Y"
+    if /i "!RETRY:~0,1!"=="Y" goto :ask_path
+    echo   [x] Cannot proceed without valid aidlc-rules path.
+    goto :end
+)
+set "AIDLC_RULES_PATH=%USER_PATH%"
+echo   [+] Valid path confirmed.
+
+:select_agent
+echo.
+echo   === Step 2: Select Your Coding Agent ===
+echo.
+echo   1) Kiro
+echo   2) Amazon Q Developer
+echo   3) Cursor IDE
+echo   4) Cline
+echo   5) Claude Code
+echo   6) GitHub Copilot
+echo   7) OpenAI Codex
+echo   8) All agents
+echo.
+set /p "AGENT_CHOICE=  Select agent [1-8]: "
+
+echo.
+echo   === Step 3: Installing Rules ===
+
+if "%AGENT_CHOICE%"=="1" goto :setup_kiro
+if "%AGENT_CHOICE%"=="2" goto :setup_amazonq
+if "%AGENT_CHOICE%"=="3" goto :setup_cursor
+if "%AGENT_CHOICE%"=="4" goto :setup_cline
+if "%AGENT_CHOICE%"=="5" goto :setup_claude
+if "%AGENT_CHOICE%"=="6" goto :setup_copilot
+if "%AGENT_CHOICE%"=="7" goto :setup_codex
+if "%AGENT_CHOICE%"=="8" goto :setup_all
+echo   [x] Invalid selection.
+goto :select_agent
+
+:setup_kiro
+echo.
+echo   [i] Setting up for Kiro...
+mkdir ".kiro\steering" 2>nul
+xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rules" ".kiro\steering\aws-aidlc-rules\" /E /I /Q /Y >nul
+xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".kiro\aws-aidlc-rule-details\" /E /I /Q /Y >nul
+echo   [+] Kiro setup complete.
+echo       -^> .kiro\steering\aws-aidlc-rules\
+echo       -^> .kiro\aws-aidlc-rule-details\
+if "%AGENT_CHOICE%"=="8" goto :setup_amazonq
+goto :done
+
+:setup_amazonq
+echo.
+echo   [i] Setting up for Amazon Q Developer...
+mkdir ".amazonq\rules" 2>nul
+xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rules" ".amazonq\rules\aws-aidlc-rules\" /E /I /Q /Y >nul
+xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".amazonq\aws-aidlc-rule-details\" /E /I /Q /Y >nul
+echo   [+] Amazon Q Developer setup complete.
+echo       -^> .amazonq\rules\aws-aidlc-rules\
+echo       -^> .amazonq\aws-aidlc-rule-details\
+if "%AGENT_CHOICE%"=="8" goto :setup_cursor
+goto :done
+
+:setup_cursor
+echo.
+echo   [i] Cursor IDE has two setup options:
+echo       1) Project Rules (.cursor\rules\) - Recommended
+echo       2) AGENTS.md (simple alternative)
+set /p "CURSOR_OPT=  Select option [1/2]: "
+if not defined CURSOR_OPT set "CURSOR_OPT=1"
+
+if "%CURSOR_OPT%"=="2" (
+    echo   [i] Setting up Cursor with AGENTS.md...
+    copy "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" "AGENTS.md" /Y >nul
+    mkdir ".aidlc-rule-details" 2>nul
+    xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+    echo   [+] Cursor setup complete (AGENTS.md^).
+) else (
+    echo   [i] Setting up Cursor with Project Rules...
+    mkdir ".cursor\rules" 2>nul
+    (
+        echo ---
+        echo description: "AI-DLC (AI-Driven Development Life Cycle) adaptive workflow for software development"
+        echo alwaysApply: true
+        echo ---
+        echo.
+    ) > ".cursor\rules\ai-dlc-workflow.mdc"
+    type "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" >> ".cursor\rules\ai-dlc-workflow.mdc"
+    mkdir ".aidlc-rule-details" 2>nul
+    xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+    echo   [+] Cursor setup complete (Project Rules^).
+)
+if "%AGENT_CHOICE%"=="8" goto :setup_cline
+goto :done
+
+:setup_cline
+echo.
+echo   [i] Cline has two setup options:
+echo       1) .clinerules directory - Recommended
+echo       2) AGENTS.md (simple alternative)
+set /p "CLINE_OPT=  Select option [1/2]: "
+if not defined CLINE_OPT set "CLINE_OPT=1"
+
+if "%CLINE_OPT%"=="2" (
+    echo   [i] Setting up Cline with AGENTS.md...
+    copy "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" "AGENTS.md" /Y >nul
+    mkdir ".aidlc-rule-details" 2>nul
+    xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+    echo   [+] Cline setup complete (AGENTS.md^).
+) else (
+    echo   [i] Setting up Cline with .clinerules...
+    mkdir ".clinerules" 2>nul
+    copy "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" ".clinerules\" /Y >nul
+    mkdir ".aidlc-rule-details" 2>nul
+    xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+    echo   [+] Cline setup complete (.clinerules^).
+)
+if "%AGENT_CHOICE%"=="8" goto :setup_claude
+goto :done
+
+:setup_claude
+echo.
+echo   [i] Claude Code has two setup options:
+echo       1) Project root CLAUDE.md - Recommended
+echo       2) .claude\CLAUDE.md directory
+set /p "CLAUDE_OPT=  Select option [1/2]: "
+if not defined CLAUDE_OPT set "CLAUDE_OPT=1"
+
+if "%CLAUDE_OPT%"=="2" (
+    echo   [i] Setting up Claude Code with .claude\CLAUDE.md...
+    mkdir ".claude" 2>nul
+    copy "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" ".claude\CLAUDE.md" /Y >nul
+    mkdir ".aidlc-rule-details" 2>nul
+    xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+    echo   [+] Claude Code setup complete (.claude\CLAUDE.md^).
+) else (
+    echo   [i] Setting up Claude Code with CLAUDE.md...
+    copy "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" "CLAUDE.md" /Y >nul
+    mkdir ".aidlc-rule-details" 2>nul
+    xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+    echo   [+] Claude Code setup complete (CLAUDE.md^).
+)
+if "%AGENT_CHOICE%"=="8" goto :setup_copilot
+goto :done
+
+:setup_copilot
+echo.
+echo   [i] Setting up for GitHub Copilot...
+mkdir ".github" 2>nul
+copy "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" ".github\copilot-instructions.md" /Y >nul
+mkdir ".aidlc-rule-details" 2>nul
+xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+echo   [+] GitHub Copilot setup complete.
+echo       -^> .github\copilot-instructions.md
+echo       -^> .aidlc-rule-details\
+if "%AGENT_CHOICE%"=="8" goto :setup_codex
+goto :done
+
+:setup_codex
+echo.
+echo   [i] Setting up for OpenAI Codex...
+copy "%AIDLC_RULES_PATH%\aws-aidlc-rules\core-workflow.md" "AGENTS.md" /Y >nul
+mkdir ".aidlc-rule-details" 2>nul
+xcopy "%AIDLC_RULES_PATH%\aws-aidlc-rule-details" ".aidlc-rule-details\" /E /I /Q /Y >nul
+echo   [+] OpenAI Codex setup complete.
+echo       -^> AGENTS.md
+echo       -^> .aidlc-rule-details\
+goto :done
+
+:setup_all
+goto :setup_kiro
+
+:done
+echo.
+echo   === Setup Complete ===
+echo.
+echo   [+] AI-DLC rules have been installed successfully.
+echo.
+echo   [i] Next steps:
+echo       1. Open your project in your coding agent
+echo       2. Start a chat with: "Using AI-DLC, ..."
+echo       3. The workflow will guide you from there
+echo.
+echo   [i] For verification steps, see:
+echo       https://github.com/%REPO%#platform-specific-setup
+echo.
+
+REM Cleanup temp directory
+if defined TMP_DIR (
+    if exist "%TMP_DIR%" rmdir /s /q "%TMP_DIR%" 2>nul
+)
+
+:end
+endlocal

--- a/scripts/setup/setup.ps1
+++ b/scripts/setup/setup.ps1
@@ -1,0 +1,388 @@
+# =============================================================================
+# AI-DLC Setup Script (Windows PowerShell)
+# =============================================================================
+# Automates the platform-specific setup of AI-DLC rules for supported coding
+# agents. Downloads the latest release from GitHub or uses a local path if
+# GitHub is unreachable.
+# =============================================================================
+# Usage: powershell -ExecutionPolicy Bypass -File setup.ps1
+# =============================================================================
+
+param(
+    [string]$ProjectRoot = (Get-Location).Path
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Constants ---------------------------------------------------------------
+$REPO = "awslabs/aidlc-workflows"
+$GITHUB_API = "https://api.github.com/repos/$REPO/releases/latest"
+
+# --- Helper Functions --------------------------------------------------------
+function Write-Info    { param([string]$msg) Write-Host "  [i] $msg" -ForegroundColor Cyan }
+function Write-Success { param([string]$msg) Write-Host "  [+] $msg" -ForegroundColor Green }
+function Write-Warn    { param([string]$msg) Write-Host "  [!] $msg" -ForegroundColor Yellow }
+function Write-Err     { param([string]$msg) Write-Host "  [x] $msg" -ForegroundColor Red }
+function Write-Header  { param([string]$msg) Write-Host "`n  === $msg ===" -ForegroundColor Magenta }
+
+# --- Detect Project Root -----------------------------------------------------
+function Get-ProjectRoot {
+    Write-Info "Project root: $ProjectRoot"
+    return $ProjectRoot
+}
+
+# --- Download or Locate Rules ------------------------------------------------
+function Get-AidlcRules {
+    Write-Header "Step 1: Obtaining AI-DLC Rules"
+
+    Write-Info "Attempting to download latest release from GitHub..."
+
+    $downloadUrl = $null
+    $version = $null
+
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        $response = Invoke-RestMethod -Uri $GITHUB_API -TimeoutSec 15 -ErrorAction Stop
+
+        $version = $response.tag_name
+        $asset = $response.assets | Where-Object { $_.name -like "*.zip" } | Select-Object -First 1
+
+        if ($asset) {
+            $downloadUrl = $asset.browser_download_url
+        }
+    }
+    catch {
+        Write-Warn "Could not reach GitHub: $($_.Exception.Message)"
+    }
+
+    if ($downloadUrl -and $version) {
+        Write-Host ""
+        Write-Info "Found latest release: $version"
+        $choice = Read-Host "  Download from GitHub? [Y/n]"
+        if ([string]::IsNullOrWhiteSpace($choice)) { $choice = "Y" }
+
+        if ($choice -match "^[Yy]") {
+            $tmpDir = Join-Path $env:TEMP "aidlc-setup-$(Get-Random)"
+            New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+            $zipFile = Join-Path $tmpDir "aidlc-rules.zip"
+
+            try {
+                Write-Info "Downloading..."
+                Invoke-WebRequest -Uri $downloadUrl -OutFile $zipFile -UseBasicParsing
+
+                Write-Info "Extracting..."
+                Expand-Archive -Path $zipFile -DestinationPath $tmpDir -Force
+
+                # Find the aidlc-rules directory
+                $rulesDir = Get-ChildItem -Path $tmpDir -Recurse -Directory -Filter "aidlc-rules" | Select-Object -First 1
+
+                if (-not $rulesDir) {
+                    # Try finding aws-aidlc-rules and go up one level
+                    $awsRulesDir = Get-ChildItem -Path $tmpDir -Recurse -Directory -Filter "aws-aidlc-rules" | Select-Object -First 1
+                    if ($awsRulesDir) {
+                        $rulesDir = $awsRulesDir.Parent
+                    }
+                }
+
+                if ($rulesDir -and (Test-Path (Join-Path $rulesDir.FullName "aws-aidlc-rules"))) {
+                    Write-Success "Downloaded and extracted successfully."
+                    return @{ Path = $rulesDir.FullName; TmpDir = $tmpDir }
+                }
+                else {
+                    Write-Err "Could not find aidlc-rules in the downloaded archive."
+                    Write-Warn "Falling back to local path..."
+                }
+            }
+            catch {
+                Write-Err "Download failed: $($_.Exception.Message)"
+                Write-Warn "Falling back to local path..."
+            }
+        }
+    }
+    else {
+        Write-Warn "Could not find a downloadable release."
+        Write-Host ""
+    }
+
+    return Get-LocalPath
+}
+
+function Get-LocalPath {
+    Write-Host ""
+    Write-Info "Please provide the path to the extracted 'aidlc-rules' folder."
+    Write-Info "This folder should contain 'aws-aidlc-rules\' and 'aws-aidlc-rule-details\'."
+    Write-Host ""
+
+    # Try common locations
+    $commonPaths = @(
+        "$env:USERPROFILE\Downloads\aidlc-rules",
+        "$env:USERPROFILE\Desktop\aidlc-rules",
+        ".\aidlc-rules"
+    )
+
+    $foundPath = $null
+    foreach ($p in $commonPaths) {
+        if ((Test-Path (Join-Path $p "aws-aidlc-rules")) -and (Test-Path (Join-Path $p "aws-aidlc-rule-details"))) {
+            $foundPath = (Resolve-Path $p).Path
+            break
+        }
+    }
+
+    if ($foundPath) {
+        Write-Info "Auto-detected: $foundPath"
+        $choice = Read-Host "  Use this path? [Y/n]"
+        if ([string]::IsNullOrWhiteSpace($choice)) { $choice = "Y" }
+        if ($choice -match "^[Yy]") {
+            return @{ Path = $foundPath; TmpDir = $null }
+        }
+    }
+
+    while ($true) {
+        $userPath = Read-Host "  Path to aidlc-rules folder"
+        $userPath = $userPath.Trim('"').Trim("'")
+
+        if ((Test-Path (Join-Path $userPath "aws-aidlc-rules")) -and (Test-Path (Join-Path $userPath "aws-aidlc-rule-details"))) {
+            Write-Success "Valid path confirmed."
+            return @{ Path = $userPath; TmpDir = $null }
+        }
+        else {
+            Write-Err "Invalid path. Expected to find 'aws-aidlc-rules\' and 'aws-aidlc-rule-details\' inside."
+            $retry = Read-Host "  Try again? [Y/n]"
+            if ([string]::IsNullOrWhiteSpace($retry)) { $retry = "Y" }
+            if ($retry -notmatch "^[Yy]") {
+                Write-Err "Cannot proceed without valid aidlc-rules path."
+                exit 1
+            }
+        }
+    }
+}
+
+# --- Select Agent ------------------------------------------------------------
+function Select-Agent {
+    Write-Header "Step 2: Select Your Coding Agent"
+
+    Write-Host ""
+    Write-Host "  1) Kiro"
+    Write-Host "  2) Amazon Q Developer"
+    Write-Host "  3) Cursor IDE"
+    Write-Host "  4) Cline"
+    Write-Host "  5) Claude Code"
+    Write-Host "  6) GitHub Copilot"
+    Write-Host "  7) OpenAI Codex"
+    Write-Host "  8) All agents"
+    Write-Host ""
+    $agentChoice = Read-Host "  Select agent [1-8]"
+
+    switch ($agentChoice) {
+        "1" { return @("kiro") }
+        "2" { return @("amazonq") }
+        "3" { return @("cursor") }
+        "4" { return @("cline") }
+        "5" { return @("claude") }
+        "6" { return @("copilot") }
+        "7" { return @("codex") }
+        "8" { return @("kiro", "amazonq", "cursor", "cline", "claude", "copilot", "codex") }
+        default {
+            Write-Err "Invalid selection. Please choose 1-8."
+            return Select-Agent
+        }
+    }
+}
+
+# --- Setup Functions ---------------------------------------------------------
+function Setup-Kiro {
+    param([string]$RulesPath, [string]$Root)
+    Write-Info "Setting up for Kiro..."
+    New-Item -ItemType Directory -Force -Path (Join-Path $Root ".kiro\steering") | Out-Null
+    Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rules") (Join-Path $Root ".kiro\steering\")
+    Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details") (Join-Path $Root ".kiro\")
+    Write-Success "Kiro setup complete."
+    Write-Host "    -> .kiro\steering\aws-aidlc-rules\"
+    Write-Host "    -> .kiro\aws-aidlc-rule-details\"
+}
+
+function Setup-AmazonQ {
+    param([string]$RulesPath, [string]$Root)
+    Write-Info "Setting up for Amazon Q Developer..."
+    New-Item -ItemType Directory -Force -Path (Join-Path $Root ".amazonq\rules") | Out-Null
+    Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rules") (Join-Path $Root ".amazonq\rules\")
+    Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details") (Join-Path $Root ".amazonq\")
+    Write-Success "Amazon Q Developer setup complete."
+    Write-Host "    -> .amazonq\rules\aws-aidlc-rules\"
+    Write-Host "    -> .amazonq\aws-aidlc-rule-details\"
+}
+
+function Setup-Cursor {
+    param([string]$RulesPath, [string]$Root)
+    Write-Host ""
+    Write-Info "Cursor IDE has two setup options:"
+    Write-Host "    1) Project Rules (.cursor\rules\) - Recommended"
+    Write-Host "    2) AGENTS.md (simple alternative)"
+    $cursorOption = Read-Host "  Select option [1/2]"
+    if ([string]::IsNullOrWhiteSpace($cursorOption)) { $cursorOption = "1" }
+
+    if ($cursorOption -eq "2") {
+        Write-Info "Setting up Cursor with AGENTS.md..."
+        Copy-Item -Force (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") (Join-Path $Root "AGENTS.md")
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+        Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+        Write-Success "Cursor setup complete (AGENTS.md)."
+        Write-Host "    -> AGENTS.md"
+        Write-Host "    -> .aidlc-rule-details\"
+    }
+    else {
+        Write-Info "Setting up Cursor with Project Rules..."
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".cursor\rules") | Out-Null
+
+        $frontmatter = @"
+---
+description: "AI-DLC (AI-Driven Development Life Cycle) adaptive workflow for software development"
+alwaysApply: true
+---
+
+"@
+        $coreContent = Get-Content -Path (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") -Raw
+        $mdcContent = $frontmatter + $coreContent
+        Set-Content -Path (Join-Path $Root ".cursor\rules\ai-dlc-workflow.mdc") -Value $mdcContent -Encoding UTF8
+
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+        Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+        Write-Success "Cursor setup complete (Project Rules)."
+        Write-Host "    -> .cursor\rules\ai-dlc-workflow.mdc"
+        Write-Host "    -> .aidlc-rule-details\"
+    }
+}
+
+function Setup-Cline {
+    param([string]$RulesPath, [string]$Root)
+    Write-Host ""
+    Write-Info "Cline has two setup options:"
+    Write-Host "    1) .clinerules directory - Recommended"
+    Write-Host "    2) AGENTS.md (simple alternative)"
+    $clineOption = Read-Host "  Select option [1/2]"
+    if ([string]::IsNullOrWhiteSpace($clineOption)) { $clineOption = "1" }
+
+    if ($clineOption -eq "2") {
+        Write-Info "Setting up Cline with AGENTS.md..."
+        Copy-Item -Force (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") (Join-Path $Root "AGENTS.md")
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+        Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+        Write-Success "Cline setup complete (AGENTS.md)."
+        Write-Host "    -> AGENTS.md"
+        Write-Host "    -> .aidlc-rule-details\"
+    }
+    else {
+        Write-Info "Setting up Cline with .clinerules..."
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".clinerules") | Out-Null
+        Copy-Item -Force (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") (Join-Path $Root ".clinerules\")
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+        Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+        Write-Success "Cline setup complete (.clinerules)."
+        Write-Host "    -> .clinerules\core-workflow.md"
+        Write-Host "    -> .aidlc-rule-details\"
+    }
+}
+
+function Setup-Claude {
+    param([string]$RulesPath, [string]$Root)
+    Write-Host ""
+    Write-Info "Claude Code has two setup options:"
+    Write-Host "    1) Project root CLAUDE.md - Recommended"
+    Write-Host "    2) .claude\CLAUDE.md directory"
+    $claudeOption = Read-Host "  Select option [1/2]"
+    if ([string]::IsNullOrWhiteSpace($claudeOption)) { $claudeOption = "1" }
+
+    if ($claudeOption -eq "2") {
+        Write-Info "Setting up Claude Code with .claude\CLAUDE.md..."
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".claude") | Out-Null
+        Copy-Item -Force (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") (Join-Path $Root ".claude\CLAUDE.md")
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+        Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+        Write-Success "Claude Code setup complete (.claude\CLAUDE.md)."
+        Write-Host "    -> .claude\CLAUDE.md"
+        Write-Host "    -> .aidlc-rule-details\"
+    }
+    else {
+        Write-Info "Setting up Claude Code with CLAUDE.md..."
+        Copy-Item -Force (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") (Join-Path $Root "CLAUDE.md")
+        New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+        Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+        Write-Success "Claude Code setup complete (CLAUDE.md)."
+        Write-Host "    -> CLAUDE.md"
+        Write-Host "    -> .aidlc-rule-details\"
+    }
+}
+
+function Setup-Copilot {
+    param([string]$RulesPath, [string]$Root)
+    Write-Info "Setting up for GitHub Copilot..."
+    New-Item -ItemType Directory -Force -Path (Join-Path $Root ".github") | Out-Null
+    Copy-Item -Force (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") (Join-Path $Root ".github\copilot-instructions.md")
+    New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+    Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+    Write-Success "GitHub Copilot setup complete."
+    Write-Host "    -> .github\copilot-instructions.md"
+    Write-Host "    -> .aidlc-rule-details\"
+}
+
+function Setup-Codex {
+    param([string]$RulesPath, [string]$Root)
+    Write-Info "Setting up for OpenAI Codex..."
+    Copy-Item -Force (Join-Path $RulesPath "aws-aidlc-rules\core-workflow.md") (Join-Path $Root "AGENTS.md")
+    New-Item -ItemType Directory -Force -Path (Join-Path $Root ".aidlc-rule-details") | Out-Null
+    Copy-Item -Recurse -Force (Join-Path $RulesPath "aws-aidlc-rule-details\*") (Join-Path $Root ".aidlc-rule-details\")
+    Write-Success "OpenAI Codex setup complete."
+    Write-Host "    -> AGENTS.md"
+    Write-Host "    -> .aidlc-rule-details\"
+}
+
+# --- Main --------------------------------------------------------------------
+function Main {
+    Write-Host ""
+    Write-Host "  ╔══════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host "  ║          AI-DLC Setup - Automated Installer             ║" -ForegroundColor Cyan
+    Write-Host "  ╚══════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Info "This script sets up AI-DLC rules for your coding agent."
+    Write-Info "Run this from your project root directory."
+    Write-Host ""
+
+    $root = Get-ProjectRoot
+    $result = Get-AidlcRules
+    $rulesPath = $result.Path
+    $agents = Select-Agent
+
+    Write-Header "Step 3: Installing Rules"
+
+    foreach ($agent in $agents) {
+        Write-Host ""
+        switch ($agent) {
+            "kiro"    { Setup-Kiro -RulesPath $rulesPath -Root $root }
+            "amazonq" { Setup-AmazonQ -RulesPath $rulesPath -Root $root }
+            "cursor"  { Setup-Cursor -RulesPath $rulesPath -Root $root }
+            "cline"   { Setup-Cline -RulesPath $rulesPath -Root $root }
+            "claude"  { Setup-Claude -RulesPath $rulesPath -Root $root }
+            "copilot" { Setup-Copilot -RulesPath $rulesPath -Root $root }
+            "codex"   { Setup-Codex -RulesPath $rulesPath -Root $root }
+        }
+    }
+
+    # Cleanup temp directory if used
+    if ($result.TmpDir -and (Test-Path $result.TmpDir)) {
+        Remove-Item -Recurse -Force $result.TmpDir
+    }
+
+    Write-Header "Setup Complete"
+    Write-Host ""
+    Write-Success "AI-DLC rules have been installed successfully."
+    Write-Host ""
+    Write-Info "Next steps:"
+    Write-Host "    1. Open your project in your coding agent"
+    Write-Host "    2. Start a chat with: `"Using AI-DLC, ...`""
+    Write-Host "    3. The workflow will guide you from there"
+    Write-Host ""
+    Write-Info "For verification steps, see: https://github.com/$REPO#platform-specific-setup"
+    Write-Host ""
+}
+
+Main

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# =============================================================================
+# AI-DLC Setup Script (macOS / Linux)
+# =============================================================================
+# Automates the platform-specific setup of AI-DLC rules for supported coding
+# agents. Downloads the latest release from GitHub or uses a local path if
+# GitHub is unreachable.
+# =============================================================================
+
+set -euo pipefail
+
+# --- Constants ---------------------------------------------------------------
+REPO="awslabs/aidlc-workflows"
+GITHUB_API="https://api.github.com/repos/${REPO}/releases/latest"
+GITHUB_RELEASES="https://github.com/${REPO}/releases"
+TMP_DIR=""
+
+# --- Colors ------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# --- Helper Functions --------------------------------------------------------
+info()    { printf "${BLUE}ℹ${NC}  %s\n" "$1"; }
+success() { printf "${GREEN}✔${NC}  %s\n" "$1"; }
+warn()    { printf "${YELLOW}⚠${NC}  %s\n" "$1"; }
+error()   { printf "${RED}✖${NC}  %s\n" "$1" >&2; }
+header()  { printf "\n${BOLD}${CYAN}%s${NC}\n" "$1"; printf '%*s\n' "${#1}" '' | tr ' ' '─'; }
+
+cleanup() {
+    if [[ -n "${TMP_DIR}" && -d "${TMP_DIR}" ]]; then
+        rm -rf "${TMP_DIR}"
+    fi
+}
+trap cleanup EXIT
+
+# --- Detect Project Root -----------------------------------------------------
+detect_project_root() {
+    # Use current directory as project root
+    PROJECT_ROOT="$(pwd)"
+    info "Project root: ${PROJECT_ROOT}"
+}
+
+# --- Download or Locate Rules ------------------------------------------------
+get_aidlc_rules() {
+    header "Step 1: Obtaining AI-DLC Rules"
+
+    # Try downloading from GitHub first
+    info "Attempting to download latest release from GitHub..."
+
+    local can_download=false
+    local download_url=""
+    local version=""
+
+    # Check if curl or wget is available
+    if command -v curl &>/dev/null; then
+        local dl_cmd="curl"
+    elif command -v wget &>/dev/null; then
+        local dl_cmd="wget"
+    else
+        warn "Neither curl nor wget found. Cannot download from GitHub."
+        get_local_path
+        return
+    fi
+
+    # Try to get latest release info
+    if [[ "${dl_cmd}" == "curl" ]]; then
+        local response
+        response=$(curl -sL --connect-timeout 10 --max-time 30 "${GITHUB_API}" 2>/dev/null) || true
+    else
+        local response
+        response=$(wget -qO- --timeout=10 "${GITHUB_API}" 2>/dev/null) || true
+    fi
+
+    if [[ -n "${response}" ]]; then
+        # Parse the tag name and zip URL from the response
+        version=$(echo "${response}" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+        download_url=$(echo "${response}" | grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*\.zip"' | head -1 | sed 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+
+        if [[ -n "${download_url}" && -n "${version}" ]]; then
+            can_download=true
+        fi
+    fi
+
+    if [[ "${can_download}" == true ]]; then
+        printf "\n"
+        info "Found latest release: ${version}"
+        printf "  Download from GitHub? [Y/n]: "
+        read -r choice
+        choice="${choice:-Y}"
+
+        if [[ "${choice}" =~ ^[Yy] ]]; then
+            TMP_DIR=$(mktemp -d)
+            local zip_file="${TMP_DIR}/aidlc-rules.zip"
+
+            info "Downloading ${download_url}..."
+            if [[ "${dl_cmd}" == "curl" ]]; then
+                curl -sL --progress-bar -o "${zip_file}" "${download_url}"
+            else
+                wget -q --show-progress -O "${zip_file}" "${download_url}"
+            fi
+
+            info "Extracting..."
+            unzip -q "${zip_file}" -d "${TMP_DIR}"
+
+            # Find the aidlc-rules directory (may be nested)
+            AIDLC_RULES_PATH=$(find "${TMP_DIR}" -type d -name "aidlc-rules" | head -1)
+
+            if [[ -z "${AIDLC_RULES_PATH}" ]]; then
+                # Try looking for aws-aidlc-rules directly
+                local aws_rules_dir
+                aws_rules_dir=$(find "${TMP_DIR}" -type d -name "aws-aidlc-rules" | head -1)
+                if [[ -n "${aws_rules_dir}" ]]; then
+                    AIDLC_RULES_PATH=$(dirname "${aws_rules_dir}")
+                fi
+            fi
+
+            if [[ -n "${AIDLC_RULES_PATH}" && -d "${AIDLC_RULES_PATH}/aws-aidlc-rules" ]]; then
+                success "Downloaded and extracted successfully."
+                return
+            else
+                error "Could not find aidlc-rules in the downloaded archive."
+                warn "Falling back to local path..."
+                get_local_path
+                return
+            fi
+        fi
+    else
+        warn "Could not reach GitHub or find a release."
+        printf "\n"
+    fi
+
+    get_local_path
+}
+
+get_local_path() {
+    printf "\n"
+    info "Please provide the path to the extracted 'aidlc-rules' folder."
+    info "This folder should contain 'aws-aidlc-rules/' and 'aws-aidlc-rule-details/'."
+    printf "\n"
+
+    # Try common locations
+    local common_paths=(
+        "${HOME}/Downloads/aidlc-rules"
+        "${HOME}/Desktop/aidlc-rules"
+        "./aidlc-rules"
+    )
+
+    local found_path=""
+    for p in "${common_paths[@]}"; do
+        if [[ -d "${p}/aws-aidlc-rules" && -d "${p}/aws-aidlc-rule-details" ]]; then
+            found_path="${p}"
+            break
+        fi
+    done
+
+    if [[ -n "${found_path}" ]]; then
+        info "Auto-detected: ${found_path}"
+        printf "  Use this path? [Y/n]: "
+        read -r choice
+        choice="${choice:-Y}"
+        if [[ "${choice}" =~ ^[Yy] ]]; then
+            AIDLC_RULES_PATH="${found_path}"
+            return
+        fi
+    fi
+
+    while true; do
+        printf "  Path to aidlc-rules folder: "
+        read -r user_path
+
+        # Expand ~ if present
+        user_path="${user_path/#\~/$HOME}"
+
+        if [[ -d "${user_path}/aws-aidlc-rules" && -d "${user_path}/aws-aidlc-rule-details" ]]; then
+            AIDLC_RULES_PATH="${user_path}"
+            success "Valid path confirmed."
+            return
+        else
+            error "Invalid path. Expected to find 'aws-aidlc-rules/' and 'aws-aidlc-rule-details/' inside."
+            printf "  Try again? [Y/n]: "
+            read -r retry
+            retry="${retry:-Y}"
+            if [[ ! "${retry}" =~ ^[Yy] ]]; then
+                error "Cannot proceed without valid aidlc-rules path."
+                exit 1
+            fi
+        fi
+    done
+}
+
+# --- Select Agent ------------------------------------------------------------
+select_agent() {
+    header "Step 2: Select Your Coding Agent"
+
+    printf "\n"
+    printf "  ${BOLD}1)${NC} Kiro\n"
+    printf "  ${BOLD}2)${NC} Amazon Q Developer\n"
+    printf "  ${BOLD}3)${NC} Cursor IDE\n"
+    printf "  ${BOLD}4)${NC} Cline\n"
+    printf "  ${BOLD}5)${NC} Claude Code\n"
+    printf "  ${BOLD}6)${NC} GitHub Copilot\n"
+    printf "  ${BOLD}7)${NC} OpenAI Codex\n"
+    printf "  ${BOLD}8)${NC} All agents\n"
+    printf "\n"
+    printf "  Select agent [1-8]: "
+    read -r agent_choice
+
+    case "${agent_choice}" in
+        1) AGENTS=("kiro") ;;
+        2) AGENTS=("amazonq") ;;
+        3) AGENTS=("cursor") ;;
+        4) AGENTS=("cline") ;;
+        5) AGENTS=("claude") ;;
+        6) AGENTS=("copilot") ;;
+        7) AGENTS=("codex") ;;
+        8) AGENTS=("kiro" "amazonq" "cursor" "cline" "claude" "copilot" "codex") ;;
+        *)
+            error "Invalid selection. Please choose 1-8."
+            select_agent
+            ;;
+    esac
+}
+
+# --- Setup Functions ---------------------------------------------------------
+setup_kiro() {
+    info "Setting up for Kiro..."
+    mkdir -p "${PROJECT_ROOT}/.kiro/steering"
+    cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rules" "${PROJECT_ROOT}/.kiro/steering/"
+    cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details" "${PROJECT_ROOT}/.kiro/"
+    success "Kiro setup complete."
+    printf "    └── .kiro/steering/aws-aidlc-rules/\n"
+    printf "    └── .kiro/aws-aidlc-rule-details/\n"
+}
+
+setup_amazonq() {
+    info "Setting up for Amazon Q Developer..."
+    mkdir -p "${PROJECT_ROOT}/.amazonq/rules"
+    cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rules" "${PROJECT_ROOT}/.amazonq/rules/"
+    cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details" "${PROJECT_ROOT}/.amazonq/"
+    success "Amazon Q Developer setup complete."
+    printf "    └── .amazonq/rules/aws-aidlc-rules/\n"
+    printf "    └── .amazonq/aws-aidlc-rule-details/\n"
+}
+
+setup_cursor() {
+    printf "\n"
+    info "Cursor IDE has two setup options:"
+    printf "    ${BOLD}1)${NC} Project Rules (.cursor/rules/) — Recommended\n"
+    printf "    ${BOLD}2)${NC} AGENTS.md (simple alternative)\n"
+    printf "  Select option [1/2]: "
+    read -r cursor_option
+    cursor_option="${cursor_option:-1}"
+
+    if [[ "${cursor_option}" == "2" ]]; then
+        info "Setting up Cursor with AGENTS.md..."
+        cp "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md" "${PROJECT_ROOT}/AGENTS.md"
+        mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+        cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+        success "Cursor setup complete (AGENTS.md)."
+        printf "    └── AGENTS.md\n"
+        printf "    └── .aidlc-rule-details/\n"
+    else
+        info "Setting up Cursor with Project Rules..."
+        mkdir -p "${PROJECT_ROOT}/.cursor/rules"
+
+        # Create the .mdc file with frontmatter + core workflow
+        {
+            printf '%s\n' '---'
+            printf '%s\n' 'description: "AI-DLC (AI-Driven Development Life Cycle) adaptive workflow for software development"'
+            printf '%s\n' 'alwaysApply: true'
+            printf '%s\n' '---'
+            printf '\n'
+            cat "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md"
+        } > "${PROJECT_ROOT}/.cursor/rules/ai-dlc-workflow.mdc"
+
+        mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+        cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+        success "Cursor setup complete (Project Rules)."
+        printf "    └── .cursor/rules/ai-dlc-workflow.mdc\n"
+        printf "    └── .aidlc-rule-details/\n"
+    fi
+}
+
+setup_cline() {
+    printf "\n"
+    info "Cline has two setup options:"
+    printf "    ${BOLD}1)${NC} .clinerules directory — Recommended\n"
+    printf "    ${BOLD}2)${NC} AGENTS.md (simple alternative)\n"
+    printf "  Select option [1/2]: "
+    read -r cline_option
+    cline_option="${cline_option:-1}"
+
+    if [[ "${cline_option}" == "2" ]]; then
+        info "Setting up Cline with AGENTS.md..."
+        cp "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md" "${PROJECT_ROOT}/AGENTS.md"
+        mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+        cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+        success "Cline setup complete (AGENTS.md)."
+        printf "    └── AGENTS.md\n"
+        printf "    └── .aidlc-rule-details/\n"
+    else
+        info "Setting up Cline with .clinerules..."
+        mkdir -p "${PROJECT_ROOT}/.clinerules"
+        cp "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md" "${PROJECT_ROOT}/.clinerules/"
+        mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+        cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+        success "Cline setup complete (.clinerules)."
+        printf "    └── .clinerules/core-workflow.md\n"
+        printf "    └── .aidlc-rule-details/\n"
+    fi
+}
+
+setup_claude() {
+    printf "\n"
+    info "Claude Code has two setup options:"
+    printf "    ${BOLD}1)${NC} Project root CLAUDE.md — Recommended\n"
+    printf "    ${BOLD}2)${NC} .claude/CLAUDE.md directory\n"
+    printf "  Select option [1/2]: "
+    read -r claude_option
+    claude_option="${claude_option:-1}"
+
+    if [[ "${claude_option}" == "2" ]]; then
+        info "Setting up Claude Code with .claude/CLAUDE.md..."
+        mkdir -p "${PROJECT_ROOT}/.claude"
+        cp "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md" "${PROJECT_ROOT}/.claude/CLAUDE.md"
+        mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+        cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+        success "Claude Code setup complete (.claude/CLAUDE.md)."
+        printf "    └── .claude/CLAUDE.md\n"
+        printf "    └── .aidlc-rule-details/\n"
+    else
+        info "Setting up Claude Code with CLAUDE.md..."
+        cp "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md" "${PROJECT_ROOT}/CLAUDE.md"
+        mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+        cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+        success "Claude Code setup complete (CLAUDE.md)."
+        printf "    └── CLAUDE.md\n"
+        printf "    └── .aidlc-rule-details/\n"
+    fi
+}
+
+setup_copilot() {
+    info "Setting up for GitHub Copilot..."
+    mkdir -p "${PROJECT_ROOT}/.github"
+    cp "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md" "${PROJECT_ROOT}/.github/copilot-instructions.md"
+    mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+    cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+    success "GitHub Copilot setup complete."
+    printf "    └── .github/copilot-instructions.md\n"
+    printf "    └── .aidlc-rule-details/\n"
+}
+
+setup_codex() {
+    info "Setting up for OpenAI Codex..."
+    cp "${AIDLC_RULES_PATH}/aws-aidlc-rules/core-workflow.md" "${PROJECT_ROOT}/AGENTS.md"
+    mkdir -p "${PROJECT_ROOT}/.aidlc-rule-details"
+    cp -R "${AIDLC_RULES_PATH}/aws-aidlc-rule-details/"* "${PROJECT_ROOT}/.aidlc-rule-details/"
+    success "OpenAI Codex setup complete."
+    printf "    └── AGENTS.md\n"
+    printf "    └── .aidlc-rule-details/\n"
+}
+
+# --- Main --------------------------------------------------------------------
+main() {
+    printf "\n"
+    printf "${BOLD}${CYAN}╔══════════════════════════════════════════════════════════╗${NC}\n"
+    printf "${BOLD}${CYAN}║          AI-DLC Setup — Automated Installer             ║${NC}\n"
+    printf "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════╝${NC}\n"
+    printf "\n"
+    info "This script sets up AI-DLC rules for your coding agent."
+    info "Run this from your project root directory."
+    printf "\n"
+
+    detect_project_root
+    get_aidlc_rules
+    select_agent
+
+    header "Step 3: Installing Rules"
+
+    for agent in "${AGENTS[@]}"; do
+        printf "\n"
+        case "${agent}" in
+            kiro)    setup_kiro ;;
+            amazonq) setup_amazonq ;;
+            cursor)  setup_cursor ;;
+            cline)   setup_cline ;;
+            claude)  setup_claude ;;
+            copilot) setup_copilot ;;
+            codex)   setup_codex ;;
+        esac
+    done
+
+    header "Setup Complete"
+    printf "\n"
+    success "AI-DLC rules have been installed successfully."
+    printf "\n"
+    info "Next steps:"
+    printf "    1. Open your project in your coding agent\n"
+    printf "    2. Start a chat with: ${BOLD}\"Using AI-DLC, ...\"${NC}\n"
+    printf "    3. The workflow will guide you from there\n"
+    printf "\n"
+    info "For verification steps, see: https://github.com/${REPO}#platform-specific-setup"
+    printf "\n"
+}
+
+main "$@"


### PR DESCRIPTION
## Description

Add interactive setup scripts (`setup.sh`, `setup.ps1`, `setup.bat`) that automate AI-DLC rules installation for all supported coding agents. This eliminates the need for users to manually follow multi-step platform-specific instructions from the README.

## What the scripts do

1. **Download** the latest AI-DLC rules from GitHub releases automatically
2. **Auto-detect** common locations where rules might already be extracted (`~/Downloads`, `~/Desktop`)
3. **Fall back** to prompting the user for a local path when GitHub is unreachable
4. **Prompt** the user to select their coding agent (Kiro, Amazon Q, Cursor, Cline, Claude Code, GitHub Copilot, OpenAI Codex, or all)
5. **Install** rules to the correct directory structure per the README instructions

## Changes

| File | Description |
| ---- | ----------- |
| `scripts/setup/setup.sh` | macOS/Linux shell script |
| `scripts/setup/setup.ps1` | Windows PowerShell script |
| `scripts/setup/setup.bat` | Windows CMD batch script |
| `scripts/setup/README.md` | Documentation for the setup scripts |
| `README.md` | Added TIP callout in Platform-Specific Setup section pointing to automated scripts |

## Testing

- Shell script syntax validated (`bash -n`)
- All copy operations programmatically verified against README instructions for all 7 agents
- Flow logic verified (GitHub download, auto-detect fallback, manual path prompt, temp cleanup)
- Markdownlint passes on all markdown files (`npx markdownlint-cli2`)

## Checklist

- [x] Follows conventional commit format
- [x] Markdownlint passes
- [x] No conflicts with existing files
- [x] Scripts match README copy operations for all 7 agents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).