### PR TITLE
Migrate application-design stage from v1 to v2

### DIFF
--- a/dist/kiro-ide/.kiro/skills/domain-modeling/SKILL.md
+++ b/dist/kiro-ide/.kiro/skills/domain-modeling/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: domain-modeling
+description: |
+  The ability to identify and define the core domain concepts of a system — its entities, their relationships, ownership boundaries, and the language the system speaks. Applied by the Systems Architect when establishing what data and concepts a system manages.
+---
+
+# Domain Modeling
+
+## Purpose
+
+Identify the core domain concepts, define their boundaries, establish ownership, and create a shared language that aligns code with the business domain.
+
+## Principles
+
+- The domain model is the backbone — components, APIs, and storage all derive from it
+- Every entity has exactly one owner — ambiguous ownership creates consistency bugs
+- Relationships have direction and cardinality — never leave them implicit
+- The model uses business language — if the business says "order", the code says "order", not "transaction record"
+- Boundaries prevent contamination — data that belongs to one domain doesn't leak into another without explicit interface
+
+## Approach
+
+### 1. Entity identification
+
+From requirements, stories, and domain context:
+- What are the core nouns? (users, orders, products, sessions, etc.)
+- What lifecycle does each have? (created, active, archived, deleted)
+- What are the natural aggregates? (order + line items are one unit)
+
+### 2. Relationship mapping
+
+Between entities:
+- What references what? In which direction?
+- One-to-one, one-to-many, many-to-many?
+- Required or optional?
+- Does the relationship cross a component boundary?
+
+### 3. Ownership assignment
+
+For each entity/aggregate:
+- Which component is the source of truth?
+- Who can write? Who can only read?
+- How does data get exposed to non-owners? (API, event, cache)
+
+### 4. Boundary validation
+
+- Can each bounded context be understood without referencing another's internals?
+- Are there entities that multiple components want to own? (resolve the conflict)
+- Does the model support the stated NFRs? (e.g., can you scale the order domain independently from the user domain?)
+
+## Application
+
+When applied at application-design, this skill drives the `data-ownership.md` artifact and informs the component boundaries in `components.md`.
+
+When applied at other stages, this skill manifests as: validating that designs respect entity ownership, flagging data access patterns that bypass the owning component, and ensuring naming consistency with the domain model.

--- a/dist/kiro-ide/.kiro/skills/units-decomposition/SKILL.md
+++ b/dist/kiro-ide/.kiro/skills/units-decomposition/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: units-decomposition
+description: |
+  The ability to decompose a system into well-bounded components with clear responsibilities, explicit interfaces, and intentional dependency directions. Applied by the Systems Architect when breaking a system into its logical parts and defining how they interact.
+---
+
+# Units Decomposition
+
+## Purpose
+
+Decompose a system into components that are cohesive internally, loosely coupled externally, and whose boundaries align with the business domain and deployment constraints.
+
+## Principles
+
+- Boundaries follow responsibility — a component exists because it owns a coherent set of behaviours, not because of technical layering
+- Interfaces before internals — define what a component exposes before designing how it works inside
+- Dependency direction is a design choice — always explicit, never accidental. Prefer dependencies that point toward stability
+- Communication patterns match coupling tolerance — synchronous calls create tight coupling; events create loose coupling. Choose deliberately
+- Fewer components is better until it isn't — don't decompose for the sake of decomposition. Split when a component has conflicting responsibilities, conflicting change rates, or conflicting scaling needs
+
+## Approach
+
+### 1. Identify candidates
+
+From requirements, stories, and domain understanding:
+- What are the distinct business capabilities?
+- What data clusters together (is read/written together)?
+- What changes together vs what changes independently?
+- What scales differently?
+
+### 2. Define boundaries
+
+For each candidate component:
+- What is it responsible for? (behaviours it owns)
+- What is it NOT responsible for? (explicit exclusions)
+- What data does it own? (connects to domain-modeling)
+- What does it expose to others? (its public interface)
+
+### 3. Map interactions
+
+Between components:
+- Who calls whom? In what direction?
+- Synchronous or asynchronous?
+- What data crosses the boundary?
+- What happens when the other side is unavailable?
+
+### 4. Validate
+
+Check the decomposition against:
+- Can each component be understood independently?
+- Does a change in one component frequently force changes in others? (coupling smell)
+- Does the decomposition support the stated NFRs (scaling, deployment, team ownership)?
+- Are there circular dependencies? (design smell)
+
+## Application
+
+When applied at application-design, this skill drives the `components.md`, `component-interactions.md`, and `services.md` artifacts.
+
+When applied at units-generation (construction phase), this skill is used to break the approved design into implementable units of work with dependency ordering.
+
+When applied as a contributor to other stages, this skill manifests as: validating that proposed changes respect component boundaries, flagging designs that create unintended coupling, and identifying components being asked to take on conflicting responsibilities.

