### PR TITLE
[Bug] Validate reviewer / reviewer_max_iterations stage fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.2] - 2026-06-18
+
+Validates the stage `reviewer:` / `reviewer_max_iterations` frontmatter fields, which were carried through schema → graph → directive by the 2.0.0 reviewer mechanism but never checked. A malformed cap, a non-positive-integer cap, a cap declared with no reviewer, or a `reviewer:` naming an agent with no `.claude/agents/*.md` file all passed validation before and surfaced only as a runtime failure or a silently-disabled review loop; they now fail validation/compile loudly and deterministically. This is a behaviour change at authoring time only — the reviewer's runtime behaviour is unchanged. Re-copy your `dist/<harness>/` to pick up the regenerated tools. Refs #389.
+
+* **Authoring impact (action required if you hand-edit stages):** a stage whose `reviewer:` names an unknown agent, or whose `reviewer_max_iterations` is non-numeric / zero / negative / non-integer / present-without-a-reviewer, now FAILS `validateStageFrontmatter` and the graph compile where it previously passed. Fix the value or remove the field.
+* **`reviewer_max_iterations` is now parsed as a number.** `parseStageFrontmatter` coerces an integer-literal cap to a real number (and `emitStageFrontmatter` round-trips it as an unquoted number), so the type is correct end-to-end instead of relying on a `Number()` coercion at compile.
+* **`reviewer` is roster-checked like `lead_agent`.** A reviewer slug with no matching agent file is rejected (stage-schema Rule 9), closing the silent-failure path.
+* **Directive validation** type-checks `reviewer` (string) and `reviewer_max_iterations` (positive integer), and the graph compiler guards the cap so a bad value can never ship NaN to `stage-graph.json`.
+* No new commands or flags; the only breaking change is that previously-accepted malformed reviewer config now errors.
+
 ## [2.0.1] - 2026-06-18
 
 Greens the default-tier test suite (smoke + unit + integration) after the 2.0.0 reviewer-mechanism merge, with no behaviour change to the reviewer feature itself. Three independent, mechanical defects rode in with the merge: the frontmatter emitter dropped the two `reviewer` fields on a round-trip, the version trio was inconsistent, and three agent-count assertions still expected the pre-merge roster of 11. This release reconciles all three so CI is green on a clean 2.0 baseline. No re-copy of `dist/<harness>/` is required for behaviour — the changes are test-correctness, metadata, and the regenerated dist copies of `aidlc-version.ts`. Refs #387.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.0.1-blue)
+![version](https://img.shields.io/badge/version-2.0.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-directive.ts
+++ b/core/tools/aidlc-directive.ts
@@ -350,6 +350,11 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // reviewer fields — optional on a run-stage directive (present only when the
+  // stage declares a reviewer). Mirror the stage-schema validator: reviewer is
+  // an optional string, reviewer_max_iterations an optional positive integer.
+  checkOptionalString(o, "reviewer", kind, errors);
+  checkOptionalPositiveInteger(o, "reviewer_max_iterations", kind, errors);
 }
 
 // --- Helpers (mirror aidlc-stage-schema.ts: presence first, then type) ---
@@ -408,6 +413,25 @@ function checkOptionalString(
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${kind}: ${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkOptionalPositiveInteger — a field that may be absent, but if present
+// must be a positive integer (>= 1) — e.g. reviewer_max_iterations. Mirrors
+// the stage-schema validator's checkPositiveInteger so the directive contract
+// matches the frontmatter contract.
+function checkOptionalPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(
+      `${kind}: ${field} must be a positive integer, got ${describe(v)}`,
+    );
   }
 }
 

--- a/core/tools/aidlc-graph.ts
+++ b/core/tools/aidlc-graph.ts
@@ -1220,12 +1220,17 @@ function buildGraphStage(
   if (parsed.reviewer !== undefined) {
     stage.reviewer = parsed.reviewer;
     // Default the cap to 2 when a reviewer is declared but no explicit cap is
-    // set. Coerce to a number — YAML frontmatter may parse the value as a
-    // string ("2"), but the directive contract and the conductor's
-    // `iterations < max` comparison require a number.
+    // set. The parser (V1) now returns a real number and validateStageFrontmatter
+    // (V2) rejects a non-positive-integer cap upstream, so this should always
+    // see a valid number or undefined. Keep the coercion defensive: a value
+    // that isn't a positive integer falls back to the default 2 rather than
+    // letting NaN reach stage-graph.json.
+    const cap = Number(parsed.reviewer_max_iterations);
     stage.reviewer_max_iterations =
-      parsed.reviewer_max_iterations !== undefined
-        ? Number(parsed.reviewer_max_iterations)
+      parsed.reviewer_max_iterations !== undefined &&
+      Number.isInteger(cap) &&
+      cap >= 1
+        ? cap
         : 2;
   }
   return stage;

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -1218,6 +1218,21 @@ export function parseStageFrontmatter(
 
   obj.consumes = objectListField(fm, CONSUMES_KEY);
 
+  // reviewer_max_iterations is the one numeric scalar field. The generic
+  // scalar loop above captured it as a string ("2"); coerce it to a real
+  // number when the raw value is an integer literal so the type is correct
+  // end-to-end — the schema validator, the directive contract, and the
+  // conductor's `iterations < max` comparison all want a number, not "2".
+  // A non-integer-literal value (e.g. "two", "2.5") is left as the string so
+  // validateStageFrontmatter rejects it loudly rather than the parser
+  // silently coercing to NaN. `reviewer` stays a string (handled by the loop).
+  if (typeof obj.reviewer_max_iterations === "string") {
+    const raw = obj.reviewer_max_iterations;
+    if (/^-?\d+$/.test(raw)) {
+      obj.reviewer_max_iterations = Number(raw);
+    }
+  }
+
   return obj;
 }
 
@@ -1495,6 +1510,12 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
       }
     } else if (typeof v === "string") {
       lines.push(`${key}: ${emitScalar(v)}`);
+    } else if (typeof v === "number") {
+      // reviewer_max_iterations round-trips as an unquoted number, matching
+      // how stages author it on disk (`reviewer_max_iterations: 2`). Without
+      // this branch the numeric value the parser now returns (V1) would be
+      // dropped on emit, breaking the parse -> emit -> parse contract (t65).
+      lines.push(`${key}: ${v}`);
     }
   }
 

--- a/core/tools/aidlc-stage-schema.ts
+++ b/core/tools/aidlc-stage-schema.ts
@@ -190,6 +190,36 @@ export function validateStageFrontmatter(
     }
   }
 
