### PR TITLE
[Bug] Green v2 reviewer-merge baseline (t65/t68/t37/t66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.1] - 2026-06-18
+
+Greens the default-tier test suite (smoke + unit + integration) after the 2.0.0 reviewer-mechanism merge, with no behaviour change to the reviewer feature itself. Three independent, mechanical defects rode in with the merge: the frontmatter emitter dropped the two `reviewer` fields on a round-trip, the version trio was inconsistent, and three agent-count assertions still expected the pre-merge roster of 11. This release reconciles all three so CI is green on a clean 2.0 baseline. No re-copy of `dist/<harness>/` is required for behaviour — the changes are test-correctness, metadata, and the regenerated dist copies of `aidlc-version.ts`. Refs #387.
+
+* **Frontmatter round-trip now carries the reviewer fields.** `emitStageFrontmatter` lists `reviewer` and `reviewer_max_iterations` in its `FIELD_ORDER` (right after `mode`, matching the order the stage files author them), so a parse → emit → parse cycle no longer drops them for reviewer-bearing stages (t65). The emitter has no runtime callers; this is a test-correctness fix.
+* **Agent-count assertions and the designer-export golden reflect the 13-agent roster.** The structure guard and element-count assertions now expect 13 agents, and the export golden fixture was regenerated via the CLI to include the two reviewer personas (t37, t66).
+* **Version trio reconciled** — `aidlc-version.ts`, the latest CHANGELOG heading, and the README badge all agree at 2.0.1 (t68).
+* No new commands or flags; no breaking change for CI or scripts.
+
+## [2.0.0] - 2026-06-18
+
+Adds **LLM-based quality verification** to the workflow: a stage may declare an optional `reviewer:` in its frontmatter, and after the stage body runs the conductor invokes that reviewer sub-agent as an advisory quality gate before the approval gate (stage-protocol.md §12a). The review loop runs up to `reviewer_max_iterations` times (default 2) and is strictly advisory — the human keeps the final say at the approval gate. Two reviewer personas ship with this release, growing the agent roster from 11 to 13. This release also lands the **Kiro IDE** harness (`dist/kiro-ide/`). It back-fills the reviewer-feature changelog entry that the 0.7.12 graph-compile fix did not record. Re-copy your `dist/<harness>/` to pick up the reviewer-bearing stages and, on Kiro IDE, the new distribution.
+
+* **Optional `reviewer:` stage field** — declare a reviewer in a stage's frontmatter and it runs after the stage body as an advisory quality gate; `reviewer_max_iterations` (default 2) caps the review loop. The reviewer never auto-approves — the human approval gate is unchanged.
+* **Two reviewer personas** — `aidlc-product-lead-agent` and `aidlc-architecture-reviewer-agent`, taking the roster from 11 to 13 agents.
+* **New `dist/kiro-ide/` distribution** — the Kiro IDE harness, alongside the existing Claude Code, Kiro CLI, and Codex CLI trees.
+* No breaking change for CI or scripts; reviewer behaviour is opt-in per stage.
+
 ## [0.7.12] - 2026-06-17
 
 Fixes a bug where the **reviewer step never ran**: stages declare a `reviewer:` in their frontmatter, but the graph compiler dropped the field, so the compiled `stage-graph.json` and the `run-stage` directive never carried it. The conductor correctly treats the directive as authoritative (stage-protocol.md §12a — invoke a reviewer only when the directive includes one), so with the field missing it always skipped the review. The compiler now carries `reviewer` and `reviewer_max_iterations` through to the compiled graph (and coerces the iteration cap to a number). Re-copy your `dist/<harness>/` to pick it up; reviewer-bearing stages (requirements-analysis, user-stories, application-design, code-generation, and others) now run their review loop before the approval gate.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.0.0-blue)
