### PR TITLE
Add construction phase stages (not tested)

### DIFF
--- a/dist/kiro-ide/.kiro/skills/aidlc-api-design-skill/SKILL.md
+++ b/dist/kiro-ide/.kiro/skills/aidlc-api-design-skill/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: aidlc-api-design-skill
+description: |
+  Design clear, versioned, backward-compatible contracts between units and services. Produce API specifications that are precise enough for consumers to code against without ambiguity. Applied by the Systems Architect at the functional-design stage when defining a unit's public interface.
+---
+
+# API Design
+
+## Purpose
+
+Design the public interface of a unit — its operations, data shapes, error handling, and versioning — so that consumers can build against it with confidence. The specification is the contract: precise, complete, and stable.
+
+## Principles
+
+- Consumers come first — design the API from the consumer's perspective, not the provider's implementation
+- Every operation has one clear purpose — if you can't name it in a few words, it's doing too much
+- Error responses are part of the contract — not an afterthought. Consumers need to know every way a call can fail
+- Backward compatibility by default — adding is safe, removing or changing is a breaking change
+- Idempotency where possible — especially for create and mutate operations. State the guarantee explicitly
+- Pagination, filtering, and sorting are first-class — not bolted on later when data grows
+
+## Approach
+
+### 1. Derive from contracts
+
+Start with `unit-contracts.md` — the inter-unit agreements. The API specification elaborates the provider side:
+- Each contract the unit provides becomes one or more operations
+- Payload shapes from the contract become request/response schemas
+- Error contracts become error responses
+
+### 2. Define operations
+
+For each operation:
+- What does it do? (one sentence)
+- What goes in? (request shape with types and constraints)
+- What comes out? (success response + all error responses)
+- Is it idempotent? (can you call it twice safely?)
+- What auth is needed?
+
+### 3. Handle the edges
+
+- What happens with invalid input? (validation error shape)
+- What happens when the resource doesn't exist?
+- What happens at scale? (pagination, rate limiting)
+- What happens during partial failure? (timeout, retry semantics)
+
+### 4. Version consciously
+
+- State the versioning strategy (URL path, header, content negotiation)
+- Define what constitutes a breaking change in this API
+- Plan for how old consumers will be supported during transitions
+
+## Application
+
+When applied at functional-design, this skill produces the `api-specification.md` artifact — the detailed provider-side interface spec for the unit.
+
+When applied at other stages, this skill manifests as: reviewing API designs for consumer-friendliness, checking backward compatibility of proposed changes, and flagging ambiguous or inconsistent interface definitions.

--- a/dist/kiro-ide/.kiro/skills/aidlc-full-stack-development-skill/SKILL.md
+++ b/dist/kiro-ide/.kiro/skills/aidlc-full-stack-development-skill/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: aidlc-full-stack-development-skill
+description: |
+  The ability to write production code across the full stack — backend, frontend, infrastructure, tests — following a disciplined write-test-verify cycle. Applied by the SW Dev Engineer at the code-generation stage.
+---
+
+# Full Stack Development
+
+## Purpose
+
+Write production-quality code that works. Not just code that looks right — code that compiles, passes tests, and handles edge cases before moving on.
+
+## Principles
+
+- Working code at every step — never leave a broken build behind you
+- Tests are not an afterthought — write them alongside the production code, not after
+- One concern at a time — scaffold first, then domain logic, then integration, then polish
+- Brownfield respect — match existing patterns, styles, and conventions. Don't introduce a new paradigm next to the old one
+- Fail fast — if a step doesn't compile or tests don't pass, fix it before moving on
+
+## Approach
+
+### Write-Test-Verify Cycle
+
+Every plan step follows this rhythm:
+
+1. **Write** — produce the production code for this step
+2. **Test** — write corresponding tests (unit, integration as appropriate)
+3. **Verify** — run build + tests. Green means proceed. Red means fix before continuing.
+
+### Typical plan structure
+
+1. **Project setup** — scaffold structure, install dependencies, verify clean build
+2. **Domain layer** — entities, business rules, core logic + unit tests → verify
+3. **Service/application layer** — orchestration, use cases + tests → verify
+4. **API/interface layer** — controllers, handlers, routes + tests → verify
+5. **Integration** — wire layers together, integration tests → verify
+6. **Infrastructure glue** — config, migrations, deployment files → verify full build
+
+Adapt the layers to the tech stack. Not every project has all of these.
+
+### Brownfield rules
+
+- Check if target files exist before creating
+- Modify in place — never create `ClassName_new` or `ClassName_modified` copies
+- Follow existing naming conventions, directory structure, and patterns
+- Read existing tests to match style (assertion library, test structure, mocking patterns)
+
+## Application
+
+When applied at code-generation, this skill drives the plan structure and the step-by-step execution. Each step in the plan is a write-test-verify cycle.
+
+When applied at build-and-test, this skill manifests as: understanding how to run the build, interpret test output, diagnose failures, and fix them.

--- a/dist/kiro-ide/.kiro/stages/code-generation/definition.md
+++ b/dist/kiro-ide/.kiro/stages/code-generation/definition.md
@@ -19,20 +19,6 @@ Artifacts this stage can produce. The owner's plan determines which are relevant
 - Database migration scripts (if applicable)
 - API documentation generated from code (if applicable)
 
-## Execution Method
-
-The plan for this stage follows a write-test-verify cycle:
-
-1. **Project setup** — scaffold the project structure, install dependencies, verify it builds clean
-2. **Per-layer or per-feature** — for each piece of functionality:
-   - Write the production code
-   - Write the corresponding tests
-   - Run build + tests — confirm green before proceeding
-3. **Integration wiring** — connect layers, verify end-to-end flow compiles and passes
-4. **Final verification** — full build, all tests pass, no regressions
-
-Each plan step must end with a verified state. Do not proceed to the next step with a broken build.
-
 ## Owner
 
 aidlc-sw-dev-engineer-agent

--- a/dist/kiro-ide/.kiro/stages/code-generation/definition.md
+++ b/dist/kiro-ide/.kiro/stages/code-generation/definition.md
@@ -1,3 +1,47 @@
-# code-generation
+# Code Generation
 
-Placeholder — not yet implemented.
+## Description
+
+Generate production code for a single unit following the rhythm of a real developer: write code, write tests, verify it compiles and passes before moving to the next layer. Each step in the plan produces working, verified code — not a batch dump at the end.
+
+## Inputs
+
+- **Required:** functional-design artifacts for this unit (business-logic, domain-entities, business-rules, api-specification)
+- **Optional context:** nfr-design artifacts (patterns, logical components), infrastructure-design (service mapping, deployment), tech-stack-decisions, unit-contracts, RE code-structure (brownfield — existing patterns to follow)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- Production source code at the workspace root (never in aidlc-docs/)
+- Test code alongside production code
+- Configuration files (env, build, deploy)
+- Database migration scripts (if applicable)
+- API documentation generated from code (if applicable)
+
+## Execution Method
+
+The plan for this stage follows a write-test-verify cycle:
+
+1. **Project setup** — scaffold the project structure, install dependencies, verify it builds clean
+2. **Per-layer or per-feature** — for each piece of functionality:
+   - Write the production code
+   - Write the corresponding tests
+   - Run build + tests — confirm green before proceeding
+3. **Integration wiring** — connect layers, verify end-to-end flow compiles and passes
+4. **Final verification** — full build, all tests pass, no regressions
+
+Each plan step must end with a verified state. Do not proceed to the next step with a broken build.
+
+## Owner
+
+aidlc-sw-dev-engineer-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate secure coding patterns, input validation, secrets handling
+- aidlc-systems-architect-agent: validate code aligns with design artifacts
+
+## Reviewer
+
+aidlc-code-reviewer-agent

--- a/dist/kiro-ide/.kiro/stages/code-generation/definition.md
+++ b/dist/kiro-ide/.kiro/stages/code-generation/definition.md
@@ -2,16 +2,16 @@
 
 ## Description
 
-Generate production code for a single unit following the rhythm of a real developer: write code, write tests, verify it compiles and passes before moving to the next layer. Each step in the plan produces working, verified code — not a batch dump at the end.
+Generate production code following the rhythm of a real developer: write code, write tests, verify it compiles and passes before moving to the next layer. Each step in the plan produces working, verified code — not a batch dump at the end.
 
 ## Inputs
 
-- **Required:** functional-design artifacts for this unit (business-logic, domain-entities, business-rules, api-specification)
+- **Required:** functional-design artifacts (business-logic, domain-entities, business-rules, api-specification)
 - **Optional context:** nfr-design artifacts (patterns, logical components), infrastructure-design (service mapping, deployment), tech-stack-decisions, unit-contracts, RE code-structure (brownfield — existing patterns to follow)
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
 - Production source code at the workspace root (never in aidlc-docs/)
 - Test code alongside production code