+  // reviewer — optional. When present, must be a string. Validated exactly
+  // like lead_agent (checkString + the Rule 9 roster cross-check below), since
+  // reviewer is an agent-slug field of the same kind. checkString does not
+  // enforce non-emptiness (lead_agent does not either); an empty reviewer is
+  // caught by the Rule 9 roster check when ctx.agents is supplied (it matches
+  // no agent file), which every production caller does. No standalone
+  // kebab-pattern check: lead_agent has none either, and a pattern-invalid slug
+  // can never match a real agent file, so Rule 9 already rejects it — a pattern
+  // check here would be redundant.
+  checkString(o, "reviewer", errors);
+
+  // reviewer_max_iterations — optional. When present, must be a positive
+  // integer (>= 1). V1 makes the parser return a number for an integer
+  // literal; a non-integer literal stays a string and is rejected here as a
+  // type error rather than silently coercing to NaN at compile.
+  checkPositiveInteger(o, "reviewer_max_iterations", errors);
+
+  // Coupling — a cap with no reviewer is silently dropped at compile
+  // (aidlc-graph.ts guards the whole reviewer block on `reviewer` being
+  // present). Make the schema's contract match the compiler: reject a cap
+  // declared without a reviewer. The inverse (reviewer present, cap absent)
+  // is valid — the cap defaults to 2.
+  if (
+    "reviewer_max_iterations" in o &&
+    o.reviewer_max_iterations !== undefined &&
+    !("reviewer" in o && o.reviewer !== undefined)
+  ) {
+    errors.push("reviewer_max_iterations requires a reviewer");
+  }
+
   checkStringArray(o, "produces", errors);
 
   // Rule 8: nested consumes[] — array of {artifact, required, conditional_on?}.
@@ -302,6 +332,17 @@ export function validateStageFrontmatter(
         }
       });
     }
+    // reviewer is an agent-slug field like lead_agent; cross-check it against
+    // the same roster (exempting the reserved orchestrator pseudo-agent). This
+    // is the silent-failure fix: a reviewer naming a non-existent agent passed
+    // validation today and surfaced only as a runtime no-op.
+    if (
+      typeof o.reviewer === "string" &&
+      o.reviewer !== RESERVED_AGENT_SLUG &&
+      !known.has(o.reviewer)
+    ) {
+      errors.push(`reviewer "${o.reviewer}" has no matching .claude/agents/*.md`);
+    }
   }
 
   if (errors.length > 0) {
@@ -332,6 +373,24 @@ function checkString(o: Record<string, unknown>, field: string, errors: string[]
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkPositiveInteger — an optional field that, when present, must be a
+// positive integer (>= 1). Mirrors checkString's presence-first shape: absent
+// is valid, present-and-wrong is reported. A non-number (e.g. the string "two"
+// the parser leaves untouched for a non-integer literal), a non-integer
+// (2.5), or a value < 1 (0, -3) all fail. reviewer_max_iterations is the only
+// numeric stage field, so the error names the contract directly.
+function checkPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(`${field} must be a positive integer, got ${describe(v)}`);
   }
 }
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.0.1";
+export const AIDLC_VERSION = "2.0.2";

--- a/dist/claude/.claude/tools/aidlc-directive.ts
+++ b/dist/claude/.claude/tools/aidlc-directive.ts
@@ -350,6 +350,11 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // reviewer fields — optional on a run-stage directive (present only when the
+  // stage declares a reviewer). Mirror the stage-schema validator: reviewer is
+  // an optional string, reviewer_max_iterations an optional positive integer.
+  checkOptionalString(o, "reviewer", kind, errors);
+  checkOptionalPositiveInteger(o, "reviewer_max_iterations", kind, errors);
 }
 
 // --- Helpers (mirror aidlc-stage-schema.ts: presence first, then type) ---
@@ -408,6 +413,25 @@ function checkOptionalString(
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${kind}: ${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkOptionalPositiveInteger — a field that may be absent, but if present
+// must be a positive integer (>= 1) — e.g. reviewer_max_iterations. Mirrors
+// the stage-schema validator's checkPositiveInteger so the directive contract
+// matches the frontmatter contract.
+function checkOptionalPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(
+      `${kind}: ${field} must be a positive integer, got ${describe(v)}`,
+    );
   }
 }
 

--- a/dist/claude/.claude/tools/aidlc-graph.ts
+++ b/dist/claude/.claude/tools/aidlc-graph.ts
@@ -1220,12 +1220,17 @@ function buildGraphStage(
   if (parsed.reviewer !== undefined) {
     stage.reviewer = parsed.reviewer;
     // Default the cap to 2 when a reviewer is declared but no explicit cap is
-    // set. Coerce to a number — YAML frontmatter may parse the value as a
-    // string ("2"), but the directive contract and the conductor's
-    // `iterations < max` comparison require a number.
+    // set. The parser (V1) now returns a real number and validateStageFrontmatter
+    // (V2) rejects a non-positive-integer cap upstream, so this should always
+    // see a valid number or undefined. Keep the coercion defensive: a value
+    // that isn't a positive integer falls back to the default 2 rather than
+    // letting NaN reach stage-graph.json.
+    const cap = Number(parsed.reviewer_max_iterations);
     stage.reviewer_max_iterations =
-      parsed.reviewer_max_iterations !== undefined
-        ? Number(parsed.reviewer_max_iterations)
+      parsed.reviewer_max_iterations !== undefined &&
+      Number.isInteger(cap) &&
+      cap >= 1
+        ? cap
         : 2;
   }
   return stage;

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -1218,6 +1218,21 @@ export function parseStageFrontmatter(
 
   obj.consumes = objectListField(fm, CONSUMES_KEY);
 
+  // reviewer_max_iterations is the one numeric scalar field. The generic
+  // scalar loop above captured it as a string ("2"); coerce it to a real
+  // number when the raw value is an integer literal so the type is correct
+  // end-to-end — the schema validator, the directive contract, and the
+  // conductor's `iterations < max` comparison all want a number, not "2".
+  // A non-integer-literal value (e.g. "two", "2.5") is left as the string so
+  // validateStageFrontmatter rejects it loudly rather than the parser
+  // silently coercing to NaN. `reviewer` stays a string (handled by the loop).
+  if (typeof obj.reviewer_max_iterations === "string") {
+    const raw = obj.reviewer_max_iterations;
+    if (/^-?\d+$/.test(raw)) {
+      obj.reviewer_max_iterations = Number(raw);
+    }
+  }
+
   return obj;
 }
 
@@ -1495,6 +1510,12 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
       }
     } else if (typeof v === "string") {
       lines.push(`${key}: ${emitScalar(v)}`);
+    } else if (typeof v === "number") {
+      // reviewer_max_iterations round-trips as an unquoted number, matching
+      // how stages author it on disk (`reviewer_max_iterations: 2`). Without
+      // this branch the numeric value the parser now returns (V1) would be
+      // dropped on emit, breaking the parse -> emit -> parse contract (t65).
+      lines.push(`${key}: ${v}`);
     }
   }
 

