### PR TITLE
Restructure catalogue and enable human clarification for workflow-composition

### DIFF
--- a/dist/kiro/.kiro/skills/aidlc-orchestrator/CATALOGUE.md
+++ b/dist/kiro/.kiro/skills/aidlc-orchestrator/CATALOGUE.md
@@ -2,7 +2,12 @@
 
 Catalogue of AI-DLC skills. Each skill is a directory under `skills/<skill-name>/` and follows the [Agent Skills specification](https://agentskills.io/specification). The catalogue is the orchestrator's source when composing a workflow.
 
-Skills are composable. Phases and stages are organising concepts the orchestrator uses to group and present skills — they are not a rigid pipeline. A customer can reorder, insert, or omit any skill when composing a workflow.
+Skills come in two types:
+
+- **Setup skills** — run once per intent during bootstrap, before the workflow exists. They create the intent skeleton and compose the workflow.
+- **Stage skills** — run as discrete steps in the workflow. Each has its own clarification/planning/execution/validation cycle.
+
+Skills are composable. Phases and stages are organising concepts the orchestrator uses to group and present skills — they are not a rigid pipeline. A customer can reorder, insert, or omit any stage skill when composing a workflow.
 
 ## Skill folder layout
 
@@ -19,6 +24,7 @@ Generic builder and validator behaviour lives in `aidlc-common/protocols/aidlc-b
 
 Every skill's `SKILL.md` frontmatter carries, under `metadata`, the fields the orchestrator reads:
 
+- `type` — `"stage"` (default) or `"setup"`
 - `phase` — `bootstrap`, `inception`, `construction`, or `operations`
 - `stage` — organising tag (e.g. `requirements-analysis`, `user-stories`); multiple skills may share a stage when fan-out happens
 - `per-unit` — `"true"` when the skill runs once per unit in the construction phase
@@ -42,44 +48,41 @@ Clarification is always *attempted* — the questions file always exists for tra
 
 All skills we supply are prefixed `aidlc-` to distinguish them from customer-contributed or third-party skills. The `stage` tag is the bare unprefixed name (e.g. `requirements-analysis`) and remains the human-facing vocabulary.
 
-## Available skills
+---
+
+## Setup Skills
+
+The bootstrap phase runs once per intent. The orchestrator drives `intent-bootstrap` outside `process_checker` (it has to — the file `process_checker` reads doesn't exist yet). After `intent-bootstrap` completes, the intent skeleton exists with a stub `workflow.md` containing only the `workflow-composition` line. From there, `workflow-composition` runs through the standard loop and rewrites `workflow.md` with the chosen downstream skills. Setup skills are never present in `workflow.md`.
+
+Both setup skills set `plan-creation: false` because planning is not needed for bootstrap decisions. `intent-bootstrap` sets `human-clarification: false` because its decisions follow rote patterns (question files are auto-answered with the builder's recommendations, recorded for audit). `workflow-composition` sets `human-clarification: true` because it asks critical decisions — which skills to include and how to tailor the workflow — that require human judgement. `workflow-composition` also keeps `artefact-verification: true` so the human approves the composed workflow.
+
+| Skill | Stage | Human-Clar | Plan | Artefact-Verify | Status |
+|---|---|---|---|---|---|
+| aidlc-intent-bootstrap     | intent-bootstrap     | false | false | false | ✅ |
+| aidlc-workflow-composition | workflow-composition | true  | false | true  | ✅ |
+
+---
+
+## Stage Skills
 
 Legend: ✅ implemented (folder exists under `skills/`), 🚧 not yet implemented.
 
 Default flags (when not stated): `human-clarification: true`, `plan-creation: true`, `plan-verification: true`, `artefact-verification: true`.
 
-### Bootstrap phase
-
-The bootstrap phase runs once per intent. The orchestrator drives `intent-bootstrap` outside `process_checker` (it has to — the file `process_checker` reads doesn't exist yet). After `intent-bootstrap` completes, the intent skeleton exists with a stub `workflow.md` containing only the `workflow-composition` line. From there, `workflow-composition` runs through the standard loop and rewrites `workflow.md` with the chosen downstream skills. Bootstrap skills are never present in `workflow.md`.
-
-Both bootstrap skills set `human-clarification: false` and `plan-creation: false` because their decisions follow rote patterns: question files are auto-answered with the builder's recommendations (recorded for audit), planning is skipped, and execution proceeds directly. `workflow-composition` keeps `artefact-verification: true` so the human still approves the composed workflow.
-
-| Skill | Stage | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
+| Skill | Phase | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
 |---|---|---|---|---|---|---|---|
-| aidlc-intent-bootstrap       | intent-bootstrap       | No  | false | false | n/a   | false | ✅ |
-| aidlc-workflow-composition   | workflow-composition   | No  | false | false | n/a   | true  | ✅ |
-
-### Inception phase
-
-| Skill | Stage | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
-|---|---|---|---|---|---|---|---|
-| aidlc-reverse-engineering    | reverse-engineering    | No  | true | true | true | true | ✅ |
-| aidlc-requirements-analysis  | requirements-analysis  | No  | true | true | true | true | ✅ |
-| aidlc-user-stories           | user-stories           | No  | true | true | true | true | ✅ |
-| aidlc-wireframes             | wireframes             | No  | true | true | true | true | ✅ |
-| aidlc-application-design     | application-design     | No  | true | true | true | true | ✅ |
-| aidlc-units-generation       | units-generation       | No  | true | true | true | true | ✅ |
-
-### Construction phase
-
-| Skill | Stage | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
-|---|---|---|---|---|---|---|---|
-| aidlc-functional-design      | functional-design      | Yes | true | true | true | true | ✅ |
-| aidlc-nfr-assessment         | nfr-assessment         | Yes | true | true | true | true | ✅ |
-| aidlc-nfr-design             | nfr-design             | Yes | true | true | true | true | ✅ |
-| aidlc-infrastructure-design  | infrastructure-design  | Yes | true | true | true | true | ✅ |
-| aidlc-code-generation        | code-generation        | Yes | true | true | true | true | ✅ |
-| aidlc-build-and-test         | build-and-test         | No  | true | true | true | true | 🚧 |
+| aidlc-reverse-engineering   | inception    | No  | true | true | true | true | ✅ |
+| aidlc-requirements-analysis | inception    | No  | true | true | true | true | ✅ |
+| aidlc-user-stories          | inception    | No  | true | true | true | true | ✅ |
+| aidlc-wireframes            | inception    | No  | true | true | true | true | ✅ |
+| aidlc-application-design    | inception    | No  | true | true | true | true | ✅ |
+| aidlc-units-generation      | inception    | No  | true | true | true | true | ✅ |
+| aidlc-functional-design     | construction | Yes | true | true | true | true | ✅ |
+| aidlc-nfr-assessment        | construction | Yes | true | true | true | true | ✅ |
+| aidlc-nfr-design            | construction | Yes | true | true | true | true | ✅ |
+| aidlc-infrastructure-design | construction | Yes | true | true | true | true | ✅ |
+| aidlc-code-generation       | construction | Yes | true | true | true | true | ✅ |
+| aidlc-build-and-test        | construction | No  | true | true | true | true | 🚧 |
 
 The orchestrator or the human may override flags per-intent when composing the workflow.
 

--- a/dist/kiro/.kiro/skills/aidlc-workflow-composition/SKILL.md
+++ b/dist/kiro/.kiro/skills/aidlc-workflow-composition/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   phase: bootstrap
   stage: workflow-composition
   per-unit: "false"
-  human-clarification: "false"
+  human-clarification: "true"
   plan-creation: "false"
   plan-verification: "false"
   artefact-verification: "true"

--- a/src/skills/aidlc-orchestrator/CATALOGUE.md
+++ b/src/skills/aidlc-orchestrator/CATALOGUE.md
@@ -2,7 +2,12 @@
 
 Catalogue of AI-DLC skills. Each skill is a directory under `skills/<skill-name>/` and follows the [Agent Skills specification](https://agentskills.io/specification). The catalogue is the orchestrator's source when composing a workflow.
 
-Skills are composable. Phases and stages are organising concepts the orchestrator uses to group and present skills — they are not a rigid pipeline. A customer can reorder, insert, or omit any skill when composing a workflow.
+Skills come in two types:
+
+- **Setup skills** — run once per intent during bootstrap, before the workflow exists. They create the intent skeleton and compose the workflow.
+- **Stage skills** — run as discrete steps in the workflow. Each has its own clarification/planning/execution/validation cycle.
+
+Skills are composable. Phases and stages are organising concepts the orchestrator uses to group and present skills — they are not a rigid pipeline. A customer can reorder, insert, or omit any stage skill when composing a workflow.
 
 ## Skill folder layout
 
@@ -19,6 +24,7 @@ Generic builder and validator behaviour lives in `aidlc-common/protocols/aidlc-b
 
 Every skill's `SKILL.md` frontmatter carries, under `metadata`, the fields the orchestrator reads:
 
+- `type` — `"stage"` (default) or `"setup"`
 - `phase` — `bootstrap`, `inception`, `construction`, or `operations`
 - `stage` — organising tag (e.g. `requirements-analysis`, `user-stories`); multiple skills may share a stage when fan-out happens
 - `per-unit` — `"true"` when the skill runs once per unit in the construction phase
@@ -42,44 +48,41 @@ Clarification is always *attempted* — the questions file always exists for tra
 
 All skills we supply are prefixed `aidlc-` to distinguish them from customer-contributed or third-party skills. The `stage` tag is the bare unprefixed name (e.g. `requirements-analysis`) and remains the human-facing vocabulary.
 
-## Available skills
+---
+
+## Setup Skills
+
+The bootstrap phase runs once per intent. The orchestrator drives `intent-bootstrap` outside `process_checker` (it has to — the file `process_checker` reads doesn't exist yet). After `intent-bootstrap` completes, the intent skeleton exists with a stub `workflow.md` containing only the `workflow-composition` line. From there, `workflow-composition` runs through the standard loop and rewrites `workflow.md` with the chosen downstream skills. Setup skills are never present in `workflow.md`.
+
+Both setup skills set `plan-creation: false` because planning is not needed for bootstrap decisions. `intent-bootstrap` sets `human-clarification: false` because its decisions follow rote patterns (question files are auto-answered with the builder's recommendations, recorded for audit). `workflow-composition` sets `human-clarification: true` because it asks critical decisions — which skills to include and how to tailor the workflow — that require human judgement. `workflow-composition` also keeps `artefact-verification: true` so the human approves the composed workflow.
+
+| Skill | Stage | Human-Clar | Plan | Artefact-Verify | Status |
+|---|---|---|---|---|---|
+| aidlc-intent-bootstrap     | intent-bootstrap     | false | false | false | ✅ |
+| aidlc-workflow-composition | workflow-composition | true  | false | true  | ✅ |
+
+---
+
+## Stage Skills
 
 Legend: ✅ implemented (folder exists under `skills/`), 🚧 not yet implemented.
 
 Default flags (when not stated): `human-clarification: true`, `plan-creation: true`, `plan-verification: true`, `artefact-verification: true`.
 
-### Bootstrap phase
-
-The bootstrap phase runs once per intent. The orchestrator drives `intent-bootstrap` outside `process_checker` (it has to — the file `process_checker` reads doesn't exist yet). After `intent-bootstrap` completes, the intent skeleton exists with a stub `workflow.md` containing only the `workflow-composition` line. From there, `workflow-composition` runs through the standard loop and rewrites `workflow.md` with the chosen downstream skills. Bootstrap skills are never present in `workflow.md`.
-
-Both bootstrap skills set `human-clarification: false` and `plan-creation: false` because their decisions follow rote patterns: question files are auto-answered with the builder's recommendations (recorded for audit), planning is skipped, and execution proceeds directly. `workflow-composition` keeps `artefact-verification: true` so the human still approves the composed workflow.
-
-| Skill | Stage | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
+| Skill | Phase | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
 |---|---|---|---|---|---|---|---|
-| aidlc-intent-bootstrap       | intent-bootstrap       | No  | false | false | n/a   | false | ✅ |
-| aidlc-workflow-composition   | workflow-composition   | No  | false | false | n/a   | true  | ✅ |
-
-### Inception phase
-
-| Skill | Stage | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
-|---|---|---|---|---|---|---|---|
-| aidlc-reverse-engineering    | reverse-engineering    | No  | true | true | true | true | ✅ |
-| aidlc-requirements-analysis  | requirements-analysis  | No  | true | true | true | true | ✅ |
-| aidlc-user-stories           | user-stories           | No  | true | true | true | true | ✅ |
-| aidlc-wireframes             | wireframes             | No  | true | true | true | true | ✅ |
-| aidlc-application-design     | application-design     | No  | true | true | true | true | ✅ |
-| aidlc-units-generation       | units-generation       | No  | true | true | true | true | ✅ |
-
-### Construction phase
-
-| Skill | Stage | Per-Unit | Human-Clar | Plan-Create | Plan-Verify | Artefact-Verify | Status |
-|---|---|---|---|---|---|---|---|
-| aidlc-functional-design      | functional-design      | Yes | true | true | true | true | ✅ |
-| aidlc-nfr-assessment         | nfr-assessment         | Yes | true | true | true | true | ✅ |
-| aidlc-nfr-design             | nfr-design             | Yes | true | true | true | true | ✅ |
-| aidlc-infrastructure-design  | infrastructure-design  | Yes | true | true | true | true | ✅ |
-| aidlc-code-generation        | code-generation        | Yes | true | true | true | true | ✅ |
-| aidlc-build-and-test         | build-and-test         | No  | true | true | true | true | 🚧 |
+| aidlc-reverse-engineering   | inception    | No  | true | true | true | true | ✅ |
+| aidlc-requirements-analysis | inception    | No  | true | true | true | true | ✅ |
+| aidlc-user-stories          | inception    | No  | true | true | true | true | ✅ |
+| aidlc-wireframes            | inception    | No  | true | true | true | true | ✅ |
+| aidlc-application-design    | inception    | No  | true | true | true | true | ✅ |
+| aidlc-units-generation      | inception    | No  | true | true | true | true | ✅ |
+| aidlc-functional-design     | construction | Yes | true | true | true | true | ✅ |
+| aidlc-nfr-assessment        | construction | Yes | true | true | true | true | ✅ |
+| aidlc-nfr-design            | construction | Yes | true | true | true | true | ✅ |
+| aidlc-infrastructure-design | construction | Yes | true | true | true | true | ✅ |
+| aidlc-code-generation       | construction | Yes | true | true | true | true | ✅ |
+| aidlc-build-and-test        | construction | No  | true | true | true | true | 🚧 |
 
 The orchestrator or the human may override flags per-intent when composing the workflow.
 

--- a/src/skills/aidlc-workflow-composition/SKILL.md
+++ b/src/skills/aidlc-workflow-composition/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   phase: bootstrap
   stage: workflow-composition
   per-unit: "false"
-  human-clarification: "false"
+  human-clarification: "true"
   plan-creation: "false"
   plan-verification: "false"
   artefact-verification: "true"


### PR DESCRIPTION
**Description:**

Restructure **CATALOGUE.md** into 2 skill types: Setup Skills and Stage Skills (single table with Phase column)
Flip **workflow-composition** human-clarification from false to true so the human is asked critical decisions about which skills to include and how to tailor the workflow

Base: v2 at cd0643e