--- a/dist/kiro-ide/.kiro/stages/application-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/application-design/definition.md
@@ -1,3 +1,32 @@
-# application-design
+# Application Design
 
-Placeholder — not yet implemented.
+## Description
+
+Design the logical component structure of the system — what the major parts are, how they relate, what responsibilities each holds, and how they communicate. This is high-level architecture: component boundaries, service layers, dependency directions, and interface contracts. Detailed business logic within each component is deferred to functional-design in the construction phase.
+
+## Inputs
+
+- **Required:** At least one of: `requirements.md`, `stories.md`, RE artifacts, or human-provided design context
+- **Optional context:** `wireframes/`, `personas.md`, existing architecture documentation, intent.md
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this system. Additional artifacts may be produced if the system warrants them.
+
+- `components.md` — component inventory with purposes, responsibilities, and boundaries
+- `component-interactions.md` — how components communicate: protocols, data flow directions, sync/async patterns
+- `services.md` — service layer definitions, orchestration patterns, and coordination responsibilities
+- `data-ownership.md` — which components own which data, storage boundaries, shared vs private data
+
+## Owner
+
+systems-architect
+
+## Contributors
+
+- security-architect
+- product-manager
+
+## Reviewer
+
+architecture-reviewer

--- a/dist/kiro-ide/.kiro/stages/application-design/templates/component-interactions.md
+++ b/dist/kiro-ide/.kiro/stages/application-design/templates/component-interactions.md
@@ -1,0 +1,34 @@
+# Component Interactions
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Interaction Diagram
+
+```mermaid
+%% Replace with actual component interaction diagram
+%% Choose diagram type (sequence, flowchart, C4) that best represents this system's communication patterns
+```
+
+## Interaction Catalogue
+
+| From | To | Method | Pattern | Purpose |
+|---|---|---|---|---|
+| [caller] | [callee] | [REST/gRPC/event/queue/direct call] | [sync/async/fire-and-forget] | [why this interaction exists] |
+
+## Key Flows
+
+Document the primary paths through the system — how a user action or system trigger propagates across components.
+
+### [Flow Name — e.g. "User places order"]
+
+1. [Step description — which component does what]
+2. [Next step]
+3. ...
+
+## Dependency Direction
+
+Document the dependency graph — which components know about which others. Flag any circular dependencies or tight coupling concerns.
+
+| Component | Depends on | Depended on by |
+|---|---|---|
+| [name] | [list] | [list] |