+![version](https://img.shields.io/badge/version-2.0.1-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -1444,6 +1444,8 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
     "lead_agent",
     "support_agents",
     "mode",
+    "reviewer",
+    "reviewer_max_iterations",
     "for_each",
     "produces",
     "consumes",

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.12";
+export const AIDLC_VERSION = "2.0.1";

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -1444,6 +1444,8 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
     "lead_agent",
     "support_agents",
     "mode",
+    "reviewer",
+    "reviewer_max_iterations",
     "for_each",
     "produces",
     "consumes",

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.12";
+export const AIDLC_VERSION = "2.0.1";

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -1444,6 +1444,8 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
     "lead_agent",
     "support_agents",
     "mode",
+    "reviewer",
+    "reviewer_max_iterations",
     "for_each",
     "produces",
     "consumes",

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.12";
+export const AIDLC_VERSION = "2.0.1";

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -1444,6 +1444,8 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
     "lead_agent",
     "support_agents",
     "mode",
+    "reviewer",
+    "reviewer_max_iterations",
     "for_each",
     "produces",
     "consumes",

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.12";
+export const AIDLC_VERSION = "2.0.1";

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -1444,6 +1444,8 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
     "lead_agent",
     "support_agents",
     "mode",
+    "reviewer",
+    "reviewer_max_iterations",
     "for_each",
     "produces",
     "consumes",

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "0.7.12";
+export const AIDLC_VERSION = "2.0.1";

--- a/tests/fixtures/designer-export/export.json
+++ b/tests/fixtures/designer-export/export.json
@@ -539,6 +539,8 @@
         "feature",
         "mvp"
       ],
+      "reviewer": "aidlc-product-lead-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "Intent statement, scope definition, intent backlog",
       "outputs": "aidlc-docs/ideation/rough-mockups/wireframes.md, aidlc-docs/ideation/rough-mockups/user-flow.md, aidlc-docs/ideation/rough-mockups/rough-mockups-questions.md",
       "rules_in_context": [
@@ -906,6 +908,8 @@
         "infra",
         "workshop"
       ],
+      "reviewer": "aidlc-product-lead-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "RE artifacts (if brownfield), user's project description (from audit.md)",
       "outputs": "aidlc-docs/inception/requirements-analysis/requirements.md, aidlc-docs/inception/requirements-analysis/requirements-analysis-questions.md",
       "rules_in_context": [
@@ -989,6 +993,8 @@
         "mvp",
         "workshop"
       ],
+      "reviewer": "aidlc-product-lead-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "aidlc-docs/inception/requirements-analysis/requirements.md, RE artifacts (if brownfield)",
       "outputs": "aidlc-docs/inception/user-stories/stories.md, aidlc-docs/inception/user-stories/personas.md, aidlc-docs/inception/user-stories/user-stories-assessment.md",
       "rules_in_context": [
@@ -1076,6 +1082,8 @@
         "mvp",
         "workshop"
       ],
+      "reviewer": "aidlc-product-lead-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "Rough mockups from rough-mockups stage, user stories from user-stories stage, requirements from requirements-analysis stage",
       "outputs": "aidlc-docs/inception/refined-mockups/mockups.md, aidlc-docs/inception/refined-mockups/interaction-spec.md, aidlc-docs/inception/refined-mockups/design-system-mapping.md, aidlc-docs/inception/refined-mockups/accessibility-checklist.md, aidlc-docs/inception/refined-mockups/refined-mockups-questions.md",
       "rules_in_context": [
@@ -1167,6 +1175,8 @@
         "mvp",
         "workshop"
       ],
+      "reviewer": "aidlc-architecture-reviewer-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "aidlc-docs/inception/requirements-analysis/requirements.md, aidlc-docs/inception/user-stories/stories.md (if produced), RE artifacts (if brownfield)",
       "outputs": "aidlc-docs/inception/application-design/components.md, aidlc-docs/inception/application-design/component-methods.md, aidlc-docs/inception/application-design/services.md, aidlc-docs/inception/application-design/component-dependency.md, aidlc-docs/inception/application-design/decisions.md",
       "rules_in_context": [
@@ -1260,6 +1270,8 @@
         "mvp",
         "workshop"
       ],
