### PR TITLE
feat(sensors): Python support for linter and type-check sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.10] - 2026-06-17
+
+The code-quality sensors (`linter`, `type-check`) now support **Python** alongside TS/JS. Both sensors dispatch on file extension: `.py`/`.pyi` files are linted with **ruff** and type-checked with **mypy** or **pyright** (whichever the project configures). The principle is "use what the project configures; do nothing otherwise" — identical to the eslint/tsc behaviour for JS. No config = quiet pass (the sensor stays silent). Test-suite prerequisite: `ruff` and `mypy` must be installed in the test environment for the new integration tests to pass (same as eslint/tsc are required for the TS tests).
+
+* **Linter sensor fires on `.py`/`.pyi`**: resolves ruff side-effect-free (`python -m ruff` → `python3 -m ruff` → bare `ruff`); gates on `ruff check --show-settings` (no ruff config = quiet pass); parses `--output-format=json` into the locked `{pass, errorCount, violations[]}` shape. `uv run` excluded (it can create a `.venv`).
+* **Type-check sensor fires on `.py`/`.pyi`**: selects mypy or pyright from project config (`[tool.mypy]`/`mypy.ini` → mypy; `[tool.pyright]`/`pyrightconfig.json` → pyright; both → mypy wins; neither → quiet pass). mypy resolved the same way as ruff (`python -m` → `python3 -m` → bare binary). pyright via `bunx` (it genuinely is npm). mypy JSONL and pyright JSON parsed + normalised (0-based → 1-based) into the locked `{pass, errors[]}` shape.
+* **Manifest globs widened**: `linter` now matches `**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}`; `type-check` now matches `**/*.{ts,tsx,py,pyi}`.
+* **No dispatcher change, no stage edits**: same two sensor ids, same pull-authoring model. Stages that already import `linter`/`type-check` get Python coverage for free.
+* **4 new integration tests** in t92 (Group C2) mirroring the TS real-fixture round-trips: passing/failing for both ruff and mypy, un-gated.
+
 ## [0.7.9] - 2026-06-16
 
 Extends the Stop-hook human-wait carve-out (v0.7.8) to the last common case: a **mid-stage clarifying question**. When the conductor asks you something mid-stage, the stage stays `[-]` in-progress — indistinguishable, by checkbox state alone, from a conductor that quit mid-work — so v0.7.8 deliberately left it to the block cap. The hook now reads the stage's `<slug>-questions.md`: when it carries an unanswered `[Answer]:` tag (a question is genuinely pending) the stop is allowed, so the workflow waits for your answer instead of nudging itself (and, as issue #356 saw, self-answering). The carve-out is strictly gated — it never fires under autonomous Construction (`Construction Autonomy Mode: autonomous`), where the loop must keep running unattended — and is positive-confirmation + fail-open like its siblings. Re-copy your `dist/<harness>/` to pick it up.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that CLI. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-0.7.9-blue)
+![version](https://img.shields.io/badge/version-0.7.10-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)
 ![Claude Code](https://img.shields.io/badge/harness-Claude%20Code-orange)

--- a/core/aidlc-common/stages/construction/code-generation.md
+++ b/core/aidlc-common/stages/construction/code-generation.md
@@ -184,12 +184,13 @@ worktree. Generated code lives at the workspace root (NEVER under
 
 The imported sensors check the code outputs:
 
-- **`linter`** wraps the project's configured linter (eslint by default).
-  Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
+- **`linter`** wraps the project's configured linter (eslint for TS/JS, ruff
+  for Python). Fires on every Write/Edit matching its
+  `matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
   detail at `aidlc-docs/.aidlc-sensors/code-generation/linter-<iso>.md`.
-- **`type-check`** wraps the project's configured type-checker (tsc by
-  default). Fires on `**/*.{ts,tsx}`. Failure mode: type errors emit
+- **`type-check`** wraps the project's configured type-checker (tsc for TS,
+  mypy or pyright for Python). Fires on `**/*.{ts,tsx,py,pyi}`. Failure mode: type errors emit
   `SENSOR_FAILED` with similar detail.
 
 The two universal markdown-shape sensors (`required-sections`,

--- a/core/sensors/aidlc-linter.md
+++ b/core/sensors/aidlc-linter.md
@@ -3,9 +3,9 @@ id: linter
 kind: deterministic
 command: bun {{HARNESS_DIR}}/tools/aidlc-sensor-linter.ts
 default_severity: advisory
-description: Wraps the project's configured linter (eslint by default for v0.5.0); fires on TS/JS code outputs
+description: Wraps the project's configured linter (eslint for TS/JS, ruff for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,js}"
+matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,8 +20,23 @@ timeout_seconds: 30
 
 # linter sensor
 
-Wraps the project's configured linter. v0.5.0 defaults to eslint; multi-language
-auto-detection (ruff, golangci-lint, clippy) is deferred to v0.6.0+.
+Wraps the project's configured linter, dispatching on file extension:
+
+- **TS/JS** (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`) → eslint
+  (`bunx eslint --format json`). Defers to eslint's own config discovery; a
+  project with no eslint config produces a quiet PASS.
+- **Python** (`.py`, `.pyi`) → ruff (`ruff check --output-format=json`). ruff is
+  a Python tool, not an npm package, so it never rides bunx. It is resolved
+  side-effect-free (a sensor fires on every write, so it must never install or
+  create a venv — which rules out `uv run`): `python -m ruff` first (the
+  project's ruff when its venv is active), then a bare `ruff` on PATH. Walks up
+  to the nearest `pyproject.toml` / `ruff.toml` / `.ruff.toml` and only runs
+  when the project actually configures ruff (probed via
+  `ruff check --show-settings`); no ruff config produces a quiet PASS, mirroring
+  the eslint no-config behaviour.
+
+Either way the sensor uses what the project configures and imposes no default
+ruleset. An unknown extension is a quiet PASS.
 
 Echoes Fowler's "Eslint, Semgrep" examples from the harness-engineering article.
 
@@ -31,7 +46,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/linter-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing the
 linter's structured output (file, line, rule, message per violation).
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate linter).
+Additional languages (go vet/golangci-lint, clippy) and Java static analysis
+remain future work — Java in particular fits the module-level build, not a
+per-file sensor.

--- a/core/sensors/aidlc-type-check.md
+++ b/core/sensors/aidlc-type-check.md
@@ -3,9 +3,9 @@ id: type-check
 kind: deterministic
 command: bun {{HARNESS_DIR}}/tools/aidlc-sensor-type-check.ts
 default_severity: advisory
-description: Wraps the project's configured type-checker (tsc by default for v0.5.0); fires on TS/TSX code outputs
+description: Wraps the project's configured type-checker (tsc for TS/TSX, mypy or pyright for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,tsx}"
+matches: "**/*.{ts,tsx,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,9 +20,26 @@ timeout_seconds: 60
 
 # type-check sensor
 
-Wraps the project's configured type-checker. v0.5.0 defaults to tsc;
-multi-language auto-detection (mypy, go vet, cargo-check) is deferred
-to v0.6.0+.
+Wraps the project's configured type-checker, dispatching on file extension:
+
+- **TS/TSX** (`.ts`, `.tsx`) → tsc (`bunx tsc --project <tsconfig> --noEmit`).
+  Project-scoped; diagnostics are post-filtered to the written file. No
+  `tsconfig.json` → quiet PASS.
+- **Python** (`.py`, `.pyi`) → mypy **or** pyright, whichever the project
+  configures:
+  - `[tool.mypy]` in `pyproject.toml`, `mypy.ini`, or `setup.cfg [mypy]` → mypy
+    (`mypy --output=json`). mypy is a Python tool, not npm, so it never rides
+    bunx; it is resolved side-effect-free as `python -m mypy` (the project's
+    mypy when its venv is active), falling back to a bare `mypy` on PATH.
+  - `[tool.pyright]` in `pyproject.toml`, or `pyrightconfig.json(c)` → pyright
+    (`bunx pyright --outputjson` — pyright is an npm package).
+  - Both configured → mypy wins (more common standard).
+  - Neither → quiet PASS.
+
+The sensor uses whatever type-checker the project declares and imposes no
+default. Python checkers are project-scoped (they follow imports), so the
+cross-file limitation documented for tsc applies equally. An unknown extension
+is a quiet PASS.
 
 Echoes Fowler's "type checkers" example from the harness-engineering article.
 
@@ -32,7 +49,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/type-check-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing
 the type-checker's structured output.
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate type-checker).
+Additional languages (go vet, cargo check) remain future work. Java type
+errors are compilation errors that fit the module-level build, not a per-file
+sensor.

--- a/core/tools/aidlc-sensor-linter.ts
+++ b/core/tools/aidlc-sensor-linter.ts
@@ -2,11 +2,28 @@
 //
 // Owns the linter check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx eslint --format
-// json --max-warnings -1 <path>` and prints the locked stdout JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errorCount": <n>, "warningCount": <n>,
 //    "violations": [{file, line, column, rule, severity, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx/.js/.jsx/.mjs/.cjs → eslint. Wraps `bunx eslint --format json
