### PR TITLE
Folder structure, README, and workflow composition fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,11 @@ The source is target-agnostic. Build scripts transform it for specific targets:
 ### Build and Install (Kiro)
 
 ```bash
+# From the aidlc-workflows directory:
 npm run build
-cp -R dist/kiro-ide/.kiro /path/to/your/project/
+
+# From your project directory:
+cp -R /path/to/aidlc-workflows/dist/kiro-ide/.kiro .
 ```
 
 ## Naming Convention

--- a/README.md
+++ b/README.md
@@ -8,16 +8,45 @@ AI-DLC (AI-Driven Development Life Cycle) is a multi-agent workflow framework th
 
 The framework has five building blocks: Stages, Personas, Skills, Tools, and Conventions.
 
-**Stages** are tasks to be done. A stage defines what goes in, what comes out, and who owns it. It does not say how to do the work — that's the persona's job. Each stage has exactly one owner (the persona who produces the artifact) and zero or more contributors (personas who review it). Example: `requirements-analysis` takes an intent and produces `requirements.md`.
+**Stages** are tasks to be done. A stage defines what goes in, what comes out, and who owns it. It does not say how to do the work — that's the persona's job. Each stage has exactly one owner (the persona who produces the artifact), zero or more contributors (personas who review from a specific lens), and an optional reviewer (the quality gate). Example: `requirements-analysis` takes an intent and produces `requirements.md`.
 
-**Personas** are specialized agents with a worldview and domain expertise. They are simulated professionals — a Product Owner thinks in user value and scope discipline, a Security Engineer thinks in threats and trust boundaries. Multiple personas collaborate at a stage through mob elaboration.
+**Personas** are specialized agents with a worldview and domain expertise. They are simulated professionals — a Product Manager thinks in user value and scope discipline, a Security Architect thinks in threats and trust boundaries. Multiple personas collaborate at a stage through mob elaboration.
 
-**Skills** are reusable capabilities personas carry. A skill defines principles and knowledge that shape how work is done. Skills are not tied to one stage — they transfer wherever relevant. Generic skills (like `work-method`) are auto-included in every persona.
+**Skills** are reusable capabilities personas carry. A skill defines principles and knowledge that shape how work is done. Skills are not tied to one stage — they transfer wherever relevant. Common skills (under `skills/common/`) are auto-included in every persona at build time.
 
 **Tools** are computational instruments that personas use during their work — things an LLM can't do alone. Security scanners, dependency checkers, build runners. A persona's skills tell it what to look for; a tool provides the raw data.
 
 **Conventions** are schemas and format definitions for runtime artifacts (state tracking, audit logs, folder structure, question format). They are the source of truth for where things go and what format they take.
 
+## Stages
+
+### Inception Phase
+
+| Stage | Purpose | Owner |
+|---|---|---|
+| reverse-engineering | Analyse existing codebase, produce design artifacts | aidlc-systems-architect-agent |
+| requirements-analysis | Elicit and structure requirements from intent | aidlc-product-manager-agent |
+| story-generation | Decompose requirements into implementable stories | aidlc-product-manager-agent |
+| wireframe-design | Design UI screens as HTML wireframes | aidlc-ux-designer-agent |
+| application-design | Design logical component structure, services, dependencies | aidlc-systems-architect-agent |
+| units-generation | Decompose application design into implementable units of work | aidlc-systems-architect-agent |
+
+### Construction Phase (per-unit)
+
+| Stage | Purpose | Owner |
+|---|---|---|
+| functional-design | Design detailed business logic, domain entities, rules, and API spec | aidlc-systems-architect-agent |
+| nfr-requirements | Determine non-functional requirements and tech stack | aidlc-systems-architect-agent |
+| nfr-design | Incorporate NFR patterns and logical components | aidlc-systems-architect-agent |
+| infrastructure-design | Map to actual infrastructure services | aidlc-systems-architect-agent |
+| code-generation | Generate production code in layers | aidlc-sw-dev-engineer-agent |
+| build-and-test | Build, test, and verify the code | aidlc-sw-dev-engineer-agent |
+
+### Operations Phase
+
+| Stage | Purpose | Owner |
+|---|---|---|
+| (future) | Deployment, monitoring, maintenance | (tbd) |
 
 ## Source Structure
 
@@ -27,68 +56,186 @@ src/
 │   ├── stage-graph.md               ← dependency graph of all stages
 │   ├── requirements-analysis/
 │   │   ├── definition.md            ← inputs, outputs, owner, contributors
