### PR TITLE
Add dependency-verification stage, factory pattern, and stage briefs

### DIFF
--- a/dist/kiro-ide/.kiro/skills/aidlc-full-stack-development-skill/SKILL.md
+++ b/dist/kiro-ide/.kiro/skills/aidlc-full-stack-development-skill/SKILL.md
@@ -17,6 +17,7 @@ Write production-quality code that works. Not just code that looks right — cod
 - One concern at a time — scaffold first, then domain logic, then integration, then polish
 - Brownfield respect — match existing patterns, styles, and conventions. Don't introduce a new paradigm next to the old one
 - Fail fast — if a step doesn't compile or tests don't pass, fix it before moving on
+- Abstract external dependencies — always place databases, queues, caches, APIs, and other external systems behind interfaces (ports/adapters, factory pattern, repository pattern). Generate both the interface and the real implementation. Tests use mock implementations; dependency-verification uses real ones.
 
 ## Approach
 
@@ -48,6 +49,6 @@ Adapt the layers to the tech stack. Not every project has all of these.
 
 ## Application
 
-When applied at code-generation, this skill drives the plan structure and the step-by-step execution. Each step in the plan is a write-test-verify cycle.
+When applied at code-generation, this skill drives the plan structure and the step-by-step execution. Each step in the plan is a write-test-verify cycle. All code is generated — business logic, real adapter implementations, infrastructure-as-code, deployment scripts — but testing during this stage uses mock dependencies.
 
-When applied at build-and-test, this skill manifests as: understanding how to run the build, interpret test output, diagnose failures, and fix them.
+When applied at dependency-verification, this skill manifests as: swapping mock implementations for real ones, configuring connections, running the code against real dependencies, and diagnosing integration failures.

--- a/dist/kiro-ide/.kiro/skills/stage-execution/SKILL.md
+++ b/dist/kiro-ide/.kiro/skills/stage-execution/SKILL.md
@@ -14,9 +14,10 @@ For each stage in `workflow.json`:
 
 1. Read **only** the current stage's `definition.md` (do NOT read all stage definitions upfront)
 2. Verify inputs exist (outputs from prior stages)
-3. Drive the stage execution cycle (below)
-4. After stage completes, update `state/state.json` outputs array with each output as `{"name": "<filename>", "locationRelativeToIntentRoot": "<path>/"}`
-5. Advance to the next stage
+3. **Stage brief** — compose a brief statement for the human explaining what will happen in this stage: what inputs are being used, what will be produced, and what's needed from them (if anything). Derive this from the definition and current context. Present it before starting work.
+4. Drive the stage execution cycle (below)
+5. After stage completes, update `state/state.json` outputs array with each output as `{"name": "<filename>", "locationRelativeToIntentRoot": "<path>/"}`
+6. Advance to the next stage
 
 ## Checkpoint
 

--- a/dist/kiro-ide/.kiro/stages/build-and-test/definition.md
+++ b/dist/kiro-ide/.kiro/stages/build-and-test/definition.md
@@ -1,3 +1,0 @@
-# build-and-test
-
-Placeholder — not yet implemented.

--- a/dist/kiro-ide/.kiro/stages/dependency-verification/definition.md
+++ b/dist/kiro-ide/.kiro/stages/dependency-verification/definition.md
@@ -1,0 +1,31 @@
+# Dependency Verification
+
+## Description
+
+Connect the generated code to real external dependencies — databases, queues, caches, third-party APIs, file systems — and verify it works against them instead of mocks. The code and real adapter implementations already exist from code-generation. This stage configures real connections, requests access from the human if needed, and runs the system against actual dependencies.
+
+## Inputs
+
+- **Required:** Generated code (from code-generation) with factory/adapter abstractions in place
+- **Optional context:** infrastructure-design artifacts (service-mapping, deployment-architecture), deployment scripts (if deployment to a lower environment is needed before verification)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
+
+- Verified working connections to all real dependencies
+- Configuration files updated with real connection details
+- Integration test results against real dependencies
+- List of verified vs unverified dependencies (if some require deployment first)
+
+## Owner
+
+aidlc-sw-dev-engineer-agent
+
+## Contributors
+
+- aidlc-systems-architect-agent: validate connection patterns and infrastructure alignment
+
+## Reviewer
+
+aidlc-code-reviewer-agent

--- a/dist/kiro-ide/.kiro/stages/stage-graph.md
+++ b/dist/kiro-ide/.kiro/stages/stage-graph.md
@@ -26,7 +26,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
 | infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
 | code-generation | Generate production code per unit with write-test-verify cycles | aidlc-sw-dev-engineer-agent |
-| build-and-test | Build, test, and verify the code | (tbd) |
+| dependency-verification | Connect code to real dependencies and verify it works against them | aidlc-sw-dev-engineer-agent |
 
 ## Dependencies
 
@@ -45,7 +45,7 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | nfr-design | nfr-assessment (targets + tech stack), functional-design artifacts, unit-contracts |
 | infrastructure-design | nfr-design (logical components + patterns), tech-stack-decisions |
 | code-generation | functional-design, nfr-assessment, nfr-design, infrastructure-design, units-generation, application-design, stories, requirements |
-| build-and-test | code-generation output |
+| dependency-verification | code-generation (generated code with adapter abstractions), infrastructure-design (service mapping) |
 
 ## Composition Rules
 

--- a/src/skills/aidlc-full-stack-development-skill/SKILL.md
+++ b/src/skills/aidlc-full-stack-development-skill/SKILL.md
@@ -17,6 +17,7 @@ Write production-quality code that works. Not just code that looks right — cod
 - One concern at a time — scaffold first, then domain logic, then integration, then polish
 - Brownfield respect — match existing patterns, styles, and conventions. Don't introduce a new paradigm next to the old one
 - Fail fast — if a step doesn't compile or tests don't pass, fix it before moving on
