### PR TITLE
docs(claude-code): don't present /aidlc slash commands as shell commands

### DIFF
--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -74,8 +74,15 @@ Everything runs on native Windows — WSL is not required. [Git for Windows](htt
 # Copy the implementation into your project
 cp -r dist/claude/.claude/ your-project/.claude/
 
+# Launch Claude Code in your project
+cd your-project && claude
+```
+
+Then, inside the Claude Code session:
+
+```
 # Verify the setup
-cd your-project && /aidlc --doctor
+/aidlc --doctor
 
 # Start a workflow — describe what you want to build
 /aidlc Build a task management API with user authentication

--- a/claude-code/docs/guide/01-getting-started.md
+++ b/claude-code/docs/guide/01-getting-started.md
@@ -267,6 +267,8 @@ See [Your First Workflow](02-your-first-workflow.md) for a step-by-step walkthro
 
 ## Quick Reference
 
+In your shell:
+
 ```bash
 # Verify prerequisites
 command -v claude >/dev/null && echo "✓ Claude Code" || echo "✗ Claude Code"
@@ -275,8 +277,14 @@ command -v bun    >/dev/null && echo "✓ bun"          || echo "✗ bun"
 # Install
 cp -r dist/claude/.claude/ your-project/.claude/
 
+# Launch Claude Code in your project
+cd your-project && claude
+```
+
+Inside the Claude Code session:
+
+```
 # Scaffold docs directory
-cd your-project
 /aidlc --init
 
 # Verify (exits 1 on any check failure; read stdout for the full report)

--- a/claude-code/docs/guide/workshop-mode.md
+++ b/claude-code/docs/guide/workshop-mode.md
@@ -39,8 +39,9 @@ Inception runs serially with the facilitator at the keyboard. Construction is wh
 
 ### Before the session
 
-```bash
-cd workshop-project
+Launch Claude Code in the project (`cd workshop-project && claude`), then:
+
+```
 /aidlc --init --scope workshop --project-dir .
 ```
 
@@ -120,9 +121,9 @@ The push has three possible outcomes:
 
 ### 3. Run the Bolt locally
 
-Once the claim is published, run the Bolt the normal way:
+Once the claim is published, run the Bolt the normal way — in the Claude Code session:
 
-```bash
+```
 /aidlc
 ```
 
@@ -172,7 +173,8 @@ Alice and Bob have each cloned the workshop repo. During Inception's stage 2.2 t
 git fetch --all
 bun .claude/tools/aidlc-worktree.ts create --slug user-profile-api --base main
 git push origin bolt-user-profile-api    # claim succeeds — first claimant
-/aidlc                           # runs Construction stages 3.1–3.5 in the worktree
+# In Claude Code (`claude`), run: /aidlc
+#   — runs Construction stages 3.1–3.5 in the worktree
 # Group reviews and approves the always-gate (workshop keeps every gate)
 bun .claude/tools/aidlc-bolt.ts complete --merge --slug user-profile-api
 git push origin main                      # publishes the merged result


### PR DESCRIPTION
## Summary

Follow-up to #348. The Quick Start docs presented `/aidlc` slash commands as shell commands — e.g. `cd your-project && /aidlc --doctor` in a `bash` fence — which fails in a terminal: `/aidlc` only works inside a Claude Code session.

Every affected block is now split into the shell part (install, `cd`, launch `claude`) and the in-session part (`/aidlc ...`):

- **README.md** — Quick Start step 2
- **docs/guide/01-getting-started.md** — Quick Reference
- **docs/guide/workshop-mode.md** — facilitator setup, "Run the Bolt locally", and the walking-skeleton worked example

Swept the rest of the docs (including the shipped `dist/` tree) for the same pattern — no other occurrences.

Docs-only; no version bump per the changelog policy.
