### PR TITLE
Add test-design stage (English-language test specification)

### DIFF
--- a/dist/kiro-ide/.kiro/stages/stage-graph.md
+++ b/dist/kiro-ide/.kiro/stages/stage-graph.md
@@ -24,6 +24,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | contract-design | Define inter-unit contracts so teams can build in parallel | aidlc-app-architect-agent |
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | nfr-design | Define quality targets, tech stack, and architectural patterns | aidlc-systems-architect-agent |
+| test-design | Produce English-language test specification as acceptance criteria | aidlc-systems-architect-agent |
 | infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
 | code-generation | Generate production code per unit with write-test-verify cycles | aidlc-sw-dev-engineer-agent |
 
@@ -42,8 +43,9 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | contract-design | units-generation (units + dependencies), components.yaml (entity shapes) |
 | functional-design | contract-design (contracts for this unit's boundaries), units-generation (unit definition + assigned stories) |
 | nfr-design | requirements.md (NFR section), functional-design artifacts, components.yaml |
+| test-design | functional-design (rules.yaml, entities.yaml, functional-spec.md), nfr-specification.md, contracts |
 | infrastructure-design | nfr-design (spec with patterns + tech stack) |
-| code-generation | functional-design, nfr-design, infrastructure-design, units-generation, domain-design, stories, requirements |
+| code-generation | functional-design, nfr-design, test-design (acceptance criteria), infrastructure-design, units-generation, domain-design, stories, requirements |
 
 ## Artifact Flow
 

--- a/dist/kiro-ide/.kiro/stages/test-design/definition.md
+++ b/dist/kiro-ide/.kiro/stages/test-design/definition.md
@@ -1,0 +1,28 @@
+# Test Design
+
+## Description
+
+Produce a complete English-language test specification covering all tiers: unit tests, component tests, and integration tests. Each test case traces to a business rule or NFR target. This artifact serves two purposes — it guides code-generation as acceptance criteria, and it provides the QA team (or a future test-code-generation track) with an independent test plan.
+
+## Inputs
+
+- **Required:** `functional-spec.md` + `rules.yaml` + `entities.yaml` from functional-design, `nfr-specification.md` from nfr-design
+- **Optional context:** Contracts from contract-design (for integration-level test cases), `components.yaml` from domain-design
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
+
+- `test-specification.md` — English-language test cases organised by tier (unit, component, integration) with traceability to rules and NFRs
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-product-manager-agent: validate test cases cover acceptance criteria from stories
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/dist/kiro-ide/.kiro/stages/test-design/templates/test-specification.md
+++ b/dist/kiro-ide/.kiro/stages/test-design/templates/test-specification.md
@@ -1,0 +1,50 @@
+# Test Specification
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit Tests
+
+Tests for individual methods/functions in isolation.
+
+### [Component / Module Name]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-001 | [short description] | [BR-n / NFR-n] | [precondition] | [action] | [expected outcome] |
+
+## Component Tests
+
+Tests for complete call chains within the unit (multiple methods working together).
+
+### [Flow / Feature Name]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-050 | [short description] | [BR-n / NFR-n] | [precondition] | [action] | [expected outcome] |
+
+## Integration Tests
+
+Tests for interactions with external dependencies and other units (via contracts).
+
+### [Integration Boundary]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-100 | [short description] | [BR-n / NFR-n / Contract C-n] | [precondition] | [action] | [expected outcome] |
+
+## NFR Tests
+
+Tests derived from non-functional requirements (performance, security, availability).
+
+### [Quality Attribute]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-150 | [short description] | [NFR-n] | [precondition / load condition] | [action] | [expected measurable outcome] |
+
+## Coverage Matrix
+
+| Rule / NFR | Test Cases | Tier |
+|---|---|---|
+| BR-001 | TC-001, TC-051 | unit, component |
+| NFR-1 | TC-150 | nfr |

--- a/future-test-workflow.md
+++ b/future-test-workflow.md
@@ -1,0 +1,55 @@
+# Future Test Workflow — Parallel Tracks
+
+## Vision
+
+Test-design produces a single English-language test specification. Today, code-generation consumes it as acceptance criteria. In the future, the workflow forks after test-design into two parallel tracks:
+
+1. **Code Generation Track** — AI writes production code guided by the test spec
+2. **Test Code Generation Track** — AI (or QA team) writes independent verification code guided by the same test spec
+
+Both tracks work against the same contract. Integration happens at deployment when the independently-written test code runs against the independently-written production code.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    subgraph INCEPTION["Inception"]
+        RQ[Requirements]
+        ST[Stories]
+        WF[Wireframes]
+        DD[Domain Design]
+        UG[Units Generation]
+        CD[Contract Design]
+    end
+
+    subgraph CONSTRUCTION["Construction (per-unit)"]
+        FD[Functional Design]
+        NFR[NFR Design]
+        TD_stage[Test Design]
+        ID[Infrastructure Design]
+        CG[Code Generation]
+    end
+
+    subgraph FUTURE["Future: Parallel Tracks"]
+        CG_future[Code Generation]
+        TCG[Test Code Generation]
+    end
+
+    RQ --> ST --> WF --> DD --> UG --> CD
+
+    CD --> FD --> NFR --> TD_stage
+    TD_stage --> ID --> CG
+
+    TD_stage -.->|"future fork"| CG_future
+    TD_stage -.->|"future fork"| TCG
+
+    style TD_stage fill:#4CAF50,stroke:#1B5E20,stroke-width:3px,color:#fff
+    style FUTURE fill:#FFF59D,stroke:#F57F17,stroke-width:2px,stroke-dasharray: 5 5
+```
+
+## Why this matters
+
+- **Independent verification** — the test code is written by a different agent/team than the production code. Neither knows the other's implementation. Bugs are caught by the mismatch.
+- **AI-native but org-compatible** — organisations with QA sign-off processes get their artifact (test plan) and their independent test execution. No process change required.
+- **Same spec, two outputs** — the test-design document is the stable contract. Whether humans or AI consume it doesn't change the artifact.
+- **Transition path** — today it's linear (test-design → code-gen). Tomorrow it forks. The test-design stage doesn't change — only what happens after it.

--- a/src/stages/stage-graph.md
+++ b/src/stages/stage-graph.md
@@ -24,6 +24,7 @@ Directed graph of all available stages. The orchestrator reads this during workf
 | contract-design | Define inter-unit contracts so teams can build in parallel | aidlc-app-architect-agent |
 | functional-design | Design detailed business logic, domain entities, rules, and API spec per unit | aidlc-systems-architect-agent |
 | nfr-design | Define quality targets, tech stack, and architectural patterns | aidlc-systems-architect-agent |
+| test-design | Produce English-language test specification as acceptance criteria | aidlc-systems-architect-agent |
 | infrastructure-design | Map logical components to infrastructure services and define deployment | aidlc-systems-architect-agent |
 | code-generation | Generate production code per unit with write-test-verify cycles | aidlc-sw-dev-engineer-agent |
 
@@ -42,8 +43,9 @@ Stages have flexible inputs — they can start from multiple predecessors or dir
 | contract-design | units-generation (units + dependencies), components.yaml (entity shapes) |
 | functional-design | contract-design (contracts for this unit's boundaries), units-generation (unit definition + assigned stories) |
 | nfr-design | requirements.md (NFR section), functional-design artifacts, components.yaml |
+| test-design | functional-design (rules.yaml, entities.yaml, functional-spec.md), nfr-specification.md, contracts |
 | infrastructure-design | nfr-design (spec with patterns + tech stack) |
-| code-generation | functional-design, nfr-design, infrastructure-design, units-generation, domain-design, stories, requirements |
+| code-generation | functional-design, nfr-design, test-design (acceptance criteria), infrastructure-design, units-generation, domain-design, stories, requirements |
 
 ## Artifact Flow
 

--- a/src/stages/test-design/definition.md
+++ b/src/stages/test-design/definition.md
@@ -1,0 +1,28 @@
+# Test Design
+
+## Description
+
+Produce a complete English-language test specification covering all tiers: unit tests, component tests, and integration tests. Each test case traces to a business rule or NFR target. This artifact serves two purposes — it guides code-generation as acceptance criteria, and it provides the QA team (or a future test-code-generation track) with an independent test plan.
+
+## Inputs
+
+- **Required:** `functional-spec.md` + `rules.yaml` + `entities.yaml` from functional-design, `nfr-specification.md` from nfr-design
+- **Optional context:** Contracts from contract-design (for integration-level test cases), `components.yaml` from domain-design
+
+## Outputs
+
+Artifacts this stage can produce. The owner's plan determines which are relevant. Additional artifacts may be produced if warranted.
+
+- `test-specification.md` — English-language test cases organised by tier (unit, component, integration) with traceability to rules and NFRs
+
+## Owner
+
+aidlc-systems-architect-agent
+
+## Contributors
+
+- aidlc-product-manager-agent: validate test cases cover acceptance criteria from stories
+
+## Reviewer
+
+aidlc-architecture-reviewer-agent

--- a/src/stages/test-design/templates/test-specification.md
+++ b/src/stages/test-design/templates/test-specification.md
@@ -1,0 +1,50 @@
+# Test Specification
+
+> Minimum structure. Sections may be omitted with rationale or extended as needed.
+
+## Unit Tests
+
+Tests for individual methods/functions in isolation.
+
+### [Component / Module Name]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-001 | [short description] | [BR-n / NFR-n] | [precondition] | [action] | [expected outcome] |
+
+## Component Tests
+
+Tests for complete call chains within the unit (multiple methods working together).
+
+### [Flow / Feature Name]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-050 | [short description] | [BR-n / NFR-n] | [precondition] | [action] | [expected outcome] |
+
+## Integration Tests
+
+Tests for interactions with external dependencies and other units (via contracts).
+
+### [Integration Boundary]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-100 | [short description] | [BR-n / NFR-n / Contract C-n] | [precondition] | [action] | [expected outcome] |
+
+## NFR Tests
+
+Tests derived from non-functional requirements (performance, security, availability).
+
+### [Quality Attribute]
+
+| ID | Test Case | Traces to | Given | When | Then |
+|---|---|---|---|---|---|
+| TC-150 | [short description] | [NFR-n] | [precondition / load condition] | [action] | [expected measurable outcome] |
+
+## Coverage Matrix
+
+| Rule / NFR | Test Cases | Tier |
+|---|---|---|
+| BR-001 | TC-001, TC-051 | unit, component |
+| NFR-1 | TC-150 | nfr |

--- a/test-design-stage-summary.md
+++ b/test-design-stage-summary.md
@@ -1,0 +1,41 @@
+# Test Design Stage — Summary
+
+## What it is
+
+- A specification stage that produces English-language test cases, not test code
+- Sits after NFR design (has both functional spec and quality targets to draw from)
+- Feeds into code-generation as acceptance criteria ("am I done?")
+
+## What it produces
+
+- Tiered test cases: unit-level (method does X), component-level (call chain within unit), integration-level (cross-unit)
+- Each test case traces to a business rule (BR-n) or NFR target (NFR-n)
+- Reviewable by product people — plain English, not framework-specific code
+
+## Two consumers of the same artifact
+
+- **Code-generation** — uses test cases as guardrails during development (TDD-like guidance)
+- **QA team / test-code-gen** — uses test cases to write independent test code on their own machine
+
+## Future fork (next iteration)
+
+- Test-design becomes the last shared stage
+- Road splits: code-gen track (production code) and test-code-gen track (verification code) run in parallel
+- Both guided by the same test design document
+
+## Traceability chain
+
+- Requirement (FR/NFR) → Business Rule (BR-n) → Test Case (TC-n) → Code
+
+## Current flow
+
+```
+functional-design → nfr-design → test-design → infrastructure-design → code-generation
+```
+
+## Future flow
+
+```
+functional-design → nfr-design → test-design → infrastructure-design ─┬─→ code-generation
+                                                                       └─→ test-code-generation (parallel)
+```


### PR DESCRIPTION
## Summary

New stage between nfr-design and infrastructure-design that produces English-language test cases as a specification, not code. Serves as acceptance criteria for code-generation and as a test plan for QA teams.

## Changes

- **test-design stage** — definition + test-specification.md template with tiered test cases (unit, component, integration, NFR)
- **stage-graph** — added test-design entry and dependencies; code-generation now consumes test-design as acceptance criteria
- **test-design-stage-summary.md** — design thinking document
- **future-test-workflow.md** — vision for parallel code-gen / test-code-gen tracks (next iteration)

## Flow after this PR

`functional-design → nfr-design → test-design → infrastructure-design → code-generation`

## Key design decisions

- **English not code** — reviewable by product people, framework-agnostic
- **Traceability**: Every test case traces to BR-n or NFR-n (traceability chain: requirement → rule → test → code)
- **Two consumers**: code-gen (guardrails) and QA team (independent test plan)
- Future fork point for parallel AI tracks (documented, not yet implemented)