+//   --max-warnings -1 <path>` (walk up to the nearest package.json; defer to
+//   eslint's own config discovery; no eslint config → quiet PASS via 127).
+// * .py/.pyi → ruff. Runs `ruff check --output-format=json <path>`. ruff is a
+//   Python tool, not an npm package, so it never rides bunx; it is resolved
+//   side-effect-free as `python -m ruff` (the project's ruff when its venv is
+//   active), falling back to a bare `ruff` on PATH. Walks up to the nearest
+//   pyproject.toml/ruff.toml/.ruff.toml; only runs when the project actually
+//   configures ruff — no ruff config → quiet PASS via 127, mirroring eslint's
+//   no-config behaviour. ruff diagnostics are findings; pass = (#diagnostics == 0).
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default ruleset, it
+// only runs a tool the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-linter.ts):
@@ -117,8 +134,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-linter --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx eslint --format json --max-warnings -1 <path>\` and\n` +
-			`prints {pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
+			`Dispatches on file extension: .ts/.js → eslint, .py → ruff.\n` +
+			`Runs the project's configured linter and prints\n` +
+			`{pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
 	);
 }
 
@@ -297,6 +315,17 @@ function buildViolations(results: ESLintResult[]): Violation[] {
 
 // --- main -------------------------------------------------------------------
 
+// Language families keyed by file extension (lowercased, leading dot stripped).
+const ESLINT_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]);
+const RUFF_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return ""; // no extension, or dotfile with no ext
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -305,16 +334,33 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const projectRoot =
-		findProjectRoot(args.filePath) ?? dirname(resolve(args.filePath));
+	const ext = extOf(args.filePath);
+	if (ESLINT_EXTS.has(ext)) {
+		runEslintFlow(args.filePath);
+		return;
+	}
+	if (RUFF_EXTS.has(ext)) {
+		runRuffFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — not a failure. Exit 127 so the
+	// dispatcher's branch b records a quiet PASSED Note=tool-unavailable.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- eslint flow (TS/JS) ----------------------------------------------------
+
+function runEslintFlow(filePath: string): void {
+	const projectRoot = findProjectRoot(filePath) ?? dirname(resolve(filePath));
 
 	// Probe order: tool first (cheap, ~1s for cached bunx), then config
 	// (~1s for --print-config). Both gates feed dispatcher branch b
 	// (PASSED Note=tool-unavailable) on non-zero.
 	probeEslintAvailable(projectRoot);
-	probeEslintConfig(args.filePath, projectRoot);
+	probeEslintConfig(filePath, projectRoot);
 
-	const { stdout } = runEslint(args.filePath, projectRoot);
+	const { stdout } = runEslint(filePath, projectRoot);
 
 	// eslint exits 1 when violations exist and 0 when clean. With
 	// --max-warnings -1 the warning-exit override is disabled so we never
@@ -348,6 +394,203 @@ function main(): void {
 		warningCount,
 		violations: buildViolations(parsed),
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
+		findings_count: errorCount,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- ruff flow (Python) -----------------------------------------------------
+//
+// Mirrors the eslint flow structure: walk up to the project manifest, gate on
+// "is ruff actually configured?" (quiet-pass 127 when not), probe availability,
+// run, normalize to the locked SensorOutput shape.
+//
+// ruff JSON (`--output-format=json`) is an array of diagnostics:
+//   {code, message, filename, location:{row,column}, end_location, fix, url, …}
+// `code` may be null (e.g. syntax errors). Every reported diagnostic counts as
+// a finding — ruff has no warning/error split in this shape, so the eslint
+// "warnings don't fail" carve-out does not apply; pass = (#diagnostics == 0).
+
+interface RuffLocation {
+	row?: number;
+	column?: number;
+}
+
+interface RuffDiagnostic {
+	code: string | null;
+	message: string;
+	filename: string;
+	location?: RuffLocation;
+}
+
+// ruff config files that stand alone (no [tool.ruff] table needed). pyproject
+// .toml is handled separately because its presence alone does NOT mean ruff is
+// configured — only a [tool.ruff] table (or one of these files) does.
+const RUFF_CONFIG_FILES = ["ruff.toml", ".ruff.toml"];
+
+// Walk up from --file-path to the nearest dir that anchors a Python project:
+// a pyproject.toml, ruff.toml, or .ruff.toml. Returns that dir, or null.
+function findRuffProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (existsSync(`${dir}/pyproject.toml`)) return dir;
+		if (RUFF_CONFIG_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+// ruff invocation. ruff is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveRuffCmd resolves a ruff WITHOUT any side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`, both of which can provision an
+// environment on first use). Side-effect-free candidates, in decreasing order
+// of project fidelity:
+//   1. `python -m ruff` / `python3 -m ruff` — the ruff importable in whatever
+//      the interpreter resolves to (the project's ruff when its venv is active).
+//      Both `python` and `python3` are tried because many systems (CI images,
+//      Homebrew-only setups, pyenv loaded only in interactive shells) expose
+//      just `python3`; probing `python` alone would silently miss ruff there.
+//      Preferred over the bare binary so a project/venv ruff wins.
+//   2. `ruff` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0, so unavailable forms fall
+// through. null when none answers — null → the flow quiet-passes (127), the
+// same model mypy uses.
+//
+// Returns the argv PREFIX (command + leading args) the other ruff calls append
+// to, or null when ruff is not runnable in this environment.
+function resolveRuffCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "ruff"],
+		["python3", "-m", "ruff"],
+		["ruff"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function spawnRuff(
+	ruffCmd: string[],
+	subArgs: string[],
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = ruffCmd;
+	const result = spawnSync(cmd, [...prefix, ...subArgs], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	// encoding: "utf-8" makes stdout a string, but spawnSync's overload union
+	// isn't narrowed by the option alone — coerce with a typeof guard.
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// "Is ruff actually configured for this file?" — the use-what's-configured
+// gate, mirroring eslint's --print-config probe. Defer to ruff's OWN discovery
+// rather than hand-parsing TOML: `ruff check --show-settings <path>` exits 0
+// and prints the resolved settings when ruff has a config it will apply, and
+// exits non-zero when there is no configuration to resolve. Non-zero → exit 127
+// (quiet PASS), so a bare pyproject.toml with no [tool.ruff] table behaves like
+// a JS project with no eslint config: the sensor stays silent.
+function probeRuffConfigured(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): void {
+	const result = spawnRuff(ruffCmd, ["check", "--show-settings", filePath], cwd);
+	if (result.status === 0) return; // ruff resolved settings → configured
+	process.stderr.write("no-ruff-config\n");
+	process.exit(127);
+}
+
+function runRuff(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	// --force-exclude makes ruff honour the project's exclude config even when
+	// the file is passed explicitly (otherwise an explicitly-named excluded
+	// file is still checked). --no-cache avoids cache writes into the project.
+	const result = spawnRuff(
+		ruffCmd,
+		[
+			"check",
+			"--output-format=json",
+			"--force-exclude",
+			"--no-cache",
+			filePath,
+		],
+		cwd,
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+function buildRuffViolations(diags: RuffDiagnostic[]): Violation[] {
+	return diags.map((d) => ({
+		file: d.filename ?? "",
+		line: d.location?.row ?? 0,
+		column: d.location?.column ?? 0,
+		rule: d.code ?? "",
+		// ruff's JSON shape carries no severity; every diagnostic is a finding
+		// that fails the check, so report it as an error for the locked shape.
+		severity: "error",
+		message: d.message ?? "",
+	}));
+}
+
+function runRuffFlow(filePath: string): void {
+	const projectRoot = findRuffProject(filePath);
+	if (!projectRoot) {
+		// No pyproject.toml / ruff.toml anywhere above the file → not a ruff
+		// project. Quiet PASS, mirroring "no package.json" for eslint.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+
+	const ruffCmd = resolveRuffCmd(projectRoot);
+	if (!ruffCmd) {
+		// ruff not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("ruff-unavailable\n");
+		process.exit(127);
+	}
+	probeRuffConfigured(ruffCmd, filePath, projectRoot);
+
+	const { stdout } = runRuff(ruffCmd, filePath, projectRoot);
+
+	// ruff writes the JSON array to stdout on both clean (exit 0) and
+	// violations-present (exit 1) runs, so we parse stdout rather than gate on
+	// the exit code.
+	let parsed: RuffDiagnostic[];
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+	if (!Array.isArray(parsed)) {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+
+	const errorCount = parsed.length;
+	const out: SensorOutput = {
+		pass: errorCount === 0,
+		errorCount,
+		warningCount: 0,
+		violations: buildRuffViolations(parsed),
 		findings_count: errorCount,
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);

--- a/core/tools/aidlc-sensor-type-check.ts
+++ b/core/tools/aidlc-sensor-type-check.ts
@@ -2,12 +2,32 @@
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under aidlc-docs/.aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx → tsc. Wraps `bunx tsc --project <tsconfig> --noEmit --pretty
+//   false --incremental` (walk up to the nearest tsconfig.json; project-scoped
+//   check post-filtered to --file-path; no tsconfig → quiet PASS).
+// * .py/.pyi → mypy OR pyright, selected by what the project configures:
+//     - [tool.mypy] in pyproject.toml, or mypy.ini, or setup.cfg [mypy] → mypy
+//       (`mypy --output=json`). mypy is not npm, so it never rides bunx; it is
+//       resolved side-effect-free as `python -m mypy` (the project's mypy when
+//       its venv is active), falling back to a bare `mypy` on PATH; not
+//       installed → quiet PASS via 127.
+//     - [tool.pyright] in pyproject.toml, or pyrightconfig.json(c) → pyright
+//       (`bunx pyright --outputjson` — pyright IS an npm package).
+//     - both configured → mypy wins (more common standard; documented tie-break).
+//     - neither → quiet PASS via 127.
+//   Python checkers report 0-based line/character; we normalise to tsc's
+//   1-based convention so the locked `errors[]` shape is uniform across langs.
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default checker, it
+// only runs the one the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-type-check.ts):
@@ -71,7 +91,7 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 interface ParsedError {
@@ -125,8 +145,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-type-check --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx tsc --project <tsconfig> --noEmit --pretty false\` and\n` +
-			`prints {pass, errors[]} JSON to stdout (filtered to --file-path).\n`,
+			`Dispatches on file extension: .ts/.tsx → tsc, .py → mypy or pyright\n` +
+			`(whichever the project configures). Prints {pass, errors[]} JSON to\n` +
+			`stdout (filtered to --file-path).\n`,
 	);
 }
 
@@ -248,6 +269,16 @@ function filterToFilePath(
 
 // --- main -------------------------------------------------------------------
 
+const TSC_EXTS = new Set(["ts", "tsx"]);
+const PY_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return "";
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -256,7 +287,24 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const tsconfigPath = findTsconfig(args.filePath);
+	const ext = extOf(args.filePath);
+	if (TSC_EXTS.has(ext)) {
+		runTscFlow(args.filePath);
+		return;
+	}
+	if (PY_EXTS.has(ext)) {
+		runPyFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — quiet PASS via dispatcher branch b.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- tsc flow (TS/TSX) ------------------------------------------------------
+
+function runTscFlow(filePath: string): void {
+	const tsconfigPath = findTsconfig(filePath);
 	if (!tsconfigPath) {
 		process.stderr.write("no-tsconfig-found\n");
 		process.exit(1);
@@ -287,7 +335,7 @@ function main(): void {
 		cwd: tsconfigDir,
 	});
 	const allErrors = parseTscOutput(output);
-	const errors = filterToFilePath(allErrors, args.filePath, tsconfigDir);
+	const errors = filterToFilePath(allErrors, filePath, tsconfigDir);
 
 	// Status gate: tsc exited non-zero but parseTscOutput found ZERO diagnostics
 	// ANYWHERE in the project (a config-load failure — e.g. TS18003 "No inputs
@@ -314,6 +362,330 @@ function main(): void {
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);
 	process.exit(0);
+}
+
+// --- Python flow (mypy / pyright) -------------------------------------------
+//
+// Selects the checker the project configured, mirroring the tsc flow's
+// project-scoped check + post-filter to --file-path. Both Python checkers are
+// project-scoped (they follow imports), so the same cross-file known limitation
+// documented for tsc applies: an error a file INTRODUCES in a consumer reports
+// under the consumer's path, not --file-path.
+//
+// mypy `--output=json` emits JSONL: one `{file, line, column, message, hint,
+// code, severity}` object per line. Older mypy (<1.21) and config errors emit
+// plain text; unparseable-line handling falls through to the status gate so a
+// broken run never reports a false clean PASS.
+//
+// pyright `--outputjson` emits a single object with `generalDiagnostics[]`
+// ({file, severity, message, rule?, range:{start:{line,character}, end}}) and a
+// `summary.errorCount`. Line/character are 0-based; we +1 to match tsc.
+
+type PyChecker = "mypy" | "pyright";
+
+interface MypyDiagnostic {
+	file?: string;
+	line?: number;
+	column?: number;
+	message?: string;
+	severity?: string;
+}
+
+interface PyrightRange {
+	start?: { line?: number; character?: number };
+}
+
+interface PyrightDiagnostic {
+	file?: string;
+	severity?: string;
+	message?: string;
+	range?: PyrightRange;
+}
+
+interface PyrightOutput {
+	generalDiagnostics?: PyrightDiagnostic[];
+}
+
+// Walk up to the nearest dir anchoring a Python project (any of the manifests
+// that could declare a checker). Returns that dir, or null.
+const PY_PROJECT_FILES = [
+	"pyproject.toml",
+	"mypy.ini",
+	"setup.cfg",
+	"pyrightconfig.json",
+	"pyrightconfig.jsonc",
+];
+
+function findPyProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (PY_PROJECT_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function readFileSafe(path: string): string {
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
+		return "";
+	}
+}
+
+// Does any config in projectRoot declare mypy? [tool.mypy] in pyproject.toml,
+// a mypy.ini, or a [mypy] section in setup.cfg.
+function mypyConfigured(projectRoot: string): boolean {
+	if (existsSync(`${projectRoot}/mypy.ini`)) return true;
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	if (/^\s*\[tool\.mypy\b/m.test(pyproject)) return true;
+	const setupCfg = readFileSafe(`${projectRoot}/setup.cfg`);
+	if (/^\s*\[mypy\b/m.test(setupCfg)) return true;
+	return false;
+}
+
+// Does any config in projectRoot declare pyright? [tool.pyright] in
+// pyproject.toml, or a pyrightconfig.json(c).
+function pyrightConfigured(projectRoot: string): boolean {
+	if (
+		existsSync(`${projectRoot}/pyrightconfig.json`) ||
+		existsSync(`${projectRoot}/pyrightconfig.jsonc`)
+	) {
+		return true;
+	}
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	return /^\s*\[tool\.pyright\b/m.test(pyproject);
+}
+
+// Pick the configured checker. mypy wins the tie when both are configured
+// (more common standard). null → neither configured → caller quiet-passes.
+function selectPyChecker(projectRoot: string): PyChecker | null {
+	if (mypyConfigured(projectRoot)) return "mypy";
+	if (pyrightConfigured(projectRoot)) return "pyright";
+	return null;
+}
+
+// --- mypy -------------------------------------------------------------------
+
+// mypy invocation. mypy is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveMypyCmd resolves a mypy WITHOUT side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`). Side-effect-free candidates,
+// in decreasing order of project fidelity:
+//   1. `python -m mypy` / `python3 -m mypy` — the project's mypy when its venv
+//      is the active interpreter. Both `python` and `python3` are tried because
+//      many systems (CI, Homebrew-only, pyenv loaded only in interactive
+//      shells) expose just `python3`; probing `python` alone would silently
+//      miss mypy there. Preferred over the bare binary so a project/venv mypy
+//      wins.
+//   2. `mypy` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0. null when none answers — null
+// → quiet PASS (127), configured-but-absent is tool-unavailable.
+//
+// Returns the argv PREFIX (command + leading args) callers append to, or null
+// when mypy is not runnable in this environment.
+function resolveMypyCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "mypy"],
+		["python3", "-m", "mypy"],
+		["mypy"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function runMypy(
+	mypyCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = mypyCmd;
+	const result = spawnSync(
+		cmd,
+		[...prefix, "--output=json", "--no-error-summary", filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// Parse mypy JSONL. Returns the parsed error-severity diagnostics AND a count
+// of lines that failed to parse as JSON (text syntax/config errors on older
+// mypy). The caller uses parseFailures to avoid a false clean PASS.
+function parseMypyOutput(stdout: string): {
+	errors: ParsedError[];
+	parseFailures: number;
+} {
+	const errors: ParsedError[] = [];
+	let parseFailures = 0;
+	for (const rawLine of stdout.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line === "") continue;
+		if (!line.startsWith("{")) {
+			parseFailures++;
+			continue;
+		}
+		let diag: MypyDiagnostic;
+		try {
+			diag = JSON.parse(line);
+		} catch {
+			parseFailures++;
+			continue;
+		}
+		if (diag.severity !== "error") continue;
+		errors.push({
+			file: diag.file ?? "",
+			line: diag.line ?? 0,
+			column: diag.column ?? 0,
+			message: diag.message ?? "",
+		});
+	}
+	return { errors, parseFailures };
+}
+
+function runMypyFlow(filePath: string, projectRoot: string): void {
+	const mypyCmd = resolveMypyCmd(projectRoot);
+	if (!mypyCmd) {
+		// mypy not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("mypy-unavailable\n");
+		process.exit(127);
+	}
+	const { stdout, status } = runMypy(mypyCmd, filePath, projectRoot);
+	const { errors: allErrors, parseFailures } = parseMypyOutput(stdout);
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+
+	// Status gate, mirroring tsc: a non-zero exit that produced ZERO parseable
+	// error diagnostics is a broken run (config error, or a syntax error that
+	// older mypy emitted as text — counted in parseFailures). Propagate the exit
+	// so the dispatcher records script-error rather than a false clean PASS.
+	// mypy exits 1 on type errors AND on config/parse failures; reaching here
+	// with no parsed errors means no usable findings, so script-error is right.
+	void parseFailures;
+	if (status !== null && status !== 0 && allErrors.length === 0) {
+		process.exit(status);
+	}
+
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- pyright ----------------------------------------------------------------
+
+function probePyrightAvailable(cwd: string): void {
+	const result = spawnSync("bunx", ["pyright", "--version"], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	if (result.status !== 0) {
+		process.stderr.write("pyright-unavailable\n");
+		process.exit(127);
+	}
+}
+
+function runPyright(
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const result = spawnSync(
+		"bunx",
+		["pyright", "--outputjson", "--project", cwd, filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+// Parse pyright JSON. Returns error-severity diagnostics, normalised from
+// 0-based line/character to tsc's 1-based convention. parsedOk=false signals a
+// JSON parse failure so the caller can avoid a false clean PASS.
+function parsePyrightOutput(stdout: string): {
+	errors: ParsedError[];
+	parsedOk: boolean;
+} {
+	let parsed: PyrightOutput;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return { errors: [], parsedOk: false };
+	}
+	const diags = Array.isArray(parsed.generalDiagnostics)
+		? parsed.generalDiagnostics
+		: [];
+	const errors: ParsedError[] = [];
+	for (const d of diags) {
+		if (d.severity !== "error") continue;
+		const startLine = d.range?.start?.line ?? 0;
+		const startChar = d.range?.start?.character ?? 0;
+		errors.push({
+			file: d.file ?? "",
+			line: startLine + 1, // 0-based → 1-based (match tsc)
+			column: startChar + 1,
+			message: d.message ?? "",
+		});
+	}
+	return { errors, parsedOk: true };
+}
+
+function runPyrightFlow(filePath: string, projectRoot: string): void {
+	probePyrightAvailable(projectRoot);
+	const { stdout, status } = runPyright(filePath, projectRoot);
+	const { errors: allErrors, parsedOk } = parsePyrightOutput(stdout);
+
+	// Bad JSON on a non-zero exit → script-error (avoid false PASS). pyright
+	// exits 1 when it reports errors and 0 when clean; stdout is pure JSON.
+	if (!parsedOk) {
+		if (status !== null && status !== 0) process.exit(status);
+		process.stderr.write("pyright-bad-output\n");
+		process.exit(2);
+	}
+
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- Python dispatch --------------------------------------------------------
+
+function runPyFlow(filePath: string): void {
+	const projectRoot = findPyProject(filePath);
+	if (!projectRoot) {
+		// No Python project manifest above the file → quiet PASS.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+	const checker = selectPyChecker(projectRoot);
+	if (checker === null) {
+		// Project exists but configures no type checker → quiet PASS, mirroring
+		// "no eslint config" / "no tsconfig" behaviour.
+		process.stderr.write("no-python-type-checker-configured\n");
+		process.exit(127);
+	}
+	if (checker === "mypy") {
+		runMypyFlow(filePath, projectRoot);
+		return;
+	}
+	runPyrightFlow(filePath, projectRoot);
 }
 
 if (import.meta.main) main();

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.9";
+export const AIDLC_VERSION = "0.7.10";

--- a/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
@@ -184,12 +184,13 @@ worktree. Generated code lives at the workspace root (NEVER under
 
 The imported sensors check the code outputs:
 
-- **`linter`** wraps the project's configured linter (eslint by default).
-  Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
+- **`linter`** wraps the project's configured linter (eslint for TS/JS, ruff
+  for Python). Fires on every Write/Edit matching its
+  `matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
   detail at `aidlc-docs/.aidlc-sensors/code-generation/linter-<iso>.md`.
-- **`type-check`** wraps the project's configured type-checker (tsc by
-  default). Fires on `**/*.{ts,tsx}`. Failure mode: type errors emit
+- **`type-check`** wraps the project's configured type-checker (tsc for TS,
+  mypy or pyright for Python). Fires on `**/*.{ts,tsx,py,pyi}`. Failure mode: type errors emit
   `SENSOR_FAILED` with similar detail.
 
 The two universal markdown-shape sensors (`required-sections`,

--- a/dist/claude/.claude/sensors/aidlc-linter.md
+++ b/dist/claude/.claude/sensors/aidlc-linter.md
@@ -3,9 +3,9 @@ id: linter
 kind: deterministic
 command: bun .claude/tools/aidlc-sensor-linter.ts
 default_severity: advisory
-description: Wraps the project's configured linter (eslint by default for v0.5.0); fires on TS/JS code outputs
+description: Wraps the project's configured linter (eslint for TS/JS, ruff for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,js}"
+matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,8 +20,23 @@ timeout_seconds: 30
 
 # linter sensor
 
-Wraps the project's configured linter. v0.5.0 defaults to eslint; multi-language
-auto-detection (ruff, golangci-lint, clippy) is deferred to v0.6.0+.
+Wraps the project's configured linter, dispatching on file extension:
+
+- **TS/JS** (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`) → eslint
+  (`bunx eslint --format json`). Defers to eslint's own config discovery; a
+  project with no eslint config produces a quiet PASS.
+- **Python** (`.py`, `.pyi`) → ruff (`ruff check --output-format=json`). ruff is
+  a Python tool, not an npm package, so it never rides bunx. It is resolved
+  side-effect-free (a sensor fires on every write, so it must never install or
+  create a venv — which rules out `uv run`): `python -m ruff` first (the
+  project's ruff when its venv is active), then a bare `ruff` on PATH. Walks up
+  to the nearest `pyproject.toml` / `ruff.toml` / `.ruff.toml` and only runs
+  when the project actually configures ruff (probed via
+  `ruff check --show-settings`); no ruff config produces a quiet PASS, mirroring
+  the eslint no-config behaviour.
+
+Either way the sensor uses what the project configures and imposes no default
+ruleset. An unknown extension is a quiet PASS.
 
 Echoes Fowler's "Eslint, Semgrep" examples from the harness-engineering article.
 
@@ -31,7 +46,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/linter-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing the
 linter's structured output (file, line, rule, message per violation).
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate linter).
+Additional languages (go vet/golangci-lint, clippy) and Java static analysis
+remain future work — Java in particular fits the module-level build, not a
+per-file sensor.

--- a/dist/claude/.claude/sensors/aidlc-type-check.md
+++ b/dist/claude/.claude/sensors/aidlc-type-check.md
@@ -3,9 +3,9 @@ id: type-check
 kind: deterministic
 command: bun .claude/tools/aidlc-sensor-type-check.ts
 default_severity: advisory
-description: Wraps the project's configured type-checker (tsc by default for v0.5.0); fires on TS/TSX code outputs
+description: Wraps the project's configured type-checker (tsc for TS/TSX, mypy or pyright for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,tsx}"
+matches: "**/*.{ts,tsx,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,9 +20,26 @@ timeout_seconds: 60
 
 # type-check sensor
 
-Wraps the project's configured type-checker. v0.5.0 defaults to tsc;
-multi-language auto-detection (mypy, go vet, cargo-check) is deferred
-to v0.6.0+.
+Wraps the project's configured type-checker, dispatching on file extension:
+
+- **TS/TSX** (`.ts`, `.tsx`) → tsc (`bunx tsc --project <tsconfig> --noEmit`).
+  Project-scoped; diagnostics are post-filtered to the written file. No
+  `tsconfig.json` → quiet PASS.
+- **Python** (`.py`, `.pyi`) → mypy **or** pyright, whichever the project
+  configures:
+  - `[tool.mypy]` in `pyproject.toml`, `mypy.ini`, or `setup.cfg [mypy]` → mypy
+    (`mypy --output=json`). mypy is a Python tool, not npm, so it never rides
+    bunx; it is resolved side-effect-free as `python -m mypy` (the project's
+    mypy when its venv is active), falling back to a bare `mypy` on PATH.
+  - `[tool.pyright]` in `pyproject.toml`, or `pyrightconfig.json(c)` → pyright
+    (`bunx pyright --outputjson` — pyright is an npm package).
+  - Both configured → mypy wins (more common standard).
+  - Neither → quiet PASS.
+
+The sensor uses whatever type-checker the project declares and imposes no
+default. Python checkers are project-scoped (they follow imports), so the
+cross-file limitation documented for tsc applies equally. An unknown extension
+is a quiet PASS.
 
 Echoes Fowler's "type checkers" example from the harness-engineering article.
 
@@ -32,7 +49,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/type-check-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing
 the type-checker's structured output.
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate type-checker).
+Additional languages (go vet, cargo check) remain future work. Java type
+errors are compilation errors that fit the module-level build, not a per-file
+sensor.

--- a/dist/claude/.claude/tools/aidlc-sensor-linter.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-linter.ts
@@ -2,11 +2,28 @@
 //
 // Owns the linter check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx eslint --format
-// json --max-warnings -1 <path>` and prints the locked stdout JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errorCount": <n>, "warningCount": <n>,
 //    "violations": [{file, line, column, rule, severity, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx/.js/.jsx/.mjs/.cjs → eslint. Wraps `bunx eslint --format json
+//   --max-warnings -1 <path>` (walk up to the nearest package.json; defer to
+//   eslint's own config discovery; no eslint config → quiet PASS via 127).
+// * .py/.pyi → ruff. Runs `ruff check --output-format=json <path>`. ruff is a
+//   Python tool, not an npm package, so it never rides bunx; it is resolved
+//   side-effect-free as `python -m ruff` (the project's ruff when its venv is
+//   active), falling back to a bare `ruff` on PATH. Walks up to the nearest
+//   pyproject.toml/ruff.toml/.ruff.toml; only runs when the project actually
+//   configures ruff — no ruff config → quiet PASS via 127, mirroring eslint's
+//   no-config behaviour. ruff diagnostics are findings; pass = (#diagnostics == 0).
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default ruleset, it
+// only runs a tool the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-linter.ts):
@@ -117,8 +134,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-linter --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx eslint --format json --max-warnings -1 <path>\` and\n` +
-			`prints {pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
+			`Dispatches on file extension: .ts/.js → eslint, .py → ruff.\n` +
+			`Runs the project's configured linter and prints\n` +
+			`{pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
 	);
 }
 
@@ -297,6 +315,17 @@ function buildViolations(results: ESLintResult[]): Violation[] {
 
 // --- main -------------------------------------------------------------------
 
+// Language families keyed by file extension (lowercased, leading dot stripped).
+const ESLINT_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]);
+const RUFF_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return ""; // no extension, or dotfile with no ext
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -305,16 +334,33 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const projectRoot =
-		findProjectRoot(args.filePath) ?? dirname(resolve(args.filePath));
+	const ext = extOf(args.filePath);
+	if (ESLINT_EXTS.has(ext)) {
+		runEslintFlow(args.filePath);
+		return;
+	}
+	if (RUFF_EXTS.has(ext)) {
+		runRuffFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — not a failure. Exit 127 so the
+	// dispatcher's branch b records a quiet PASSED Note=tool-unavailable.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- eslint flow (TS/JS) ----------------------------------------------------
+
+function runEslintFlow(filePath: string): void {
+	const projectRoot = findProjectRoot(filePath) ?? dirname(resolve(filePath));
 
 	// Probe order: tool first (cheap, ~1s for cached bunx), then config
 	// (~1s for --print-config). Both gates feed dispatcher branch b
 	// (PASSED Note=tool-unavailable) on non-zero.
 	probeEslintAvailable(projectRoot);
-	probeEslintConfig(args.filePath, projectRoot);
+	probeEslintConfig(filePath, projectRoot);
 
-	const { stdout } = runEslint(args.filePath, projectRoot);
+	const { stdout } = runEslint(filePath, projectRoot);
 
 	// eslint exits 1 when violations exist and 0 when clean. With
 	// --max-warnings -1 the warning-exit override is disabled so we never
@@ -348,6 +394,203 @@ function main(): void {
 		warningCount,
 		violations: buildViolations(parsed),
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
+		findings_count: errorCount,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- ruff flow (Python) -----------------------------------------------------
+//
+// Mirrors the eslint flow structure: walk up to the project manifest, gate on
+// "is ruff actually configured?" (quiet-pass 127 when not), probe availability,
+// run, normalize to the locked SensorOutput shape.
+//
+// ruff JSON (`--output-format=json`) is an array of diagnostics:
+//   {code, message, filename, location:{row,column}, end_location, fix, url, …}
+// `code` may be null (e.g. syntax errors). Every reported diagnostic counts as
+// a finding — ruff has no warning/error split in this shape, so the eslint
+// "warnings don't fail" carve-out does not apply; pass = (#diagnostics == 0).
+
+interface RuffLocation {
+	row?: number;
+	column?: number;
+}
+
+interface RuffDiagnostic {
+	code: string | null;
+	message: string;
+	filename: string;
+	location?: RuffLocation;
+}
+
+// ruff config files that stand alone (no [tool.ruff] table needed). pyproject
+// .toml is handled separately because its presence alone does NOT mean ruff is
+// configured — only a [tool.ruff] table (or one of these files) does.
+const RUFF_CONFIG_FILES = ["ruff.toml", ".ruff.toml"];
+
+// Walk up from --file-path to the nearest dir that anchors a Python project:
+// a pyproject.toml, ruff.toml, or .ruff.toml. Returns that dir, or null.
+function findRuffProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (existsSync(`${dir}/pyproject.toml`)) return dir;
+		if (RUFF_CONFIG_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+// ruff invocation. ruff is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveRuffCmd resolves a ruff WITHOUT any side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`, both of which can provision an
+// environment on first use). Side-effect-free candidates, in decreasing order
+// of project fidelity:
+//   1. `python -m ruff` / `python3 -m ruff` — the ruff importable in whatever
+//      the interpreter resolves to (the project's ruff when its venv is active).
+//      Both `python` and `python3` are tried because many systems (CI images,
+//      Homebrew-only setups, pyenv loaded only in interactive shells) expose
+//      just `python3`; probing `python` alone would silently miss ruff there.
+//      Preferred over the bare binary so a project/venv ruff wins.
+//   2. `ruff` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0, so unavailable forms fall
+// through. null when none answers — null → the flow quiet-passes (127), the
+// same model mypy uses.
+//
+// Returns the argv PREFIX (command + leading args) the other ruff calls append
+// to, or null when ruff is not runnable in this environment.
+function resolveRuffCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "ruff"],
+		["python3", "-m", "ruff"],
+		["ruff"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function spawnRuff(
+	ruffCmd: string[],
+	subArgs: string[],
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = ruffCmd;
+	const result = spawnSync(cmd, [...prefix, ...subArgs], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	// encoding: "utf-8" makes stdout a string, but spawnSync's overload union
+	// isn't narrowed by the option alone — coerce with a typeof guard.
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// "Is ruff actually configured for this file?" — the use-what's-configured
+// gate, mirroring eslint's --print-config probe. Defer to ruff's OWN discovery
+// rather than hand-parsing TOML: `ruff check --show-settings <path>` exits 0
+// and prints the resolved settings when ruff has a config it will apply, and
+// exits non-zero when there is no configuration to resolve. Non-zero → exit 127
+// (quiet PASS), so a bare pyproject.toml with no [tool.ruff] table behaves like
+// a JS project with no eslint config: the sensor stays silent.
+function probeRuffConfigured(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): void {
+	const result = spawnRuff(ruffCmd, ["check", "--show-settings", filePath], cwd);
+	if (result.status === 0) return; // ruff resolved settings → configured
+	process.stderr.write("no-ruff-config\n");
+	process.exit(127);
+}
+
+function runRuff(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	// --force-exclude makes ruff honour the project's exclude config even when
+	// the file is passed explicitly (otherwise an explicitly-named excluded
+	// file is still checked). --no-cache avoids cache writes into the project.
+	const result = spawnRuff(
+		ruffCmd,
+		[
+			"check",
+			"--output-format=json",
+			"--force-exclude",
+			"--no-cache",
+			filePath,
+		],
+		cwd,
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+function buildRuffViolations(diags: RuffDiagnostic[]): Violation[] {
+	return diags.map((d) => ({
+		file: d.filename ?? "",
+		line: d.location?.row ?? 0,
+		column: d.location?.column ?? 0,
+		rule: d.code ?? "",
+		// ruff's JSON shape carries no severity; every diagnostic is a finding
+		// that fails the check, so report it as an error for the locked shape.
+		severity: "error",
+		message: d.message ?? "",
+	}));
+}
+
+function runRuffFlow(filePath: string): void {
+	const projectRoot = findRuffProject(filePath);
+	if (!projectRoot) {
+		// No pyproject.toml / ruff.toml anywhere above the file → not a ruff
+		// project. Quiet PASS, mirroring "no package.json" for eslint.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+
+	const ruffCmd = resolveRuffCmd(projectRoot);
+	if (!ruffCmd) {
+		// ruff not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("ruff-unavailable\n");
+		process.exit(127);
+	}
+	probeRuffConfigured(ruffCmd, filePath, projectRoot);
+
+	const { stdout } = runRuff(ruffCmd, filePath, projectRoot);
+
+	// ruff writes the JSON array to stdout on both clean (exit 0) and
+	// violations-present (exit 1) runs, so we parse stdout rather than gate on
+	// the exit code.
+	let parsed: RuffDiagnostic[];
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+	if (!Array.isArray(parsed)) {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+
+	const errorCount = parsed.length;
+	const out: SensorOutput = {
+		pass: errorCount === 0,
+		errorCount,
+		warningCount: 0,
+		violations: buildRuffViolations(parsed),
 		findings_count: errorCount,
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);

--- a/dist/claude/.claude/tools/aidlc-sensor-type-check.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-type-check.ts
@@ -2,12 +2,32 @@
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under aidlc-docs/.aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx → tsc. Wraps `bunx tsc --project <tsconfig> --noEmit --pretty
+//   false --incremental` (walk up to the nearest tsconfig.json; project-scoped
+//   check post-filtered to --file-path; no tsconfig → quiet PASS).
+// * .py/.pyi → mypy OR pyright, selected by what the project configures:
+//     - [tool.mypy] in pyproject.toml, or mypy.ini, or setup.cfg [mypy] → mypy
+//       (`mypy --output=json`). mypy is not npm, so it never rides bunx; it is
+//       resolved side-effect-free as `python -m mypy` (the project's mypy when
+//       its venv is active), falling back to a bare `mypy` on PATH; not
+//       installed → quiet PASS via 127.
+//     - [tool.pyright] in pyproject.toml, or pyrightconfig.json(c) → pyright
+//       (`bunx pyright --outputjson` — pyright IS an npm package).
+//     - both configured → mypy wins (more common standard; documented tie-break).
+//     - neither → quiet PASS via 127.
+//   Python checkers report 0-based line/character; we normalise to tsc's
+//   1-based convention so the locked `errors[]` shape is uniform across langs.
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default checker, it
+// only runs the one the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-type-check.ts):
@@ -71,7 +91,7 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 interface ParsedError {
@@ -125,8 +145,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-type-check --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx tsc --project <tsconfig> --noEmit --pretty false\` and\n` +
-			`prints {pass, errors[]} JSON to stdout (filtered to --file-path).\n`,
+			`Dispatches on file extension: .ts/.tsx → tsc, .py → mypy or pyright\n` +
+			`(whichever the project configures). Prints {pass, errors[]} JSON to\n` +
+			`stdout (filtered to --file-path).\n`,
 	);
 }
 
@@ -248,6 +269,16 @@ function filterToFilePath(
 
 // --- main -------------------------------------------------------------------
 
+const TSC_EXTS = new Set(["ts", "tsx"]);
+const PY_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return "";
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -256,7 +287,24 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const tsconfigPath = findTsconfig(args.filePath);
+	const ext = extOf(args.filePath);
+	if (TSC_EXTS.has(ext)) {
+		runTscFlow(args.filePath);
+		return;
+	}
+	if (PY_EXTS.has(ext)) {
+		runPyFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — quiet PASS via dispatcher branch b.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- tsc flow (TS/TSX) ------------------------------------------------------
+
+function runTscFlow(filePath: string): void {
+	const tsconfigPath = findTsconfig(filePath);
 	if (!tsconfigPath) {
 		process.stderr.write("no-tsconfig-found\n");
 		process.exit(1);
@@ -287,7 +335,7 @@ function main(): void {
 		cwd: tsconfigDir,
 	});
 	const allErrors = parseTscOutput(output);
-	const errors = filterToFilePath(allErrors, args.filePath, tsconfigDir);
+	const errors = filterToFilePath(allErrors, filePath, tsconfigDir);
 
 	// Status gate: tsc exited non-zero but parseTscOutput found ZERO diagnostics
 	// ANYWHERE in the project (a config-load failure — e.g. TS18003 "No inputs
@@ -314,6 +362,330 @@ function main(): void {
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);
 	process.exit(0);
+}
+
+// --- Python flow (mypy / pyright) -------------------------------------------
+//
+// Selects the checker the project configured, mirroring the tsc flow's
+// project-scoped check + post-filter to --file-path. Both Python checkers are
+// project-scoped (they follow imports), so the same cross-file known limitation
+// documented for tsc applies: an error a file INTRODUCES in a consumer reports
+// under the consumer's path, not --file-path.
+//
+// mypy `--output=json` emits JSONL: one `{file, line, column, message, hint,
+// code, severity}` object per line. Older mypy (<1.21) and config errors emit
+// plain text; unparseable-line handling falls through to the status gate so a
+// broken run never reports a false clean PASS.
+//
+// pyright `--outputjson` emits a single object with `generalDiagnostics[]`
+// ({file, severity, message, rule?, range:{start:{line,character}, end}}) and a
+// `summary.errorCount`. Line/character are 0-based; we +1 to match tsc.
+
+type PyChecker = "mypy" | "pyright";
+
+interface MypyDiagnostic {
+	file?: string;
+	line?: number;
+	column?: number;
+	message?: string;
+	severity?: string;
+}
+
+interface PyrightRange {
+	start?: { line?: number; character?: number };
+}
+
+interface PyrightDiagnostic {
+	file?: string;
+	severity?: string;
+	message?: string;
+	range?: PyrightRange;
+}
+
+interface PyrightOutput {
+	generalDiagnostics?: PyrightDiagnostic[];
+}
+
+// Walk up to the nearest dir anchoring a Python project (any of the manifests
+// that could declare a checker). Returns that dir, or null.
+const PY_PROJECT_FILES = [
+	"pyproject.toml",
+	"mypy.ini",
+	"setup.cfg",
+	"pyrightconfig.json",
+	"pyrightconfig.jsonc",
+];
+
+function findPyProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (PY_PROJECT_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function readFileSafe(path: string): string {
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
+		return "";
+	}
+}
+
+// Does any config in projectRoot declare mypy? [tool.mypy] in pyproject.toml,
+// a mypy.ini, or a [mypy] section in setup.cfg.
+function mypyConfigured(projectRoot: string): boolean {
+	if (existsSync(`${projectRoot}/mypy.ini`)) return true;
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	if (/^\s*\[tool\.mypy\b/m.test(pyproject)) return true;
+	const setupCfg = readFileSafe(`${projectRoot}/setup.cfg`);
+	if (/^\s*\[mypy\b/m.test(setupCfg)) return true;
+	return false;
+}
+
+// Does any config in projectRoot declare pyright? [tool.pyright] in
+// pyproject.toml, or a pyrightconfig.json(c).
+function pyrightConfigured(projectRoot: string): boolean {
+	if (
+		existsSync(`${projectRoot}/pyrightconfig.json`) ||
+		existsSync(`${projectRoot}/pyrightconfig.jsonc`)
+	) {
+		return true;
+	}
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	return /^\s*\[tool\.pyright\b/m.test(pyproject);
+}
+
+// Pick the configured checker. mypy wins the tie when both are configured
+// (more common standard). null → neither configured → caller quiet-passes.
+function selectPyChecker(projectRoot: string): PyChecker | null {
+	if (mypyConfigured(projectRoot)) return "mypy";
+	if (pyrightConfigured(projectRoot)) return "pyright";
+	return null;
+}
+
+// --- mypy -------------------------------------------------------------------
+
+// mypy invocation. mypy is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveMypyCmd resolves a mypy WITHOUT side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`). Side-effect-free candidates,
+// in decreasing order of project fidelity:
+//   1. `python -m mypy` / `python3 -m mypy` — the project's mypy when its venv
+//      is the active interpreter. Both `python` and `python3` are tried because
+//      many systems (CI, Homebrew-only, pyenv loaded only in interactive
+//      shells) expose just `python3`; probing `python` alone would silently
+//      miss mypy there. Preferred over the bare binary so a project/venv mypy
+//      wins.
+//   2. `mypy` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0. null when none answers — null
+// → quiet PASS (127), configured-but-absent is tool-unavailable.
+//
+// Returns the argv PREFIX (command + leading args) callers append to, or null
+// when mypy is not runnable in this environment.
+function resolveMypyCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "mypy"],
+		["python3", "-m", "mypy"],
+		["mypy"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function runMypy(
+	mypyCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = mypyCmd;
+	const result = spawnSync(
+		cmd,
+		[...prefix, "--output=json", "--no-error-summary", filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// Parse mypy JSONL. Returns the parsed error-severity diagnostics AND a count
+// of lines that failed to parse as JSON (text syntax/config errors on older
+// mypy). The caller uses parseFailures to avoid a false clean PASS.
+function parseMypyOutput(stdout: string): {
+	errors: ParsedError[];
+	parseFailures: number;
+} {
+	const errors: ParsedError[] = [];
+	let parseFailures = 0;
+	for (const rawLine of stdout.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line === "") continue;
+		if (!line.startsWith("{")) {
+			parseFailures++;
+			continue;
+		}
+		let diag: MypyDiagnostic;
+		try {
+			diag = JSON.parse(line);
+		} catch {
+			parseFailures++;
+			continue;
+		}
+		if (diag.severity !== "error") continue;
+		errors.push({
+			file: diag.file ?? "",
+			line: diag.line ?? 0,
+			column: diag.column ?? 0,
+			message: diag.message ?? "",
+		});
+	}
+	return { errors, parseFailures };
+}
+
+function runMypyFlow(filePath: string, projectRoot: string): void {
+	const mypyCmd = resolveMypyCmd(projectRoot);
+	if (!mypyCmd) {
+		// mypy not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("mypy-unavailable\n");
+		process.exit(127);
+	}
+	const { stdout, status } = runMypy(mypyCmd, filePath, projectRoot);
+	const { errors: allErrors, parseFailures } = parseMypyOutput(stdout);
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+
+	// Status gate, mirroring tsc: a non-zero exit that produced ZERO parseable
+	// error diagnostics is a broken run (config error, or a syntax error that
+	// older mypy emitted as text — counted in parseFailures). Propagate the exit
+	// so the dispatcher records script-error rather than a false clean PASS.
+	// mypy exits 1 on type errors AND on config/parse failures; reaching here
+	// with no parsed errors means no usable findings, so script-error is right.
+	void parseFailures;
+	if (status !== null && status !== 0 && allErrors.length === 0) {
+		process.exit(status);
+	}
+
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- pyright ----------------------------------------------------------------
+
+function probePyrightAvailable(cwd: string): void {
+	const result = spawnSync("bunx", ["pyright", "--version"], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	if (result.status !== 0) {
+		process.stderr.write("pyright-unavailable\n");
+		process.exit(127);
+	}
+}
+
+function runPyright(
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const result = spawnSync(
+		"bunx",
+		["pyright", "--outputjson", "--project", cwd, filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+// Parse pyright JSON. Returns error-severity diagnostics, normalised from
+// 0-based line/character to tsc's 1-based convention. parsedOk=false signals a
+// JSON parse failure so the caller can avoid a false clean PASS.
+function parsePyrightOutput(stdout: string): {
+	errors: ParsedError[];
+	parsedOk: boolean;
+} {
+	let parsed: PyrightOutput;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return { errors: [], parsedOk: false };
+	}
+	const diags = Array.isArray(parsed.generalDiagnostics)
+		? parsed.generalDiagnostics
+		: [];
+	const errors: ParsedError[] = [];
+	for (const d of diags) {
+		if (d.severity !== "error") continue;
+		const startLine = d.range?.start?.line ?? 0;
+		const startChar = d.range?.start?.character ?? 0;
+		errors.push({
+			file: d.file ?? "",
+			line: startLine + 1, // 0-based → 1-based (match tsc)
+			column: startChar + 1,
+			message: d.message ?? "",
+		});
+	}
+	return { errors, parsedOk: true };
+}
+
+function runPyrightFlow(filePath: string, projectRoot: string): void {
+	probePyrightAvailable(projectRoot);
+	const { stdout, status } = runPyright(filePath, projectRoot);
+	const { errors: allErrors, parsedOk } = parsePyrightOutput(stdout);
+
+	// Bad JSON on a non-zero exit → script-error (avoid false PASS). pyright
+	// exits 1 when it reports errors and 0 when clean; stdout is pure JSON.
+	if (!parsedOk) {
+		if (status !== null && status !== 0) process.exit(status);
+		process.stderr.write("pyright-bad-output\n");
+		process.exit(2);
+	}
+
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- Python dispatch --------------------------------------------------------
+
+function runPyFlow(filePath: string): void {
+	const projectRoot = findPyProject(filePath);
+	if (!projectRoot) {
+		// No Python project manifest above the file → quiet PASS.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+	const checker = selectPyChecker(projectRoot);
+	if (checker === null) {
+		// Project exists but configures no type checker → quiet PASS, mirroring
+		// "no eslint config" / "no tsconfig" behaviour.
+		process.stderr.write("no-python-type-checker-configured\n");
+		process.exit(127);
+	}
+	if (checker === "mypy") {
+		runMypyFlow(filePath, projectRoot);
+		return;
+	}
+	runPyrightFlow(filePath, projectRoot);
 }
 
 if (import.meta.main) main();

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.9";
+export const AIDLC_VERSION = "0.7.10";

--- a/dist/claude/.claude/tools/data/stage-graph.json
+++ b/dist/claude/.claude/tools/data/stage-graph.json
@@ -1486,12 +1486,12 @@
       {
         "id": "linter",
         "path": ".claude/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".claude/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1588,12 +1588,12 @@
       {
         "id": "linter",
         "path": ".claude/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".claude/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1694,12 +1694,12 @@
       {
         "id": "linter",
         "path": ".claude/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".claude/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1809,12 +1809,12 @@
       {
         "id": "linter",
         "path": ".claude/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".claude/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1912,12 +1912,12 @@
       {
         "id": "linter",
         "path": ".claude/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".claude/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -2004,7 +2004,7 @@
       {
         "id": "type-check",
         "path": ".claude/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -2087,12 +2087,12 @@
       {
         "id": "linter",
         "path": ".claude/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".claude/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },

--- a/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
@@ -184,12 +184,13 @@ worktree. Generated code lives at the workspace root (NEVER under
 
 The imported sensors check the code outputs:
 
-- **`linter`** wraps the project's configured linter (eslint by default).
-  Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
+- **`linter`** wraps the project's configured linter (eslint for TS/JS, ruff
+  for Python). Fires on every Write/Edit matching its
+  `matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
   detail at `aidlc-docs/.aidlc-sensors/code-generation/linter-<iso>.md`.
-- **`type-check`** wraps the project's configured type-checker (tsc by
-  default). Fires on `**/*.{ts,tsx}`. Failure mode: type errors emit
+- **`type-check`** wraps the project's configured type-checker (tsc for TS,
+  mypy or pyright for Python). Fires on `**/*.{ts,tsx,py,pyi}`. Failure mode: type errors emit
   `SENSOR_FAILED` with similar detail.
 
 The two universal markdown-shape sensors (`required-sections`,

--- a/dist/codex/.codex/sensors/aidlc-linter.md
+++ b/dist/codex/.codex/sensors/aidlc-linter.md
@@ -3,9 +3,9 @@ id: linter
 kind: deterministic
 command: bun .codex/tools/aidlc-sensor-linter.ts
 default_severity: advisory
-description: Wraps the project's configured linter (eslint by default for v0.5.0); fires on TS/JS code outputs
+description: Wraps the project's configured linter (eslint for TS/JS, ruff for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,js}"
+matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,8 +20,23 @@ timeout_seconds: 30
 
 # linter sensor
 
-Wraps the project's configured linter. v0.5.0 defaults to eslint; multi-language
-auto-detection (ruff, golangci-lint, clippy) is deferred to v0.6.0+.
+Wraps the project's configured linter, dispatching on file extension:
+
+- **TS/JS** (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`) → eslint
+  (`bunx eslint --format json`). Defers to eslint's own config discovery; a
+  project with no eslint config produces a quiet PASS.
+- **Python** (`.py`, `.pyi`) → ruff (`ruff check --output-format=json`). ruff is
+  a Python tool, not an npm package, so it never rides bunx. It is resolved
+  side-effect-free (a sensor fires on every write, so it must never install or
+  create a venv — which rules out `uv run`): `python -m ruff` first (the
+  project's ruff when its venv is active), then a bare `ruff` on PATH. Walks up
+  to the nearest `pyproject.toml` / `ruff.toml` / `.ruff.toml` and only runs
+  when the project actually configures ruff (probed via
+  `ruff check --show-settings`); no ruff config produces a quiet PASS, mirroring
+  the eslint no-config behaviour.
+
+Either way the sensor uses what the project configures and imposes no default
+ruleset. An unknown extension is a quiet PASS.
 
 Echoes Fowler's "Eslint, Semgrep" examples from the harness-engineering article.
 
@@ -31,7 +46,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/linter-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing the
 linter's structured output (file, line, rule, message per violation).
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate linter).
+Additional languages (go vet/golangci-lint, clippy) and Java static analysis
+remain future work — Java in particular fits the module-level build, not a
+per-file sensor.

--- a/dist/codex/.codex/sensors/aidlc-type-check.md
+++ b/dist/codex/.codex/sensors/aidlc-type-check.md
@@ -3,9 +3,9 @@ id: type-check
 kind: deterministic
 command: bun .codex/tools/aidlc-sensor-type-check.ts
 default_severity: advisory
-description: Wraps the project's configured type-checker (tsc by default for v0.5.0); fires on TS/TSX code outputs
+description: Wraps the project's configured type-checker (tsc for TS/TSX, mypy or pyright for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,tsx}"
+matches: "**/*.{ts,tsx,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,9 +20,26 @@ timeout_seconds: 60
 
 # type-check sensor
 
-Wraps the project's configured type-checker. v0.5.0 defaults to tsc;
-multi-language auto-detection (mypy, go vet, cargo-check) is deferred
-to v0.6.0+.
+Wraps the project's configured type-checker, dispatching on file extension:
+
+- **TS/TSX** (`.ts`, `.tsx`) → tsc (`bunx tsc --project <tsconfig> --noEmit`).
+  Project-scoped; diagnostics are post-filtered to the written file. No
+  `tsconfig.json` → quiet PASS.
+- **Python** (`.py`, `.pyi`) → mypy **or** pyright, whichever the project
+  configures:
+  - `[tool.mypy]` in `pyproject.toml`, `mypy.ini`, or `setup.cfg [mypy]` → mypy
+    (`mypy --output=json`). mypy is a Python tool, not npm, so it never rides
+    bunx; it is resolved side-effect-free as `python -m mypy` (the project's
+    mypy when its venv is active), falling back to a bare `mypy` on PATH.
+  - `[tool.pyright]` in `pyproject.toml`, or `pyrightconfig.json(c)` → pyright
+    (`bunx pyright --outputjson` — pyright is an npm package).
+  - Both configured → mypy wins (more common standard).
+  - Neither → quiet PASS.
+
+The sensor uses whatever type-checker the project declares and imposes no
+default. Python checkers are project-scoped (they follow imports), so the
+cross-file limitation documented for tsc applies equally. An unknown extension
+is a quiet PASS.
 
 Echoes Fowler's "type checkers" example from the harness-engineering article.
 
@@ -32,7 +49,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/type-check-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing
 the type-checker's structured output.
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate type-checker).
+Additional languages (go vet, cargo check) remain future work. Java type
+errors are compilation errors that fit the module-level build, not a per-file
+sensor.

--- a/dist/codex/.codex/tools/aidlc-sensor-linter.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-linter.ts
@@ -2,11 +2,28 @@
 //
 // Owns the linter check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx eslint --format
-// json --max-warnings -1 <path>` and prints the locked stdout JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errorCount": <n>, "warningCount": <n>,
 //    "violations": [{file, line, column, rule, severity, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx/.js/.jsx/.mjs/.cjs → eslint. Wraps `bunx eslint --format json
+//   --max-warnings -1 <path>` (walk up to the nearest package.json; defer to
+//   eslint's own config discovery; no eslint config → quiet PASS via 127).
+// * .py/.pyi → ruff. Runs `ruff check --output-format=json <path>`. ruff is a
+//   Python tool, not an npm package, so it never rides bunx; it is resolved
+//   side-effect-free as `python -m ruff` (the project's ruff when its venv is
+//   active), falling back to a bare `ruff` on PATH. Walks up to the nearest
+//   pyproject.toml/ruff.toml/.ruff.toml; only runs when the project actually
+//   configures ruff — no ruff config → quiet PASS via 127, mirroring eslint's
+//   no-config behaviour. ruff diagnostics are findings; pass = (#diagnostics == 0).
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default ruleset, it
+// only runs a tool the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-linter.ts):
@@ -117,8 +134,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-linter --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx eslint --format json --max-warnings -1 <path>\` and\n` +
-			`prints {pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
+			`Dispatches on file extension: .ts/.js → eslint, .py → ruff.\n` +
+			`Runs the project's configured linter and prints\n` +
+			`{pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
 	);
 }
 
@@ -297,6 +315,17 @@ function buildViolations(results: ESLintResult[]): Violation[] {
 
 // --- main -------------------------------------------------------------------
 
+// Language families keyed by file extension (lowercased, leading dot stripped).
+const ESLINT_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]);
+const RUFF_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return ""; // no extension, or dotfile with no ext
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -305,16 +334,33 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const projectRoot =
-		findProjectRoot(args.filePath) ?? dirname(resolve(args.filePath));
+	const ext = extOf(args.filePath);
+	if (ESLINT_EXTS.has(ext)) {
+		runEslintFlow(args.filePath);
+		return;
+	}
+	if (RUFF_EXTS.has(ext)) {
+		runRuffFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — not a failure. Exit 127 so the
+	// dispatcher's branch b records a quiet PASSED Note=tool-unavailable.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- eslint flow (TS/JS) ----------------------------------------------------
+
+function runEslintFlow(filePath: string): void {
+	const projectRoot = findProjectRoot(filePath) ?? dirname(resolve(filePath));
 
 	// Probe order: tool first (cheap, ~1s for cached bunx), then config
 	// (~1s for --print-config). Both gates feed dispatcher branch b
 	// (PASSED Note=tool-unavailable) on non-zero.
 	probeEslintAvailable(projectRoot);
-	probeEslintConfig(args.filePath, projectRoot);
+	probeEslintConfig(filePath, projectRoot);
 
-	const { stdout } = runEslint(args.filePath, projectRoot);
+	const { stdout } = runEslint(filePath, projectRoot);
 
 	// eslint exits 1 when violations exist and 0 when clean. With
 	// --max-warnings -1 the warning-exit override is disabled so we never
@@ -348,6 +394,203 @@ function main(): void {
 		warningCount,
 		violations: buildViolations(parsed),
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
+		findings_count: errorCount,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- ruff flow (Python) -----------------------------------------------------
+//
+// Mirrors the eslint flow structure: walk up to the project manifest, gate on
+// "is ruff actually configured?" (quiet-pass 127 when not), probe availability,
+// run, normalize to the locked SensorOutput shape.
+//
+// ruff JSON (`--output-format=json`) is an array of diagnostics:
+//   {code, message, filename, location:{row,column}, end_location, fix, url, …}
+// `code` may be null (e.g. syntax errors). Every reported diagnostic counts as
+// a finding — ruff has no warning/error split in this shape, so the eslint
+// "warnings don't fail" carve-out does not apply; pass = (#diagnostics == 0).
+
+interface RuffLocation {
+	row?: number;
+	column?: number;
+}
+
+interface RuffDiagnostic {
+	code: string | null;
+	message: string;
+	filename: string;
+	location?: RuffLocation;
+}
+
+// ruff config files that stand alone (no [tool.ruff] table needed). pyproject
+// .toml is handled separately because its presence alone does NOT mean ruff is
+// configured — only a [tool.ruff] table (or one of these files) does.
+const RUFF_CONFIG_FILES = ["ruff.toml", ".ruff.toml"];
+
+// Walk up from --file-path to the nearest dir that anchors a Python project:
+// a pyproject.toml, ruff.toml, or .ruff.toml. Returns that dir, or null.
+function findRuffProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (existsSync(`${dir}/pyproject.toml`)) return dir;
+		if (RUFF_CONFIG_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+// ruff invocation. ruff is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveRuffCmd resolves a ruff WITHOUT any side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`, both of which can provision an
+// environment on first use). Side-effect-free candidates, in decreasing order
+// of project fidelity:
+//   1. `python -m ruff` / `python3 -m ruff` — the ruff importable in whatever
+//      the interpreter resolves to (the project's ruff when its venv is active).
+//      Both `python` and `python3` are tried because many systems (CI images,
+//      Homebrew-only setups, pyenv loaded only in interactive shells) expose
+//      just `python3`; probing `python` alone would silently miss ruff there.
+//      Preferred over the bare binary so a project/venv ruff wins.
+//   2. `ruff` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0, so unavailable forms fall
+// through. null when none answers — null → the flow quiet-passes (127), the
+// same model mypy uses.
+//
+// Returns the argv PREFIX (command + leading args) the other ruff calls append
+// to, or null when ruff is not runnable in this environment.
+function resolveRuffCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "ruff"],
+		["python3", "-m", "ruff"],
+		["ruff"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function spawnRuff(
+	ruffCmd: string[],
+	subArgs: string[],
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = ruffCmd;
+	const result = spawnSync(cmd, [...prefix, ...subArgs], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	// encoding: "utf-8" makes stdout a string, but spawnSync's overload union
+	// isn't narrowed by the option alone — coerce with a typeof guard.
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// "Is ruff actually configured for this file?" — the use-what's-configured
+// gate, mirroring eslint's --print-config probe. Defer to ruff's OWN discovery
+// rather than hand-parsing TOML: `ruff check --show-settings <path>` exits 0
+// and prints the resolved settings when ruff has a config it will apply, and
+// exits non-zero when there is no configuration to resolve. Non-zero → exit 127
+// (quiet PASS), so a bare pyproject.toml with no [tool.ruff] table behaves like
+// a JS project with no eslint config: the sensor stays silent.
+function probeRuffConfigured(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): void {
+	const result = spawnRuff(ruffCmd, ["check", "--show-settings", filePath], cwd);
+	if (result.status === 0) return; // ruff resolved settings → configured
+	process.stderr.write("no-ruff-config\n");
+	process.exit(127);
+}
+
+function runRuff(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	// --force-exclude makes ruff honour the project's exclude config even when
+	// the file is passed explicitly (otherwise an explicitly-named excluded
+	// file is still checked). --no-cache avoids cache writes into the project.
+	const result = spawnRuff(
+		ruffCmd,
+		[
+			"check",
+			"--output-format=json",
+			"--force-exclude",
+			"--no-cache",
+			filePath,
+		],
+		cwd,
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+function buildRuffViolations(diags: RuffDiagnostic[]): Violation[] {
+	return diags.map((d) => ({
+		file: d.filename ?? "",
+		line: d.location?.row ?? 0,
+		column: d.location?.column ?? 0,
+		rule: d.code ?? "",
+		// ruff's JSON shape carries no severity; every diagnostic is a finding
+		// that fails the check, so report it as an error for the locked shape.
+		severity: "error",
+		message: d.message ?? "",
+	}));
+}
+
+function runRuffFlow(filePath: string): void {
+	const projectRoot = findRuffProject(filePath);
+	if (!projectRoot) {
+		// No pyproject.toml / ruff.toml anywhere above the file → not a ruff
+		// project. Quiet PASS, mirroring "no package.json" for eslint.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+
+	const ruffCmd = resolveRuffCmd(projectRoot);
+	if (!ruffCmd) {
+		// ruff not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("ruff-unavailable\n");
+		process.exit(127);
+	}
+	probeRuffConfigured(ruffCmd, filePath, projectRoot);
+
+	const { stdout } = runRuff(ruffCmd, filePath, projectRoot);
+
+	// ruff writes the JSON array to stdout on both clean (exit 0) and
+	// violations-present (exit 1) runs, so we parse stdout rather than gate on
+	// the exit code.
+	let parsed: RuffDiagnostic[];
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+	if (!Array.isArray(parsed)) {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+
+	const errorCount = parsed.length;
+	const out: SensorOutput = {
+		pass: errorCount === 0,
+		errorCount,
+		warningCount: 0,
+		violations: buildRuffViolations(parsed),
 		findings_count: errorCount,
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);

--- a/dist/codex/.codex/tools/aidlc-sensor-type-check.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-type-check.ts
@@ -2,12 +2,32 @@
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under aidlc-docs/.aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx → tsc. Wraps `bunx tsc --project <tsconfig> --noEmit --pretty
+//   false --incremental` (walk up to the nearest tsconfig.json; project-scoped
+//   check post-filtered to --file-path; no tsconfig → quiet PASS).
+// * .py/.pyi → mypy OR pyright, selected by what the project configures:
+//     - [tool.mypy] in pyproject.toml, or mypy.ini, or setup.cfg [mypy] → mypy
+//       (`mypy --output=json`). mypy is not npm, so it never rides bunx; it is
+//       resolved side-effect-free as `python -m mypy` (the project's mypy when
+//       its venv is active), falling back to a bare `mypy` on PATH; not
+//       installed → quiet PASS via 127.
+//     - [tool.pyright] in pyproject.toml, or pyrightconfig.json(c) → pyright
+//       (`bunx pyright --outputjson` — pyright IS an npm package).
+//     - both configured → mypy wins (more common standard; documented tie-break).
+//     - neither → quiet PASS via 127.
+//   Python checkers report 0-based line/character; we normalise to tsc's
+//   1-based convention so the locked `errors[]` shape is uniform across langs.
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default checker, it
+// only runs the one the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-type-check.ts):
@@ -71,7 +91,7 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 interface ParsedError {
@@ -125,8 +145,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-type-check --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx tsc --project <tsconfig> --noEmit --pretty false\` and\n` +
-			`prints {pass, errors[]} JSON to stdout (filtered to --file-path).\n`,
+			`Dispatches on file extension: .ts/.tsx → tsc, .py → mypy or pyright\n` +
+			`(whichever the project configures). Prints {pass, errors[]} JSON to\n` +
+			`stdout (filtered to --file-path).\n`,
 	);
 }
 
@@ -248,6 +269,16 @@ function filterToFilePath(
 
 // --- main -------------------------------------------------------------------
 
+const TSC_EXTS = new Set(["ts", "tsx"]);
+const PY_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return "";
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -256,7 +287,24 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const tsconfigPath = findTsconfig(args.filePath);
+	const ext = extOf(args.filePath);
+	if (TSC_EXTS.has(ext)) {
+		runTscFlow(args.filePath);
+		return;
+	}
+	if (PY_EXTS.has(ext)) {
+		runPyFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — quiet PASS via dispatcher branch b.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- tsc flow (TS/TSX) ------------------------------------------------------
+
+function runTscFlow(filePath: string): void {
+	const tsconfigPath = findTsconfig(filePath);
 	if (!tsconfigPath) {
 		process.stderr.write("no-tsconfig-found\n");
 		process.exit(1);
@@ -287,7 +335,7 @@ function main(): void {
 		cwd: tsconfigDir,
 	});
 	const allErrors = parseTscOutput(output);
-	const errors = filterToFilePath(allErrors, args.filePath, tsconfigDir);
+	const errors = filterToFilePath(allErrors, filePath, tsconfigDir);
 
 	// Status gate: tsc exited non-zero but parseTscOutput found ZERO diagnostics
 	// ANYWHERE in the project (a config-load failure — e.g. TS18003 "No inputs
@@ -314,6 +362,330 @@ function main(): void {
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);
 	process.exit(0);
+}
+
+// --- Python flow (mypy / pyright) -------------------------------------------
+//
+// Selects the checker the project configured, mirroring the tsc flow's
+// project-scoped check + post-filter to --file-path. Both Python checkers are
+// project-scoped (they follow imports), so the same cross-file known limitation
+// documented for tsc applies: an error a file INTRODUCES in a consumer reports
+// under the consumer's path, not --file-path.
+//
+// mypy `--output=json` emits JSONL: one `{file, line, column, message, hint,
+// code, severity}` object per line. Older mypy (<1.21) and config errors emit
+// plain text; unparseable-line handling falls through to the status gate so a
+// broken run never reports a false clean PASS.
+//
+// pyright `--outputjson` emits a single object with `generalDiagnostics[]`
+// ({file, severity, message, rule?, range:{start:{line,character}, end}}) and a
+// `summary.errorCount`. Line/character are 0-based; we +1 to match tsc.
+
+type PyChecker = "mypy" | "pyright";
+
+interface MypyDiagnostic {
+	file?: string;
+	line?: number;
+	column?: number;
+	message?: string;
+	severity?: string;
+}
+
+interface PyrightRange {
+	start?: { line?: number; character?: number };
+}
+
+interface PyrightDiagnostic {
+	file?: string;
+	severity?: string;
+	message?: string;
+	range?: PyrightRange;
+}
+
+interface PyrightOutput {
+	generalDiagnostics?: PyrightDiagnostic[];
+}
+
+// Walk up to the nearest dir anchoring a Python project (any of the manifests
+// that could declare a checker). Returns that dir, or null.
+const PY_PROJECT_FILES = [
+	"pyproject.toml",
+	"mypy.ini",
+	"setup.cfg",
+	"pyrightconfig.json",
+	"pyrightconfig.jsonc",
+];
+
+function findPyProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (PY_PROJECT_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function readFileSafe(path: string): string {
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
+		return "";
+	}
+}
+
+// Does any config in projectRoot declare mypy? [tool.mypy] in pyproject.toml,
+// a mypy.ini, or a [mypy] section in setup.cfg.
+function mypyConfigured(projectRoot: string): boolean {
+	if (existsSync(`${projectRoot}/mypy.ini`)) return true;
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	if (/^\s*\[tool\.mypy\b/m.test(pyproject)) return true;
+	const setupCfg = readFileSafe(`${projectRoot}/setup.cfg`);
+	if (/^\s*\[mypy\b/m.test(setupCfg)) return true;
+	return false;
+}
+
+// Does any config in projectRoot declare pyright? [tool.pyright] in
+// pyproject.toml, or a pyrightconfig.json(c).
+function pyrightConfigured(projectRoot: string): boolean {
+	if (
+		existsSync(`${projectRoot}/pyrightconfig.json`) ||
+		existsSync(`${projectRoot}/pyrightconfig.jsonc`)
+	) {
+		return true;
+	}
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	return /^\s*\[tool\.pyright\b/m.test(pyproject);
+}
+
+// Pick the configured checker. mypy wins the tie when both are configured
+// (more common standard). null → neither configured → caller quiet-passes.
+function selectPyChecker(projectRoot: string): PyChecker | null {
+	if (mypyConfigured(projectRoot)) return "mypy";
+	if (pyrightConfigured(projectRoot)) return "pyright";
+	return null;
+}
+
+// --- mypy -------------------------------------------------------------------
+
+// mypy invocation. mypy is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveMypyCmd resolves a mypy WITHOUT side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`). Side-effect-free candidates,
+// in decreasing order of project fidelity:
+//   1. `python -m mypy` / `python3 -m mypy` — the project's mypy when its venv
+//      is the active interpreter. Both `python` and `python3` are tried because
+//      many systems (CI, Homebrew-only, pyenv loaded only in interactive
+//      shells) expose just `python3`; probing `python` alone would silently
+//      miss mypy there. Preferred over the bare binary so a project/venv mypy
+//      wins.
+//   2. `mypy` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0. null when none answers — null
+// → quiet PASS (127), configured-but-absent is tool-unavailable.
+//
+// Returns the argv PREFIX (command + leading args) callers append to, or null
+// when mypy is not runnable in this environment.
+function resolveMypyCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "mypy"],
+		["python3", "-m", "mypy"],
+		["mypy"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function runMypy(
+	mypyCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = mypyCmd;
+	const result = spawnSync(
+		cmd,
+		[...prefix, "--output=json", "--no-error-summary", filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// Parse mypy JSONL. Returns the parsed error-severity diagnostics AND a count
+// of lines that failed to parse as JSON (text syntax/config errors on older
+// mypy). The caller uses parseFailures to avoid a false clean PASS.
+function parseMypyOutput(stdout: string): {
+	errors: ParsedError[];
+	parseFailures: number;
+} {
+	const errors: ParsedError[] = [];
+	let parseFailures = 0;
+	for (const rawLine of stdout.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line === "") continue;
+		if (!line.startsWith("{")) {
+			parseFailures++;
+			continue;
+		}
+		let diag: MypyDiagnostic;
+		try {
+			diag = JSON.parse(line);
+		} catch {
+			parseFailures++;
+			continue;
+		}
+		if (diag.severity !== "error") continue;
+		errors.push({
+			file: diag.file ?? "",
+			line: diag.line ?? 0,
+			column: diag.column ?? 0,
+			message: diag.message ?? "",
+		});
+	}
+	return { errors, parseFailures };
+}
+
+function runMypyFlow(filePath: string, projectRoot: string): void {
+	const mypyCmd = resolveMypyCmd(projectRoot);
+	if (!mypyCmd) {
+		// mypy not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("mypy-unavailable\n");
+		process.exit(127);
+	}
+	const { stdout, status } = runMypy(mypyCmd, filePath, projectRoot);
+	const { errors: allErrors, parseFailures } = parseMypyOutput(stdout);
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+
+	// Status gate, mirroring tsc: a non-zero exit that produced ZERO parseable
+	// error diagnostics is a broken run (config error, or a syntax error that
+	// older mypy emitted as text — counted in parseFailures). Propagate the exit
+	// so the dispatcher records script-error rather than a false clean PASS.
+	// mypy exits 1 on type errors AND on config/parse failures; reaching here
+	// with no parsed errors means no usable findings, so script-error is right.
+	void parseFailures;
+	if (status !== null && status !== 0 && allErrors.length === 0) {
+		process.exit(status);
+	}
+
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- pyright ----------------------------------------------------------------
+
+function probePyrightAvailable(cwd: string): void {
+	const result = spawnSync("bunx", ["pyright", "--version"], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	if (result.status !== 0) {
+		process.stderr.write("pyright-unavailable\n");
+		process.exit(127);
+	}
+}
+
+function runPyright(
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const result = spawnSync(
+		"bunx",
+		["pyright", "--outputjson", "--project", cwd, filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+// Parse pyright JSON. Returns error-severity diagnostics, normalised from
+// 0-based line/character to tsc's 1-based convention. parsedOk=false signals a
+// JSON parse failure so the caller can avoid a false clean PASS.
+function parsePyrightOutput(stdout: string): {
+	errors: ParsedError[];
+	parsedOk: boolean;
+} {
+	let parsed: PyrightOutput;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return { errors: [], parsedOk: false };
+	}
+	const diags = Array.isArray(parsed.generalDiagnostics)
+		? parsed.generalDiagnostics
+		: [];
+	const errors: ParsedError[] = [];
+	for (const d of diags) {
+		if (d.severity !== "error") continue;
+		const startLine = d.range?.start?.line ?? 0;
+		const startChar = d.range?.start?.character ?? 0;
+		errors.push({
+			file: d.file ?? "",
+			line: startLine + 1, // 0-based → 1-based (match tsc)
+			column: startChar + 1,
+			message: d.message ?? "",
+		});
+	}
+	return { errors, parsedOk: true };
+}
+
+function runPyrightFlow(filePath: string, projectRoot: string): void {
+	probePyrightAvailable(projectRoot);
+	const { stdout, status } = runPyright(filePath, projectRoot);
+	const { errors: allErrors, parsedOk } = parsePyrightOutput(stdout);
+
+	// Bad JSON on a non-zero exit → script-error (avoid false PASS). pyright
+	// exits 1 when it reports errors and 0 when clean; stdout is pure JSON.
+	if (!parsedOk) {
+		if (status !== null && status !== 0) process.exit(status);
+		process.stderr.write("pyright-bad-output\n");
+		process.exit(2);
+	}
+
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- Python dispatch --------------------------------------------------------
+
+function runPyFlow(filePath: string): void {
+	const projectRoot = findPyProject(filePath);
+	if (!projectRoot) {
+		// No Python project manifest above the file → quiet PASS.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+	const checker = selectPyChecker(projectRoot);
+	if (checker === null) {
+		// Project exists but configures no type checker → quiet PASS, mirroring
+		// "no eslint config" / "no tsconfig" behaviour.
+		process.stderr.write("no-python-type-checker-configured\n");
+		process.exit(127);
+	}
+	if (checker === "mypy") {
+		runMypyFlow(filePath, projectRoot);
+		return;
+	}
+	runPyrightFlow(filePath, projectRoot);
 }
 
 if (import.meta.main) main();

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.9";
+export const AIDLC_VERSION = "0.7.10";

--- a/dist/codex/.codex/tools/data/stage-graph.json
+++ b/dist/codex/.codex/tools/data/stage-graph.json
@@ -1486,12 +1486,12 @@
       {
         "id": "linter",
         "path": ".codex/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".codex/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1588,12 +1588,12 @@
       {
         "id": "linter",
         "path": ".codex/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".codex/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1694,12 +1694,12 @@
       {
         "id": "linter",
         "path": ".codex/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".codex/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1809,12 +1809,12 @@
       {
         "id": "linter",
         "path": ".codex/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".codex/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1912,12 +1912,12 @@
       {
         "id": "linter",
         "path": ".codex/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".codex/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -2004,7 +2004,7 @@
       {
         "id": "type-check",
         "path": ".codex/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -2087,12 +2087,12 @@
       {
         "id": "linter",
         "path": ".codex/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".codex/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -184,12 +184,13 @@ worktree. Generated code lives at the workspace root (NEVER under
 
 The imported sensors check the code outputs:
 
-- **`linter`** wraps the project's configured linter (eslint by default).
-  Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
+- **`linter`** wraps the project's configured linter (eslint for TS/JS, ruff
+  for Python). Fires on every Write/Edit matching its
+  `matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
   detail at `aidlc-docs/.aidlc-sensors/code-generation/linter-<iso>.md`.
-- **`type-check`** wraps the project's configured type-checker (tsc by
-  default). Fires on `**/*.{ts,tsx}`. Failure mode: type errors emit
+- **`type-check`** wraps the project's configured type-checker (tsc for TS,
+  mypy or pyright for Python). Fires on `**/*.{ts,tsx,py,pyi}`. Failure mode: type errors emit
   `SENSOR_FAILED` with similar detail.
 
 The two universal markdown-shape sensors (`required-sections`,

--- a/dist/kiro/.kiro/sensors/aidlc-linter.md
+++ b/dist/kiro/.kiro/sensors/aidlc-linter.md
@@ -3,9 +3,9 @@ id: linter
 kind: deterministic
 command: bun .kiro/tools/aidlc-sensor-linter.ts
 default_severity: advisory
-description: Wraps the project's configured linter (eslint by default for v0.5.0); fires on TS/JS code outputs
+description: Wraps the project's configured linter (eslint for TS/JS, ruff for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,js}"
+matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,8 +20,23 @@ timeout_seconds: 30
 
 # linter sensor
 
-Wraps the project's configured linter. v0.5.0 defaults to eslint; multi-language
-auto-detection (ruff, golangci-lint, clippy) is deferred to v0.6.0+.
+Wraps the project's configured linter, dispatching on file extension:
+
+- **TS/JS** (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`) → eslint
+  (`bunx eslint --format json`). Defers to eslint's own config discovery; a
+  project with no eslint config produces a quiet PASS.
+- **Python** (`.py`, `.pyi`) → ruff (`ruff check --output-format=json`). ruff is
+  a Python tool, not an npm package, so it never rides bunx. It is resolved
+  side-effect-free (a sensor fires on every write, so it must never install or
+  create a venv — which rules out `uv run`): `python -m ruff` first (the
+  project's ruff when its venv is active), then a bare `ruff` on PATH. Walks up
+  to the nearest `pyproject.toml` / `ruff.toml` / `.ruff.toml` and only runs
+  when the project actually configures ruff (probed via
+  `ruff check --show-settings`); no ruff config produces a quiet PASS, mirroring
+  the eslint no-config behaviour.
+
+Either way the sensor uses what the project configures and imposes no default
+ruleset. An unknown extension is a quiet PASS.
 
 Echoes Fowler's "Eslint, Semgrep" examples from the harness-engineering article.
 
@@ -31,7 +46,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/linter-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing the
 linter's structured output (file, line, rule, message per violation).
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate linter).
+Additional languages (go vet/golangci-lint, clippy) and Java static analysis
+remain future work — Java in particular fits the module-level build, not a
+per-file sensor.

--- a/dist/kiro/.kiro/sensors/aidlc-type-check.md
+++ b/dist/kiro/.kiro/sensors/aidlc-type-check.md
@@ -3,9 +3,9 @@ id: type-check
 kind: deterministic
 command: bun .kiro/tools/aidlc-sensor-type-check.ts
 default_severity: advisory
-description: Wraps the project's configured type-checker (tsc by default for v0.5.0); fires on TS/TSX code outputs
+description: Wraps the project's configured type-checker (tsc for TS/TSX, mypy or pyright for Python); fires on code outputs
 category: code-quality
-matches: "**/*.{ts,tsx}"
+matches: "**/*.{ts,tsx,py,pyi}"
 input_schema:
   file_path: string
 output_schema:
@@ -20,9 +20,26 @@ timeout_seconds: 60
 
 # type-check sensor
 
-Wraps the project's configured type-checker. v0.5.0 defaults to tsc;
-multi-language auto-detection (mypy, go vet, cargo-check) is deferred
-to v0.6.0+.
+Wraps the project's configured type-checker, dispatching on file extension:
+
+- **TS/TSX** (`.ts`, `.tsx`) → tsc (`bunx tsc --project <tsconfig> --noEmit`).
+  Project-scoped; diagnostics are post-filtered to the written file. No
+  `tsconfig.json` → quiet PASS.
+- **Python** (`.py`, `.pyi`) → mypy **or** pyright, whichever the project
+  configures:
+  - `[tool.mypy]` in `pyproject.toml`, `mypy.ini`, or `setup.cfg [mypy]` → mypy
+    (`mypy --output=json`). mypy is a Python tool, not npm, so it never rides
+    bunx; it is resolved side-effect-free as `python -m mypy` (the project's
+    mypy when its venv is active), falling back to a bare `mypy` on PATH.
+  - `[tool.pyright]` in `pyproject.toml`, or `pyrightconfig.json(c)` → pyright
+    (`bunx pyright --outputjson` — pyright is an npm package).
+  - Both configured → mypy wins (more common standard).
+  - Neither → quiet PASS.
+
+The sensor uses whatever type-checker the project declares and imposes no
+default. Python checkers are project-scoped (they follow imports), so the
+cross-file limitation documented for tsc applies equally. An unknown extension
+is a quiet PASS.
 
 Echoes Fowler's "type checkers" example from the harness-engineering article.
 
@@ -32,7 +49,8 @@ Emits `SENSOR_FAILED` and writes detail to
 `aidlc-docs/.aidlc-sensors/<stage-slug>/type-check-<fire-id>.md` (Fire id is the 8-hex correlator from the SENSOR_FIRED audit row) containing
 the type-checker's structured output.
 
-## v0.6.0 carry-forward
+## Carry-forward
 
-Multi-language detection at framework boundary (read project type from
-practices `## Tech Stack` section, dispatch appropriate type-checker).
+Additional languages (go vet, cargo check) remain future work. Java type
+errors are compilation errors that fit the module-level build, not a per-file
+sensor.

--- a/dist/kiro/.kiro/tools/aidlc-sensor-linter.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-linter.ts
@@ -2,11 +2,28 @@
 //
 // Owns the linter check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx eslint --format
-// json --max-warnings -1 <path>` and prints the locked stdout JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errorCount": <n>, "warningCount": <n>,
 //    "violations": [{file, line, column, rule, severity, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx/.js/.jsx/.mjs/.cjs → eslint. Wraps `bunx eslint --format json
+//   --max-warnings -1 <path>` (walk up to the nearest package.json; defer to
+//   eslint's own config discovery; no eslint config → quiet PASS via 127).
+// * .py/.pyi → ruff. Runs `ruff check --output-format=json <path>`. ruff is a
+//   Python tool, not an npm package, so it never rides bunx; it is resolved
+//   side-effect-free as `python -m ruff` (the project's ruff when its venv is
+//   active), falling back to a bare `ruff` on PATH. Walks up to the nearest
+//   pyproject.toml/ruff.toml/.ruff.toml; only runs when the project actually
+//   configures ruff — no ruff config → quiet PASS via 127, mirroring eslint's
+//   no-config behaviour. ruff diagnostics are findings; pass = (#diagnostics == 0).
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default ruleset, it
+// only runs a tool the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-linter.ts):
@@ -117,8 +134,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-linter --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx eslint --format json --max-warnings -1 <path>\` and\n` +
-			`prints {pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
+			`Dispatches on file extension: .ts/.js → eslint, .py → ruff.\n` +
+			`Runs the project's configured linter and prints\n` +
+			`{pass, errorCount, warningCount, violations[]} JSON to stdout.\n`,
 	);
 }
 
@@ -297,6 +315,17 @@ function buildViolations(results: ESLintResult[]): Violation[] {
 
 // --- main -------------------------------------------------------------------
 
+// Language families keyed by file extension (lowercased, leading dot stripped).
+const ESLINT_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"]);
+const RUFF_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return ""; // no extension, or dotfile with no ext
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -305,16 +334,33 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const projectRoot =
-		findProjectRoot(args.filePath) ?? dirname(resolve(args.filePath));
+	const ext = extOf(args.filePath);
+	if (ESLINT_EXTS.has(ext)) {
+		runEslintFlow(args.filePath);
+		return;
+	}
+	if (RUFF_EXTS.has(ext)) {
+		runRuffFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — not a failure. Exit 127 so the
+	// dispatcher's branch b records a quiet PASSED Note=tool-unavailable.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- eslint flow (TS/JS) ----------------------------------------------------
+
+function runEslintFlow(filePath: string): void {
+	const projectRoot = findProjectRoot(filePath) ?? dirname(resolve(filePath));
 
 	// Probe order: tool first (cheap, ~1s for cached bunx), then config
 	// (~1s for --print-config). Both gates feed dispatcher branch b
 	// (PASSED Note=tool-unavailable) on non-zero.
 	probeEslintAvailable(projectRoot);
-	probeEslintConfig(args.filePath, projectRoot);
+	probeEslintConfig(filePath, projectRoot);
 
-	const { stdout } = runEslint(args.filePath, projectRoot);
+	const { stdout } = runEslint(filePath, projectRoot);
 
 	// eslint exits 1 when violations exist and 0 when clean. With
 	// --max-warnings -1 the warning-exit override is disabled so we never
@@ -348,6 +394,203 @@ function main(): void {
 		warningCount,
 		violations: buildViolations(parsed),
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
+		findings_count: errorCount,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- ruff flow (Python) -----------------------------------------------------
+//
+// Mirrors the eslint flow structure: walk up to the project manifest, gate on
+// "is ruff actually configured?" (quiet-pass 127 when not), probe availability,
+// run, normalize to the locked SensorOutput shape.
+//
+// ruff JSON (`--output-format=json`) is an array of diagnostics:
+//   {code, message, filename, location:{row,column}, end_location, fix, url, …}
+// `code` may be null (e.g. syntax errors). Every reported diagnostic counts as
+// a finding — ruff has no warning/error split in this shape, so the eslint
+// "warnings don't fail" carve-out does not apply; pass = (#diagnostics == 0).
+
+interface RuffLocation {
+	row?: number;
+	column?: number;
+}
+
+interface RuffDiagnostic {
+	code: string | null;
+	message: string;
+	filename: string;
+	location?: RuffLocation;
+}
+
+// ruff config files that stand alone (no [tool.ruff] table needed). pyproject
+// .toml is handled separately because its presence alone does NOT mean ruff is
+// configured — only a [tool.ruff] table (or one of these files) does.
+const RUFF_CONFIG_FILES = ["ruff.toml", ".ruff.toml"];
+
+// Walk up from --file-path to the nearest dir that anchors a Python project:
+// a pyproject.toml, ruff.toml, or .ruff.toml. Returns that dir, or null.
+function findRuffProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (existsSync(`${dir}/pyproject.toml`)) return dir;
+		if (RUFF_CONFIG_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+// ruff invocation. ruff is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveRuffCmd resolves a ruff WITHOUT any side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`, both of which can provision an
+// environment on first use). Side-effect-free candidates, in decreasing order
+// of project fidelity:
+//   1. `python -m ruff` / `python3 -m ruff` — the ruff importable in whatever
+//      the interpreter resolves to (the project's ruff when its venv is active).
+//      Both `python` and `python3` are tried because many systems (CI images,
+//      Homebrew-only setups, pyenv loaded only in interactive shells) expose
+//      just `python3`; probing `python` alone would silently miss ruff there.
+//      Preferred over the bare binary so a project/venv ruff wins.
+//   2. `ruff` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0, so unavailable forms fall
+// through. null when none answers — null → the flow quiet-passes (127), the
+// same model mypy uses.
+//
+// Returns the argv PREFIX (command + leading args) the other ruff calls append
+// to, or null when ruff is not runnable in this environment.
+function resolveRuffCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "ruff"],
+		["python3", "-m", "ruff"],
+		["ruff"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function spawnRuff(
+	ruffCmd: string[],
+	subArgs: string[],
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = ruffCmd;
+	const result = spawnSync(cmd, [...prefix, ...subArgs], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	// encoding: "utf-8" makes stdout a string, but spawnSync's overload union
+	// isn't narrowed by the option alone — coerce with a typeof guard.
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// "Is ruff actually configured for this file?" — the use-what's-configured
+// gate, mirroring eslint's --print-config probe. Defer to ruff's OWN discovery
+// rather than hand-parsing TOML: `ruff check --show-settings <path>` exits 0
+// and prints the resolved settings when ruff has a config it will apply, and
+// exits non-zero when there is no configuration to resolve. Non-zero → exit 127
+// (quiet PASS), so a bare pyproject.toml with no [tool.ruff] table behaves like
+// a JS project with no eslint config: the sensor stays silent.
+function probeRuffConfigured(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): void {
+	const result = spawnRuff(ruffCmd, ["check", "--show-settings", filePath], cwd);
+	if (result.status === 0) return; // ruff resolved settings → configured
+	process.stderr.write("no-ruff-config\n");
+	process.exit(127);
+}
+
+function runRuff(
+	ruffCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	// --force-exclude makes ruff honour the project's exclude config even when
+	// the file is passed explicitly (otherwise an explicitly-named excluded
+	// file is still checked). --no-cache avoids cache writes into the project.
+	const result = spawnRuff(
+		ruffCmd,
+		[
+			"check",
+			"--output-format=json",
+			"--force-exclude",
+			"--no-cache",
+			filePath,
+		],
+		cwd,
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+function buildRuffViolations(diags: RuffDiagnostic[]): Violation[] {
+	return diags.map((d) => ({
+		file: d.filename ?? "",
+		line: d.location?.row ?? 0,
+		column: d.location?.column ?? 0,
+		rule: d.code ?? "",
+		// ruff's JSON shape carries no severity; every diagnostic is a finding
+		// that fails the check, so report it as an error for the locked shape.
+		severity: "error",
+		message: d.message ?? "",
+	}));
+}
+
+function runRuffFlow(filePath: string): void {
+	const projectRoot = findRuffProject(filePath);
+	if (!projectRoot) {
+		// No pyproject.toml / ruff.toml anywhere above the file → not a ruff
+		// project. Quiet PASS, mirroring "no package.json" for eslint.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+
+	const ruffCmd = resolveRuffCmd(projectRoot);
+	if (!ruffCmd) {
+		// ruff not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("ruff-unavailable\n");
+		process.exit(127);
+	}
+	probeRuffConfigured(ruffCmd, filePath, projectRoot);
+
+	const { stdout } = runRuff(ruffCmd, filePath, projectRoot);
+
+	// ruff writes the JSON array to stdout on both clean (exit 0) and
+	// violations-present (exit 1) runs, so we parse stdout rather than gate on
+	// the exit code.
+	let parsed: RuffDiagnostic[];
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+	if (!Array.isArray(parsed)) {
+		process.stderr.write("ruff-bad-output\n");
+		process.exit(1);
+	}
+
+	const errorCount = parsed.length;
+	const out: SensorOutput = {
+		pass: errorCount === 0,
+		errorCount,
+		warningCount: 0,
+		violations: buildRuffViolations(parsed),
 		findings_count: errorCount,
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);

--- a/dist/kiro/.kiro/tools/aidlc-sensor-type-check.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-type-check.ts
@@ -2,12 +2,32 @@
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
 // SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under aidlc-docs/.aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// contained: no imports from sibling tools. Prints the locked stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
+//
+// Polyglot dispatch (on --file-path extension):
+//
+// * .ts/.tsx → tsc. Wraps `bunx tsc --project <tsconfig> --noEmit --pretty
+//   false --incremental` (walk up to the nearest tsconfig.json; project-scoped
+//   check post-filtered to --file-path; no tsconfig → quiet PASS).
+// * .py/.pyi → mypy OR pyright, selected by what the project configures:
+//     - [tool.mypy] in pyproject.toml, or mypy.ini, or setup.cfg [mypy] → mypy
+//       (`mypy --output=json`). mypy is not npm, so it never rides bunx; it is
+//       resolved side-effect-free as `python -m mypy` (the project's mypy when
+//       its venv is active), falling back to a bare `mypy` on PATH; not
+//       installed → quiet PASS via 127.
+//     - [tool.pyright] in pyproject.toml, or pyrightconfig.json(c) → pyright
+//       (`bunx pyright --outputjson` — pyright IS an npm package).
+//     - both configured → mypy wins (more common standard; documented tie-break).
+//     - neither → quiet PASS via 127.
+//   Python checkers report 0-based line/character; we normalise to tsc's
+//   1-based convention so the locked `errors[]` shape is uniform across langs.
+// * anything else → exit 127 (unknown language is not a failure → quiet PASS).
+//
+// The "use what the project configures; do nothing otherwise" principle is
+// identical across languages: the script never imposes a default checker, it
+// only runs the one the project opted into, and quiet-passes when none is set.
 //
 // Decisions (see tmp/v05-mr9-plan-draft.md § Per-sensor script contracts
 // → aidlc-sensor-type-check.ts):
@@ -71,7 +91,7 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 interface ParsedError {
@@ -125,8 +145,9 @@ function parseArgs(argv: string[]): Args {
 function printHelp(): void {
 	process.stdout.write(
 		`Usage: aidlc-sensor-type-check --stage <slug> --file-path <path>\n\n` +
-			`Wraps \`bunx tsc --project <tsconfig> --noEmit --pretty false\` and\n` +
-			`prints {pass, errors[]} JSON to stdout (filtered to --file-path).\n`,
+			`Dispatches on file extension: .ts/.tsx → tsc, .py → mypy or pyright\n` +
+			`(whichever the project configures). Prints {pass, errors[]} JSON to\n` +
+			`stdout (filtered to --file-path).\n`,
 	);
 }
 
@@ -248,6 +269,16 @@ function filterToFilePath(
 
 // --- main -------------------------------------------------------------------
 
+const TSC_EXTS = new Set(["ts", "tsx"]);
+const PY_EXTS = new Set(["py", "pyi"]);
+
+function extOf(filePath: string): string {
+	const base = filePath.split("/").pop() ?? filePath;
+	const dot = base.lastIndexOf(".");
+	if (dot <= 0) return "";
+	return base.slice(dot + 1).toLowerCase();
+}
+
 function main(): void {
 	const args = parseArgs(process.argv.slice(2));
 
@@ -256,7 +287,24 @@ function main(): void {
 		process.exit(1);
 	}
 
-	const tsconfigPath = findTsconfig(args.filePath);
+	const ext = extOf(args.filePath);
+	if (TSC_EXTS.has(ext)) {
+		runTscFlow(args.filePath);
+		return;
+	}
+	if (PY_EXTS.has(ext)) {
+		runPyFlow(args.filePath);
+		return;
+	}
+	// Unknown language for this sensor — quiet PASS via dispatcher branch b.
+	process.stderr.write(`unsupported-language: .${ext || "(none)"}\n`);
+	process.exit(127);
+}
+
+// --- tsc flow (TS/TSX) ------------------------------------------------------
+
+function runTscFlow(filePath: string): void {
+	const tsconfigPath = findTsconfig(filePath);
 	if (!tsconfigPath) {
 		process.stderr.write("no-tsconfig-found\n");
 		process.exit(1);
@@ -287,7 +335,7 @@ function main(): void {
 		cwd: tsconfigDir,
 	});
 	const allErrors = parseTscOutput(output);
-	const errors = filterToFilePath(allErrors, args.filePath, tsconfigDir);
+	const errors = filterToFilePath(allErrors, filePath, tsconfigDir);
 
 	// Status gate: tsc exited non-zero but parseTscOutput found ZERO diagnostics
 	// ANYWHERE in the project (a config-load failure — e.g. TS18003 "No inputs
@@ -314,6 +362,330 @@ function main(): void {
 	};
 	process.stdout.write(`${JSON.stringify(out)}\n`);
 	process.exit(0);
+}
+
+// --- Python flow (mypy / pyright) -------------------------------------------
+//
+// Selects the checker the project configured, mirroring the tsc flow's
+// project-scoped check + post-filter to --file-path. Both Python checkers are
+// project-scoped (they follow imports), so the same cross-file known limitation
+// documented for tsc applies: an error a file INTRODUCES in a consumer reports
+// under the consumer's path, not --file-path.
+//
+// mypy `--output=json` emits JSONL: one `{file, line, column, message, hint,
+// code, severity}` object per line. Older mypy (<1.21) and config errors emit
+// plain text; unparseable-line handling falls through to the status gate so a
+// broken run never reports a false clean PASS.
+//
+// pyright `--outputjson` emits a single object with `generalDiagnostics[]`
+// ({file, severity, message, rule?, range:{start:{line,character}, end}}) and a
+// `summary.errorCount`. Line/character are 0-based; we +1 to match tsc.
+
+type PyChecker = "mypy" | "pyright";
+
+interface MypyDiagnostic {
+	file?: string;
+	line?: number;
+	column?: number;
+	message?: string;
+	severity?: string;
+}
+
+interface PyrightRange {
+	start?: { line?: number; character?: number };
+}
+
+interface PyrightDiagnostic {
+	file?: string;
+	severity?: string;
+	message?: string;
+	range?: PyrightRange;
+}
+
+interface PyrightOutput {
+	generalDiagnostics?: PyrightDiagnostic[];
+}
+
+// Walk up to the nearest dir anchoring a Python project (any of the manifests
+// that could declare a checker). Returns that dir, or null.
+const PY_PROJECT_FILES = [
+	"pyproject.toml",
+	"mypy.ini",
+	"setup.cfg",
+	"pyrightconfig.json",
+	"pyrightconfig.jsonc",
+];
+
+function findPyProject(filePath: string): string | null {
+	const abs = resolve(filePath);
+	let dir = dirname(abs);
+	while (true) {
+		if (PY_PROJECT_FILES.some((f) => existsSync(`${dir}/${f}`))) return dir;
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function readFileSafe(path: string): string {
+	try {
+		return readFileSync(path, "utf-8");
+	} catch {
+		return "";
+	}
+}
+
+// Does any config in projectRoot declare mypy? [tool.mypy] in pyproject.toml,
+// a mypy.ini, or a [mypy] section in setup.cfg.
+function mypyConfigured(projectRoot: string): boolean {
+	if (existsSync(`${projectRoot}/mypy.ini`)) return true;
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	if (/^\s*\[tool\.mypy\b/m.test(pyproject)) return true;
+	const setupCfg = readFileSafe(`${projectRoot}/setup.cfg`);
+	if (/^\s*\[mypy\b/m.test(setupCfg)) return true;
+	return false;
+}
+
+// Does any config in projectRoot declare pyright? [tool.pyright] in
+// pyproject.toml, or a pyrightconfig.json(c).
+function pyrightConfigured(projectRoot: string): boolean {
+	if (
+		existsSync(`${projectRoot}/pyrightconfig.json`) ||
+		existsSync(`${projectRoot}/pyrightconfig.jsonc`)
+	) {
+		return true;
+	}
+	const pyproject = readFileSafe(`${projectRoot}/pyproject.toml`);
+	return /^\s*\[tool\.pyright\b/m.test(pyproject);
+}
+
+// Pick the configured checker. mypy wins the tie when both are configured
+// (more common standard). null → neither configured → caller quiet-passes.
+function selectPyChecker(projectRoot: string): PyChecker | null {
+	if (mypyConfigured(projectRoot)) return "mypy";
+	if (pyrightConfigured(projectRoot)) return "pyright";
+	return null;
+}
+
+// --- mypy -------------------------------------------------------------------
+
+// mypy invocation. mypy is a Python tool — NOT an npm package — so it cannot
+// ride bunx. resolveMypyCmd resolves a mypy WITHOUT side effects (a sensor
+// fires on every file write, so it must never install packages or create a
+// venv — which rules out `uv run`/`poetry run`). Side-effect-free candidates,
+// in decreasing order of project fidelity:
+//   1. `python -m mypy` / `python3 -m mypy` — the project's mypy when its venv
+//      is the active interpreter. Both `python` and `python3` are tried because
+//      many systems (CI, Homebrew-only, pyenv loaded only in interactive
+//      shells) expose just `python3`; probing `python` alone would silently
+//      miss mypy there. Preferred over the bare binary so a project/venv mypy
+//      wins.
+//   2. `mypy` — a bare console script on PATH, last resort.
+// Each candidate is gated on `--version` exit 0. null when none answers — null
+// → quiet PASS (127), configured-but-absent is tool-unavailable.
+//
+// Returns the argv PREFIX (command + leading args) callers append to, or null
+// when mypy is not runnable in this environment.
+function resolveMypyCmd(cwd: string): string[] | null {
+	const candidates: string[][] = [
+		["python", "-m", "mypy"],
+		["python3", "-m", "mypy"],
+		["mypy"],
+	];
+	for (const cand of candidates) {
+		const [cmd, ...prefix] = cand;
+		const probe = spawnSync(cmd, [...prefix, "--version"], {
+			encoding: "utf-8",
+			timeout: 30_000,
+			cwd,
+		});
+		if (probe.status === 0) return cand;
+	}
+	return null;
+}
+
+function runMypy(
+	mypyCmd: string[],
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const [cmd, ...prefix] = mypyCmd;
+	const result = spawnSync(
+		cmd,
+		[...prefix, "--output=json", "--no-error-summary", filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	const stdout = typeof result.stdout === "string" ? result.stdout : "";
+	return { stdout, status: result.status };
+}
+
+// Parse mypy JSONL. Returns the parsed error-severity diagnostics AND a count
+// of lines that failed to parse as JSON (text syntax/config errors on older
+// mypy). The caller uses parseFailures to avoid a false clean PASS.
+function parseMypyOutput(stdout: string): {
+	errors: ParsedError[];
+	parseFailures: number;
+} {
+	const errors: ParsedError[] = [];
+	let parseFailures = 0;
+	for (const rawLine of stdout.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (line === "") continue;
+		if (!line.startsWith("{")) {
+			parseFailures++;
+			continue;
+		}
+		let diag: MypyDiagnostic;
+		try {
+			diag = JSON.parse(line);
+		} catch {
+			parseFailures++;
+			continue;
+		}
+		if (diag.severity !== "error") continue;
+		errors.push({
+			file: diag.file ?? "",
+			line: diag.line ?? 0,
+			column: diag.column ?? 0,
+			message: diag.message ?? "",
+		});
+	}
+	return { errors, parseFailures };
+}
+
+function runMypyFlow(filePath: string, projectRoot: string): void {
+	const mypyCmd = resolveMypyCmd(projectRoot);
+	if (!mypyCmd) {
+		// mypy not runnable (not installed as a binary, not importable as a
+		// module, or no python). Quiet PASS, the tool-unavailable contract.
+		process.stderr.write("mypy-unavailable\n");
+		process.exit(127);
+	}
+	const { stdout, status } = runMypy(mypyCmd, filePath, projectRoot);
+	const { errors: allErrors, parseFailures } = parseMypyOutput(stdout);
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+
+	// Status gate, mirroring tsc: a non-zero exit that produced ZERO parseable
+	// error diagnostics is a broken run (config error, or a syntax error that
+	// older mypy emitted as text — counted in parseFailures). Propagate the exit
+	// so the dispatcher records script-error rather than a false clean PASS.
+	// mypy exits 1 on type errors AND on config/parse failures; reaching here
+	// with no parsed errors means no usable findings, so script-error is right.
+	void parseFailures;
+	if (status !== null && status !== 0 && allErrors.length === 0) {
+		process.exit(status);
+	}
+
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- pyright ----------------------------------------------------------------
+
+function probePyrightAvailable(cwd: string): void {
+	const result = spawnSync("bunx", ["pyright", "--version"], {
+		encoding: "utf-8",
+		timeout: 30_000,
+		cwd,
+	});
+	if (result.status !== 0) {
+		process.stderr.write("pyright-unavailable\n");
+		process.exit(127);
+	}
+}
+
+function runPyright(
+	filePath: string,
+	cwd: string,
+): { stdout: string; status: number | null } {
+	const result = spawnSync(
+		"bunx",
+		["pyright", "--outputjson", "--project", cwd, filePath],
+		{ encoding: "utf-8", timeout: 60_000, cwd },
+	);
+	return { stdout: result.stdout ?? "", status: result.status };
+}
+
+// Parse pyright JSON. Returns error-severity diagnostics, normalised from
+// 0-based line/character to tsc's 1-based convention. parsedOk=false signals a
+// JSON parse failure so the caller can avoid a false clean PASS.
+function parsePyrightOutput(stdout: string): {
+	errors: ParsedError[];
+	parsedOk: boolean;
+} {
+	let parsed: PyrightOutput;
+	try {
+		parsed = JSON.parse(stdout);
+	} catch {
+		return { errors: [], parsedOk: false };
+	}
+	const diags = Array.isArray(parsed.generalDiagnostics)
+		? parsed.generalDiagnostics
+		: [];
+	const errors: ParsedError[] = [];
+	for (const d of diags) {
+		if (d.severity !== "error") continue;
+		const startLine = d.range?.start?.line ?? 0;
+		const startChar = d.range?.start?.character ?? 0;
+		errors.push({
+			file: d.file ?? "",
+			line: startLine + 1, // 0-based → 1-based (match tsc)
+			column: startChar + 1,
+			message: d.message ?? "",
+		});
+	}
+	return { errors, parsedOk: true };
+}
+
+function runPyrightFlow(filePath: string, projectRoot: string): void {
+	probePyrightAvailable(projectRoot);
+	const { stdout, status } = runPyright(filePath, projectRoot);
+	const { errors: allErrors, parsedOk } = parsePyrightOutput(stdout);
+
+	// Bad JSON on a non-zero exit → script-error (avoid false PASS). pyright
+	// exits 1 when it reports errors and 0 when clean; stdout is pure JSON.
+	if (!parsedOk) {
+		if (status !== null && status !== 0) process.exit(status);
+		process.stderr.write("pyright-bad-output\n");
+		process.exit(2);
+	}
+
+	const errors = filterToFilePath(allErrors, filePath, projectRoot);
+	const out: SensorOutput = {
+		pass: errors.length === 0,
+		errors,
+		findings_count: errors.length,
+	};
+	process.stdout.write(`${JSON.stringify(out)}\n`);
+	process.exit(0);
+}
+
+// --- Python dispatch --------------------------------------------------------
+
+function runPyFlow(filePath: string): void {
+	const projectRoot = findPyProject(filePath);
+	if (!projectRoot) {
+		// No Python project manifest above the file → quiet PASS.
+		process.stderr.write("no-python-project\n");
+		process.exit(127);
+	}
+	const checker = selectPyChecker(projectRoot);
+	if (checker === null) {
+		// Project exists but configures no type checker → quiet PASS, mirroring
+		// "no eslint config" / "no tsconfig" behaviour.
+		process.stderr.write("no-python-type-checker-configured\n");
+		process.exit(127);
+	}
+	if (checker === "mypy") {
+		runMypyFlow(filePath, projectRoot);
+		return;
+	}
+	runPyrightFlow(filePath, projectRoot);
 }
 
 if (import.meta.main) main();

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.9";
+export const AIDLC_VERSION = "0.7.10";

--- a/dist/kiro/.kiro/tools/data/stage-graph.json
+++ b/dist/kiro/.kiro/tools/data/stage-graph.json
@@ -1486,12 +1486,12 @@
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".kiro/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1588,12 +1588,12 @@
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".kiro/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1694,12 +1694,12 @@
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".kiro/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1809,12 +1809,12 @@
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".kiro/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -1912,12 +1912,12 @@
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".kiro/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -2004,7 +2004,7 @@
       {
         "id": "type-check",
         "path": ".kiro/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },
@@ -2087,12 +2087,12 @@
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
-        "matches": "**/*.{ts,js}"
+        "matches": "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"
       },
       {
         "id": "type-check",
         "path": ".kiro/sensors/aidlc-type-check.md",
-        "matches": "**/*.{ts,tsx}"
+        "matches": "**/*.{ts,tsx,py,pyi}"
       }
     ]
   },

--- a/docs/harness-engineering/06-sensors.md
+++ b/docs/harness-engineering/06-sensors.md
@@ -60,12 +60,12 @@ Four manifests ship under `.claude/sensors/`, each prefixed `aidlc-`:
 |----------|----------|--------|
 | `aidlc-required-sections.md` | `aidlc-docs/` markdown output | The output carries the required H2 headings — a generic content-shape check |
 | `aidlc-upstream-coverage.md` | `aidlc-docs/` markdown output | The prose references each upstream artifact the stage declares it consumes |
-| `aidlc-linter.md` | `.ts` / `.js` code output | Wraps your configured linter (ESLint by default) |
-| `aidlc-type-check.md` | `.ts` / `.tsx` code output | Wraps your configured type-checker (`tsc` by default) |
+| `aidlc-linter.md` | `.ts` / `.js` / `.py` code output | Wraps your configured linter (ESLint for TS/JS, ruff for Python) |
+| `aidlc-type-check.md` | `.ts` / `.tsx` / `.py` code output | Wraps your configured type-checker (tsc for TS, mypy or pyright for Python) |
 
 All four are gated by a `matches:` glob (more on that below): the first two
 document-shape checks scope to `**/aidlc-docs/**` (the artifact tree), the two
-code-quality checks to their language globs (`**/*.{ts,js}`, `**/*.{ts,tsx}`).
+code-quality checks to their language globs (`**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}` for the linter, `**/*.{ts,tsx,py,pyi}` for the type-checker).
 Read `aidlc-required-sections.md` end to end before authoring your own — it is
 the smallest of the four and shows the whole shape, frontmatter plus prose body.
 

--- a/docs/reference/07-sensor-system.md
+++ b/docs/reference/07-sensor-system.md
@@ -190,8 +190,8 @@ the PostToolUse hook at fire time, not by the resolver at compile time.
 |---|---|
 | `aidlc-required-sections.md` | `**/aidlc-docs/**` |
 | `aidlc-upstream-coverage.md` | `**/aidlc-docs/**` |
-| `aidlc-linter.md` | `**/*.{ts,js}` |
-| `aidlc-type-check.md` | `**/*.{ts,tsx}` |
+| `aidlc-linter.md` | `**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}` |
+| `aidlc-type-check.md` | `**/*.{ts,tsx,py,pyi}` |
 
 `matches` **is** the fire filter — it is not optional in practice. The hook
 compares the path being written against the glob and fires only on a match;
@@ -341,8 +341,8 @@ The four shipped manifests illustrate the variation these defaults
 later evolve into: `aidlc-required-sections.md` and
 `aidlc-upstream-coverage.md` use `timeout_seconds: 5` with
 `matches: "**/aidlc-docs/**"` (they fire on the artifact tree);
-`aidlc-linter.md` uses `30` with `matches: "**/*.{ts,js}"`;
-`aidlc-type-check.md` uses `60` with `matches: "**/*.{ts,tsx}"`.
+`aidlc-linter.md` uses `30` with `matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"`;
+`aidlc-type-check.md` uses `60` with `matches: "**/*.{ts,tsx,py,pyi}"`.
 
 ---
 

--- a/tests/fixtures/v05-mr9-sensor-fire/failing-mypy/pyproject.toml
+++ b/tests/fixtures/v05-mr9-sensor-fire/failing-mypy/pyproject.toml
@@ -1,0 +1,13 @@
+# failing-mypy fixture for t92 — mypy (type-check) sensor FAILED round-trip.
+#
+# [tool.mypy] selects mypy for the type-check sensor. sample.py assigns a str
+# to an int-annotated binding, producing one mypy error
+# ([assignment]) so the per-sensor script's error count == 1 and the
+# dispatcher records FAILED with Findings count=1.
+[project]
+name = "aidlc-t92-failing-mypy-fixture"
+version = "0.0.0"
+requires-python = ">=3.9"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/tests/fixtures/v05-mr9-sensor-fire/failing-mypy/sample.py
+++ b/tests/fixtures/v05-mr9-sensor-fire/failing-mypy/sample.py
@@ -1,0 +1,8 @@
+# failing-mypy fixture sample — exactly one mypy type error.
+#
+# Assigning a str literal to an int-annotated binding triggers mypy's
+# [assignment] error ("Incompatible types in assignment"). mypy emits a
+# single error-severity diagnostic, so the type-check sensor's error count
+# == 1 and the dispatcher records FAILED with Findings count=1.
+x: int = "string"
+value = x

--- a/tests/fixtures/v05-mr9-sensor-fire/failing-ruff/pyproject.toml
+++ b/tests/fixtures/v05-mr9-sensor-fire/failing-ruff/pyproject.toml
@@ -1,0 +1,14 @@
+# failing-ruff fixture for t92 — ruff (linter) sensor FAILED round-trip.
+#
+# [tool.ruff] enables the linter sensor (the --show-settings probe resolves a
+# config). The F-series (pyflakes) rules are on by default, so the unused
+# import in sample.py (F401) produces exactly one diagnostic — the per-sensor
+# script reports errorCount=1, pass=false, and the dispatcher classifies it as
+# FAILED with Findings count=1.
+[project]
+name = "aidlc-t92-failing-ruff-fixture"
+version = "0.0.0"
+requires-python = ">=3.9"
+
+[tool.ruff]
+line-length = 100

--- a/tests/fixtures/v05-mr9-sensor-fire/failing-ruff/sample.py
+++ b/tests/fixtures/v05-mr9-sensor-fire/failing-ruff/sample.py
@@ -1,0 +1,7 @@
+# failing-ruff fixture sample — exactly one ruff violation.
+#
+# `import os` is unused → ruff F401 (unused-import), a default-enabled
+# pyflakes rule. ruff emits a single diagnostic, so the linter sensor's
+# errorCount aggregation == 1 and the dispatcher records FAILED with
+# Findings count=1.
+import os

--- a/tests/fixtures/v05-mr9-sensor-fire/passing-python/pyproject.toml
+++ b/tests/fixtures/v05-mr9-sensor-fire/passing-python/pyproject.toml
@@ -1,0 +1,17 @@
+# passing-python fixture for t92 — shared by the ruff (linter) and mypy
+# (type-check) Python PASS round-trips, mirroring passing-typescript.
+#
+# [tool.ruff] makes the linter sensor's "is ruff configured?" probe
+# (`ruff check --show-settings`) resolve a config, so the sensor runs rather
+# than quiet-passing. [tool.mypy] selects mypy for the type-check sensor.
+# sample.py is clean under both, so both sensors emit pass=true.
+[project]
+name = "aidlc-t92-passing-python-fixture"
+version = "0.0.0"
+requires-python = ">=3.9"
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/tests/fixtures/v05-mr9-sensor-fire/passing-python/sample.py
+++ b/tests/fixtures/v05-mr9-sensor-fire/passing-python/sample.py
@@ -1,0 +1,13 @@
+# passing-python fixture sample — clean under both ruff and mypy.
+#
+# Exercised by:
+#   - linter sensor: `ruff check --output-format=json sample.py` emits an
+#     empty array, pass=true.
+#   - type-check sensor: `mypy --output=json sample.py` emits no error
+#     diagnostics, pass=true.
+#
+# Fully type-annotated and lint-clean so neither tool reports a finding.
+
+
+def greet(name: str) -> str:
+    return f"hello {name}"

--- a/tests/integration/t66.test.ts
+++ b/tests/integration/t66.test.ts
@@ -1175,7 +1175,7 @@ description: Probe sensor for canonical-emitter test
     // Edit the linter manifest's matches glob; --check should now fail.
     const linterPath = join(sensorsDrift, "aidlc-linter.md");
     const orig = readFileSync(linterPath, "utf8");
-    writeFileSync(linterPath, orig.replace('"**/*.{ts,js}"', '"**/post-edit/*.ts"'));
+    writeFileSync(linterPath, orig.replace('"**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"', '"**/post-edit/*.ts"'));
     const check = spawnSync(BUN, [GRAPH_TS, "compile", "--check"], { env, encoding: "utf8" });
     expect(check.status).toBe(1);
   });

--- a/tests/integration/t89.test.ts
+++ b/tests/integration/t89.test.ts
@@ -301,15 +301,15 @@ describe("t89 sensors_applicable resolution (in-process compileStageGraph)", () 
     const beforeGlob = stageBySlug(before.stages, "code-generation").sensors_applicable.find(
       (s) => s.id === "linter",
     )?.matches;
-    expect(beforeGlob).toBe("**/*.{ts,js}");
+    expect(beforeGlob).toBe("**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}");
 
     // Mutate the manifest on disk AFTER the first compile.
     const orig = readFileSync(linterPath, "utf-8");
-    writeFileSync(linterPath, orig.replace('"**/*.{ts,js}"', '"**/post-edit/*.ts"'));
+    writeFileSync(linterPath, orig.replace('"**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"', '"**/post-edit/*.ts"'));
 
     // The already-emitted snapshot string is unchanged (it is a value, not a
     // live view) — its serialized glob is still the pre-edit value.
-    expect(before.json).toContain('"**/*.{ts,js}"');
+    expect(before.json).toContain('"**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"');
     expect(before.json).not.toContain('"**/post-edit/*.ts"');
 
     // A fresh compile reflects the edit — proving the snapshot is frozen only
@@ -417,7 +417,7 @@ describe("t89 CLI exit-code shell (Bun.spawnSync env-seam)", () => {
     // Edit the linter manifest's matches glob; --check should now fail.
     const linterPath = join(dir, "aidlc-linter.md");
     const orig = readFileSync(linterPath, "utf-8");
-    writeFileSync(linterPath, orig.replace('"**/*.{ts,js}"', '"**/*.{ts,js,jsx}"'));
+    writeFileSync(linterPath, orig.replace('"**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}"', '"**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi,go}"'));
 
     const check = spawnSync(BUN, [GRAPH_TS, "compile", "--check"], { env, encoding: "utf8" });
     expect(check.status).toBe(1);

--- a/tests/integration/t92.test.ts
+++ b/tests/integration/t92.test.ts
@@ -644,6 +644,120 @@ describe("t92 Group C: FAILED real round-trip per sensor", () => {
 });
 
 // ============================================================
+// Group C2 — PASSED + FAILED round-trip per sensor, REAL Python fixtures (4).
+// Mirrors Group B tests 11-12 + Group C tests 15-16 but for Python:
+//   - linter sensor → ruff (python -m ruff / bare ruff)
+//   - type-check sensor → mypy (python -m mypy / bare mypy)
+// Same shape: copy fixture into a temp project, fire the real dispatcher,
+// assert on the audit rows (SENSOR_FIRED/PASSED/FAILED, findings count).
+// ============================================================
+
+/** run_passed_py_real — mirrors runPassedTsReal but fires on sample.py. */
+function runPassedPyReal(
+  id: string,
+  stage: string,
+  fixtureDir: string,
+): {
+  fired: number;
+  passed: number;
+  dur: string;
+  firedId: string;
+  passedId: string;
+  path: string;
+  note: string;
+  detailExists: boolean;
+  subdir: string;
+} {
+  const proj = makeProj();
+  const subdir = basename(fixtureDir);
+  cpSync(fixtureDir, join(proj, subdir), { recursive: true });
+  fire([id, "--stage", stage, "--output-path", join(proj, subdir, "sample.py")], {
+    CLAUDE_PROJECT_DIR: proj,
+  });
+  const f = auditPath(proj);
+  return {
+    fired: auditEventCount(f, "SENSOR_FIRED"),
+    passed: auditEventCount(f, "SENSOR_PASSED"),
+    dur: auditField(f, "SENSOR_PASSED", "Duration ms"),
+    firedId: auditField(f, "SENSOR_FIRED", "Fire id"),
+    passedId: auditField(f, "SENSOR_PASSED", "Fire id"),
+    path: auditField(f, "SENSOR_PASSED", "Output path"),
+    note: auditField(f, "SENSOR_PASSED", "Note"),
+    detailExists: existsSync(join(proj, "aidlc-docs", ".aidlc-sensors")),
+    subdir,
+  };
+}
+
+/** run_failed_py_real — mirrors runFailedTsReal but fires on sample.py. */
+function runFailedPyReal(
+  id: string,
+  stage: string,
+  fixtureDir: string,
+  expectedFindings: string,
+): void {
+  const proj = makeProj();
+  const subdir = basename(fixtureDir);
+  cpSync(fixtureDir, join(proj, subdir), { recursive: true });
+  fire([id, "--stage", stage, "--output-path", join(proj, subdir, "sample.py")], {
+    CLAUDE_PROJECT_DIR: proj,
+  });
+  const f = auditPath(proj);
+  const fired = auditEventCount(f, "SENSOR_FIRED");
+  const failed = auditEventCount(f, "SENSOR_FAILED");
+  const firedId = auditField(f, "SENSOR_FIRED", "Fire id");
+  const failedId = auditField(f, "SENSOR_FAILED", "Fire id");
+  const findings = auditField(f, "SENSOR_FAILED", "Findings count");
+  const detailPath = auditField(f, "SENSOR_FAILED", "Detail path");
+  const path = auditField(f, "SENSOR_FAILED", "Output path");
+  expect(fired).toBe(1);
+  expect(failed).toBe(1);
+  expect(firedId).not.toBe("");
+  expect(firedId).toBe(failedId);
+  expect(findings).toBe(expectedFindings);
+  expect(detailPath).toBe(`aidlc-docs/.aidlc-sensors/${stage}/${id}-${firedId}.md`);
+  expect(existsSync(join(proj, detailPath))).toBe(true);
+  expect(path).toBe(`${subdir}/sample.py`);
+}
+
+describe("t92 Group C2: PASSED + FAILED real round-trip — Python sensors", () => {
+  // ruff spawns the real ruff binary; generous timeout for first cold run.
+  test("11b: linter — passing Python (ruff clean) -> PASSED, relative path, no Note", () => {
+    const r = runPassedPyReal("linter", "code-generation", join(FIXTURES_ROOT, "passing-python"));
+    expect(r.fired).toBe(1);
+    expect(r.passed).toBe(1);
+    expect(r.firedId).not.toBe("");
+    expect(r.firedId).toBe(r.passedId);
+    expect(isInteger(r.dur)).toBe(true);
+    expect(r.detailExists).toBe(false);
+    expect(r.path).toBe(`${r.subdir}/sample.py`);
+    expect(r.note).toBe("");
+  }, 60000);
+
+  // mypy spawns the real mypy binary (manifest timeout_seconds=60); generous headroom.
+  test("12b: type-check — passing Python (mypy clean) -> PASSED, relative path, no Note", () => {
+    const r = runPassedPyReal("type-check", "code-generation", join(FIXTURES_ROOT, "passing-python"));
+    expect(r.fired).toBe(1);
+    expect(r.passed).toBe(1);
+    expect(r.firedId).not.toBe("");
+    expect(r.firedId).toBe(r.passedId);
+    expect(isInteger(r.dur)).toBe(true);
+    expect(r.detailExists).toBe(false);
+    expect(r.path).toBe(`${r.subdir}/sample.py`);
+    expect(r.note).toBe("");
+  }, 90000);
+
+  // Real ruff spawn — failing fixture has unused import (F401).
+  test("15b: linter — failing Python (ruff F401) -> Findings count=1", () => {
+    runFailedPyReal("linter", "code-generation", join(FIXTURES_ROOT, "failing-ruff"), "1");
+  }, 60000);
+
+  // Real mypy spawn — failing fixture has type mismatch.
+  test("16b: type-check — failing Python (mypy assignment error) -> Findings count=1", () => {
+    runFailedPyReal("type-check", "code-generation", join(FIXTURES_ROOT, "failing-mypy"), "1");
+  }, 90000);
+});
+
+// ============================================================
 // Group D — Tool-unavailable (2): per-sensor script exits 127.
 // Dispatcher classifies branch b -> SENSOR_PASSED Note=tool-unavailable.
 // (t92-sensor-fire.sh:507-535)

--- a/tests/integration/t93.test.ts
+++ b/tests/integration/t93.test.ts
@@ -176,21 +176,23 @@ describe("t93 aidlc-sensor describe (migrated from t93-sensor-list-describe.sh, 
     expect(hasLine(r.out, "matches: **/aidlc-docs/**")).toBe(true);
   });
 
-  test("7: describe linter includes matches: **/*.{ts,js} and canonical fields", () => {
+  test("7: describe linter includes its matches glob and canonical fields", () => {
     const r = sensor("describe", "linter");
     expect(r.status).toBe(0);
     expect(hasLine(r.out, "id: linter")).toBe(true);
-    expect(hasLine(r.out, "matches: **/*.{ts,js}")).toBe(true);
+    expect(hasLine(r.out, "matches: **/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}")).toBe(
+      true,
+    );
     expect(
       hasLine(r.out, "command: bun .claude/tools/aidlc-sensor-linter.ts"),
     ).toBe(true);
   });
 
-  test("8: describe type-check includes matches: **/*.{ts,tsx} and canonical fields", () => {
+  test("8: describe type-check includes its matches glob and canonical fields", () => {
     const r = sensor("describe", "type-check");
     expect(r.status).toBe(0);
     expect(hasLine(r.out, "id: type-check")).toBe(true);
-    expect(hasLine(r.out, "matches: **/*.{ts,tsx}")).toBe(true);
+    expect(hasLine(r.out, "matches: **/*.{ts,tsx,py,pyi}")).toBe(true);
     expect(
       hasLine(r.out, "command: bun .claude/tools/aidlc-sensor-type-check.ts"),
     ).toBe(true);

--- a/tests/integration/t95-sensor-fire-hook-feature.test.ts
+++ b/tests/integration/t95-sensor-fire-hook-feature.test.ts
@@ -318,8 +318,8 @@ describe("t95 sensor-fire hook — single & multi-entry fire (mechanism cli — 
 
 describe("t95 sensor-fire hook — multi-glob filtering at the stage level (mechanism cli — spawnSync)", () => {
   const CODE_STAGE: SynthSensor[] = [
-    { id: "linter", path: ".claude/sensors/aidlc-linter.md", matches: "**/*.{ts,js}" },
-    { id: "type-check", path: ".claude/sensors/aidlc-type-check.md", matches: "**/*.{ts,tsx}" },
+    { id: "linter", path: ".claude/sensors/aidlc-linter.md", matches: "**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}" },
+    { id: "type-check", path: ".claude/sensors/aidlc-type-check.md", matches: "**/*.{ts,tsx,py,pyi}" },
     { id: "required-sections", path: ".claude/sensors/aidlc-required-sections.md", matches: "**/aidlc-docs/**" },
     { id: "upstream-coverage", path: ".claude/sensors/aidlc-upstream-coverage.md", matches: "**/aidlc-docs/**" },
   ];


### PR DESCRIPTION

# Summary

The code-quality sensors (linter, type-check) now fire on .py/.pyi files alongside TS/JS, dispatching on file extension:

- linter: ruff (resolved side-effect-free as python -m ruff / python3 -m ruff / bare ruff; uv run excluded — it can create a .venv). Only runs when the project configures ruff ([tool.ruff] / ruff.toml); no config = quiet pass, mirroring eslint's no-config behaviour.

- type-check: mypy or pyright, whichever the project configures ([tool.mypy]/mypy.ini -> mypy; [tool.pyright]/pyrightconfig.json -> pyright; both -> mypy wins; neither -> quiet pass). mypy resolved the same way as ruff; pyright via bunx (it genuinely is npm).

Design: same two sensor ids, same pull-authoring model — no dispatcher change, no stage edits. Stages that already import linter/type-check get Python coverage for free.

Includes 4 new integration tests (t92 Group C2) mirroring the TS real-fixture round-trips, 3 Python fixtures, updated glob assertions in t93/t95/t66/t89, and docs sweep.

Bumps version to 0.7.10.

## Changes

**Core scripts (the real work):**
- `core/tools/aidlc-sensor-linter.ts` — refactored `main()` to dispatch on extension; added full ruff flow (project walk-up, config-presence gate via `ruff check --show-settings`, resolver `python -m ruff` → `python3 -m ruff` → bare `ruff`, JSON parse into locked shape)
- `core/tools/aidlc-sensor-type-check.ts` — same extension dispatch; added mypy/pyright selection from project config (`[tool.mypy]`/`mypy.ini` → mypy, `[tool.pyright]`/`pyrightconfig.json` → pyright, both → mypy wins, neither → 127); mypy JSONL parser + pyright JSON parser with 0-based→1-based normalization; same resolver pattern as ruff

**Manifests:**
- `core/sensors/aidlc-linter.md` — glob widened to `**/*.{ts,tsx,js,jsx,mjs,cjs,py,pyi}`, prose rewritten
- `core/sensors/aidlc-type-check.md` — glob widened to `**/*.{ts,tsx,py,pyi}`, prose rewritten

**Tests:**
- 3 new fixtures: `tests/fixtures/v05-mr9-sensor-fire/passing-python/`, `failing-ruff/`, `failing-mypy/`
- 4 new integration tests in `t92.test.ts` (Group C2) — real ruff/mypy invocations, un-gated
- Updated glob assertions in `t93.test.ts`, `t95-sensor-fire-hook-feature.test.ts`, `t66.test.ts`, `t89.test.ts`

**Docs:**
- `docs/harness-engineering/06-sensors.md` — "four sensors" table updated
- `docs/reference/07-sensor-system.md` — matches examples updated
- `core/aidlc-common/stages/construction/code-generation.md` — sensor description updated

**Version:**
- `core/tools/aidlc-version.ts` → `0.7.10`
- `CHANGELOG.md` — new `## [0.7.10]` entry
- `README.md` — badge bumped

**Dist:** all 3 harnesses regenerated (`dist/claude/`, `dist/kiro/`, `dist/codex/`) — drift check passes.

## User experience

From the user's perspective: **nothing changes in their workflow.** They don't configure anything new, don't add sensor ids to stages, don't run any new command.

**Before this change:**
- User writes a `.py` file during code-generation → sensor doesn't fire (glob didn't match) → no lint/type feedback on Python code

**After this change:**
- User writes a `.py` file during code-generation → sensor fires automatically → if their project has ruff/mypy configured, they get `SENSOR_FAILED` audit rows with violations (same as they already get for TS lint/type errors)
- If their project has **no** ruff/mypy config → nothing happens (quiet pass, no noise)
- If ruff/mypy aren't **installed** → nothing happens (quiet pass, no noise)

**Zero friction path:** a Python project that already has `[tool.ruff]` in `pyproject.toml` and `ruff`/`mypy` installed gets lint + type-check feedback automatically on every `.py` write during any stage that imports `linter`/`type-check`. No opt-in, no config, no stage edits.

**What they see when it fires (same UX as eslint/tsc today):**
- `SENSOR_FIRED` + `SENSOR_PASSED` or `SENSOR_FAILED` in the audit log
- On failure: a detail file at `aidlc-docs/.aidlc-sensors/<stage>/linter-<id>.md` with the violation (file, line, rule, message)
- Advisory only — doesn't block the approval gate

**What they never see:**
- No new commands, no new flags
- No "install ruff" prompts or errors
- No noise on non-Python projects or unconfigured Python projects

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

**Prerequisites:** `ruff` and `mypy` installed in the test environment (`pip install ruff mypy`). Verify with `ruff --version` and `mypy --version`.

**Automated (the real coverage):**
```bash
bun test tests/integration/t92.test.ts   # 49 tests — includes 4 new Python round-trips (Group C2)
bun test tests/integration/t93.test.ts   # 12 tests — updated glob assertions for describe
bun test tests/integration/t95-sensor-fire-hook-feature.test.ts
bun test tests/integration/t66.test.ts
bun test tests/integration/t89.test.ts
bun test tests/unit/t68-version-changelog-sync.test.ts  # version/changelog/badge agree
bun scripts/package.ts --check           # dist drift guard
```

**Manual spot-check (optional — confirms real tool invocation):**
```bash
# Linter — passing Python (expect pass:true, 0 findings)
bun core/tools/aidlc-sensor-linter.ts --stage code-generation \
  --file-path "$(pwd)/tests/fixtures/v05-mr9-sensor-fire/passing-python/sample.py"

# Linter — failing Python (expect pass:false, 1 finding: F401)
bun core/tools/aidlc-sensor-linter.ts --stage code-generation \
  --file-path "$(pwd)/tests/fixtures/v05-mr9-sensor-fire/failing-ruff/sample.py"

# Type-check — passing Python (expect pass:true)
bun core/tools/aidlc-sensor-type-check.ts --stage code-generation \
  --file-path "$(pwd)/tests/fixtures/v05-mr9-sensor-fire/passing-python/sample.py"

# Type-check — failing Python (expect pass:false, 1 error: assignment)
bun core/tools/aidlc-sensor-type-check.ts --stage code-generation \
  --file-path "$(pwd)/tests/fixtures/v05-mr9-sensor-fire/failing-mypy/sample.py"

# Unknown extension — quiet pass (exit 127)
bun core/tools/aidlc-sensor-linter.ts --stage code-generation \
  --file-path "$(pwd)/README.md"
```

**Negative cases (no tools installed — simulates a TS-only project):**
- Temporarily rename `ruff` binary → linter on `.py` should exit 127 (quiet pass, no error spam)
- Project with `pyproject.toml` but no `[tool.ruff]` → linter should exit 127
- Project with no `[tool.mypy]` and no `pyrightconfig.json` → type-check should exit 127

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