--- a/dist/claude/.claude/tools/aidlc-stage-schema.ts
+++ b/dist/claude/.claude/tools/aidlc-stage-schema.ts
@@ -190,6 +190,36 @@ export function validateStageFrontmatter(
     }
   }
 
+  // reviewer — optional. When present, must be a string. Validated exactly
+  // like lead_agent (checkString + the Rule 9 roster cross-check below), since
+  // reviewer is an agent-slug field of the same kind. checkString does not
+  // enforce non-emptiness (lead_agent does not either); an empty reviewer is
+  // caught by the Rule 9 roster check when ctx.agents is supplied (it matches
+  // no agent file), which every production caller does. No standalone
+  // kebab-pattern check: lead_agent has none either, and a pattern-invalid slug
+  // can never match a real agent file, so Rule 9 already rejects it — a pattern
+  // check here would be redundant.
+  checkString(o, "reviewer", errors);
+
+  // reviewer_max_iterations — optional. When present, must be a positive
+  // integer (>= 1). V1 makes the parser return a number for an integer
+  // literal; a non-integer literal stays a string and is rejected here as a
+  // type error rather than silently coercing to NaN at compile.
+  checkPositiveInteger(o, "reviewer_max_iterations", errors);
+
+  // Coupling — a cap with no reviewer is silently dropped at compile
+  // (aidlc-graph.ts guards the whole reviewer block on `reviewer` being
+  // present). Make the schema's contract match the compiler: reject a cap
+  // declared without a reviewer. The inverse (reviewer present, cap absent)
+  // is valid — the cap defaults to 2.
+  if (
+    "reviewer_max_iterations" in o &&
+    o.reviewer_max_iterations !== undefined &&
+    !("reviewer" in o && o.reviewer !== undefined)
+  ) {
+    errors.push("reviewer_max_iterations requires a reviewer");
+  }
+
   checkStringArray(o, "produces", errors);
 
   // Rule 8: nested consumes[] — array of {artifact, required, conditional_on?}.
@@ -302,6 +332,17 @@ export function validateStageFrontmatter(
         }
       });
     }
+    // reviewer is an agent-slug field like lead_agent; cross-check it against
+    // the same roster (exempting the reserved orchestrator pseudo-agent). This
+    // is the silent-failure fix: a reviewer naming a non-existent agent passed
+    // validation today and surfaced only as a runtime no-op.
+    if (
+      typeof o.reviewer === "string" &&
+      o.reviewer !== RESERVED_AGENT_SLUG &&
+      !known.has(o.reviewer)
+    ) {
+      errors.push(`reviewer "${o.reviewer}" has no matching .claude/agents/*.md`);
+    }
   }
 
   if (errors.length > 0) {
@@ -332,6 +373,24 @@ function checkString(o: Record<string, unknown>, field: string, errors: string[]
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkPositiveInteger — an optional field that, when present, must be a
+// positive integer (>= 1). Mirrors checkString's presence-first shape: absent
+// is valid, present-and-wrong is reported. A non-number (e.g. the string "two"
+// the parser leaves untouched for a non-integer literal), a non-integer
+// (2.5), or a value < 1 (0, -3) all fail. reviewer_max_iterations is the only
+// numeric stage field, so the error names the contract directly.
+function checkPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(`${field} must be a positive integer, got ${describe(v)}`);
   }
 }
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.0.1";
+export const AIDLC_VERSION = "2.0.2";

--- a/dist/codex/.codex/tools/aidlc-directive.ts
+++ b/dist/codex/.codex/tools/aidlc-directive.ts
@@ -350,6 +350,11 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // reviewer fields — optional on a run-stage directive (present only when the
+  // stage declares a reviewer). Mirror the stage-schema validator: reviewer is
+  // an optional string, reviewer_max_iterations an optional positive integer.
+  checkOptionalString(o, "reviewer", kind, errors);
+  checkOptionalPositiveInteger(o, "reviewer_max_iterations", kind, errors);
 }
 
 // --- Helpers (mirror aidlc-stage-schema.ts: presence first, then type) ---
@@ -408,6 +413,25 @@ function checkOptionalString(
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${kind}: ${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkOptionalPositiveInteger — a field that may be absent, but if present
+// must be a positive integer (>= 1) — e.g. reviewer_max_iterations. Mirrors
+// the stage-schema validator's checkPositiveInteger so the directive contract
+// matches the frontmatter contract.
+function checkOptionalPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(
+      `${kind}: ${field} must be a positive integer, got ${describe(v)}`,
+    );
   }
 }
 