+- Abstract external dependencies — always place databases, queues, caches, APIs, and other external systems behind interfaces (ports/adapters, factory pattern, repository pattern). Generate both the interface and the real implementation. Tests use mock implementations; dependency-verification uses real ones.
 
 ## Approach
 
@@ -48,6 +49,6 @@ Adapt the layers to the tech stack. Not every project has all of these.
 
 ## Application
 
-When applied at code-generation, this skill drives the plan structure and the step-by-step execution. Each step in the plan is a write-test-verify cycle.
+When applied at code-generation, this skill drives the plan structure and the step-by-step execution. Each step in the plan is a write-test-verify cycle. All code is generated — business logic, real adapter implementations, infrastructure-as-code, deployment scripts — but testing during this stage uses mock dependencies.
 
-When applied at build-and-test, this skill manifests as: understanding how to run the build, interpret test output, diagnose failures, and fix them.
+When applied at dependency-verification, this skill manifests as: swapping mock implementations for real ones, configuring connections, running the code against real dependencies, and diagnosing integration failures.

--- a/src/skills/stage-execution/SKILL.md
+++ b/src/skills/stage-execution/SKILL.md
@@ -14,9 +14,10 @@ For each stage in `workflow.json`:
 
 1. Read **only** the current stage's `definition.md` (do NOT read all stage definitions upfront)
 2. Verify inputs exist (outputs from prior stages)
-3. Drive the stage execution cycle (below)
-4. After stage completes, update `state/state.json` outputs array with each output as `{"name": "<filename>", "locationRelativeToIntentRoot": "<path>/"}`
-5. Advance to the next stage
+3. **Stage brief** — compose a brief statement for the human explaining what will happen in this stage: what inputs are being used, what will be produced, and what's needed from them (if anything). Derive this from the definition and current context. Present it before starting work.
+4. Drive the stage execution cycle (below)
+5. After stage completes, update `state/state.json` outputs array with each output as `{"name": "<filename>", "locationRelativeToIntentRoot": "<path>/"}`
+6. Advance to the next stage
 
 ## Checkpoint
 

--- a/src/stages/build-and-test/definition.md
+++ b/src/stages/build-and-test/definition.md
@@ -1,3 +1,0 @@
-# build-and-test
-
-Placeholder — not yet implemented.

--- a/src/stages/dependency-verification/definition.md
+++ b/src/stages/dependency-verification/definition.md
@@ -1,0 +1,31 @@
+# Dependency Verification
+
+## Description
+
+Connect the generated code to real external dependencies — databases, queues, caches, third-party APIs, file systems — and verify it works against them instead of mocks. The code and real adapter implementations already exist from code-generation. This stage configures real connections, requests access from the human if needed, and runs the system against actual dependencies.
+
+## Inputs
+
+- **Required:** Generated code (from code-generation) with factory/adapter abstractions in place
+- **Optional context:** infrastructure-design artifacts (service-mapping, deployment-architecture), deployment scripts (if deployment to a lower environment is needed before verification)
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
+
+- Verified working connections to all real dependencies
+- Configuration files updated with real connection details
+- Integration test results against real dependencies
+- List of verified vs unverified dependencies (if some require deployment first)
+
+## Owner
+
+aidlc-sw-dev-engineer-agent
+
+## Contributors
+
+- aidlc-systems-architect-agent: validate connection patterns and infrastructure alignment
+
+## Reviewer
+
+aidlc-code-reviewer-agent

--- a/src/stages/stage-graph.md
+++ b/src/stages/stage-graph.md
@@ -26,7 +26,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | nfr-design | Design patterns and logical components that satisfy NFR targets per unit | aidlc-systems-architect-agent |
 | infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
 | code-generation | Generate production code per unit with write-test-verify cycles | aidlc-sw-dev-engineer-agent |
-| build-and-test | Build, test, and verify the code | (tbd) |
+| dependency-verification | Connect code to real dependencies and verify it works against them | aidlc-sw-dev-engineer-agent |
 
 ## Dependencies
 
@@ -45,7 +45,7 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | nfr-design | nfr-assessment (targets + tech stack), functional-design artifacts, unit-contracts |
 | infrastructure-design | nfr-design (logical components + patterns), tech-stack-decisions |
 | code-generation | functional-design, nfr-assessment, nfr-design, infrastructure-design, units-generation, application-design, stories, requirements |
-| build-and-test | code-generation output |
+| dependency-verification | code-generation (generated code with adapter abstractions), infrastructure-design (service mapping) |
 
 ## Composition Rules
 


### PR DESCRIPTION
## Summary
Three changes that improve the construction phase realism: code-gen now always abstracts dependencies, a new stage verifies code against real dependencies, and the orchestrator announces what's happening at every stage entry.

## Changes
### 1. Factory pattern principle (aidlc-full-stack-development-skill)

Added principle: always abstract external dependencies behind interfaces (ports/adapters, factory pattern). Code-gen produces both the interface and the real implementation. Tests during code-gen use mocks; dependency-verification swaps in real connections.

### 2. New stage: dependency-verification (replaces build-and-test)

- Connect generated code to real dependencies (databases, queues, caches, APIs) and verify it works
- Human provides access credentials or says "deploy first" — stage adapts
- Owner: aidlc-sw-dev-engineer-agent, Reviewer: aidlc-code-reviewer-agent
- Removes the old build-and-test placeholder

### 3. Stage brief rule (stage-execution)

When entering any stage, the orchestrator composes a brief statement for the human: what inputs are being used, what will be produced, what's needed from them. Derived dynamically from the definition and current context — not hardcoded.