+      "reviewer": "aidlc-architecture-reviewer-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "aidlc-docs/inception/application-design/ (all design artifacts), aidlc-docs/inception/requirements-analysis/requirements.md, aidlc-docs/inception/user-stories/stories.md (if produced)",
       "outputs": "aidlc-docs/inception/units-generation/unit-of-work.md, aidlc-docs/inception/units-generation/unit-of-work-dependency.md, aidlc-docs/inception/units-generation/unit-of-work-story-map.md",
       "rules_in_context": [
@@ -1453,6 +1465,8 @@
         "refactor",
         "workshop"
       ],
+      "reviewer": "aidlc-architecture-reviewer-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, application design artifacts",
       "outputs": "aidlc-docs/construction/{unit-name}/functional-design/ (business-logic-model.md, business-rules.md, domain-entities.md, CONDITIONAL: frontend-components.md)",
       "rules_in_context": [
@@ -1555,6 +1569,8 @@
         "security-patch",
         "workshop"
       ],
+      "reviewer": "aidlc-architecture-reviewer-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "functional design artifacts, requirements.md, RE artifacts",
       "outputs": "aidlc-docs/construction/{unit-name}/nfr-requirements/ (performance-requirements.md, security-requirements.md, scalability-requirements.md, reliability-requirements.md, tech-stack-decisions.md)",
       "rules_in_context": [
@@ -1661,6 +1677,8 @@
         "infra",
         "workshop"
       ],
+      "reviewer": "aidlc-architecture-reviewer-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "NFR requirements artifacts, functional design artifacts",
       "outputs": "aidlc-docs/construction/{unit-name}/nfr-design/ (performance-design.md, security-design.md, scalability-design.md, reliability-design.md, logical-components.md)",
       "rules_in_context": [
@@ -1776,6 +1794,8 @@
         "infra",
         "workshop"
       ],
+      "reviewer": "aidlc-architecture-reviewer-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "NFR design artifacts, application design, functional design",
       "outputs": "aidlc-docs/construction/{unit-name}/infrastructure-design/ (deployment-architecture.md, infrastructure-services.md, monitoring-design.md, cicd-pipeline.md, CONDITIONAL: shared-infrastructure.md)",
       "rules_in_context": [
@@ -1889,6 +1909,8 @@
         "security-patch",
         "workshop"
       ],