--- a/dist/codex/.codex/tools/aidlc-graph.ts
+++ b/dist/codex/.codex/tools/aidlc-graph.ts
@@ -1220,12 +1220,17 @@ function buildGraphStage(
   if (parsed.reviewer !== undefined) {
     stage.reviewer = parsed.reviewer;
     // Default the cap to 2 when a reviewer is declared but no explicit cap is
-    // set. Coerce to a number — YAML frontmatter may parse the value as a
-    // string ("2"), but the directive contract and the conductor's
-    // `iterations < max` comparison require a number.
+    // set. The parser (V1) now returns a real number and validateStageFrontmatter
+    // (V2) rejects a non-positive-integer cap upstream, so this should always
+    // see a valid number or undefined. Keep the coercion defensive: a value
+    // that isn't a positive integer falls back to the default 2 rather than
+    // letting NaN reach stage-graph.json.
+    const cap = Number(parsed.reviewer_max_iterations);
     stage.reviewer_max_iterations =
-      parsed.reviewer_max_iterations !== undefined
-        ? Number(parsed.reviewer_max_iterations)
+      parsed.reviewer_max_iterations !== undefined &&
+      Number.isInteger(cap) &&
+      cap >= 1
+        ? cap
         : 2;
   }
   return stage;

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -1218,6 +1218,21 @@ export function parseStageFrontmatter(
 
   obj.consumes = objectListField(fm, CONSUMES_KEY);
 
+  // reviewer_max_iterations is the one numeric scalar field. The generic
+  // scalar loop above captured it as a string ("2"); coerce it to a real
+  // number when the raw value is an integer literal so the type is correct
+  // end-to-end — the schema validator, the directive contract, and the
+  // conductor's `iterations < max` comparison all want a number, not "2".
+  // A non-integer-literal value (e.g. "two", "2.5") is left as the string so
+  // validateStageFrontmatter rejects it loudly rather than the parser
+  // silently coercing to NaN. `reviewer` stays a string (handled by the loop).
+  if (typeof obj.reviewer_max_iterations === "string") {
+    const raw = obj.reviewer_max_iterations;
+    if (/^-?\d+$/.test(raw)) {
+      obj.reviewer_max_iterations = Number(raw);
+    }
+  }
+
   return obj;
 }
 
@@ -1495,6 +1510,12 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
       }
     } else if (typeof v === "string") {
       lines.push(`${key}: ${emitScalar(v)}`);
+    } else if (typeof v === "number") {
+      // reviewer_max_iterations round-trips as an unquoted number, matching
+      // how stages author it on disk (`reviewer_max_iterations: 2`). Without
+      // this branch the numeric value the parser now returns (V1) would be
+      // dropped on emit, breaking the parse -> emit -> parse contract (t65).
+      lines.push(`${key}: ${v}`);
     }
   }
 

--- a/dist/codex/.codex/tools/aidlc-stage-schema.ts
+++ b/dist/codex/.codex/tools/aidlc-stage-schema.ts
@@ -190,6 +190,36 @@ export function validateStageFrontmatter(
     }
   }
 
+  // reviewer — optional. When present, must be a string. Validated exactly
+  // like lead_agent (checkString + the Rule 9 roster cross-check below), since
+  // reviewer is an agent-slug field of the same kind. checkString does not
+  // enforce non-emptiness (lead_agent does not either); an empty reviewer is
+  // caught by the Rule 9 roster check when ctx.agents is supplied (it matches
+  // no agent file), which every production caller does. No standalone
+  // kebab-pattern check: lead_agent has none either, and a pattern-invalid slug
+  // can never match a real agent file, so Rule 9 already rejects it — a pattern
+  // check here would be redundant.
+  checkString(o, "reviewer", errors);
+
+  // reviewer_max_iterations — optional. When present, must be a positive
+  // integer (>= 1). V1 makes the parser return a number for an integer
+  // literal; a non-integer literal stays a string and is rejected here as a
+  // type error rather than silently coercing to NaN at compile.
+  checkPositiveInteger(o, "reviewer_max_iterations", errors);
+
+  // Coupling — a cap with no reviewer is silently dropped at compile
+  // (aidlc-graph.ts guards the whole reviewer block on `reviewer` being
+  // present). Make the schema's contract match the compiler: reject a cap
+  // declared without a reviewer. The inverse (reviewer present, cap absent)
+  // is valid — the cap defaults to 2.
+  if (
+    "reviewer_max_iterations" in o &&
+    o.reviewer_max_iterations !== undefined &&
+    !("reviewer" in o && o.reviewer !== undefined)
+  ) {
+    errors.push("reviewer_max_iterations requires a reviewer");
+  }
+
   checkStringArray(o, "produces", errors);
 
   // Rule 8: nested consumes[] — array of {artifact, required, conditional_on?}.
@@ -302,6 +332,17 @@ export function validateStageFrontmatter(
         }
       });
     }
+    // reviewer is an agent-slug field like lead_agent; cross-check it against
+    // the same roster (exempting the reserved orchestrator pseudo-agent). This
+    // is the silent-failure fix: a reviewer naming a non-existent agent passed
+    // validation today and surfaced only as a runtime no-op.
+    if (
+      typeof o.reviewer === "string" &&
+      o.reviewer !== RESERVED_AGENT_SLUG &&
+      !known.has(o.reviewer)
+    ) {
+      errors.push(`reviewer "${o.reviewer}" has no matching .claude/agents/*.md`);
+    }
   }
 
   if (errors.length > 0) {
@@ -332,6 +373,24 @@ function checkString(o: Record<string, unknown>, field: string, errors: string[]
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkPositiveInteger — an optional field that, when present, must be a
+// positive integer (>= 1). Mirrors checkString's presence-first shape: absent
+// is valid, present-and-wrong is reported. A non-number (e.g. the string "two"
+// the parser leaves untouched for a non-integer literal), a non-integer
+// (2.5), or a value < 1 (0, -3) all fail. reviewer_max_iterations is the only
+// numeric stage field, so the error names the contract directly.
+function checkPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(`${field} must be a positive integer, got ${describe(v)}`);
   }
 }
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.0.1";
+export const AIDLC_VERSION = "2.0.2";

--- a/dist/kiro-ide/.kiro/tools/aidlc-directive.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-directive.ts
@@ -350,6 +350,11 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // reviewer fields — optional on a run-stage directive (present only when the
+  // stage declares a reviewer). Mirror the stage-schema validator: reviewer is
+  // an optional string, reviewer_max_iterations an optional positive integer.
+  checkOptionalString(o, "reviewer", kind, errors);
+  checkOptionalPositiveInteger(o, "reviewer_max_iterations", kind, errors);
 }
 
 // --- Helpers (mirror aidlc-stage-schema.ts: presence first, then type) ---
