### PR TITLE
ci: add dist-drift guard and smoke+unit test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - v2-unified
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    name: dist drift guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Verify dist is in sync with core/ + harness/
+        run: bun scripts/package.ts --check
+
+  tests:
+    name: smoke + unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run smoke + unit tests
+        run: bash tests/run-tests.sh --smoke --unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - v2-unified
+      - v2
 
 permissions:
   contents: read


### PR DESCRIPTION
# Summary

Adds the repository's first GitHub Actions workflow. There is currently no CI, which is how a recent stop-hook fix was able to merge with its `dist/` copies left un-regenerated. This adds two deterministic gates so that class of mistake cannot reach `v2-unified` again.

## Changes

New `.github/workflows/ci.yml` with two jobs, triggered on every pull request and on pushes to `main` / `v2-unified`:

* **drift-check** — runs `bun scripts/package.ts --check`, failing any change where `dist/<harness>/` is out of sync with `core/` + `harness/`.
* **tests** — runs `bash tests/run-tests.sh --smoke --unit` (102 files).

Both jobs install with `bun install --frozen-lockfile` and pin bun to `1.3.14`.

Integration and e2e tiers are intentionally excluded: they gate on an authenticated Claude CLI (the `t19` preflight) that vanilla GitHub Actions has no credentials for. They remain runnable locally and can move to a separate credentialed workflow later.

## User experience

Before: nothing verifies a contribution on push or PR. A PR that edits `core/` or `harness/` without regenerating `dist/`, or that breaks a smoke/unit test, can be merged with no signal.

After: every PR and push to `main` / `v2-unified` shows two required-style checks. A stale `dist/` or a failing smoke/unit test turns the PR red with the exact `--check` drift output or the failing test name. No change for end users of the framework — this is repository-maintenance tooling only.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

## Test Plan

1. Confirm the workflow is syntactically valid and appears under the repo's Actions tab once merged.
2. On this PR, verify both jobs run and pass:
   * `drift-check` — green, ending in `package --check: all harness trees in sync`.
   * `tests` — green, `RESULT: PASS` over 102 files.
3. To prove the drift gate bites: on a scratch branch, edit a file under `core/` without running `bun scripts/package.ts`, push, and confirm `drift-check` fails with a `DIFFERS:` line.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).