--- a/dist/kiro-ide/.kiro/stages/application-design/templates/components.md
+++ b/dist/kiro-ide/.kiro/stages/application-design/templates/components.md
@@ -1,0 +1,20 @@
+# Components
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Component Inventory
+
+| Component | Purpose | Type | Owns |
+|---|---|---|---|
+| [name] | [what it does] | [categorise as fits the system] | [what data/resources it's responsible for] |
+
+## Component Details
+
+### [Component Name]
+
+- **Purpose:** [single-sentence reason this component exists]
+- **Responsibilities:**
+  - [what it does — expressed as behaviours, not implementation]
+- **Boundaries:** [what is explicitly NOT this component's job]
+- **Public interface:** [what other components can ask it to do — methods, events, messages]
+- **Dependencies:** [what it needs from other components]

--- a/dist/kiro-ide/.kiro/stages/application-design/templates/data-ownership.md
+++ b/dist/kiro-ide/.kiro/stages/application-design/templates/data-ownership.md
@@ -1,0 +1,24 @@
+# Data Ownership
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Ownership Map
+
+| Data Entity / Resource | Owner Component | Access Pattern | Shared? |
+|---|---|---|---|
+| [entity name] | [which component is the source of truth] | [CRUD, read-only, event-sourced, etc.] | [private / shared-read / shared-write] |
+
+## Boundary Rules
+
+Document the rules governing how data crosses component boundaries:
+
+- [Rule — e.g. "Component A exposes user data via API only, never direct DB access"]
+- [Rule — e.g. "Orders are event-sourced; other components consume the event stream"]
+
+## Shared Data Concerns
+
+Document any data that multiple components need access to and how that access is governed. Flag risks (tight coupling, consistency challenges, ownership ambiguity).
+
+| Shared Data | Components Involved | Access Mechanism | Risk |
+|---|---|---|---|
+| [entity] | [who needs it] | [API / event / shared DB / cache] | [consistency, coupling, etc.] |

--- a/dist/kiro-ide/.kiro/stages/application-design/templates/services.md
+++ b/dist/kiro-ide/.kiro/stages/application-design/templates/services.md
@@ -1,0 +1,20 @@
+# Services
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> This artifact is relevant when the system has a service/orchestration layer distinct from its domain components. Omit if the system is a simple monolith with no service layer.
+
+## Service Inventory
+
+| Service | Purpose | Orchestrates |
+|---|---|---|
+| [name] | [what coordination it provides] | [which components it ties together] |
+
+## Service Details
+
+### [Service Name]
+
+- **Purpose:** [why this orchestration exists as a distinct concern]
+- **Coordinates:** [which components participate]
+- **Trigger:** [what initiates this service — API call, event, schedule, etc.]
+- **Outcome:** [what state the system is in when this service completes]
+- **Error handling:** [what happens when a participant fails]

--- a/src/skills/domain-modeling/SKILL.md
+++ b/src/skills/domain-modeling/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: domain-modeling
+description: |
+  The ability to identify and define the core domain concepts of a system — its entities, their relationships, ownership boundaries, and the language the system speaks. Applied by the Systems Architect when establishing what data and concepts a system manages.
+---
+
+# Domain Modeling
+
+## Purpose
+
+Identify the core domain concepts, define their boundaries, establish ownership, and create a shared language that aligns code with the business domain.
+
+## Principles
+
+- The domain model is the backbone — components, APIs, and storage all derive from it
+- Every entity has exactly one owner — ambiguous ownership creates consistency bugs
+- Relationships have direction and cardinality — never leave them implicit
+- The model uses business language — if the business says "order", the code says "order", not "transaction record"
+- Boundaries prevent contamination — data that belongs to one domain doesn't leak into another without explicit interface
+
+## Approach
+
+### 1. Entity identification
+
+From requirements, stories, and domain context:
+- What are the core nouns? (users, orders, products, sessions, etc.)
+- What lifecycle does each have? (created, active, archived, deleted)
+- What are the natural aggregates? (order + line items are one unit)
+
+### 2. Relationship mapping
+
+Between entities:
+- What references what? In which direction?
+- One-to-one, one-to-many, many-to-many?
+- Required or optional?
+- Does the relationship cross a component boundary?
+
+### 3. Ownership assignment
+
+For each entity/aggregate:
+- Which component is the source of truth?
+- Who can write? Who can only read?
+- How does data get exposed to non-owners? (API, event, cache)
+
+### 4. Boundary validation
+
+- Can each bounded context be understood without referencing another's internals?
+- Are there entities that multiple components want to own? (resolve the conflict)
+- Does the model support the stated NFRs? (e.g., can you scale the order domain independently from the user domain?)
+
+## Application
+
+When applied at application-design, this skill drives the `data-ownership.md` artifact and informs the component boundaries in `components.md`.
+
+When applied at other stages, this skill manifests as: validating that designs respect entity ownership, flagging data access patterns that bypass the owning component, and ensuring naming consistency with the domain model.

--- a/src/skills/units-decomposition/SKILL.md
+++ b/src/skills/units-decomposition/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: units-decomposition
+description: |
+  The ability to decompose a system into well-bounded components with clear responsibilities, explicit interfaces, and intentional dependency directions. Applied by the Systems Architect when breaking a system into its logical parts and defining how they interact.
+---
+
+# Units Decomposition
+
+## Purpose
+
+Decompose a system into components that are cohesive internally, loosely coupled externally, and whose boundaries align with the business domain and deployment constraints.
+
+## Principles
+
+- Boundaries follow responsibility — a component exists because it owns a coherent set of behaviours, not because of technical layering
+- Interfaces before internals — define what a component exposes before designing how it works inside
+- Dependency direction is a design choice — always explicit, never accidental. Prefer dependencies that point toward stability
+- Communication patterns match coupling tolerance — synchronous calls create tight coupling; events create loose coupling. Choose deliberately
+- Fewer components is better until it isn't — don't decompose for the sake of decomposition. Split when a component has conflicting responsibilities, conflicting change rates, or conflicting scaling needs
+
+## Approach
+
+### 1. Identify candidates
+
+From requirements, stories, and domain understanding:
+- What are the distinct business capabilities?
+- What data clusters together (is read/written together)?
+- What changes together vs what changes independently?
+- What scales differently?
+
+### 2. Define boundaries
+
+For each candidate component:
+- What is it responsible for? (behaviours it owns)
+- What is it NOT responsible for? (explicit exclusions)
+- What data does it own? (connects to domain-modeling)
+- What does it expose to others? (its public interface)
+
+### 3. Map interactions
+
+Between components:
+- Who calls whom? In what direction?
+- Synchronous or asynchronous?
+- What data crosses the boundary?
+- What happens when the other side is unavailable?
+
+### 4. Validate
+
+Check the decomposition against:
+- Can each component be understood independently?
+- Does a change in one component frequently force changes in others? (coupling smell)
+- Does the decomposition support the stated NFRs (scaling, deployment, team ownership)?
+- Are there circular dependencies? (design smell)
+
+## Application
+
+When applied at application-design, this skill drives the `components.md`, `component-interactions.md`, and `services.md` artifacts.
+
+When applied at units-generation (construction phase), this skill is used to break the approved design into implementable units of work with dependency ordering.
+
+When applied as a contributor to other stages, this skill manifests as: validating that proposed changes respect component boundaries, flagging designs that create unintended coupling, and identifying components being asked to take on conflicting responsibilities.

--- a/src/stages/application-design/definition.md
+++ b/src/stages/application-design/definition.md
@@ -1,3 +1,32 @@
-# application-design
+# Application Design
 
-Placeholder — not yet implemented.
+## Description
+
+Design the logical component structure of the system — what the major parts are, how they relate, what responsibilities each holds, and how they communicate. This is high-level architecture: component boundaries, service layers, dependency directions, and interface contracts. Detailed business logic within each component is deferred to functional-design in the construction phase.
+
+## Inputs
+
+- **Required:** At least one of: `requirements.md`, `stories.md`, RE artifacts, or human-provided design context
+- **Optional context:** `wireframes/`, `personas.md`, existing architecture documentation, intent.md
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this system. Additional artifacts may be produced if the system warrants them.
+
+- `components.md` — component inventory with purposes, responsibilities, and boundaries
+- `component-interactions.md` — how components communicate: protocols, data flow directions, sync/async patterns
+- `services.md` — service layer definitions, orchestration patterns, and coordination responsibilities
+- `data-ownership.md` — which components own which data, storage boundaries, shared vs private data
+
+## Owner
+
+systems-architect
+
+## Contributors
+
+- security-architect
+- product-manager
+
+## Reviewer
+
+architecture-reviewer

--- a/src/stages/application-design/templates/component-interactions.md
+++ b/src/stages/application-design/templates/component-interactions.md
@@ -1,0 +1,34 @@
+# Component Interactions
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Interaction Diagram
+
+```mermaid
+%% Replace with actual component interaction diagram
+%% Choose diagram type (sequence, flowchart, C4) that best represents this system's communication patterns
+```
+
+## Interaction Catalogue
+
+| From | To | Method | Pattern | Purpose |
+|---|---|---|---|---|
+| [caller] | [callee] | [REST/gRPC/event/queue/direct call] | [sync/async/fire-and-forget] | [why this interaction exists] |
+
+## Key Flows
+
+Document the primary paths through the system — how a user action or system trigger propagates across components.
+
+### [Flow Name — e.g. "User places order"]
+
+1. [Step description — which component does what]
+2. [Next step]
+3. ...
+
+## Dependency Direction
+
+Document the dependency graph — which components know about which others. Flag any circular dependencies or tight coupling concerns.
+
+| Component | Depends on | Depended on by |
+|---|---|---|
+| [name] | [list] | [list] |

--- a/src/stages/application-design/templates/components.md
+++ b/src/stages/application-design/templates/components.md
@@ -1,0 +1,20 @@
+# Components
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Component Inventory
+
+| Component | Purpose | Type | Owns |
+|---|---|---|---|
+| [name] | [what it does] | [categorise as fits the system] | [what data/resources it's responsible for] |
+
+## Component Details
+
+### [Component Name]
+
+- **Purpose:** [single-sentence reason this component exists]
+- **Responsibilities:**
+  - [what it does — expressed as behaviours, not implementation]
+- **Boundaries:** [what is explicitly NOT this component's job]
+- **Public interface:** [what other components can ask it to do — methods, events, messages]
+- **Dependencies:** [what it needs from other components]

--- a/src/stages/application-design/templates/data-ownership.md
+++ b/src/stages/application-design/templates/data-ownership.md
@@ -1,0 +1,24 @@
+# Data Ownership
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Ownership Map
+
+| Data Entity / Resource | Owner Component | Access Pattern | Shared? |
+|---|---|---|---|
+| [entity name] | [which component is the source of truth] | [CRUD, read-only, event-sourced, etc.] | [private / shared-read / shared-write] |
+
+## Boundary Rules
+
+Document the rules governing how data crosses component boundaries:
+
+- [Rule — e.g. "Component A exposes user data via API only, never direct DB access"]
+- [Rule — e.g. "Orders are event-sourced; other components consume the event stream"]
+
+## Shared Data Concerns
+
+Document any data that multiple components need access to and how that access is governed. Flag risks (tight coupling, consistency challenges, ownership ambiguity).
+
+| Shared Data | Components Involved | Access Mechanism | Risk |
+|---|---|---|---|
+| [entity] | [who needs it] | [API / event / shared DB / cache] | [consistency, coupling, etc.] |

--- a/src/stages/application-design/templates/services.md
+++ b/src/stages/application-design/templates/services.md
@@ -1,0 +1,20 @@
+# Services
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> This artifact is relevant when the system has a service/orchestration layer distinct from its domain components. Omit if the system is a simple monolith with no service layer.
+
+## Service Inventory
+
+| Service | Purpose | Orchestrates |
+|---|---|---|
+| [name] | [what coordination it provides] | [which components it ties together] |
+
+## Service Details
+
+### [Service Name]
+
+- **Purpose:** [why this orchestration exists as a distinct concern]
+- **Coordinates:** [which components participate]
+- **Trigger:** [what initiates this service — API call, event, schedule, etc.]
+- **Outcome:** [what state the system is in when this service completes]
+- **Error handling:** [what happens when a participant fails]


### PR DESCRIPTION
### Summary
Replaces the application-design placeholder with a fully defined stage. Introduces two new skills (domain-modeling, units-decomposition) and 4 output templates. Uses new agent naming from the persona restructure table.

### Changes
**Stage: application-design**

Full definition.md — high-level component structure, service layers, dependency directions, interface contracts
4 output templates: components.md, component-interactions.md, services.md, data-ownership.md
Owner: systems-architect, Contributors: security-architect + product-manager, Reviewer: architecture-reviewer

**Skills**

domain-modeling — entity identification, ownership boundaries, relationship mapping, shared data governance
units-decomposition — component boundaries, interfaces, interactions, validation against NFRs

**Notes**

- Reviewer (architecture-reviewer) is a reference only — persona file lives on the RE branch, will resolve on merge
- No persona files created or modified on this branch
- Templates follow guardrail-not-restriction principle