@@ -408,6 +413,25 @@ function checkOptionalString(
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${kind}: ${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkOptionalPositiveInteger — a field that may be absent, but if present
+// must be a positive integer (>= 1) — e.g. reviewer_max_iterations. Mirrors
+// the stage-schema validator's checkPositiveInteger so the directive contract
+// matches the frontmatter contract.
+function checkOptionalPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(
+      `${kind}: ${field} must be a positive integer, got ${describe(v)}`,
+    );
   }
 }
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-graph.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-graph.ts
@@ -1220,12 +1220,17 @@ function buildGraphStage(
   if (parsed.reviewer !== undefined) {
     stage.reviewer = parsed.reviewer;
     // Default the cap to 2 when a reviewer is declared but no explicit cap is
-    // set. Coerce to a number — YAML frontmatter may parse the value as a
-    // string ("2"), but the directive contract and the conductor's
-    // `iterations < max` comparison require a number.
+    // set. The parser (V1) now returns a real number and validateStageFrontmatter
+    // (V2) rejects a non-positive-integer cap upstream, so this should always
+    // see a valid number or undefined. Keep the coercion defensive: a value
+    // that isn't a positive integer falls back to the default 2 rather than
+    // letting NaN reach stage-graph.json.
+    const cap = Number(parsed.reviewer_max_iterations);
     stage.reviewer_max_iterations =
-      parsed.reviewer_max_iterations !== undefined
-        ? Number(parsed.reviewer_max_iterations)
+      parsed.reviewer_max_iterations !== undefined &&
+      Number.isInteger(cap) &&
+      cap >= 1
+        ? cap
         : 2;
   }
   return stage;

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -1218,6 +1218,21 @@ export function parseStageFrontmatter(
 
   obj.consumes = objectListField(fm, CONSUMES_KEY);
 
+  // reviewer_max_iterations is the one numeric scalar field. The generic
+  // scalar loop above captured it as a string ("2"); coerce it to a real
+  // number when the raw value is an integer literal so the type is correct
+  // end-to-end — the schema validator, the directive contract, and the
+  // conductor's `iterations < max` comparison all want a number, not "2".
+  // A non-integer-literal value (e.g. "two", "2.5") is left as the string so
+  // validateStageFrontmatter rejects it loudly rather than the parser
+  // silently coercing to NaN. `reviewer` stays a string (handled by the loop).
+  if (typeof obj.reviewer_max_iterations === "string") {
+    const raw = obj.reviewer_max_iterations;
+    if (/^-?\d+$/.test(raw)) {
+      obj.reviewer_max_iterations = Number(raw);
+    }
+  }
+
   return obj;
 }
 
@@ -1495,6 +1510,12 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
       }
     } else if (typeof v === "string") {
       lines.push(`${key}: ${emitScalar(v)}`);
+    } else if (typeof v === "number") {
+      // reviewer_max_iterations round-trips as an unquoted number, matching
+      // how stages author it on disk (`reviewer_max_iterations: 2`). Without
+      // this branch the numeric value the parser now returns (V1) would be
+      // dropped on emit, breaking the parse -> emit -> parse contract (t65).
+      lines.push(`${key}: ${v}`);
     }
   }
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-stage-schema.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-stage-schema.ts
@@ -190,6 +190,36 @@ export function validateStageFrontmatter(
     }
   }
 
+  // reviewer — optional. When present, must be a string. Validated exactly
+  // like lead_agent (checkString + the Rule 9 roster cross-check below), since
+  // reviewer is an agent-slug field of the same kind. checkString does not
+  // enforce non-emptiness (lead_agent does not either); an empty reviewer is
+  // caught by the Rule 9 roster check when ctx.agents is supplied (it matches
+  // no agent file), which every production caller does. No standalone
+  // kebab-pattern check: lead_agent has none either, and a pattern-invalid slug
+  // can never match a real agent file, so Rule 9 already rejects it — a pattern
+  // check here would be redundant.
+  checkString(o, "reviewer", errors);
+
+  // reviewer_max_iterations — optional. When present, must be a positive
+  // integer (>= 1). V1 makes the parser return a number for an integer
+  // literal; a non-integer literal stays a string and is rejected here as a
+  // type error rather than silently coercing to NaN at compile.
+  checkPositiveInteger(o, "reviewer_max_iterations", errors);
+
+  // Coupling — a cap with no reviewer is silently dropped at compile
+  // (aidlc-graph.ts guards the whole reviewer block on `reviewer` being
+  // present). Make the schema's contract match the compiler: reject a cap
+  // declared without a reviewer. The inverse (reviewer present, cap absent)
+  // is valid — the cap defaults to 2.
+  if (
+    "reviewer_max_iterations" in o &&
+    o.reviewer_max_iterations !== undefined &&
+    !("reviewer" in o && o.reviewer !== undefined)
+  ) {
+    errors.push("reviewer_max_iterations requires a reviewer");
+  }
+
   checkStringArray(o, "produces", errors);
 
   // Rule 8: nested consumes[] — array of {artifact, required, conditional_on?}.
@@ -302,6 +332,17 @@ export function validateStageFrontmatter(
         }
       });
     }
+    // reviewer is an agent-slug field like lead_agent; cross-check it against
+    // the same roster (exempting the reserved orchestrator pseudo-agent). This
+    // is the silent-failure fix: a reviewer naming a non-existent agent passed
+    // validation today and surfaced only as a runtime no-op.
+    if (
+      typeof o.reviewer === "string" &&
+      o.reviewer !== RESERVED_AGENT_SLUG &&
+      !known.has(o.reviewer)
+    ) {
+      errors.push(`reviewer "${o.reviewer}" has no matching .claude/agents/*.md`);
+    }
   }
 
   if (errors.length > 0) {
@@ -332,6 +373,24 @@ function checkString(o: Record<string, unknown>, field: string, errors: string[]
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkPositiveInteger — an optional field that, when present, must be a
+// positive integer (>= 1). Mirrors checkString's presence-first shape: absent
+// is valid, present-and-wrong is reported. A non-number (e.g. the string "two"
+// the parser leaves untouched for a non-integer literal), a non-integer
+// (2.5), or a value < 1 (0, -3) all fail. reviewer_max_iterations is the only
+// numeric stage field, so the error names the contract directly.
+function checkPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(`${field} must be a positive integer, got ${describe(v)}`);
   }
 }
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.0.1";
+export const AIDLC_VERSION = "2.0.2";

--- a/dist/kiro/.kiro/tools/aidlc-directive.ts
+++ b/dist/kiro/.kiro/tools/aidlc-directive.ts
@@ -350,6 +350,11 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // reviewer fields — optional on a run-stage directive (present only when the
+  // stage declares a reviewer). Mirror the stage-schema validator: reviewer is
+  // an optional string, reviewer_max_iterations an optional positive integer.
+  checkOptionalString(o, "reviewer", kind, errors);
+  checkOptionalPositiveInteger(o, "reviewer_max_iterations", kind, errors);
 }
 
 // --- Helpers (mirror aidlc-stage-schema.ts: presence first, then type) ---
@@ -408,6 +413,25 @@ function checkOptionalString(
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${kind}: ${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkOptionalPositiveInteger — a field that may be absent, but if present
+// must be a positive integer (>= 1) — e.g. reviewer_max_iterations. Mirrors
+// the stage-schema validator's checkPositiveInteger so the directive contract
+// matches the frontmatter contract.
+function checkOptionalPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(
+      `${kind}: ${field} must be a positive integer, got ${describe(v)}`,
+    );
   }
 }
 