--- a/dist/kiro-ide/.kiro/stages/functional-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/functional-design/definition.md
@@ -1,0 +1,32 @@
+# Functional Design
+
+## Description
+
+Design the detailed business logic for a single unit of work — its domain entities, business rules, algorithms, data flows, and public API specification. This is technology-agnostic: it describes *what the logic does*, not what infrastructure runs it. Each unit gets its own functional-design pass. The API specification elaborates on this unit's provider-side contracts from `unit-contracts.md`.
+
+## Inputs
+
+- **Required:** Unit definition from `units.md` + stories assigned to this unit from `unit-story-map.md`
+- **Optional context:** `unit-contracts.md` (for contracts this unit provides), `components.md`, `requirements.md`, RE artifacts
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `business-logic.md` — algorithms, workflows, state machines, decision trees describing how the unit processes inputs to produce outputs
+- `domain-entities.md` — entities, value objects, aggregates owned by this unit with their fields, invariants, and lifecycle
+- `business-rules.md` — validation rules, constraints, policies expressed as logic
+- `api-specification.md` — the unit's public interface: endpoints, operations, request/response shapes, error codes, fulfilling this unit's provider-side contracts
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent
+- aidlc-product-manager-agent
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/dist/kiro-ide/.kiro/stages/functional-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/functional-design/definition.md
@@ -2,21 +2,21 @@
 
 ## Description
 
-Design the detailed business logic for a single unit of work — its domain entities, business rules, algorithms, data flows, and public API specification. This is technology-agnostic: it describes *what the logic does*, not what infrastructure runs it. Each unit gets its own functional-design pass. The API specification elaborates on this unit's provider-side contracts from `unit-contracts.md`.
+Design the detailed business logic — domain entities, business rules, algorithms, data flows, and public API specification. Technology-agnostic: describes *what the logic does*, not what infrastructure runs it. The API specification elaborates on provider-side contracts from `unit-contracts.md`.
 
 ## Inputs
 
-- **Required:** Unit definition from `units.md` + stories assigned to this unit from `unit-story-map.md`
-- **Optional context:** `unit-contracts.md` (for contracts this unit provides), `components.md`, `requirements.md`, RE artifacts
+- **Required:** Unit definition from `units.md` + assigned stories from `unit-story-map.md`
+- **Optional context:** `unit-contracts.md` (provider-side contracts), `components.md`, `requirements.md`, RE artifacts
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
-- `business-logic.md` — algorithms, workflows, state machines, decision trees describing how the unit processes inputs to produce outputs
-- `domain-entities.md` — entities, value objects, aggregates owned by this unit with their fields, invariants, and lifecycle
+- `business-logic.md` — algorithms, workflows, state machines, decision trees
+- `domain-entities.md` — entities, value objects, aggregates with fields, invariants, and lifecycle
 - `business-rules.md` — validation rules, constraints, policies expressed as logic
-- `api-specification.md` — the unit's public interface: endpoints, operations, request/response shapes, error codes, fulfilling this unit's provider-side contracts
+- `api-specification.md` — public interface: endpoints, operations, request/response shapes, error codes
 
 ## Owner
 

--- a/dist/kiro-ide/.kiro/stages/functional-design/templates/api-specification.md
+++ b/dist/kiro-ide/.kiro/stages/functional-design/templates/api-specification.md
@@ -1,0 +1,57 @@
+# API Specification
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> This elaborates on this unit's provider-side contracts defined in unit-contracts.md.
+
+## API Overview
+
+- **Unit:** [unit name]
+- **Base path / topic prefix:** [e.g. /api/v1/leaves, events.leave.*]
+- **Auth mechanism:** [how consumers authenticate]
+- **Contracts fulfilled:** [C-1, C-3 from unit-contracts.md]
+
+## Operations
+
+### [Operation Name — e.g. "Create leave request"]
+
+| Field | Value |
+|---|---|
+| Method / Trigger | [POST / event / message / etc.] |
+| Path / Topic | [/leaves, leave.requested, etc.] |
+| Purpose | [what it does] |
+| Idempotent | [yes/no] |
+
+**Request:**
+
+```
+{
+  // request/message shape with field types and constraints
+}
+```
+
+**Response (success):**
+
+```
+{
+  // response shape
+}
+```
+
+**Error responses:**
+
+| Status/Code | Condition | Body |
+|---|---|---|
+| [4xx/error code] | [when this happens] | [error shape] |
+
+**Validation rules:**
+- [field-level and request-level validations applied]
+
+---
+
+## Pagination / Filtering
+
+[If applicable — describe how list endpoints handle pagination, sorting, filtering]
+
+## Versioning
+
+[How this API is versioned — URL path, header, content negotiation — per the versioning strategy in unit-contracts.md]

--- a/dist/kiro-ide/.kiro/stages/functional-design/templates/business-logic.md
+++ b/dist/kiro-ide/.kiro/stages/functional-design/templates/business-logic.md
@@ -1,0 +1,55 @@
+# Business Logic
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit Purpose
+
+[Single paragraph: what this unit does from a business perspective]
+
+## Workflows
+
+Document the key business workflows this unit implements. Each workflow is a sequence of steps that transforms inputs into outcomes.
+
+### [Workflow Name — e.g. "Submit leave request"]
+
+- **Trigger:** [what initiates this workflow]
+- **Inputs:** [what data enters]
+- **Steps:**
+  1. [step description — what logic is applied]
+  2. [next step]
+- **Outputs:** [what the workflow produces]
+- **Side effects:** [what state changes, events emitted, notifications triggered]
+
+## State Machines
+
+For entities with lifecycle states, document the transitions:
+
+### [Entity] States
+
+| Current state | Event/Action | Next state | Guard condition |
+|---|---|---|---|
+| [state] | [what triggers transition] | [state] | [condition that must be true] |
+
+## Decision Logic
+
+For complex branching decisions, document the rules:
+
+### [Decision Name]
+
+| Condition | Outcome |
+|---|---|
+| [if this is true] | [then this happens] |
+| [else if this] | [then this] |
+| [default] | [fallback behaviour] |
+
+## Algorithms
+
+For non-trivial computations (scoring, matching, scheduling, etc.):
+
+### [Algorithm Name]
+
+- **Purpose:** [what it computes]
+- **Inputs:** [what it needs]
+- **Logic:** [describe the algorithm in plain language or pseudocode]
+- **Outputs:** [what it returns]
+- **Edge cases:** [what happens with empty inputs, boundary values, etc.]

--- a/dist/kiro-ide/.kiro/stages/functional-design/templates/business-rules.md
+++ b/dist/kiro-ide/.kiro/stages/functional-design/templates/business-rules.md
@@ -1,0 +1,31 @@
+# Business Rules
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Rules Inventory
+
+| ID | Rule | Category | Applies to | Source |
+|---|---|---|---|---|
+| BR-1 | [short description] | [validation / authorization / calculation / constraint / policy] | [which entity or workflow] | [requirement or story ID] |
+
+## Rule Details
+
+### BR-1: [Rule Name]
+
+- **Category:** [validation / authorization / calculation / constraint / policy]
+- **Statement:** [precise statement of what the rule enforces]
+- **When applied:** [at what point in which workflow]
+- **Inputs:** [what data the rule evaluates]
+- **Logic:**
+  - IF [condition] THEN [outcome]
+  - ELSE [alternative outcome]
+- **Violation behaviour:** [what happens when the rule is broken — reject, warn, default, escalate]
+- **Source:** [FR-n or S-n that requires this rule]
+
+## Cross-cutting Rules
+
+Rules that apply across multiple workflows or entities:
+
+| Rule | Scope | Description |
+|---|---|---|
+| [name] | [where it applies] | [what it enforces everywhere] |

