### PR TITLE
fix: add steering to enforce orchestration for all code-change prompts

### DIFF
--- a/kiro/build/kiro-ide/build.js
+++ b/kiro/build/kiro-ide/build.js
@@ -8,6 +8,7 @@
  *   src/stages/              → dist/kiro-ide/.kiro/stages/        (copy)
  *   src/conventions/         → dist/kiro-ide/.kiro/conventions/   (copy)
  *   src/tools/               → dist/kiro-ide/.kiro/tools/         (copy)
+ *   src/steering/            → dist/kiro-ide/.kiro/steering/     (copy)
  *   src/kiro-ide/hooks/      → dist/kiro-ide/.kiro/hooks/         (copy)
  *
  * Usage: node build/kiro-ide/build.js
@@ -219,7 +220,10 @@ cpR(path.join(SRC, "conventions"), path.join(OUT, "conventions"));
 // 5. Copy tools
 cpR(path.join(SRC, "tools"), path.join(OUT, "tools"));
 
-// 6. Copy Kiro-specific hooks
+// 6. Copy steering files
+cpR(path.join(SRC, "steering"), path.join(OUT, "steering"));
+
+// 7. Copy Kiro-specific hooks
 const hooksSrc = path.join(SRC, "target-config", "kiro-ide", "hooks");
 const hooksDest = path.join(OUT, "hooks");
 fs.mkdirSync(hooksDest, { recursive: true });

--- a/kiro/src/steering/aidlc-workflows.md
+++ b/kiro/src/steering/aidlc-workflows.md
@@ -1,0 +1,11 @@
+---
+inclusion: always
+---
+
+# AI-DLC Workflow Enforcement
+
+Every user message that implies a change to the codebase — no matter how small — MUST go through the aidlc-orchestration skill before any other action is taken.
+
+This includes: adding features, fixing bugs, modifying UI, updating logic, refactoring, changing config, or any other code-related request.
+
+Do NOT proceed with implementation directly. Activate `aidlc-orchestration` first.


### PR DESCRIPTION
In brownfield repos, Kiro's default routing intercepts small code-change requests ("make buttons yellow", "add a grid to dashboard") and invokes its built-in context-gatherer instead of the aidlc orchestrator. The orchestration skill never gets activated.

**Fix**: Add an always-included steering file that tells Kiro to route ALL code-change requests through `aidlc-orchestration `first, regardless of workspace state.

- Added `aidlc-workflows.md` with `inclusion: always`
- Broadened `orchestration` skill description to cover small changes explicitly