### PR TITLE
fix: #356 workflow should stop when asking questions (ask) or waiting for approval ([?] state)

### DIFF
--- a/core/hooks/aidlc-stop.ts
+++ b/core/hooks/aidlc-stop.ts
@@ -359,6 +359,19 @@ if (kind === "done") {
   allowStop();
 }
 
+// `ask` → the engine is waiting for human input (scope confirmation, gate
+// question, etc.). Allow the agent to end its turn so the user can respond.
+if (kind === "ask") {
+  allowStop();
+}
+
+// Stage is awaiting human approval ([?] state) — the agent presented the gate
+// and should stop to let the user decide. Allow the stop.
+const awaitingMatch = stateContent.match(/\[\?]\s/);
+if (awaitingMatch && kind === "run-stage") {
+  allowStop();
+}
+
 // A directive is PENDING (run-stage / dispatch-subagent / invoke-swarm /
 // present-gate / ask / print / error). Decide whether to block, honouring the
 // recursion bounds. When the bounds say release, LET GO — a stuck loop must


### PR DESCRIPTION

# Summary

Fix issue #356. Workflow now stop when asking questions or needing approval.

## Changes

Update the stop hook to allow stop in these 2 conditions.

## User experience

Before change, the workflow was trying to push the agent to continue, and the agent finally self answered the questions and approved the gate.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

## Test Plan

Restarting a fresh workflow (same intent, same model) as in #356, this time the workflow stopped for me to answer.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
