### PR TITLE
chore: regenerate dist for #356 aidlc-stop fix

### DIFF
--- a/dist/claude/.claude/hooks/aidlc-stop.ts
+++ b/dist/claude/.claude/hooks/aidlc-stop.ts
@@ -359,6 +359,19 @@ if (kind === "done") {
   allowStop();
 }
 
+// `ask` → the engine is waiting for human input (scope confirmation, gate
+// question, etc.). Allow the agent to end its turn so the user can respond.
+if (kind === "ask") {
+  allowStop();
+}
+
+// Stage is awaiting human approval ([?] state) — the agent presented the gate
+// and should stop to let the user decide. Allow the stop.
+const awaitingMatch = stateContent.match(/\[\?]\s/);
+if (awaitingMatch && kind === "run-stage") {
+  allowStop();
+}
+
 // A directive is PENDING (run-stage / dispatch-subagent / invoke-swarm /
 // present-gate / ask / print / error). Decide whether to block, honouring the
 // recursion bounds. When the bounds say release, LET GO — a stuck loop must

--- a/dist/codex/.codex/hooks/aidlc-stop.ts
+++ b/dist/codex/.codex/hooks/aidlc-stop.ts
@@ -359,6 +359,19 @@ if (kind === "done") {
   allowStop();
 }
 
+// `ask` → the engine is waiting for human input (scope confirmation, gate
+// question, etc.). Allow the agent to end its turn so the user can respond.
+if (kind === "ask") {
+  allowStop();
+}
+
+// Stage is awaiting human approval ([?] state) — the agent presented the gate
+// and should stop to let the user decide. Allow the stop.
+const awaitingMatch = stateContent.match(/\[\?]\s/);
+if (awaitingMatch && kind === "run-stage") {
+  allowStop();
+}
+
 // A directive is PENDING (run-stage / dispatch-subagent / invoke-swarm /
 // present-gate / ask / print / error). Decide whether to block, honouring the
 // recursion bounds. When the bounds say release, LET GO — a stuck loop must

--- a/dist/kiro/.kiro/hooks/aidlc-stop.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-stop.ts
@@ -359,6 +359,19 @@ if (kind === "done") {
   allowStop();
 }
 
+// `ask` → the engine is waiting for human input (scope confirmation, gate
+// question, etc.). Allow the agent to end its turn so the user can respond.
+if (kind === "ask") {
+  allowStop();
+}
+
+// Stage is awaiting human approval ([?] state) — the agent presented the gate
+// and should stop to let the user decide. Allow the stop.
+const awaitingMatch = stateContent.match(/\[\?]\s/);
+if (awaitingMatch && kind === "run-stage") {
+  allowStop();
+}
+
 // A directive is PENDING (run-stage / dispatch-subagent / invoke-swarm /
 // present-gate / ask / print / error). Decide whether to block, honouring the
 // recursion bounds. When the bounds say release, LET GO — a stuck loop must


### PR DESCRIPTION

# Summary

PR #357 changed core/hooks/aidlc-stop.ts but did not regenerate the dist/<harness>/ copies, so the ask/[?]-state stop fix never shipped to users and package.ts --check fails on the drift. Regenerate all three harness trees so dist matches core.

## Changes

Regenerate the dist for all 3 harnesses.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

`bun scripts/package.ts --check` ==> no more `DIFFERS`

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