-│   │   └── templates/requirements.md
-│   ├── story-generation/
-│   │   ├── definition.md
-│   │   └── templates/stories.md, personas.md
-│   ├── wireframe-design/
-│   │   ├── definition.md
-│   │   └── templates/screen-data-map.md, screen-structure.md, wireframe-guidance.md
-│   ├── workspace-setup/
-│   │   ├── definition.md
-│   │   └── templates/intent.md, state.json, audit.json
-│   └── workflow-composition/
+│   │   └── templates/               ← output artifact templates
+│   └── <stage-name>/
 │       ├── definition.md
-│       └── templates/workflow.json
+│       └── templates/
 ├── personas/                        ← agent definitions (YAML)
-│   ├── product-owner.yaml
-│   ├── security-engineer.yaml
-│   └── solutions-architect.yaml
-├── skills/                          ← domain skills (SKILL.md per agentskills.io spec)
-│   ├── orchestration/SKILL.md       ← main agent skill (workflow composition + execution)
-│   ├── requirements-analysis/SKILL.md
-│   ├── security-thinking/SKILL.md
-│   ├── system-thinking/SKILL.md
-│   ├── user-empathy/SKILL.md
-│   └── generic/                     ← auto-included in all personas during build
-│       └── work-method/SKILL.md     ← how every persona works (steps, persistence, conventions)
+│   ├── aidlc-product-manager-agent.yaml
+│   ├── aidlc-systems-architect-agent.yaml
+│   ├── aidlc-security-architect-agent.yaml
+│   ├── aidlc-ux-designer-agent.yaml
+│   ├── aidlc-architecture-reviewer-agent.yaml
+│   └── aidlc-sw-quality-reviewer.yaml
+├── skills/                          ← domain skills (SKILL.md)
+│   ├── common/                      ← auto-included in ALL personas at build time
+│   │   ├── aidlc-work-method/
+│   │   └── prioritization/
+│   ├── aidlc-requirements-analysis-skill/
+│   ├── aidlc-reverse-engineering-skill/
+│   ├── aidlc-domain-modeling-skill/
+│   └── <skill-name>/SKILL.md
 ├── tools/                           ← computational scripts personas use
-│   ├── process-checker.js           ← verifies outputs exist + reviews completed
-│   └── security-scan.js             ← wraps SAST scanners (future use)
 ├── conventions/                     ← schemas and format definitions
-│   ├── folder-structure.md          ← runtime directory layout for intents
-│   ├── state-schema.json            ← progress tracking format
-│   ├── audit-schema.json            ← human decision log format
-│   ├── workflow-schema.json         ← composed workflow format
-│   └── question-format.md           ← clarification question format
 └── target-config/                   ← target-specific source files