+      "reviewer": "aidlc-architecture-reviewer-agent",
+      "reviewer_max_iterations": 2,
       "inputs": "ALL prior design artifacts for this unit",
       "outputs": "application code + aidlc-docs/construction/{unit-name}/code-generation/ (code-generation-plan.md, code-summary.md)",
       "rules_in_context": [
@@ -3210,6 +3232,11 @@
       ]
     },
     {
+      "slug": "aidlc-architecture-reviewer-agent",
+      "display_name": "Architecture Reviewer",
+      "examples": []
+    },
+    {
       "slug": "aidlc-aws-platform-agent",
       "display_name": "AWS Platform Agent",
       "examples": [
@@ -3280,6 +3307,11 @@
         "roadmap.md",
         "personas.md"
       ]
+    },
+    {
+      "slug": "aidlc-product-lead-agent",
+      "display_name": "Product Lead",
+      "examples": []
     },
     {
       "slug": "aidlc-quality-agent",

--- a/tests/integration/t37-stage-protocol-compliance.test.ts
+++ b/tests/integration/t37-stage-protocol-compliance.test.ts
@@ -51,8 +51,8 @@
 //   .sh stage-protocol loop (32 stages, one ok/not_ok each)
 //        -> "every stage file references stage-protocol" (32 expects, one/stage)
 //        -> STRONGER: "no non-initialization stage omits stage-protocol"
-//   .sh agent knowledge-dir loop (11 agents)
-//        -> "every agent has a knowledge directory" (11 expects, one/agent)
+//   .sh agent knowledge-dir loop (13 agents)
+//        -> "every agent has a knowledge directory" (13 expects, one/agent)
 //   .sh state-template section loop (7 sections)
 //        -> "state template has every required ## section" (7 expects)
 //   .sh fixture mid-ideation section loop (5 sections)
@@ -165,8 +165,8 @@ describe("every agent has a knowledge directory", () => {
     .map((f) => basename(f, ".md"))
     .sort();
 
-  test("there are 11 agent files [structure guard]", () => {
-    expect(agents.length).toBe(11);
+  test("there are 13 agent files [structure guard]", () => {
+    expect(agents.length).toBe(13);
   });
 
   for (const agent of agents) {

--- a/tests/integration/t66.test.ts
+++ b/tests/integration/t66.test.ts
@@ -935,7 +935,7 @@ describe("t66 designer export (spawnSync CLI-boundary)", () => {
   });
 
   // .sh:892-900 — Group B: element counts match live sources (4 assertions)
-  test("export element counts: stages=32, scopes=9, artifacts=122, agents=11", () => {
+  test("export element counts: stages=32, scopes=9, artifacts=122, agents=13", () => {
     const res = spawnSync(BUN, [GRAPH_TS, "export"], { encoding: "utf8" });
     const out = JSON.parse(res.stdout) as {
       stages: unknown[];
@@ -946,7 +946,7 @@ describe("t66 designer export (spawnSync CLI-boundary)", () => {
     expect(out.stages.length).toBe(32);
     expect(Object.keys(out.scopes).length).toBe(9);
     expect(out.artifacts.length).toBe(122);
-    expect(out.agents.length).toBe(11);
+    expect(out.agents.length).toBe(13);
   });
 
   // .sh:903-904 — Group C: determinism across two invocations


### PR DESCRIPTION
## Summary

The v2 reviewer-mechanism merge left the default-tier test suite (smoke + unit +
integration) RED on three independent, mechanical defects. This PR greens it with
no behaviour change to the reviewer feature, and completes the 2.0.0 release —
shipping this fix as 2.0.1.

## Fixes

- **Frontmatter round-trip (t65)** — `emitStageFrontmatter`'s `FIELD_ORDER` omitted
  `reviewer` / `reviewer_max_iterations`, so a parse → emit → parse cycle dropped
  them for the 11 reviewer-bearing stages. Added both keys right after `mode`,
  matching the order the stage files author them (the round-trip deep-equal is
  order-sensitive, so the emit order must match the source order). Test-correctness
  fix — the emitter has no runtime callers.
- **Version trio (t68)** — the README badge was 2.0.0 while `aidlc-version.ts` and
  the latest CHANGELOG heading were 0.7.12. Set `version.ts` + README badge to
  2.0.1, added `## [2.0.0]` (back-filling the reviewer-feature + Kiro IDE harness
  entry) and `## [2.0.1]` (this greening) CHANGELOG headings, regenerated the dist
  copies of `aidlc-version.ts` across all four harness trees.
- **Agent count 11→13 (t37, t66)** — two reviewer personas grew the roster to 13.
  Updated t37's structure-guard assertion + description, t66's element-count
  assertion + title, and regenerated the designer-export golden via the CLI so it
  carries the two new personas.

## Verification

- `bun run typecheck` — clean (0 errors)
- `bun scripts/package.ts --check` — all four harness trees in sync
- Full default-tier suite — **182 files, 3234 assertions, 0 failures** (incl. t65/t68/t37/t66)

## Out of scope (tracked as follow-up)

Cross-harness reviewer inertness, reviewer roster + type validation, reviewer
`fs_write` least-privilege, `for_each` × reviewer semantics (already #368), and the
reviewer / Kiro-IDE docs gap.

Closes #387