--- a/dist/kiro-ide/.kiro/stages/functional-design/templates/domain-entities.md
+++ b/dist/kiro-ide/.kiro/stages/functional-design/templates/domain-entities.md
@@ -1,0 +1,30 @@
+# Domain Entities
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Entity Inventory
+
+| Entity | Type | Aggregate root? | Lifecycle |
+|---|---|---|---|
+| [name] | [entity / value object / aggregate] | [yes/no] | [states it passes through] |
+
+## Entity Details
+
+### [Entity Name]
+
+- **Purpose:** [why this entity exists in the domain]
+- **Fields:**
+
+| Field | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| [name] | [logical type] | [yes/no] | [validation rules] | [what it represents] |
+
+- **Invariants:** [rules that must always be true for this entity]
+  - [e.g. "balance must never be negative"]
+  - [e.g. "start date must be before end date"]
+- **Lifecycle:** [how it's created, modified, archived/deleted]
+- **Relationships:**
+
+| Related to | Cardinality | Direction | Description |
+|---|---|---|---|
+| [other entity] | [1:1 / 1:N / N:M] | [owns / references / associated] | [nature of relationship] |

--- a/dist/kiro-ide/.kiro/stages/infrastructure-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/infrastructure-design/definition.md
@@ -1,0 +1,29 @@
+# Infrastructure Design
+
+## Description
+
+Map logical components from nfr-design to actual infrastructure services and define the deployment architecture for this unit.
+
+## Inputs
+
+- **Required:** `logical-components.md` and `nfr-patterns.md` from nfr-design, `tech-stack-decisions.md` from nfr-assessment
+- **Optional context:** RE artifacts (existing infrastructure), deployment constraints
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `service-mapping.md` — logical components mapped to concrete infrastructure services
+- `deployment-architecture.md` — how the unit is deployed, scaled, and networked
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate network boundaries, access controls, secrets management
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/dist/kiro-ide/.kiro/stages/infrastructure-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/infrastructure-design/definition.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Map logical components from nfr-design to actual infrastructure services and define the deployment architecture for this unit.
+Map logical components from nfr-design to actual infrastructure services and define the deployment architecture.
 
 ## Inputs
 
@@ -11,10 +11,10 @@ Map logical components from nfr-design to actual infrastructure services and def
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
 - `service-mapping.md` — logical components mapped to concrete infrastructure services
-- `deployment-architecture.md` — how the unit is deployed, scaled, and networked
+- `deployment-architecture.md` — how the system is deployed, scaled, and networked
 
 ## Owner
 

--- a/dist/kiro-ide/.kiro/stages/infrastructure-design/templates/deployment-architecture.md
+++ b/dist/kiro-ide/.kiro/stages/infrastructure-design/templates/deployment-architecture.md
@@ -1,0 +1,31 @@
+# Deployment Architecture
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Compute
+
+| Component | Compute type | Sizing | Scaling trigger |
+|---|---|---|---|
+| [component] | [Lambda/ECS/EC2/Fargate/etc.] | [memory, CPU, concurrency] | [what triggers scale] |
+
+## Networking
+
+| Element | Configuration |
+|---|---|
+| VPC / Subnet | [placement] |
+| Load balancer | [type, listeners] |
+| Security groups | [inbound/outbound rules summary] |
+| DNS | [routing] |
+
+## Deployment
+
+| Aspect | Choice |
+|---|---|
+| Strategy | [rolling / blue-green / canary] |
+| IaC tool | [CDK / Terraform / CloudFormation / other] |
+| Pipeline | [CI/CD approach] |
+| Rollback | [how to recover from bad deploy] |

--- a/dist/kiro-ide/.kiro/stages/infrastructure-design/templates/service-mapping.md
+++ b/dist/kiro-ide/.kiro/stages/infrastructure-design/templates/service-mapping.md
@@ -1,0 +1,21 @@
+# Service Mapping
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Mappings
+
+| Logical Component | Service | Provider | Rationale |
+|---|---|---|---|
+| [from logical-components.md] | [actual service — e.g. ElastiCache, SQS, CloudWatch] | [AWS/Azure/GCP/other] | [why this service for this component] |
+
+## Shared Infrastructure
+
+Services shared across units (if applicable):
+
+| Service | Shared by | Ownership | Access pattern |
+|---|---|---|---|
+| [service] | [which units] | [who manages it] | [how units access it] |

--- a/dist/kiro-ide/.kiro/stages/nfr-assessment/definition.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-assessment/definition.md
@@ -1,0 +1,29 @@
+# NFR Assessment
+
+## Description
+
+Operationalise the non-functional requirements for a single unit. The heavy NFR analysis was done during requirements-analysis (with systems-architect and security-architect contributing). This stage takes those stated NFRs and makes them concrete for this unit: measurable targets, tech stack choices, and quality attribute trade-offs. Minimal by design — it refines what exists, not re-discovers.
+
+## Inputs
+
+- **Required:** `requirements.md` (NFR section — already has architect and security input), functional-design artifacts for this unit
+- **Optional context:** `unit-contracts.md` (integration patterns affect performance/reliability targets), RE artifacts (existing tech stack constraints)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `nfr-targets.md` — measurable targets per quality attribute (latency, throughput, availability, recovery) specific to this unit
+- `tech-stack-decisions.md` — technology choices for this unit with rationale tied to NFR targets
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate security NFR targets are sufficient and tech choices don't introduce vulnerabilities
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/dist/kiro-ide/.kiro/stages/nfr-assessment/definition.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-assessment/definition.md
@@ -2,19 +2,19 @@
 
 ## Description
 
-Operationalise the non-functional requirements for a single unit. The heavy NFR analysis was done during requirements-analysis (with systems-architect and security-architect contributing). This stage takes those stated NFRs and makes them concrete for this unit: measurable targets, tech stack choices, and quality attribute trade-offs. Minimal by design — it refines what exists, not re-discovers.
+Operationalise the non-functional requirements into measurable targets, tech stack choices, and quality attribute trade-offs. The heavy NFR analysis was done during requirements-analysis (with systems-architect and security-architect contributing). This stage refines what exists, not re-discovers.
 
 ## Inputs
 
-- **Required:** `requirements.md` (NFR section — already has architect and security input), functional-design artifacts for this unit
+- **Required:** `requirements.md` (NFR section), functional-design artifacts
 - **Optional context:** `unit-contracts.md` (integration patterns affect performance/reliability targets), RE artifacts (existing tech stack constraints)
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
-- `nfr-targets.md` — measurable targets per quality attribute (latency, throughput, availability, recovery) specific to this unit
-- `tech-stack-decisions.md` — technology choices for this unit with rationale tied to NFR targets
+- `nfr-targets.md` — measurable targets per quality attribute (latency, throughput, availability, recovery)
+- `tech-stack-decisions.md` — technology choices with rationale tied to NFR targets
 
 ## Owner
 

--- a/dist/kiro-ide/.kiro/stages/nfr-assessment/templates/nfr-targets.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-assessment/templates/nfr-targets.md
@@ -1,0 +1,28 @@
+# NFR Targets
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> Each target traces back to an NFR in requirements.md. If a requirement is not applicable to this unit, state so.
+
+## Unit
+
+[Unit name]
+
+## Quality Attribute Targets
+
+| NFR Source | Quality Attribute | Target | Measure | Rationale |
+|---|---|---|---|---|
+| NFR-1 | [performance / availability / scalability / security / reliability / etc.] | [specific measurable target] | [how it's measured] | [why this number for this unit] |
+
+## Trade-offs
+
+Explicit trade-offs made for this unit:
+
+| Attribute A | Attribute B | Decision | Rationale |
+|---|---|---|---|
+| [e.g. consistency] | [e.g. availability] | [which was prioritised] | [why, for this unit] |
+
+## Assumptions
+
+Assumptions made when setting targets (flag for validation):
+
+- [assumption — e.g. "peak load is 10x average based on similar systems"]

--- a/dist/kiro-ide/.kiro/stages/nfr-assessment/templates/nfr-targets.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-assessment/templates/nfr-targets.md
@@ -1,7 +1,6 @@
 # NFR Targets
 
 > Minimum structure. Sections may be omitted with rationale or extended as needed.
-> Each target traces back to an NFR in requirements.md. If a requirement is not applicable to this unit, state so.
 
 ## Unit
 

--- a/dist/kiro-ide/.kiro/stages/nfr-assessment/templates/tech-stack-decisions.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-assessment/templates/tech-stack-decisions.md
@@ -1,0 +1,33 @@
+# Tech Stack Decisions
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Decisions
+
+### [Decision Area — e.g. "Runtime", "Database", "Messaging", "Auth"]
+
+| Option considered | Chosen? | Rationale |
+|---|---|---|
+| [option A] | ✓ | [why — tied to which NFR target] |
+| [option B] | ✗ | [why not — what NFR it couldn't meet] |
+
+## Stack Summary
+
+| Layer | Choice | Supports NFR |
+|---|---|---|
+| [language/runtime] | [e.g. Node.js 20] | [NFR-x: performance target] |
+| [database] | [e.g. DynamoDB] | [NFR-y: availability target] |
+| [messaging] | [e.g. SQS] | [NFR-z: reliability target] |
+| [framework] | [e.g. Fastify] | [NFR-x: latency target] |
+
+## Constraints
+
+Choices constrained by factors outside NFR targets:
+
+| Constraint | Impact on choice | Source |
+|---|---|---|
+| [e.g. org standard, existing infra, team expertise, licence] | [what it forced or ruled out] | [where constraint comes from] |

--- a/dist/kiro-ide/.kiro/stages/nfr-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-design/definition.md
@@ -1,0 +1,29 @@
+# NFR Design
+
+## Description
+
+Design the architectural patterns and logical components that satisfy the NFR targets established in nfr-assessment. This is about *how* to meet the quality attributes: resilience patterns, caching strategies, scaling mechanisms, observability instrumentation, security enforcement points. Technology-aware but not infrastructure-specific — it defines what logical capabilities are needed, not which cloud services implement them (that's infrastructure-design).
+
+## Inputs
+
+- **Required:** `nfr-targets.md` and `tech-stack-decisions.md` from nfr-assessment for this unit
+- **Optional context:** `functional-design/` artifacts (business logic shapes the patterns), `unit-contracts.md` (integration patterns affect resilience design)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `nfr-patterns.md` — architectural patterns selected to meet each NFR target (with rationale and trade-offs)
+- `logical-components.md` — non-business components the unit needs: caches, queues, circuit breakers, rate limiters, health checks, metric emitters, etc.
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate security patterns are defence-in-depth and enforcement points are complete
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/dist/kiro-ide/.kiro/stages/nfr-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-design/definition.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Design the architectural patterns and logical components that satisfy the NFR targets established in nfr-assessment. This is about *how* to meet the quality attributes: resilience patterns, caching strategies, scaling mechanisms, observability instrumentation, security enforcement points. Technology-aware but not infrastructure-specific — it defines what logical capabilities are needed, not which cloud services implement them (that's infrastructure-design).
+Design the architectural patterns and logical components that satisfy the NFR targets established in nfr-assessment. Resilience patterns, caching strategies, scaling mechanisms, observability instrumentation, security enforcement points. Defines what logical capabilities are needed, not which cloud services implement them.
 
 ## Inputs
 

--- a/dist/kiro-ide/.kiro/stages/nfr-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-design/definition.md
@@ -6,15 +6,15 @@ Design the architectural patterns and logical components that satisfy the NFR ta
 
 ## Inputs
 
-- **Required:** `nfr-targets.md` and `tech-stack-decisions.md` from nfr-assessment for this unit
-- **Optional context:** `functional-design/` artifacts (business logic shapes the patterns), `unit-contracts.md` (integration patterns affect resilience design)
+- **Required:** `nfr-targets.md` and `tech-stack-decisions.md` from nfr-assessment
+- **Optional context:** functional-design artifacts (business logic shapes the patterns), `unit-contracts.md` (integration patterns affect resilience design)
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
 - `nfr-patterns.md` — architectural patterns selected to meet each NFR target (with rationale and trade-offs)
-- `logical-components.md` — non-business components the unit needs: caches, queues, circuit breakers, rate limiters, health checks, metric emitters, etc.
+- `logical-components.md` — non-business components needed: caches, queues, circuit breakers, rate limiters, health checks, metric emitters
 
 ## Owner
 

--- a/dist/kiro-ide/.kiro/stages/nfr-design/templates/logical-components.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-design/templates/logical-components.md
@@ -1,0 +1,28 @@
+# Logical Components
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> These are non-business components the unit needs to satisfy its NFR targets. They exist alongside the domain logic but serve quality attributes, not business rules.
+
+## Unit
+
+[Unit name]
+
+## Component Inventory
+
+| Component | Type | Satisfies NFR | Integrates with |
+|---|---|---|---|
+| [e.g. request cache] | [cache / queue / circuit breaker / rate limiter / health check / metric emitter / retry handler / etc.] | [NFR-x] | [which business component uses it] |
+
+## Component Details
+
+### [Component Name]
+
+- **Type:** [what kind of infrastructure-adjacent component]
+- **Purpose:** [what quality attribute it serves and how]
+- **Behaviour:**
+  - [how it operates in the happy path]
+  - [how it operates under failure]
+  - [how it recovers]
+- **Configuration:** [key knobs — TTL, max retries, thresholds, window sizes]
+- **Observability:** [what metrics/logs this component emits for monitoring]
+- **Dependencies:** [what it needs to function — connection to a cache store, access to a queue, etc. Actual service selection happens in infrastructure-design]

--- a/dist/kiro-ide/.kiro/stages/nfr-design/templates/logical-components.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-design/templates/logical-components.md
@@ -1,7 +1,6 @@
 # Logical Components
 
 > Minimum structure. Sections may be omitted with rationale or extended as needed.
-> These are non-business components the unit needs to satisfy its NFR targets. They exist alongside the domain logic but serve quality attributes, not business rules.
 
 ## Unit
 
@@ -25,4 +24,4 @@
   - [how it recovers]
 - **Configuration:** [key knobs — TTL, max retries, thresholds, window sizes]
 - **Observability:** [what metrics/logs this component emits for monitoring]
-- **Dependencies:** [what it needs to function — connection to a cache store, access to a queue, etc. Actual service selection happens in infrastructure-design]
+- **Dependencies:** [what it needs to function]

--- a/dist/kiro-ide/.kiro/stages/nfr-design/templates/nfr-patterns.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-design/templates/nfr-patterns.md
@@ -1,0 +1,36 @@
+# NFR Patterns
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Patterns Applied
+
+### [Pattern Name — e.g. "Circuit Breaker", "Write-Behind Cache", "Rate Limiting"]
+
+| Field | Value |
+|---|---|
+| Satisfies NFR | [NFR-x from nfr-targets.md] |
+| Quality attribute | [resilience / performance / scalability / security / observability] |
+| Where applied | [which component/interaction in this unit] |
+| How it works | [brief description of the pattern's behaviour in this context] |
+| Trade-off | [what you give up by using this pattern — complexity, latency, cost, etc.] |
+| Failure mode | [what happens if this pattern itself fails or is misconfigured] |
+
+## Pattern Interactions
+
+Document how patterns interact or depend on each other:
+
+| Pattern A | Pattern B | Interaction |
+|---|---|---|
+| [e.g. circuit breaker] | [e.g. retry] | [e.g. retries must respect circuit state — don't retry when open] |
+
+## Gaps
+
+NFR targets not yet addressed by a pattern (should be empty if design is complete):
+
+| NFR Target | Gap | Resolution path |
+|---|---|---|
+| [target] | [what's not covered] | [what's needed — deferred to infra-design? needs further analysis?] |

--- a/dist/kiro-ide/.kiro/stages/nfr-design/templates/nfr-patterns.md
+++ b/dist/kiro-ide/.kiro/stages/nfr-design/templates/nfr-patterns.md
@@ -29,8 +29,6 @@ Document how patterns interact or depend on each other:
 
 ## Gaps
 
-NFR targets not yet addressed by a pattern (should be empty if design is complete):
-
 | NFR Target | Gap | Resolution path |
 |---|---|---|
-| [target] | [what's not covered] | [what's needed — deferred to infra-design? needs further analysis?] |
+| [target] | [what's not covered] | [what's needed] |

--- a/dist/kiro-ide/.kiro/stages/stage-graph.md
+++ b/dist/kiro-ide/.kiro/stages/stage-graph.md
@@ -22,6 +22,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | application-design | Design logical component structure, services, dependencies | aidlc-systems-architect-agent |
 | units-generation | Decompose application design into implementable units of work | aidlc-systems-architect-agent |
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
+| nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -38,7 +39,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | application-design | requirements, stories, wireframes, RE artifacts |
 | units-generation | application-design (components + interactions must be known) |
 | functional-design | units-generation (unit definition + assigned stories + contracts) |
-| code-generation | functional-design, units-generation, application-design, stories, requirements |
+| nfr-assessment | requirements.md (NFR section), functional-design artifacts for this unit |
+| code-generation | functional-design, nfr-assessment, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules

--- a/dist/kiro-ide/.kiro/stages/stage-graph.md
+++ b/dist/kiro-ide/.kiro/stages/stage-graph.md
@@ -21,6 +21,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | wireframe-design | Design UI screens as HTML wireframes | aidlc-ux-designer-agent |
 | application-design | Design logical component structure, services, dependencies | aidlc-systems-architect-agent |
 | units-generation | Decompose application design into implementable units of work | aidlc-systems-architect-agent |
+| functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -36,7 +37,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | wireframe-design | stories + personas, requirements, intent |
 | application-design | requirements, stories, wireframes, RE artifacts |
 | units-generation | application-design (components + interactions must be known) |
-| code-generation | units-generation, application-design, stories, requirements |
+| functional-design | units-generation (unit definition + assigned stories + contracts) |
+| code-generation | functional-design, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules

--- a/dist/kiro-ide/.kiro/stages/stage-graph.md
+++ b/dist/kiro-ide/.kiro/stages/stage-graph.md
@@ -25,7 +25,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
 | nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
 | infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
-| code-generation | Generate production code in layers | (tbd) |
+| code-generation | Generate production code per unit with write-test-verify cycles | aidlc-sw-dev-engineer-agent |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
 ## Dependencies

--- a/dist/kiro-ide/.kiro/stages/stage-graph.md
+++ b/dist/kiro-ide/.kiro/stages/stage-graph.md
@@ -24,6 +24,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
 | nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
+| infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -42,7 +43,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | functional-design | units-generation (unit definition + assigned stories + contracts) |
 | nfr-assessment | requirements.md (NFR section), functional-design artifacts for this unit |
 | nfr-design | nfr-assessment (targets + tech stack), functional-design artifacts, unit-contracts |
-| code-generation | functional-design, nfr-assessment, nfr-design, units-generation, application-design, stories, requirements |
+| infrastructure-design | nfr-design (logical components + patterns), tech-stack-decisions |
+| code-generation | functional-design, nfr-assessment, nfr-design, infrastructure-design, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules

--- a/dist/kiro-ide/.kiro/stages/stage-graph.md
+++ b/dist/kiro-ide/.kiro/stages/stage-graph.md
@@ -23,6 +23,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | units-generation | Decompose application design into implementable units of work | aidlc-systems-architect-agent |
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
+| nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -40,7 +41,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | units-generation | application-design (components + interactions must be known) |
 | functional-design | units-generation (unit definition + assigned stories + contracts) |
 | nfr-assessment | requirements.md (NFR section), functional-design artifacts for this unit |
-| code-generation | functional-design, nfr-assessment, units-generation, application-design, stories, requirements |
+| nfr-design | nfr-assessment (targets + tech stack), functional-design artifacts, unit-contracts |
+| code-generation | functional-design, nfr-assessment, nfr-design, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules

--- a/src/skills/aidlc-api-design-skill/SKILL.md
+++ b/src/skills/aidlc-api-design-skill/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: aidlc-api-design-skill
+description: |
+  Design clear, versioned, backward-compatible contracts between units and services. Produce API specifications that are precise enough for consumers to code against without ambiguity. Applied by the Systems Architect at the functional-design stage when defining a unit's public interface.
+---
+
+# API Design
+
+## Purpose
+
+Design the public interface of a unit — its operations, data shapes, error handling, and versioning — so that consumers can build against it with confidence. The specification is the contract: precise, complete, and stable.
+
+## Principles
+
+- Consumers come first — design the API from the consumer's perspective, not the provider's implementation
+- Every operation has one clear purpose — if you can't name it in a few words, it's doing too much
+- Error responses are part of the contract — not an afterthought. Consumers need to know every way a call can fail
+- Backward compatibility by default — adding is safe, removing or changing is a breaking change
+- Idempotency where possible — especially for create and mutate operations. State the guarantee explicitly
+- Pagination, filtering, and sorting are first-class — not bolted on later when data grows
+
+## Approach
+
+### 1. Derive from contracts
+
+Start with `unit-contracts.md` — the inter-unit agreements. The API specification elaborates the provider side:
+- Each contract the unit provides becomes one or more operations
+- Payload shapes from the contract become request/response schemas
+- Error contracts become error responses
+
+### 2. Define operations
+
+For each operation:
+- What does it do? (one sentence)
+- What goes in? (request shape with types and constraints)
+- What comes out? (success response + all error responses)
+- Is it idempotent? (can you call it twice safely?)
+- What auth is needed?
+
+### 3. Handle the edges
+
+- What happens with invalid input? (validation error shape)
+- What happens when the resource doesn't exist?
+- What happens at scale? (pagination, rate limiting)
+- What happens during partial failure? (timeout, retry semantics)
+
+### 4. Version consciously
+
+- State the versioning strategy (URL path, header, content negotiation)
+- Define what constitutes a breaking change in this API
+- Plan for how old consumers will be supported during transitions
+
+## Application
+
+When applied at functional-design, this skill produces the `api-specification.md` artifact — the detailed provider-side interface spec for the unit.
+
+When applied at other stages, this skill manifests as: reviewing API designs for consumer-friendliness, checking backward compatibility of proposed changes, and flagging ambiguous or inconsistent interface definitions.

--- a/src/skills/aidlc-full-stack-development-skill/SKILL.md
+++ b/src/skills/aidlc-full-stack-development-skill/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: aidlc-full-stack-development-skill
+description: |
+  The ability to write production code across the full stack — backend, frontend, infrastructure, tests — following a disciplined write-test-verify cycle. Applied by the SW Dev Engineer at the code-generation stage.
+---
+
+# Full Stack Development
+
+## Purpose
+
+Write production-quality code that works. Not just code that looks right — code that compiles, passes tests, and handles edge cases before moving on.
+
+## Principles
+
+- Working code at every step — never leave a broken build behind you
+- Tests are not an afterthought — write them alongside the production code, not after
+- One concern at a time — scaffold first, then domain logic, then integration, then polish
+- Brownfield respect — match existing patterns, styles, and conventions. Don't introduce a new paradigm next to the old one
+- Fail fast — if a step doesn't compile or tests don't pass, fix it before moving on
+
+## Approach
+
+### Write-Test-Verify Cycle
+
+Every plan step follows this rhythm:
+
+1. **Write** — produce the production code for this step
+2. **Test** — write corresponding tests (unit, integration as appropriate)
+3. **Verify** — run build + tests. Green means proceed. Red means fix before continuing.
+
+### Typical plan structure
+
+1. **Project setup** — scaffold structure, install dependencies, verify clean build
+2. **Domain layer** — entities, business rules, core logic + unit tests → verify
+3. **Service/application layer** — orchestration, use cases + tests → verify
+4. **API/interface layer** — controllers, handlers, routes + tests → verify
+5. **Integration** — wire layers together, integration tests → verify
+6. **Infrastructure glue** — config, migrations, deployment files → verify full build
+
+Adapt the layers to the tech stack. Not every project has all of these.
+
+### Brownfield rules
+
+- Check if target files exist before creating
+- Modify in place — never create `ClassName_new` or `ClassName_modified` copies
+- Follow existing naming conventions, directory structure, and patterns
+- Read existing tests to match style (assertion library, test structure, mocking patterns)
+
+## Application
+
+When applied at code-generation, this skill drives the plan structure and the step-by-step execution. Each step in the plan is a write-test-verify cycle.
+
+When applied at build-and-test, this skill manifests as: understanding how to run the build, interpret test output, diagnose failures, and fix them.

--- a/src/stages/code-generation/definition.md
+++ b/src/stages/code-generation/definition.md
@@ -19,20 +19,6 @@ Artifacts this stage can produce. The owner's plan determines which are relevant
 - Database migration scripts (if applicable)
 - API documentation generated from code (if applicable)
 
-## Execution Method
-
-The plan for this stage follows a write-test-verify cycle:
-
-1. **Project setup** — scaffold the project structure, install dependencies, verify it builds clean
-2. **Per-layer or per-feature** — for each piece of functionality:
-   - Write the production code
-   - Write the corresponding tests
-   - Run build + tests — confirm green before proceeding
-3. **Integration wiring** — connect layers, verify end-to-end flow compiles and passes
-4. **Final verification** — full build, all tests pass, no regressions
-
-Each plan step must end with a verified state. Do not proceed to the next step with a broken build.
-
 ## Owner
 
 aidlc-sw-dev-engineer-agent

--- a/src/stages/code-generation/definition.md
+++ b/src/stages/code-generation/definition.md
@@ -1,3 +1,47 @@
-# code-generation
+# Code Generation
 
-Placeholder — not yet implemented.
+## Description
+
+Generate production code for a single unit following the rhythm of a real developer: write code, write tests, verify it compiles and passes before moving to the next layer. Each step in the plan produces working, verified code — not a batch dump at the end.
+
+## Inputs
+
+- **Required:** functional-design artifacts for this unit (business-logic, domain-entities, business-rules, api-specification)
+- **Optional context:** nfr-design artifacts (patterns, logical components), infrastructure-design (service mapping, deployment), tech-stack-decisions, unit-contracts, RE code-structure (brownfield — existing patterns to follow)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- Production source code at the workspace root (never in aidlc-docs/)
+- Test code alongside production code
+- Configuration files (env, build, deploy)
+- Database migration scripts (if applicable)
+- API documentation generated from code (if applicable)
+
+## Execution Method
+
+The plan for this stage follows a write-test-verify cycle:
+
+1. **Project setup** — scaffold the project structure, install dependencies, verify it builds clean
+2. **Per-layer or per-feature** — for each piece of functionality:
+   - Write the production code
+   - Write the corresponding tests
+   - Run build + tests — confirm green before proceeding
+3. **Integration wiring** — connect layers, verify end-to-end flow compiles and passes
+4. **Final verification** — full build, all tests pass, no regressions
+
+Each plan step must end with a verified state. Do not proceed to the next step with a broken build.
+
+## Owner
+
+aidlc-sw-dev-engineer-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate secure coding patterns, input validation, secrets handling
+- aidlc-systems-architect-agent: validate code aligns with design artifacts
+
+## Reviewer
+
+aidlc-code-reviewer-agent

--- a/src/stages/code-generation/definition.md
+++ b/src/stages/code-generation/definition.md
@@ -2,16 +2,16 @@
 
 ## Description
 
-Generate production code for a single unit following the rhythm of a real developer: write code, write tests, verify it compiles and passes before moving to the next layer. Each step in the plan produces working, verified code — not a batch dump at the end.
+Generate production code following the rhythm of a real developer: write code, write tests, verify it compiles and passes before moving to the next layer. Each step in the plan produces working, verified code — not a batch dump at the end.
 
 ## Inputs
 
-- **Required:** functional-design artifacts for this unit (business-logic, domain-entities, business-rules, api-specification)
+- **Required:** functional-design artifacts (business-logic, domain-entities, business-rules, api-specification)
 - **Optional context:** nfr-design artifacts (patterns, logical components), infrastructure-design (service mapping, deployment), tech-stack-decisions, unit-contracts, RE code-structure (brownfield — existing patterns to follow)
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
 - Production source code at the workspace root (never in aidlc-docs/)
 - Test code alongside production code

--- a/src/stages/functional-design/definition.md
+++ b/src/stages/functional-design/definition.md
@@ -1,0 +1,32 @@
+# Functional Design
+
+## Description
+
+Design the detailed business logic for a single unit of work — its domain entities, business rules, algorithms, data flows, and public API specification. This is technology-agnostic: it describes *what the logic does*, not what infrastructure runs it. Each unit gets its own functional-design pass. The API specification elaborates on this unit's provider-side contracts from `unit-contracts.md`.
+
+## Inputs
+
+- **Required:** Unit definition from `units.md` + stories assigned to this unit from `unit-story-map.md`
+- **Optional context:** `unit-contracts.md` (for contracts this unit provides), `components.md`, `requirements.md`, RE artifacts
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `business-logic.md` — algorithms, workflows, state machines, decision trees describing how the unit processes inputs to produce outputs
+- `domain-entities.md` — entities, value objects, aggregates owned by this unit with their fields, invariants, and lifecycle
+- `business-rules.md` — validation rules, constraints, policies expressed as logic
+- `api-specification.md` — the unit's public interface: endpoints, operations, request/response shapes, error codes, fulfilling this unit's provider-side contracts
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent
+- aidlc-product-manager-agent
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/src/stages/functional-design/definition.md
+++ b/src/stages/functional-design/definition.md
@@ -2,21 +2,21 @@
 
 ## Description
 
-Design the detailed business logic for a single unit of work — its domain entities, business rules, algorithms, data flows, and public API specification. This is technology-agnostic: it describes *what the logic does*, not what infrastructure runs it. Each unit gets its own functional-design pass. The API specification elaborates on this unit's provider-side contracts from `unit-contracts.md`.
+Design the detailed business logic — domain entities, business rules, algorithms, data flows, and public API specification. Technology-agnostic: describes *what the logic does*, not what infrastructure runs it. The API specification elaborates on provider-side contracts from `unit-contracts.md`.
 
 ## Inputs
 
-- **Required:** Unit definition from `units.md` + stories assigned to this unit from `unit-story-map.md`
-- **Optional context:** `unit-contracts.md` (for contracts this unit provides), `components.md`, `requirements.md`, RE artifacts
+- **Required:** Unit definition from `units.md` + assigned stories from `unit-story-map.md`
+- **Optional context:** `unit-contracts.md` (provider-side contracts), `components.md`, `requirements.md`, RE artifacts
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
-- `business-logic.md` — algorithms, workflows, state machines, decision trees describing how the unit processes inputs to produce outputs
-- `domain-entities.md` — entities, value objects, aggregates owned by this unit with their fields, invariants, and lifecycle
+- `business-logic.md` — algorithms, workflows, state machines, decision trees
+- `domain-entities.md` — entities, value objects, aggregates with fields, invariants, and lifecycle
 - `business-rules.md` — validation rules, constraints, policies expressed as logic
-- `api-specification.md` — the unit's public interface: endpoints, operations, request/response shapes, error codes, fulfilling this unit's provider-side contracts
+- `api-specification.md` — public interface: endpoints, operations, request/response shapes, error codes
 
 ## Owner
 

--- a/src/stages/functional-design/templates/api-specification.md
+++ b/src/stages/functional-design/templates/api-specification.md
@@ -1,0 +1,57 @@
+# API Specification
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> This elaborates on this unit's provider-side contracts defined in unit-contracts.md.
+
+## API Overview
+
+- **Unit:** [unit name]
+- **Base path / topic prefix:** [e.g. /api/v1/leaves, events.leave.*]
+- **Auth mechanism:** [how consumers authenticate]
+- **Contracts fulfilled:** [C-1, C-3 from unit-contracts.md]
+
+## Operations
+
+### [Operation Name — e.g. "Create leave request"]
+
+| Field | Value |
+|---|---|
+| Method / Trigger | [POST / event / message / etc.] |
+| Path / Topic | [/leaves, leave.requested, etc.] |
+| Purpose | [what it does] |
+| Idempotent | [yes/no] |
+
+**Request:**
+
+```
+{
+  // request/message shape with field types and constraints
+}
+```
+
+**Response (success):**
+
+```
+{
+  // response shape
+}
+```
+
+**Error responses:**
+
+| Status/Code | Condition | Body |
+|---|---|---|
+| [4xx/error code] | [when this happens] | [error shape] |
+
+**Validation rules:**
+- [field-level and request-level validations applied]
+
+---
+
+## Pagination / Filtering
+
+[If applicable — describe how list endpoints handle pagination, sorting, filtering]
+
+## Versioning
+
+[How this API is versioned — URL path, header, content negotiation — per the versioning strategy in unit-contracts.md]

--- a/src/stages/functional-design/templates/business-logic.md
+++ b/src/stages/functional-design/templates/business-logic.md
@@ -1,0 +1,55 @@
+# Business Logic
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit Purpose
+
+[Single paragraph: what this unit does from a business perspective]
+
+## Workflows
+
+Document the key business workflows this unit implements. Each workflow is a sequence of steps that transforms inputs into outcomes.
+
+### [Workflow Name — e.g. "Submit leave request"]
+
+- **Trigger:** [what initiates this workflow]
+- **Inputs:** [what data enters]
+- **Steps:**
+  1. [step description — what logic is applied]
+  2. [next step]
+- **Outputs:** [what the workflow produces]
+- **Side effects:** [what state changes, events emitted, notifications triggered]
+
+## State Machines
+
+For entities with lifecycle states, document the transitions:
+
+### [Entity] States
+
+| Current state | Event/Action | Next state | Guard condition |
+|---|---|---|---|
+| [state] | [what triggers transition] | [state] | [condition that must be true] |
+
+## Decision Logic
+
+For complex branching decisions, document the rules:
+
+### [Decision Name]
+
+| Condition | Outcome |
+|---|---|
+| [if this is true] | [then this happens] |
+| [else if this] | [then this] |
+| [default] | [fallback behaviour] |
+
+## Algorithms
+
+For non-trivial computations (scoring, matching, scheduling, etc.):
+
+### [Algorithm Name]
+
+- **Purpose:** [what it computes]
+- **Inputs:** [what it needs]
+- **Logic:** [describe the algorithm in plain language or pseudocode]
+- **Outputs:** [what it returns]
+- **Edge cases:** [what happens with empty inputs, boundary values, etc.]

--- a/src/stages/functional-design/templates/business-rules.md
+++ b/src/stages/functional-design/templates/business-rules.md
@@ -1,0 +1,31 @@
+# Business Rules
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Rules Inventory
+
+| ID | Rule | Category | Applies to | Source |
+|---|---|---|---|---|
+| BR-1 | [short description] | [validation / authorization / calculation / constraint / policy] | [which entity or workflow] | [requirement or story ID] |
+
+## Rule Details
+
+### BR-1: [Rule Name]
+
+- **Category:** [validation / authorization / calculation / constraint / policy]
+- **Statement:** [precise statement of what the rule enforces]
+- **When applied:** [at what point in which workflow]
+- **Inputs:** [what data the rule evaluates]
+- **Logic:**
+  - IF [condition] THEN [outcome]
+  - ELSE [alternative outcome]
+- **Violation behaviour:** [what happens when the rule is broken — reject, warn, default, escalate]
+- **Source:** [FR-n or S-n that requires this rule]
+
+## Cross-cutting Rules
+
+Rules that apply across multiple workflows or entities:
+
+| Rule | Scope | Description |
+|---|---|---|
+| [name] | [where it applies] | [what it enforces everywhere] |

--- a/src/stages/functional-design/templates/domain-entities.md
+++ b/src/stages/functional-design/templates/domain-entities.md
@@ -1,0 +1,30 @@
+# Domain Entities
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Entity Inventory
+
+| Entity | Type | Aggregate root? | Lifecycle |
+|---|---|---|---|
+| [name] | [entity / value object / aggregate] | [yes/no] | [states it passes through] |
+
+## Entity Details
+
+### [Entity Name]
+
+- **Purpose:** [why this entity exists in the domain]
+- **Fields:**
+
+| Field | Type | Required | Constraints | Description |
+|---|---|---|---|---|
+| [name] | [logical type] | [yes/no] | [validation rules] | [what it represents] |
+
+- **Invariants:** [rules that must always be true for this entity]
+  - [e.g. "balance must never be negative"]
+  - [e.g. "start date must be before end date"]
+- **Lifecycle:** [how it's created, modified, archived/deleted]
+- **Relationships:**
+
+| Related to | Cardinality | Direction | Description |
+|---|---|---|---|
+| [other entity] | [1:1 / 1:N / N:M] | [owns / references / associated] | [nature of relationship] |

--- a/src/stages/infrastructure-design/definition.md
+++ b/src/stages/infrastructure-design/definition.md
@@ -1,0 +1,29 @@
+# Infrastructure Design
+
+## Description
+
+Map logical components from nfr-design to actual infrastructure services and define the deployment architecture for this unit.
+
+## Inputs
+
+- **Required:** `logical-components.md` and `nfr-patterns.md` from nfr-design, `tech-stack-decisions.md` from nfr-assessment
+- **Optional context:** RE artifacts (existing infrastructure), deployment constraints
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `service-mapping.md` — logical components mapped to concrete infrastructure services
+- `deployment-architecture.md` — how the unit is deployed, scaled, and networked
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate network boundaries, access controls, secrets management
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/src/stages/infrastructure-design/definition.md
+++ b/src/stages/infrastructure-design/definition.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Map logical components from nfr-design to actual infrastructure services and define the deployment architecture for this unit.
+Map logical components from nfr-design to actual infrastructure services and define the deployment architecture.
 
 ## Inputs
 
@@ -11,10 +11,10 @@ Map logical components from nfr-design to actual infrastructure services and def
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
 - `service-mapping.md` — logical components mapped to concrete infrastructure services
-- `deployment-architecture.md` — how the unit is deployed, scaled, and networked
+- `deployment-architecture.md` — how the system is deployed, scaled, and networked
 
 ## Owner
 

--- a/src/stages/infrastructure-design/templates/deployment-architecture.md
+++ b/src/stages/infrastructure-design/templates/deployment-architecture.md
@@ -1,0 +1,31 @@
+# Deployment Architecture
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Compute
+
+| Component | Compute type | Sizing | Scaling trigger |
+|---|---|---|---|
+| [component] | [Lambda/ECS/EC2/Fargate/etc.] | [memory, CPU, concurrency] | [what triggers scale] |
+
+## Networking
+
+| Element | Configuration |
+|---|---|
+| VPC / Subnet | [placement] |
+| Load balancer | [type, listeners] |
+| Security groups | [inbound/outbound rules summary] |
+| DNS | [routing] |
+
+## Deployment
+
+| Aspect | Choice |
+|---|---|
+| Strategy | [rolling / blue-green / canary] |
+| IaC tool | [CDK / Terraform / CloudFormation / other] |
+| Pipeline | [CI/CD approach] |
+| Rollback | [how to recover from bad deploy] |

--- a/src/stages/infrastructure-design/templates/service-mapping.md
+++ b/src/stages/infrastructure-design/templates/service-mapping.md
@@ -1,0 +1,21 @@
+# Service Mapping
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Mappings
+
+| Logical Component | Service | Provider | Rationale |
+|---|---|---|---|
+| [from logical-components.md] | [actual service — e.g. ElastiCache, SQS, CloudWatch] | [AWS/Azure/GCP/other] | [why this service for this component] |
+
+## Shared Infrastructure
+
+Services shared across units (if applicable):
+
+| Service | Shared by | Ownership | Access pattern |
+|---|---|---|---|
+| [service] | [which units] | [who manages it] | [how units access it] |

--- a/src/stages/nfr-assessment/definition.md
+++ b/src/stages/nfr-assessment/definition.md
@@ -1,0 +1,29 @@
+# NFR Assessment
+
+## Description
+
+Operationalise the non-functional requirements for a single unit. The heavy NFR analysis was done during requirements-analysis (with systems-architect and security-architect contributing). This stage takes those stated NFRs and makes them concrete for this unit: measurable targets, tech stack choices, and quality attribute trade-offs. Minimal by design — it refines what exists, not re-discovers.
+
+## Inputs
+
+- **Required:** `requirements.md` (NFR section — already has architect and security input), functional-design artifacts for this unit
+- **Optional context:** `unit-contracts.md` (integration patterns affect performance/reliability targets), RE artifacts (existing tech stack constraints)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `nfr-targets.md` — measurable targets per quality attribute (latency, throughput, availability, recovery) specific to this unit
+- `tech-stack-decisions.md` — technology choices for this unit with rationale tied to NFR targets
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate security NFR targets are sufficient and tech choices don't introduce vulnerabilities
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/src/stages/nfr-assessment/definition.md
+++ b/src/stages/nfr-assessment/definition.md
@@ -2,19 +2,19 @@
 
 ## Description
 
-Operationalise the non-functional requirements for a single unit. The heavy NFR analysis was done during requirements-analysis (with systems-architect and security-architect contributing). This stage takes those stated NFRs and makes them concrete for this unit: measurable targets, tech stack choices, and quality attribute trade-offs. Minimal by design — it refines what exists, not re-discovers.
+Operationalise the non-functional requirements into measurable targets, tech stack choices, and quality attribute trade-offs. The heavy NFR analysis was done during requirements-analysis (with systems-architect and security-architect contributing). This stage refines what exists, not re-discovers.
 
 ## Inputs
 
-- **Required:** `requirements.md` (NFR section — already has architect and security input), functional-design artifacts for this unit
+- **Required:** `requirements.md` (NFR section), functional-design artifacts
 - **Optional context:** `unit-contracts.md` (integration patterns affect performance/reliability targets), RE artifacts (existing tech stack constraints)
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
-- `nfr-targets.md` — measurable targets per quality attribute (latency, throughput, availability, recovery) specific to this unit
-- `tech-stack-decisions.md` — technology choices for this unit with rationale tied to NFR targets
+- `nfr-targets.md` — measurable targets per quality attribute (latency, throughput, availability, recovery)
+- `tech-stack-decisions.md` — technology choices with rationale tied to NFR targets
 
 ## Owner
 

--- a/src/stages/nfr-assessment/templates/nfr-targets.md
+++ b/src/stages/nfr-assessment/templates/nfr-targets.md
@@ -1,0 +1,28 @@
+# NFR Targets
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> Each target traces back to an NFR in requirements.md. If a requirement is not applicable to this unit, state so.
+
+## Unit
+
+[Unit name]
+
+## Quality Attribute Targets
+
+| NFR Source | Quality Attribute | Target | Measure | Rationale |
+|---|---|---|---|---|
+| NFR-1 | [performance / availability / scalability / security / reliability / etc.] | [specific measurable target] | [how it's measured] | [why this number for this unit] |
+
+## Trade-offs
+
+Explicit trade-offs made for this unit:
+
+| Attribute A | Attribute B | Decision | Rationale |
+|---|---|---|---|
+| [e.g. consistency] | [e.g. availability] | [which was prioritised] | [why, for this unit] |
+
+## Assumptions
+
+Assumptions made when setting targets (flag for validation):
+
+- [assumption — e.g. "peak load is 10x average based on similar systems"]

--- a/src/stages/nfr-assessment/templates/nfr-targets.md
+++ b/src/stages/nfr-assessment/templates/nfr-targets.md
@@ -1,7 +1,6 @@
 # NFR Targets
 
 > Minimum structure. Sections may be omitted with rationale or extended as needed.
-> Each target traces back to an NFR in requirements.md. If a requirement is not applicable to this unit, state so.
 
 ## Unit
 

--- a/src/stages/nfr-assessment/templates/tech-stack-decisions.md
+++ b/src/stages/nfr-assessment/templates/tech-stack-decisions.md
@@ -1,0 +1,33 @@
+# Tech Stack Decisions
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Decisions
+
+### [Decision Area — e.g. "Runtime", "Database", "Messaging", "Auth"]
+
+| Option considered | Chosen? | Rationale |
+|---|---|---|
+| [option A] | ✓ | [why — tied to which NFR target] |
+| [option B] | ✗ | [why not — what NFR it couldn't meet] |
+
+## Stack Summary
+
+| Layer | Choice | Supports NFR |
+|---|---|---|
+| [language/runtime] | [e.g. Node.js 20] | [NFR-x: performance target] |
+| [database] | [e.g. DynamoDB] | [NFR-y: availability target] |
+| [messaging] | [e.g. SQS] | [NFR-z: reliability target] |
+| [framework] | [e.g. Fastify] | [NFR-x: latency target] |
+
+## Constraints
+
+Choices constrained by factors outside NFR targets:
+
+| Constraint | Impact on choice | Source |
+|---|---|---|
+| [e.g. org standard, existing infra, team expertise, licence] | [what it forced or ruled out] | [where constraint comes from] |

--- a/src/stages/nfr-design/definition.md
+++ b/src/stages/nfr-design/definition.md
@@ -1,0 +1,29 @@
+# NFR Design
+
+## Description
+
+Design the architectural patterns and logical components that satisfy the NFR targets established in nfr-assessment. This is about *how* to meet the quality attributes: resilience patterns, caching strategies, scaling mechanisms, observability instrumentation, security enforcement points. Technology-aware but not infrastructure-specific — it defines what logical capabilities are needed, not which cloud services implement them (that's infrastructure-design).
+
+## Inputs
+
+- **Required:** `nfr-targets.md` and `tech-stack-decisions.md` from nfr-assessment for this unit
+- **Optional context:** `functional-design/` artifacts (business logic shapes the patterns), `unit-contracts.md` (integration patterns affect resilience design)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+
+- `nfr-patterns.md` — architectural patterns selected to meet each NFR target (with rationale and trade-offs)
+- `logical-components.md` — non-business components the unit needs: caches, queues, circuit breakers, rate limiters, health checks, metric emitters, etc.
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-security-architect-agent: validate security patterns are defence-in-depth and enforcement points are complete
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/src/stages/nfr-design/definition.md
+++ b/src/stages/nfr-design/definition.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Design the architectural patterns and logical components that satisfy the NFR targets established in nfr-assessment. This is about *how* to meet the quality attributes: resilience patterns, caching strategies, scaling mechanisms, observability instrumentation, security enforcement points. Technology-aware but not infrastructure-specific — it defines what logical capabilities are needed, not which cloud services implement them (that's infrastructure-design).
+Design the architectural patterns and logical components that satisfy the NFR targets established in nfr-assessment. Resilience patterns, caching strategies, scaling mechanisms, observability instrumentation, security enforcement points. Defines what logical capabilities are needed, not which cloud services implement them.
 
 ## Inputs
 

--- a/src/stages/nfr-design/definition.md
+++ b/src/stages/nfr-design/definition.md
@@ -6,15 +6,15 @@ Design the architectural patterns and logical components that satisfy the NFR ta
 
 ## Inputs
 
-- **Required:** `nfr-targets.md` and `tech-stack-decisions.md` from nfr-assessment for this unit
-- **Optional context:** `functional-design/` artifacts (business logic shapes the patterns), `unit-contracts.md` (integration patterns affect resilience design)
+- **Required:** `nfr-targets.md` and `tech-stack-decisions.md` from nfr-assessment
+- **Optional context:** functional-design artifacts (business logic shapes the patterns), `unit-contracts.md` (integration patterns affect resilience design)
 
 ## Outputs
 
-Artifacts this stage can produce. The owner's plan determines which are relevant for this unit. Additional artifacts may be produced if the unit warrants them.
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
 
 - `nfr-patterns.md` — architectural patterns selected to meet each NFR target (with rationale and trade-offs)
-- `logical-components.md` — non-business components the unit needs: caches, queues, circuit breakers, rate limiters, health checks, metric emitters, etc.
+- `logical-components.md` — non-business components needed: caches, queues, circuit breakers, rate limiters, health checks, metric emitters
 
 ## Owner
 

--- a/src/stages/nfr-design/templates/logical-components.md
+++ b/src/stages/nfr-design/templates/logical-components.md
@@ -1,0 +1,28 @@
+# Logical Components
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+> These are non-business components the unit needs to satisfy its NFR targets. They exist alongside the domain logic but serve quality attributes, not business rules.
+
+## Unit
+
+[Unit name]
+
+## Component Inventory
+
+| Component | Type | Satisfies NFR | Integrates with |
+|---|---|---|---|
+| [e.g. request cache] | [cache / queue / circuit breaker / rate limiter / health check / metric emitter / retry handler / etc.] | [NFR-x] | [which business component uses it] |
+
+## Component Details
+
+### [Component Name]
+
+- **Type:** [what kind of infrastructure-adjacent component]
+- **Purpose:** [what quality attribute it serves and how]
+- **Behaviour:**
+  - [how it operates in the happy path]
+  - [how it operates under failure]
+  - [how it recovers]
+- **Configuration:** [key knobs — TTL, max retries, thresholds, window sizes]
+- **Observability:** [what metrics/logs this component emits for monitoring]
+- **Dependencies:** [what it needs to function — connection to a cache store, access to a queue, etc. Actual service selection happens in infrastructure-design]

--- a/src/stages/nfr-design/templates/logical-components.md
+++ b/src/stages/nfr-design/templates/logical-components.md
@@ -1,7 +1,6 @@
 # Logical Components
 
 > Minimum structure. Sections may be omitted with rationale or extended as needed.
-> These are non-business components the unit needs to satisfy its NFR targets. They exist alongside the domain logic but serve quality attributes, not business rules.
 
 ## Unit
 
@@ -25,4 +24,4 @@
   - [how it recovers]
 - **Configuration:** [key knobs — TTL, max retries, thresholds, window sizes]
 - **Observability:** [what metrics/logs this component emits for monitoring]
-- **Dependencies:** [what it needs to function — connection to a cache store, access to a queue, etc. Actual service selection happens in infrastructure-design]
+- **Dependencies:** [what it needs to function]

--- a/src/stages/nfr-design/templates/nfr-patterns.md
+++ b/src/stages/nfr-design/templates/nfr-patterns.md
@@ -1,0 +1,36 @@
+# NFR Patterns
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit
+
+[Unit name]
+
+## Patterns Applied
+
+### [Pattern Name — e.g. "Circuit Breaker", "Write-Behind Cache", "Rate Limiting"]
+
+| Field | Value |
+|---|---|
+| Satisfies NFR | [NFR-x from nfr-targets.md] |
+| Quality attribute | [resilience / performance / scalability / security / observability] |
+| Where applied | [which component/interaction in this unit] |
+| How it works | [brief description of the pattern's behaviour in this context] |
+| Trade-off | [what you give up by using this pattern — complexity, latency, cost, etc.] |
+| Failure mode | [what happens if this pattern itself fails or is misconfigured] |
+
+## Pattern Interactions
+
+Document how patterns interact or depend on each other:
+
+| Pattern A | Pattern B | Interaction |
+|---|---|---|
+| [e.g. circuit breaker] | [e.g. retry] | [e.g. retries must respect circuit state — don't retry when open] |
+
+## Gaps
+
+NFR targets not yet addressed by a pattern (should be empty if design is complete):
+
+| NFR Target | Gap | Resolution path |
+|---|---|---|
+| [target] | [what's not covered] | [what's needed — deferred to infra-design? needs further analysis?] |

--- a/src/stages/nfr-design/templates/nfr-patterns.md
+++ b/src/stages/nfr-design/templates/nfr-patterns.md
@@ -29,8 +29,6 @@ Document how patterns interact or depend on each other:
 
 ## Gaps
 
-NFR targets not yet addressed by a pattern (should be empty if design is complete):
-
 | NFR Target | Gap | Resolution path |
 |---|---|---|
-| [target] | [what's not covered] | [what's needed — deferred to infra-design? needs further analysis?] |
+| [target] | [what's not covered] | [what's needed] |

--- a/src/stages/stage-graph.md
+++ b/src/stages/stage-graph.md
@@ -22,6 +22,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | application-design | Design logical component structure, services, dependencies | aidlc-systems-architect-agent |
 | units-generation | Decompose application design into implementable units of work | aidlc-systems-architect-agent |
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
+| nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -38,7 +39,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | application-design | requirements, stories, wireframes, RE artifacts |
 | units-generation | application-design (components + interactions must be known) |
 | functional-design | units-generation (unit definition + assigned stories + contracts) |
-| code-generation | functional-design, units-generation, application-design, stories, requirements |
+| nfr-assessment | requirements.md (NFR section), functional-design artifacts for this unit |
+| code-generation | functional-design, nfr-assessment, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules

--- a/src/stages/stage-graph.md
+++ b/src/stages/stage-graph.md
@@ -21,6 +21,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | wireframe-design | Design UI screens as HTML wireframes | aidlc-ux-designer-agent |
 | application-design | Design logical component structure, services, dependencies | aidlc-systems-architect-agent |
 | units-generation | Decompose application design into implementable units of work | aidlc-systems-architect-agent |
+| functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -36,7 +37,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | wireframe-design | stories + personas, requirements, intent |
 | application-design | requirements, stories, wireframes, RE artifacts |
 | units-generation | application-design (components + interactions must be known) |
-| code-generation | units-generation, application-design, stories, requirements |
+| functional-design | units-generation (unit definition + assigned stories + contracts) |
+| code-generation | functional-design, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules

--- a/src/stages/stage-graph.md
+++ b/src/stages/stage-graph.md
@@ -25,7 +25,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
 | nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
 | infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
-| code-generation | Generate production code in layers | (tbd) |
+| code-generation | Generate production code per unit with write-test-verify cycles | aidlc-sw-dev-engineer-agent |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
 ## Dependencies

--- a/src/stages/stage-graph.md
+++ b/src/stages/stage-graph.md
@@ -24,6 +24,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
 | nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
+| infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -42,7 +43,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | functional-design | units-generation (unit definition + assigned stories + contracts) |
 | nfr-assessment | requirements.md (NFR section), functional-design artifacts for this unit |
 | nfr-design | nfr-assessment (targets + tech stack), functional-design artifacts, unit-contracts |
-| code-generation | functional-design, nfr-assessment, nfr-design, units-generation, application-design, stories, requirements |
+| infrastructure-design | nfr-design (logical components + patterns), tech-stack-decisions |
+| code-generation | functional-design, nfr-assessment, nfr-design, infrastructure-design, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules

--- a/src/stages/stage-graph.md
+++ b/src/stages/stage-graph.md
@@ -23,6 +23,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | units-generation | Decompose application design into implementable units of work | aidlc-systems-architect-agent |
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | nfr-assessment | Operationalise NFRs into measurable targets and tech stack choices per unit | aidlc-systems-architect-agent |
+| nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
 | code-generation | Generate production code in layers | (tbd) |
 | build-and-test | Build, test, and verify the code | (tbd) |
 
@@ -40,7 +41,8 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | units-generation | application-design (components + interactions must be known) |
 | functional-design | units-generation (unit definition + assigned stories + contracts) |
 | nfr-assessment | requirements.md (NFR section), functional-design artifacts for this unit |
-| code-generation | functional-design, nfr-assessment, units-generation, application-design, stories, requirements |
+| nfr-design | nfr-assessment (targets + tech stack), functional-design artifacts, unit-contracts |
+| code-generation | functional-design, nfr-assessment, nfr-design, units-generation, application-design, stories, requirements |
 | build-and-test | code-generation output |
 
 ## Composition Rules


### PR DESCRIPTION
## Summary
Adds all per-unit construction stages: functional-design, nfr-assessment, nfr-design, infrastructure-design, and code-generation. Creates the aidlc-full-stack-development-skill and aidlc-api-design-skill.

## Stages added
**functional-design** — business logic, domain entities, business rules, API specification (2 new skills: api-design, full-stack-development)
**nfr-assessment** — measurable NFR targets + tech stack decisions (minimal — refines what requirements already captured)
**nfr-design** — architectural patterns and logical components to satisfy targets
infrastructure-design — map logical components to actual services + deployment architecture
**code-generation** — produce working code with write-test-verify discipline

## Design decisions

- Stages don't reference "per-unit" — the orchestrator handles looping, stages just do their job
- No Execution Method in definitions — process belongs in skills, not stage definitions
- NFR assessment is minimal by design — heavy analysis already done at requirements with architect/security contributions
- Code-generation's write-test-verify cycle lives in aidlc-full-stack-development-skill
- Templates follow guardrail-not-restriction principle (no directive instructions, no cross-stage behaviour constraints)
- Stage-graph updated with all entries and dependency chains