### PR TITLE
fix: constrain *-design to design-level artifacts, no code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.72] - 2026-08-13
+
+Construction design stages no longer ship implementation-ready code in design artifacts. `functional-design`, `nfr-design`, and `infrastructure-design` now carry an explicit Constraints section: artifacts describe what is needed and why at an architectural level, code is capped at short illustrative snippets (pseudocode or interface-level, 15 lines or fewer), and complete implementations (IaC modules, Lambda handlers, IAM policy documents, middleware) belong in `code-generation` (#396). **Upgrade:** re-copy your harness tree from `dist/<harness>/` to pick up the revised stage files.
+
+* `functional-design`, `nfr-design`, and `infrastructure-design` stage prose gains a `## Constraints` section scoping artifacts to design-level content.
+* No command, flag, or artifact-path changes.
+
 ## [2.5.71] - 2026-08-13
 
 Stages now carry deterministic element-level traceability from requirements through stories, Units, design, code, and the Construction exit checks. **Upgrade:** refresh `dist/<harness>/`; for an existing intent whose current or completed in-flight stage predates `traceability.json`, revisit that stage and create its declared traceability artifact before attempting completion or downstream phase verification.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.71-blue)
+![version](https://img.shields.io/badge/version-2.5.72-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/stages/construction/functional-design.md
+++ b/core/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/core/aidlc-common/stages/construction/infrastructure-design.md
+++ b/core/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/core/aidlc-common/stages/construction/nfr-design.md
+++ b/core/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";

--- a/dist/claude/.claude/aidlc-common/stages/construction/functional-design.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/claude/.claude/aidlc-common/stages/construction/infrastructure-design.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/claude/.claude/aidlc-common/stages/construction/nfr-design.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";

--- a/dist/codex/.codex/aidlc-common/stages/construction/functional-design.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/codex/.codex/aidlc-common/stages/construction/infrastructure-design.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/codex/.codex/aidlc-common/stages/construction/nfr-design.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/functional-design.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/infrastructure-design.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/nfr-design.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/functional-design.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/infrastructure-design.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/nfr-design.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/functional-design.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/infrastructure-design.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/nfr-design.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/functional-design.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/infrastructure-design.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/nfr-design.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/functional-design.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/functional-design.md
@@ -59,6 +59,10 @@ outputs: "business-logic-model.md, business-rules.md, domain-entities.md, tracea
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe business logic, domain models, and rules at an architectural level, not implementation-ready code. Complete function bodies, class implementations, and framework-specific code belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/infrastructure-design.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/infrastructure-design.md
@@ -66,6 +66,10 @@ outputs: "deployment-architecture.md, infrastructure-services.md, monitoring-des
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe what infrastructure is needed and why, not implementation-ready code. Complete IaC (CDK constructs, Terraform modules, CloudFormation), full Lambda handlers, and IAM policy documents belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/nfr-design.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/nfr-design.md
@@ -59,6 +59,10 @@ outputs: "performance-design.md, security-design.md, scalability-design.md, reli
 
 MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
 
+## Constraints
+
+This is a design stage — artifacts describe architectural patterns, strategies, and decisions, not implementation-ready code. Complete implementations (middleware, interceptors, retry libraries, encryption routines) belong in code-generation. Limit code to short illustrative snippets (pseudocode or interface-level, ≤15 lines) that clarify a design decision.
+
 ## Steps
 
 ### Execution Modes

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.71";
+export const AIDLC_VERSION = "2.5.72";


### PR DESCRIPTION
## Summary

Adds a `## Constraints` section to `infrastructure-design.md`, `functional-design.md` and `nfr-design.md` stage files, explicitly stating that implementation-ready code belongs in `code-generation`, not in design stages.

Design artifacts should describe *what* infrastructure/patterns are needed and *why* — not ship complete CDK constructs, Lambda handlers, or IAM policy documents. Code snippets are limited to short illustrative pseudocode (≤15 lines) that clarify a design decision.

Fixes https://github.com/awslabs/aidlc-workflows/issues/396

## Changes

- `core/aidlc-common/stages/construction/infrastructure-design.md` — added Constraints section
- `core/aidlc-common/stages/construction/functional-design.md` — added Constraints section
- `core/aidlc-common/stages/construction/nfr-design.md` — added Constraints section
- `dist/` regenerated via `bun scripts/package.ts`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