--- a/dist/kiro/.kiro/tools/aidlc-graph.ts
+++ b/dist/kiro/.kiro/tools/aidlc-graph.ts
@@ -1220,12 +1220,17 @@ function buildGraphStage(
   if (parsed.reviewer !== undefined) {
     stage.reviewer = parsed.reviewer;
     // Default the cap to 2 when a reviewer is declared but no explicit cap is
-    // set. Coerce to a number — YAML frontmatter may parse the value as a
-    // string ("2"), but the directive contract and the conductor's
-    // `iterations < max` comparison require a number.
+    // set. The parser (V1) now returns a real number and validateStageFrontmatter
+    // (V2) rejects a non-positive-integer cap upstream, so this should always
+    // see a valid number or undefined. Keep the coercion defensive: a value
+    // that isn't a positive integer falls back to the default 2 rather than
+    // letting NaN reach stage-graph.json.
+    const cap = Number(parsed.reviewer_max_iterations);
     stage.reviewer_max_iterations =
-      parsed.reviewer_max_iterations !== undefined
-        ? Number(parsed.reviewer_max_iterations)
+      parsed.reviewer_max_iterations !== undefined &&
+      Number.isInteger(cap) &&
+      cap >= 1
+        ? cap
         : 2;
   }
   return stage;

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -1218,6 +1218,21 @@ export function parseStageFrontmatter(
 
   obj.consumes = objectListField(fm, CONSUMES_KEY);
 
+  // reviewer_max_iterations is the one numeric scalar field. The generic
+  // scalar loop above captured it as a string ("2"); coerce it to a real
+  // number when the raw value is an integer literal so the type is correct
+  // end-to-end — the schema validator, the directive contract, and the
+  // conductor's `iterations < max` comparison all want a number, not "2".
+  // A non-integer-literal value (e.g. "two", "2.5") is left as the string so
+  // validateStageFrontmatter rejects it loudly rather than the parser
+  // silently coercing to NaN. `reviewer` stays a string (handled by the loop).
+  if (typeof obj.reviewer_max_iterations === "string") {
+    const raw = obj.reviewer_max_iterations;
+    if (/^-?\d+$/.test(raw)) {
+      obj.reviewer_max_iterations = Number(raw);
+    }
+  }
+
   return obj;
 }
 
@@ -1495,6 +1510,12 @@ export function emitStageFrontmatter(obj: Record<string, unknown>): string {
       }
     } else if (typeof v === "string") {
       lines.push(`${key}: ${emitScalar(v)}`);
+    } else if (typeof v === "number") {
+      // reviewer_max_iterations round-trips as an unquoted number, matching
+      // how stages author it on disk (`reviewer_max_iterations: 2`). Without
+      // this branch the numeric value the parser now returns (V1) would be
+      // dropped on emit, breaking the parse -> emit -> parse contract (t65).
+      lines.push(`${key}: ${v}`);
     }
   }
 

--- a/dist/kiro/.kiro/tools/aidlc-stage-schema.ts
+++ b/dist/kiro/.kiro/tools/aidlc-stage-schema.ts
@@ -190,6 +190,36 @@ export function validateStageFrontmatter(
     }
   }
 
+  // reviewer — optional. When present, must be a string. Validated exactly
+  // like lead_agent (checkString + the Rule 9 roster cross-check below), since
+  // reviewer is an agent-slug field of the same kind. checkString does not
+  // enforce non-emptiness (lead_agent does not either); an empty reviewer is
+  // caught by the Rule 9 roster check when ctx.agents is supplied (it matches
+  // no agent file), which every production caller does. No standalone
+  // kebab-pattern check: lead_agent has none either, and a pattern-invalid slug
+  // can never match a real agent file, so Rule 9 already rejects it — a pattern
+  // check here would be redundant.
+  checkString(o, "reviewer", errors);
+
+  // reviewer_max_iterations — optional. When present, must be a positive
+  // integer (>= 1). V1 makes the parser return a number for an integer
+  // literal; a non-integer literal stays a string and is rejected here as a
+  // type error rather than silently coercing to NaN at compile.
+  checkPositiveInteger(o, "reviewer_max_iterations", errors);
+
+  // Coupling — a cap with no reviewer is silently dropped at compile
+  // (aidlc-graph.ts guards the whole reviewer block on `reviewer` being
+  // present). Make the schema's contract match the compiler: reject a cap
+  // declared without a reviewer. The inverse (reviewer present, cap absent)
+  // is valid — the cap defaults to 2.
+  if (
+    "reviewer_max_iterations" in o &&
+    o.reviewer_max_iterations !== undefined &&
+    !("reviewer" in o && o.reviewer !== undefined)
+  ) {
+    errors.push("reviewer_max_iterations requires a reviewer");
+  }
+
   checkStringArray(o, "produces", errors);
 
   // Rule 8: nested consumes[] — array of {artifact, required, conditional_on?}.
@@ -302,6 +332,17 @@ export function validateStageFrontmatter(
         }
       });
     }
+    // reviewer is an agent-slug field like lead_agent; cross-check it against
+    // the same roster (exempting the reserved orchestrator pseudo-agent). This
+    // is the silent-failure fix: a reviewer naming a non-existent agent passed
+    // validation today and surfaced only as a runtime no-op.
+    if (
+      typeof o.reviewer === "string" &&
+      o.reviewer !== RESERVED_AGENT_SLUG &&
+      !known.has(o.reviewer)
+    ) {
+      errors.push(`reviewer "${o.reviewer}" has no matching .claude/agents/*.md`);
+    }
   }
 
   if (errors.length > 0) {
@@ -332,6 +373,24 @@ function checkString(o: Record<string, unknown>, field: string, errors: string[]
   if (!(field in o)) return;
   if (typeof o[field] !== "string") {
     errors.push(`${field} must be string, got ${describe(o[field])}`);
+  }
+}
+
+// checkPositiveInteger — an optional field that, when present, must be a
+// positive integer (>= 1). Mirrors checkString's presence-first shape: absent
+// is valid, present-and-wrong is reported. A non-number (e.g. the string "two"
+// the parser leaves untouched for a non-integer literal), a non-integer
+// (2.5), or a value < 1 (0, -3) all fail. reviewer_max_iterations is the only
+// numeric stage field, so the error names the contract directly.
+function checkPositiveInteger(
+  o: Record<string, unknown>,
+  field: string,
+  errors: string[],
+): void {
+  if (!(field in o) || o[field] === undefined) return;
+  const v = o[field];
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1) {
+    errors.push(`${field} must be a positive integer, got ${describe(v)}`);
   }
 }
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.0.1";
+export const AIDLC_VERSION = "2.0.2";