-    ├── kiro-ide/hooks/              ← Kiro-specific hooks
-    └── claude-code/.keep            ← future
+    └── kiro-ide/hooks/
 ```
 
 ## How It Works
 
 1. Human states an intent ("build a library app")
 2. The orchestrator composes an adaptive workflow (selects stages, assigns personas)
-3. For each stage: owner persona plans, clarifies, produces artifacts; contributors review; owner refines; human approves
-4. The process checker verifies outputs exist and reviews completed
-5. Artifacts accumulate in `org-ai-kb/aidlc-docs/intent-<nnn>-<slug>/`
+3. For each stage: owner persona plans, clarifies, produces artifacts; contributors review from their lens; owner refines; reviewer validates
+4. Owner and reviewer cycle until reviewer says "ready" (max 3 iterations, configurable). If cap is reached, human becomes the quality gate
+5. Human approves or requests changes
+6. Artifacts accumulate in `org-ai-kb/aidlc-docs/intent-<nnn>-<slug>/`
 
 ## Usage
 
 State your intent naturally in chat. The orchestrator activates and proposes a workflow:
 
-- "Build a library management app with admin and member roles" → full workflow (requirements → stories → wireframes)
+- "Build a multi-tenant SaaS platform for leave management" → full workflow
 - "We only want wireframes for a library app" → minimal workflow (wireframes only)
 - "Fix the overdue notification bug" → lightweight workflow (code-generation → build-and-test)
 
-The orchestrator right-sizes the workflow to your intent. You approve before it starts, and you can adjust mid-flight ("add security-engineer as reviewer").
+The orchestrator right-sizes the workflow to your intent. You approve before it starts, and you can adjust mid-flight.
+
+## Customization
+
+AI-DLC is designed to be extended. You can add your own stages, personas, and skills, or modify existing ones to match your team's process.
+
+### Add a Custom Stage
+
+Create a new directory under `src/stages/`:
+
+```
+src/stages/my-custom-stage/
+├── definition.md
+└── templates/
+    └── my-output.md
+```
+
+**definition.md** follows this format:
+
+```markdown
+# My Custom Stage
+
+## Description
+[What this stage does]
+
+## Inputs
+- **Required:** [what must exist before this stage runs]
+- **Optional context:** [what helps but isn't mandatory]
+
+## Outputs
+Artifacts this stage can produce. The owner's plan determines which are relevant.
+- `my-output.md` — [description]
+
+## Owner
+aidlc-systems-architect-agent
+
+## Contributors
+- aidlc-security-architect-agent: [optional brief — what lens to apply]
+
+## Reviewer
+aidlc-architecture-reviewer-agent
+```
+
+Then add your stage to `src/stages/stage-graph.md` in both the stages table and the dependencies table.
+
+### Add a Custom Persona
+
+Create a YAML file under `src/personas/`:
+
+```yaml
+name: aidlc-my-custom-agent
+
+description: >
+  [One paragraph describing who this persona is]
+
+behaviour: |
+  [How this persona thinks and acts — principles, focus areas, traits]
+
+associated-skills:
+  - aidlc-my-skill
+  - aidlc-another-skill
+
+stages-owned:
+  - my-custom-stage
+
+contributor-at:
+  - requirements-analysis
+
+reviewer-at: []
+```
+
+Common skills (everything under `src/skills/common/`) are automatically included at build time — you don't need to list them.
+
+### Add a Custom Skill
+
+Create a directory under `src/skills/`:
+
+```
+src/skills/aidlc-my-custom-skill/
+└── SKILL.md
+```
+
+**SKILL.md** follows this format:
+
+```markdown
+---
+name: aidlc-my-custom-skill
+description: |
+  [What this skill enables]
+---
+
+# My Custom Skill
+
+## Purpose
+[What capability this provides]
+
+## Principles
+- [How to think when applying this skill]
+
+## Approach
+[Steps or methodology]
+
+## Application
+[How this skill manifests at different stages]
+```
+
+Then add the skill to the relevant persona's `associated-skills` list.
+
+To make a skill **common** (auto-included in all personas), place it under `src/skills/common/` instead.
+
+### Change Contributors, Owners, or Reviewers
+
+Edit the stage's `definition.md` directly:
+
+- **Change owner:** Replace the persona name under `## Owner`
+- **Add/remove contributors:** Edit the list under `## Contributors`
+- **Add a contribution brief:** Append a colon and description after the contributor name to focus their lens (optional — without it, they review generally)
+- **Change reviewer:** Replace the persona name under `## Reviewer`
+
+You can also override these during workflow composition — the orchestrator will ask if you want to adjust contributors and reviewers before execution begins.
+
+### Configure the Review Loop
+
+The review iteration cap is set in `workflow.json` at runtime:
+
+```json
+{
+  "maxReviewIterations": 3
+}
+```
+
+Increase for high-rigour projects, decrease for rapid prototyping. After the cap, the reviewer is bypassed and the human becomes the quality gate.
 
 ## Target Support
 
 The source is target-agnostic. Build scripts transform it for specific targets:
 
-- **Kiro IDE** — `node build/kiro-ide/build.js` → `dist/kiro-ide/.kiro/`
+- **Kiro IDE** — `npm run build` → `dist/kiro-ide/.kiro/`
 - **Claude Code** — coming soon
 
 ## Getting Started
@@ -101,17 +248,23 @@ The source is target-agnostic. Build scripts transform it for specific targets:
 ### Build and Install (Kiro)
 
 ```bash
-node build/kiro-ide/build.js
+npm run build
 cp -R dist/kiro-ide/.kiro /path/to/your/project/
 ```
+
+## Naming Convention
+
+- **Agents:** `aidlc-<role>-agent` (e.g. `aidlc-systems-architect-agent`)
+- **Skills:** `aidlc-<skill-name>-skill` (e.g. `aidlc-reverse-engineering-skill`)
+- **Common skills** live under `src/skills/common/` and are auto-injected into all agents at build time
 
 ## Contributing
 
 - Edit `src/` only — never hand-edit `dist/`
-- Rebuild with `node build/kiro-ide/build.js` after changes
+- Rebuild with `npm run build` after changes
 - Stages are self-contained folders — add a new stage by creating `stages/<name>/definition.md` + `templates/`
 - Personas are YAML — add a new persona by creating `personas/<name>.yaml`
-- Skills follow the [agentskills.io specification](https://agentskills.io/specification)
+- Skills follow the frontmatter + markdown format shown above
 
 ## License
 

--- a/dist/kiro-ide/.kiro/conventions/folder-structure.md
+++ b/dist/kiro-ide/.kiro/conventions/folder-structure.md
@@ -18,28 +18,35 @@ The runtime folder structure for an intent execution. Created by the workspace-s
         │   └── audit.json               participation log (machine-parseable, append-only)
         │
         └── stages/
-            ├── requirements-analysis/
-            │   ├── requirements.md
-            │   └── questions.md
-            ├── story-generation/
-            │   ├── stories.md
-            │   ├── personas.md
-            │   └── questions.md
-            ├── wireframe-design/
-            │   ├── screen-data-map.md
-            │   ├── screen-structure.md
-            │   ├── wireframe-guidance.md
-            │   └── questions.md
-            └── <stage-name>/
-                ├── <output-artifacts>
-                └── questions.md
+            ├── inception/
+            │   ├── reverse-engineering/
+            │   ├── requirements-analysis/
+            │   ├── story-generation/
+            │   ├── wireframe-design/
+            │   ├── application-design/
+            │   └── units-generation/
+            │
+            ├── construction/
+            │   ├── <unit-name>/
+            │   │   ├── functional-design/
+            │   │   ├── nfr-requirements/
+            │   │   ├── nfr-design/
+            │   │   ├── infrastructure-design/
+            │   │   └── code-generation/
+            │   └── build-and-test/
+            │
+            └── operations/
+                └── (future stages)
 ```
 
 ## Rules
 
-1. Each stage gets its own subdirectory under `stages/`.
-2. Output artifacts live in the stage's directory.
-3. Questions asked during clarification are recorded in `questions.md` within the stage directory.
-4. `state.json` and `audit.json` are machine-parseable — see their respective schemas in `conventions/`.
-5. `workflow.json` records the composed workflow for this intent — see `workflow-schema.json`.
-6. The workspace-setup stage creates this entire structure. No other stage creates directories.
+1. Stages are grouped by phase: `inception/`, `construction/`, `operations/`.
+2. Each stage gets its own subdirectory under its phase.
+3. Construction stages are scoped per-unit: `construction/<unit-name>/<stage-name>/`.
+4. `build-and-test` sits at the construction level (not per-unit) — it runs after all units.
+5. Output artifacts live in the stage's directory.
+6. Questions asked during clarification are recorded in `questions.md` within the stage directory.
+7. `state.json` and `audit.json` are machine-parseable — see their respective schemas in `conventions/`.
+8. `workflow.json` records the composed workflow for this intent — see `workflow-schema.json`.
+9. The workspace-setup stage creates the phase directories. Per-unit directories are created when units-generation completes.

--- a/dist/kiro-ide/.kiro/skills/workflow-composition/SKILL.md
+++ b/dist/kiro-ide/.kiro/skills/workflow-composition/SKILL.md
@@ -17,7 +17,13 @@ Compose the adaptive workflow for this intent. This is a conversation, not a for
 5. **Identify what's implied** — greenfield or brownfield? Simple or complex? What stages are obviously needed, what can be skipped?
 5. **Ask only what you can't infer** — don't ask 10 questions. Ask the 1-2 that actually affect the workflow (beyond the integration scan).
 6. **Propose the workflow** — present as a table with columns: #, Stage, Owner, Contributors, Reviewer. Add a brief rationale paragraph below the table. Use language like "Here's what I think we could do" and "What do you think?"
-7. **Offer contributor choice** — ask as a question: "Do you want security/architecture review on this? I'd recommend it given [reason], but your call."
+7. **Offer to adjust** — after presenting the proposal, offer context-specific options derived from the actual workflow you just proposed. Examples of what to surface (pick what's relevant, not all):
+   - If contributors are included: "Run without reviews for a faster pass"
+   - If a stage could reasonably be skipped: "Drop [stage] if you want to defer that"
+   - If a reviewer is assigned: "Skip [reviewer] if this is exploratory"
+   - If a stage is missing that might add value: "Add [stage] if you want [benefit]"
+   
+   These should be actionable suggestions based on the proposed workflow, not generic boilerplate.
 8. **Handle artifacts the human already has** — if they mention existing docs, stories, or wireframes, ask how to source them (paste, file path, MCP) or offer to generate.
 
 ## Composition principles

--- a/src/conventions/folder-structure.md
+++ b/src/conventions/folder-structure.md
@@ -18,28 +18,35 @@ The runtime folder structure for an intent execution. Created by the workspace-s
         │   └── audit.json               participation log (machine-parseable, append-only)
         │
         └── stages/
-            ├── requirements-analysis/
-            │   ├── requirements.md
-            │   └── questions.md
-            ├── story-generation/
-            │   ├── stories.md
-            │   ├── personas.md
-            │   └── questions.md
-            ├── wireframe-design/
-            │   ├── screen-data-map.md
-            │   ├── screen-structure.md
-            │   ├── wireframe-guidance.md
-            │   └── questions.md
-            └── <stage-name>/
-                ├── <output-artifacts>
-                └── questions.md
+            ├── inception/
+            │   ├── reverse-engineering/
+            │   ├── requirements-analysis/
+            │   ├── story-generation/
+            │   ├── wireframe-design/
+            │   ├── application-design/
+            │   └── units-generation/
+            │
+            ├── construction/
+            │   ├── <unit-name>/
+            │   │   ├── functional-design/
+            │   │   ├── nfr-requirements/
+            │   │   ├── nfr-design/
+            │   │   ├── infrastructure-design/
+            │   │   └── code-generation/
+            │   └── build-and-test/
+            │
+            └── operations/
+                └── (future stages)
 ```
 
 ## Rules
 
-1. Each stage gets its own subdirectory under `stages/`.
-2. Output artifacts live in the stage's directory.
-3. Questions asked during clarification are recorded in `questions.md` within the stage directory.
-4. `state.json` and `audit.json` are machine-parseable — see their respective schemas in `conventions/`.
-5. `workflow.json` records the composed workflow for this intent — see `workflow-schema.json`.
-6. The workspace-setup stage creates this entire structure. No other stage creates directories.
+1. Stages are grouped by phase: `inception/`, `construction/`, `operations/`.
+2. Each stage gets its own subdirectory under its phase.
+3. Construction stages are scoped per-unit: `construction/<unit-name>/<stage-name>/`.
+4. `build-and-test` sits at the construction level (not per-unit) — it runs after all units.
+5. Output artifacts live in the stage's directory.
+6. Questions asked during clarification are recorded in `questions.md` within the stage directory.
+7. `state.json` and `audit.json` are machine-parseable — see their respective schemas in `conventions/`.
+8. `workflow.json` records the composed workflow for this intent — see `workflow-schema.json`.
+9. The workspace-setup stage creates the phase directories. Per-unit directories are created when units-generation completes.

--- a/src/skills/workflow-composition/SKILL.md
+++ b/src/skills/workflow-composition/SKILL.md
@@ -17,7 +17,13 @@ Compose the adaptive workflow for this intent. This is a conversation, not a for
 5. **Identify what's implied** — greenfield or brownfield? Simple or complex? What stages are obviously needed, what can be skipped?
 5. **Ask only what you can't infer** — don't ask 10 questions. Ask the 1-2 that actually affect the workflow (beyond the integration scan).
 6. **Propose the workflow** — present as a table with columns: #, Stage, Owner, Contributors, Reviewer. Add a brief rationale paragraph below the table. Use language like "Here's what I think we could do" and "What do you think?"
-7. **Offer contributor choice** — ask as a question: "Do you want security/architecture review on this? I'd recommend it given [reason], but your call."
+7. **Offer to adjust** — after presenting the proposal, offer context-specific options derived from the actual workflow you just proposed. Examples of what to surface (pick what's relevant, not all):
+   - If contributors are included: "Run without reviews for a faster pass"
+   - If a stage could reasonably be skipped: "Drop [stage] if you want to defer that"
+   - If a reviewer is assigned: "Skip [reviewer] if this is exploratory"
+   - If a stage is missing that might add value: "Add [stage] if you want [benefit]"
+   
+   These should be actionable suggestions based on the proposed workflow, not generic boilerplate.
 8. **Handle artifacts the human already has** — if they mention existing docs, stories, or wireframes, ask how to source them (paste, file path, MCP) or offer to generate.
 
 ## Composition principles


### PR DESCRIPTION
- Add phase hierarchy (inception/construction/operations) to runtime folder structure
- Update README with current architecture, stage tables, and customization guide
- Replace hardcoded security/architecture opt-in question with context-specific adjustment options derived from the actual proposed workflow
- Fix install instructions to run cp from the project directory