--- a/tests/unit/t113.test.ts
+++ b/tests/unit/t113.test.ts
@@ -333,6 +333,43 @@ describe("t113 directive-schema — validateDirective (migrated from t113-direct
   });
 
   // ============================================================
+  // Reviewer fields on a run-stage directive (V4a)
+  // ============================================================
+  // reviewer / reviewer_max_iterations are optional run-stage fields, present
+  // only when the stage declares a reviewer. The directive validator mirrors
+  // the stage-schema validator: reviewer optional-string,
+  // reviewer_max_iterations optional positive-integer. Absent is fine; a valid
+  // pair validates; a non-string reviewer or non-integer cap is rejected.
+
+  test("run-stage reviewer + cap present and valid -> VALID", () => {
+    expect(
+      errs({
+        ...runStage(),
+        reviewer: "aidlc-architecture-reviewer-agent",
+        reviewer_max_iterations: 3,
+      }),
+    ).toBe("VALID");
+  });
+
+  test("run-stage non-string reviewer -> type error", () => {
+    expect(errs({ ...runStage(), reviewer: 42 })).toContain(
+      "run-stage: reviewer must be string, got number",
+    );
+  });
+
+  test("run-stage non-integer reviewer_max_iterations -> positive-integer error", () => {
+    expect(
+      errs({
+        ...runStage(),
+        reviewer: "aidlc-architecture-reviewer-agent",
+        reviewer_max_iterations: "two",
+      }),
+    ).toContain(
+      "run-stage: reviewer_max_iterations must be a positive integer, got string",
+    );
+  });
+
+  // ============================================================
   // Shape failures — non-object inputs (3 assertions)
   // .sh lines 186-188
   // ============================================================

--- a/tests/unit/t62.test.ts
+++ b/tests/unit/t62.test.ts
@@ -484,4 +484,118 @@ describe("t62 stage-schema — validateStageFrontmatter (migrated from t62-stage
     const errors = (r as { valid: false; errors: string[] }).errors;
     expect(errors.find((e) => e.includes("consumes[0].artifact"))).toBeDefined();
   });
+
+  // ============================================================
+  // Reviewer field validation (V2 + V3) — type, positive-integer,
+  // cap⇒reviewer coupling, and the Rule 9 roster cross-check.
+  // Both fields are OPTIONAL: absent → valid; the only required relation is
+  // the coupling (cap present ⇒ reviewer present). Exercises checkString on
+  // `reviewer`, the new checkPositiveInteger on `reviewer_max_iterations`,
+  // and the reviewer arm of Rule 9.
+  // ============================================================
+
+  test("both reviewer fields absent -> valid", () => {
+    expect(errs(fixture())).toBe("VALID");
+  });
+
+  test("reviewer present, cap absent -> valid (cap defaults to 2)", () => {
+    expect(errs({ ...fixture(), reviewer: "aidlc-product-lead-agent" })).toBe(
+      "VALID",
+    );
+  });
+
+  test("valid reviewer + cap 2 -> valid", () => {
+    expect(
+      errs({
+        ...fixture(),
+        reviewer: "aidlc-product-lead-agent",
+        reviewer_max_iterations: 2,
+      }),
+    ).toBe("VALID");
+  });
+
+  test("non-string reviewer (42) -> type error", () => {
+    expect(errs({ ...fixture(), reviewer: 42 })).toContain(
+      "reviewer must be string",
+    );
+  });
+
+  test("reviewer_max_iterations as string '2' -> positive-integer error", () => {
+    // The parser only coerces an integer LITERAL to a number; a value that
+    // reaches the validator still a string must be rejected, not coerced.
+    expect(
+      errs({
+        ...fixture(),
+        reviewer: "aidlc-product-lead-agent",
+        reviewer_max_iterations: "2",
+      }),
+    ).toContain("reviewer_max_iterations must be a positive integer");
+  });
+
+  test("reviewer_max_iterations zero -> positive-integer error", () => {
+    expect(
+      errs({
+        ...fixture(),
+        reviewer: "aidlc-product-lead-agent",
+        reviewer_max_iterations: 0,
+      }),
+    ).toContain("reviewer_max_iterations must be a positive integer");
+  });
+
+  test("reviewer_max_iterations negative -> positive-integer error", () => {
+    expect(
+      errs({
+        ...fixture(),
+        reviewer: "aidlc-product-lead-agent",
+        reviewer_max_iterations: -3,
+      }),
+    ).toContain("reviewer_max_iterations must be a positive integer");
+  });
+
+  test("reviewer_max_iterations non-integer (2.5) -> positive-integer error", () => {
+    expect(
+      errs({
+        ...fixture(),
+        reviewer: "aidlc-product-lead-agent",
+        reviewer_max_iterations: 2.5,
+      }),
+    ).toContain("reviewer_max_iterations must be a positive integer");
+  });
+
+  test("cap present with reviewer absent -> coupling error", () => {
+    expect(errs({ ...fixture(), reviewer_max_iterations: 2 })).toContain(
+      "reviewer_max_iterations requires a reviewer",
+    );
+  });
+
+  test("reviewer not in ctx.agents -> Rule 9 roster error", () => {
+    const out = errs(
+      { ...fixture(), reviewer: "ghost-reviewer-agent" },
+      { agents: ["aidlc-product-agent", "aidlc-delivery-agent"] },
+    );
+    expect(out).toContain('reviewer "ghost-reviewer-agent" has no matching');
+  });
+
+  test("reviewer in ctx.agents -> valid", () => {
+    expect(
+      errs(
+        { ...fixture(), reviewer: "aidlc-product-lead-agent" },
+        {
+          agents: [
+            "aidlc-product-agent",
+            "aidlc-delivery-agent",
+            "aidlc-product-lead-agent",
+          ],
+        },
+      ),
+    ).toBe("VALID");
+  });
+
+  test("without ctx.agents -> reviewer not roster-checked", () => {
+    // No ctx → agent-slug lookup skipped (same as lead_agent), so a ghost
+    // reviewer still validates as a string.
+    expect(errs({ ...fixture(), reviewer: "ghost-reviewer-agent" })).toBe(
+      "VALID",
+    );
+  });
 });

--- a/tests/unit/t64.test.ts
+++ b/tests/unit/t64.test.ts
@@ -463,6 +463,28 @@ outputs: b
 ---
 `;
 
+// Reviewer-bearing stage — `reviewer` is a string, `reviewer_max_iterations`
+// is authored as an unquoted integer (the canonical on-disk form). Exercises
+// V1: the parser coerces the cap to a NUMBER, and the emitter round-trips it
+// as an unquoted number.
+const REVIEWER = `---
+slug: test
+phase: inception
+execution: ALWAYS
+condition: x
+lead_agent: aidlc-product-agent
+mode: inline
+reviewer: aidlc-product-lead-agent
+reviewer_max_iterations: 2
+support_agents: []
+produces: []
+consumes: []
+requires_stage: []
+inputs: a
+outputs: b
+---
+`;
+
 // ============================================================
 // Positive baseline (.sh assertions 1-6)
 // ============================================================
@@ -711,6 +733,41 @@ describe("round-trip parse -> emit -> parse", () => {
   test("empty lists -> EQ", () => {
     // .sh: "round-trip: empty lists"
     expect(roundtrip(FLOW_EMPTY)).toBe("EQ");
+  });
+
+  // V1: reviewer-bearing stage round-trips with the cap as a NUMBER.
+  test("reviewer + numeric cap -> EQ", () => {
+    expect(roundtrip(REVIEWER)).toBe("EQ");
+  });
+});
+
+// ============================================================
+// Reviewer field parse/emit (V1) — reviewer_max_iterations is the one
+// numeric scalar field: the parser returns it as a NUMBER (not the string
+// "2"), and the emitter writes it back as an unquoted number that re-parses
+// to the same number.
+// ============================================================
+describe("reviewer fields parse/emit (V1)", () => {
+  test("reviewer_max_iterations parses to a number", () => {
+    const obj = parseStageFrontmatter(REVIEWER) as Record<string, unknown>;
+    expect(typeof obj.reviewer_max_iterations).toBe("number");
+    expect(obj.reviewer_max_iterations).toBe(2);
+  });
+
+  test("reviewer stays a string", () => {
+    const obj = parseStageFrontmatter(REVIEWER) as Record<string, unknown>;
+    expect(typeof obj.reviewer).toBe("string");
+    expect(obj.reviewer).toBe("aidlc-product-lead-agent");
+  });
+
+  test("emitted cap is an unquoted number that re-parses as a number", () => {
+    const obj = parseStageFrontmatter(REVIEWER) as Record<string, unknown>;
+    const yaml = emitStageFrontmatter(obj);
+    // Canonical on-disk form: unquoted integer, no surrounding quotes.
+    expect(yaml).toContain("reviewer_max_iterations: 2\n");
+    const reparsed = parseStageFrontmatter(yaml) as Record<string, unknown>;
+    expect(typeof reparsed.reviewer_max_iterations).toBe("number");
+    expect(reparsed.reviewer_max_iterations).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

The stage `reviewer:` / `reviewer_max_iterations` frontmatter fields were carried through schema → graph → directive by the 2.0.0 reviewer mechanism but were **never validated**. A malformed cap, a non-positive-integer cap, a cap declared with no reviewer, or a `reviewer:` naming a non-existent agent all passed validation and surfaced only as a runtime failure or a silently-disabled review loop.

This PR makes those failures **loud and deterministic** with the smallest changes that achieve it. Reviewer **runtime behaviour is unchanged** — only malformed/unknown config now errors at authoring/compile time.

Closes #389

## What changed (V1–V5)

- **V1 — parser returns `reviewer_max_iterations` as a number** (`core/tools/aidlc-lib.ts`). `parseStageFrontmatter` coerces an integer-literal cap to a real number (a non-integer literal is left a string for V2 to reject); `emitStageFrontmatter` gains a numeric emit branch so the cap round-trips as an unquoted number. `reviewer` stays a string.
- **V2 — stage-schema per-field validation + coupling** (`core/tools/aidlc-stage-schema.ts`). `validateStageFrontmatter` checks `reviewer` (optional string, via `checkString` exactly like `lead_agent`) and `reviewer_max_iterations` (optional positive integer, via a new `checkPositiveInteger` helper), and rejects a cap declared with no reviewer. Neither field is required.
- **V3 — reviewer roster cross-check in Rule 9** (`core/tools/aidlc-stage-schema.ts`). `reviewer` is cross-checked against `ctx.agents` like `lead_agent` (exempting the reserved orchestrator slug); a reviewer with no matching `.claude/agents/*.md` is rejected. This closes the silent-failure path.
- **V4 — directive validator + safe cap coercion** (`core/tools/aidlc-directive.ts`, `core/tools/aidlc-graph.ts`). The directive validator type-checks `reviewer` (string) and `reviewer_max_iterations` (positive integer, via a new `checkOptionalPositiveInteger` helper); the graph cap coercion is guarded so a bad value can never ship NaN to `stage-graph.json`. `aidlc-orchestrate.ts` is unchanged — V1+V4 guarantee a valid number upstream, so its `?? 2` can't emit NaN.
- **V5 — tests** (`tests/unit/t62.test.ts`, `t113.test.ts`, `t64.test.ts`). Reject/accept cases for every new rule, the directive checks, and the parse→number→round-trip contract.

## Authoring / CI impact

A stage whose `reviewer:` names an unknown agent, or whose `reviewer_max_iterations` is non-numeric / zero / negative / non-integer / present-without-a-reviewer, now **FAILS** `validateStageFrontmatter` and the graph compile where it previously passed. Fix the value or remove the field. No new commands or flags.

## Version

Bumps `2.0.1 → 2.0.2` (`aidlc-version.ts`, README badge, `## [2.0.2]` CHANGELOG entry) and regenerates `dist/` for all four harnesses. Re-copy your `dist/<harness>/` to pick up the regenerated tools.

## Out of scope

Cross-harness reviewer wiring (Codex/Kiro `trustedAgents` / SKILL steps), the stage-protocol §12a loop, reviewer `fs_write` grants, the `for_each` × reviewer iteration semantics (#368), and docs. These are separate, later efforts.

## Testing

- `bun run typecheck` — 0 errors
- `bun scripts/package.ts --check` — all four harness trees in sync (no hand-edited dist)
- Default-tier suite (`bash tests/run-tests.sh --debug -P 8`) — 182 files / 3253 assertions; the only failure is `t72-stage-reverse-engineering`, a pre-existing live-SDK timing flake unrelated to this change
- Target tests `t62` / `t113` / `t64` / `t65` / `t68` — all green
