### PR TITLE
fix: move unit-test-instructions from build-and-test to code-generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.73] - 2026-08-13
+
+Re-authored from PR #403 by @jeromevdl, unit test instructions now belong to each Code Generation unit before implementation and flow into the cross-unit Build and Test stage. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* Code Generation produces `unit-test-instructions.md` per unit alongside the implementation plan, and Build and Test consumes those instructions instead of recreating them after code exists.
+* Plan Approval now covers both the code generation plan and unit test instructions; changing either file requires renewed approval before developer-agent dispatch.
+* Per-unit test commands must use exact test paths or an exact unit filter, and Build and Test deduplicates identical commands so each distinct command runs once.
+* Code Generation now imports the advisory `required-sections` sensor so the moved markdown artifact retains the document-shape validation applied at its former stage.
+
 ## [2.5.72] - 2026-08-13
 
 Construction design stages no longer ship implementation-ready code in design artifacts. `functional-design`, `nfr-design`, and `infrastructure-design` now carry an explicit Constraints section: artifacts describe what is needed and why at an architectural level, code is capped at short illustrative snippets (pseudocode or interface-level, 15 lines or fewer), and complete implementations (IaC modules, Lambda handlers, IAM policy documents, middleware) belong in `code-generation` (#396). **Upgrade:** re-copy your harness tree from `dist/<harness>/` to pick up the revised stage files.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.72-blue)
+![version](https://img.shields.io/badge/version-2.5.73-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/stages/construction/build-and-test.md
+++ b/core/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/core/aidlc-common/stages/construction/code-generation.md
+++ b/core/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/claude/.claude/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/claude/.claude/tools/data/stage-graph.json
+++ b/dist/claude/.claude/tools/data/stage-graph.json
@@ -2031,6 +2031,7 @@
     "workspace_requires": true,
     "produces": [
       "code-generation-plan",
+      "unit-test-instructions",
       "code-summary",
       "traceability"
     ],
@@ -2076,6 +2077,7 @@
       "infrastructure-design"
     ],
     "sensors": [
+      "required-sections",
       "linter",
       "type-check",
       "traceability"
@@ -2094,7 +2096,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "inputs": "ALL prior design artifacts for this unit",
-    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",
@@ -2114,6 +2116,11 @@
       }
     ],
     "sensors_applicable": [
+      {
+        "id": "required-sections",
+        "path": ".claude/sensors/aidlc-required-sections.md",
+        "matches": "**/{aidlc-docs,intents}/**"
+      },
       {
         "id": "linter",
         "path": ".claude/sensors/aidlc-linter.md",
@@ -2145,7 +2152,6 @@
     "mode": "inline",
     "produces": [
       "build-instructions",
-      "unit-test-instructions",
       "integration-test-instructions",
       "performance-test-instructions",
       "security-test-instructions",
@@ -2156,6 +2162,10 @@
     "consumes": [
       {
         "artifact": "code-generation-plan",
+        "required": true
+      },
+      {
+        "artifact": "unit-test-instructions",
         "required": true
       },
       {
@@ -2182,7 +2192,7 @@
       "workshop"
     ],
     "inputs": "ALL code generation outputs across all units",
-    "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+    "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",

--- a/dist/codex/.codex/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/codex/.codex/tools/data/stage-graph.json
+++ b/dist/codex/.codex/tools/data/stage-graph.json
@@ -2031,6 +2031,7 @@
     "workspace_requires": true,
     "produces": [
       "code-generation-plan",
+      "unit-test-instructions",
       "code-summary",
       "traceability"
     ],
@@ -2076,6 +2077,7 @@
       "infrastructure-design"
     ],
     "sensors": [
+      "required-sections",
       "linter",
       "type-check",
       "traceability"
@@ -2094,7 +2096,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "inputs": "ALL prior design artifacts for this unit",
-    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",
@@ -2114,6 +2116,11 @@
       }
     ],
     "sensors_applicable": [
+      {
+        "id": "required-sections",
+        "path": ".codex/sensors/aidlc-required-sections.md",
+        "matches": "**/{aidlc-docs,intents}/**"
+      },
       {
         "id": "linter",
         "path": ".codex/sensors/aidlc-linter.md",
@@ -2145,7 +2152,6 @@
     "mode": "inline",
     "produces": [
       "build-instructions",
-      "unit-test-instructions",
       "integration-test-instructions",
       "performance-test-instructions",
       "security-test-instructions",
@@ -2156,6 +2162,10 @@
     "consumes": [
       {
         "artifact": "code-generation-plan",
+        "required": true
+      },
+      {
+        "artifact": "unit-test-instructions",
         "required": true
       },
       {
@@ -2182,7 +2192,7 @@
       "workshop"
     ],
     "inputs": "ALL code generation outputs across all units",
-    "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+    "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/copilot/.aidlc/tools/data/stage-graph.json
+++ b/dist/copilot/.aidlc/tools/data/stage-graph.json
@@ -2031,6 +2031,7 @@
     "workspace_requires": true,
     "produces": [
       "code-generation-plan",
+      "unit-test-instructions",
       "code-summary",
       "traceability"
     ],
@@ -2076,6 +2077,7 @@
       "infrastructure-design"
     ],
     "sensors": [
+      "required-sections",
       "linter",
       "type-check",
       "traceability"
@@ -2094,7 +2096,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "inputs": "ALL prior design artifacts for this unit",
-    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",
@@ -2114,6 +2116,11 @@
       }
     ],
     "sensors_applicable": [
+      {
+        "id": "required-sections",
+        "path": ".aidlc/sensors/aidlc-required-sections.md",
+        "matches": "**/{aidlc-docs,intents}/**"
+      },
       {
         "id": "linter",
         "path": ".aidlc/sensors/aidlc-linter.md",
@@ -2145,7 +2152,6 @@
     "mode": "inline",
     "produces": [
       "build-instructions",
-      "unit-test-instructions",
       "integration-test-instructions",
       "performance-test-instructions",
       "security-test-instructions",
@@ -2156,6 +2162,10 @@
     "consumes": [
       {
         "artifact": "code-generation-plan",
+        "required": true
+      },
+      {
+        "artifact": "unit-test-instructions",
         "required": true
       },
       {
@@ -2182,7 +2192,7 @@
       "workshop"
     ],
     "inputs": "ALL code generation outputs across all units",
-    "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+    "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
+++ b/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/cursor/.cursor/tools/data/stage-graph.json
+++ b/dist/cursor/.cursor/tools/data/stage-graph.json
@@ -2031,6 +2031,7 @@
     "workspace_requires": true,
     "produces": [
       "code-generation-plan",
+      "unit-test-instructions",
       "code-summary",
       "traceability"
     ],
@@ -2076,6 +2077,7 @@
       "infrastructure-design"
     ],
     "sensors": [
+      "required-sections",
       "linter",
       "type-check",
       "traceability"
@@ -2094,7 +2096,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "inputs": "ALL prior design artifacts for this unit",
-    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",
@@ -2114,6 +2116,11 @@
       }
     ],
     "sensors_applicable": [
+      {
+        "id": "required-sections",
+        "path": ".cursor/sensors/aidlc-required-sections.md",
+        "matches": "**/{aidlc-docs,intents}/**"
+      },
       {
         "id": "linter",
         "path": ".cursor/sensors/aidlc-linter.md",
@@ -2145,7 +2152,6 @@
     "mode": "inline",
     "produces": [
       "build-instructions",
-      "unit-test-instructions",
       "integration-test-instructions",
       "performance-test-instructions",
       "security-test-instructions",
@@ -2156,6 +2162,10 @@
     "consumes": [
       {
         "artifact": "code-generation-plan",
+        "required": true
+      },
+      {
+        "artifact": "unit-test-instructions",
         "required": true
       },
       {
@@ -2182,7 +2192,7 @@
       "workshop"
     ],
     "inputs": "ALL code generation outputs across all units",
-    "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+    "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/kiro-ide/.kiro/tools/data/stage-graph.json
+++ b/dist/kiro-ide/.kiro/tools/data/stage-graph.json
@@ -2031,6 +2031,7 @@
     "workspace_requires": true,
     "produces": [
       "code-generation-plan",
+      "unit-test-instructions",
       "code-summary",
       "traceability"
     ],
@@ -2076,6 +2077,7 @@
       "infrastructure-design"
     ],
     "sensors": [
+      "required-sections",
       "linter",
       "type-check",
       "traceability"
@@ -2094,7 +2096,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "inputs": "ALL prior design artifacts for this unit",
-    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",
@@ -2114,6 +2116,11 @@
       }
     ],
     "sensors_applicable": [
+      {
+        "id": "required-sections",
+        "path": ".kiro/sensors/aidlc-required-sections.md",
+        "matches": "**/{aidlc-docs,intents}/**"
+      },
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
@@ -2145,7 +2152,6 @@
     "mode": "inline",
     "produces": [
       "build-instructions",
-      "unit-test-instructions",
       "integration-test-instructions",
       "performance-test-instructions",
       "security-test-instructions",
@@ -2156,6 +2162,10 @@
     "consumes": [
       {
         "artifact": "code-generation-plan",
+        "required": true
+      },
+      {
+        "artifact": "unit-test-instructions",
         "required": true
       },
       {
@@ -2182,7 +2192,7 @@
       "workshop"
     ],
     "inputs": "ALL code generation outputs across all units",
-    "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+    "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/kiro/.kiro/tools/data/stage-graph.json
+++ b/dist/kiro/.kiro/tools/data/stage-graph.json
@@ -2031,6 +2031,7 @@
     "workspace_requires": true,
     "produces": [
       "code-generation-plan",
+      "unit-test-instructions",
       "code-summary",
       "traceability"
     ],
@@ -2076,6 +2077,7 @@
       "infrastructure-design"
     ],
     "sensors": [
+      "required-sections",
       "linter",
       "type-check",
       "traceability"
@@ -2094,7 +2096,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "inputs": "ALL prior design artifacts for this unit",
-    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",
@@ -2114,6 +2116,11 @@
       }
     ],
     "sensors_applicable": [
+      {
+        "id": "required-sections",
+        "path": ".kiro/sensors/aidlc-required-sections.md",
+        "matches": "**/{aidlc-docs,intents}/**"
+      },
       {
         "id": "linter",
         "path": ".kiro/sensors/aidlc-linter.md",
@@ -2145,7 +2152,6 @@
     "mode": "inline",
     "produces": [
       "build-instructions",
-      "unit-test-instructions",
       "integration-test-instructions",
       "performance-test-instructions",
       "security-test-instructions",
@@ -2156,6 +2162,10 @@
     "consumes": [
       {
         "artifact": "code-generation-plan",
+        "required": true
+      },
+      {
+        "artifact": "unit-test-instructions",
         "required": true
       },
       {
@@ -2182,7 +2192,7 @@
       "workshop"
     ],
     "inputs": "ALL code generation outputs across all units",
-    "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+    "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/build-and-test.md
@@ -9,7 +9,6 @@ support_agents:
 mode: inline
 produces:
   - build-instructions
-  - unit-test-instructions
   - integration-test-instructions
   - performance-test-instructions
   - security-test-instructions
@@ -18,6 +17,8 @@ produces:
   - cross-unit-traceability
 consumes:
   - artifact: code-generation-plan
+    required: true
+  - artifact: unit-test-instructions
     required: true
   - artifact: code-summary
     required: true
@@ -37,7 +38,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL code generation outputs across all units
-outputs: build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
+outputs: build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)
 ---
 
 # Build and Test
@@ -52,7 +53,7 @@ Load aidlc-quality-agent (lead) persona from `agents/aidlc-quality-agent.md` and
 
 ### Step 2: Analyze Testing Requirements
 
-Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
+Read code generation outputs across all units from `<record>/construction/*/code-generation/code-summary.md` and per-unit test instructions from `<record>/construction/*/code-generation/unit-test-instructions.md`. Review NFR requirements across units (if they exist) to identify performance and security testing needs. Catalog all test types required.
 
 ### Step 3: Generate Build Instructions
 
@@ -65,17 +66,15 @@ Create `<record>/construction/build-and-test/build-instructions.md`:
 
 ### Step 4-8: Generate Test Instructions (Strategy-Aware)
 
-Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate test instruction files based on the strategy level:
+Consult the active test strategy from `aidlc-state.md` → `**Test Strategy**` (see stage-protocol.md §8 "Test Strategy"). Generate additional test instruction files based on the strategy level:
 
-**Minimal strategy** — generate ONLY:
-- `unit-test-instructions.md`: Requirement-driven unit tests (1 test per requirement, happy-path floor per component). ~5-15 tests total. Skip all other test types.
+**Minimal strategy** — generate no additional test instruction files. Unit
+tests are covered per-unit by Code Generation.
 
 **Standard strategy** — generate:
-- `unit-test-instructions.md`: 5-8 tests per component, key behavior coverage
 - `integration-test-instructions.md`: Key boundary tests, cross-unit interaction
 
 **Comprehensive strategy** — generate all applicable:
-- `unit-test-instructions.md`: 10-15 tests per component, thorough coverage
 - `integration-test-instructions.md`: Cross-unit interaction, external dependency handling
 - `performance-test-instructions.md` (IF NFR performance requirements exist): Load testing, benchmarks, regression detection
 - `security-test-instructions.md` (IF NFR security requirements exist): SAST/DAST, auth testing, injection testing
@@ -105,7 +104,13 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 Attempt to execute the build and test commands documented in the instruction files:
 
 1. **Build**: Run the build commands from `build-instructions.md` via Bash. Capture output.
-2. **Unit tests**: Run the unit test command from `unit-test-instructions.md` via Bash. Capture pass/fail counts.
+2. **Unit tests**: Collect the run commands across all per-unit
+   `<record>/construction/*/code-generation/unit-test-instructions.md` files,
+   deduplicate identical commands, and run each distinct command ONCE via
+   Bash. Every command should already be scoped to its unit. If a file
+   violates that rule and carries a project-wide command, run it once, never N
+   times. Capture and report per-unit pass/fail results without double
+   counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
 4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
    - Build status (success/failure + output)
@@ -175,7 +180,8 @@ The imported sensors check those outputs:
 - **`required-sections`** verifies each instruction file contains the
   registry default (≥2 H2 headings).
 - **`upstream-coverage`** verifies the prose references the upstream
-  artefacts this stage consumes (`code-generation-plan`, `code-summary`).
+  artefacts this stage consumes (`code-generation-plan`,
+  `unit-test-instructions`, `code-summary`).
 - **`type-check`** runs against any TypeScript/TSX code touched as part
   of test generation (matches `**/*.{ts,tsx}`).
 

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -12,6 +12,7 @@ for_each: unit-of-work
 workspace_requires: true
 produces:
   - code-generation-plan
+  - unit-test-instructions
   - code-summary
   - traceability
 consumes:
@@ -38,6 +39,7 @@ requires_stage:
   - nfr-design
   - infrastructure-design
 sensors:
+  - required-sections
   - linter
   - type-check
   - traceability
@@ -51,7 +53,7 @@ scopes:
   - security-patch
   - workshop
 inputs: ALL prior design artifacts for this unit
-outputs: application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
+outputs: application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)
 ---
 
 # Code Generation
@@ -127,24 +129,51 @@ Step 12: Documentation (inline docs, API docs, README updates)
 
 This layer-by-layer approach ensures dependencies are built before dependents (data models before business logic, business logic before API). Deviate when the architecture requires it (e.g., event-driven systems, microservices with independent stacks).
 
-Present a summary of the plan to the user.
+Also create
+`<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+before Plan Approval. Consult the active test strategy (stage-protocol.md §8
+"Test Strategy") and use the matching unit-test scope:
+
+- **Minimal strategy**: Requirement-driven unit tests (1 test per requirement,
+  happy-path floor per component), approximately 5-15 tests total
+- **Standard strategy**: 5-8 tests per component, with key behavior coverage
+- **Comprehensive strategy**: 10-15 tests per component, with thorough coverage
+
+Include:
+- Test framework setup and configuration
+- How to run THIS UNIT's tests
+- Expected coverage targets
+- Mocking/stubbing guidance
+- Test data management
+
+Every run command in this file MUST be scoped to this unit only, using exact
+test file paths or an exact unit filter. A bare project-wide command like
+`npm test` is not acceptable. Build and Test executes every unit's commands,
+so an unscoped command would rerun the whole suite once per unit.
+
+Present a summary of the unit test instructions together with the plan summary
+to the user.
 
 ### Step 3: Plan Approval
 
 Before presenting the approval, create or update
 `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
-with a **Plan Approval** question, both options below, and a blank `[Answer]:`
-tag:
+with a **Plan Approval** question that covers both
+`code-generation-plan.md` and `unit-test-instructions.md`, both options below,
+and a blank `[Answer]:` tag:
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan
 
 Then present that question as a structured question and STOP the turn. Fill the
 `[Answer]:` tag only after the human explicitly responds. On "Request Changes",
-record that answer, revise the plan, reset the Plan Approval `[Answer]:` to
-blank, and present the question again. Do not begin Step 4, dispatch the
-developer agent, or infer approval from a forwarding-loop continuation. Only an
-explicit "Approve Plan" response authorizes generation.
+record that answer, revise the plan and unit test instructions as needed, reset
+the Plan Approval `[Answer]:` to blank, and present the question again. Any
+post-approval change to `unit-test-instructions.md` reopens Plan Approval:
+reset the `[Answer]:` to blank and re-ask before generation. Do not begin Step
+4, dispatch the developer agent, or infer approval from a forwarding-loop
+continuation. Only an explicit "Approve Plan" response authorizes generation
+from the approved versions of both files.
 
 ### Step 4: PART 2 — Generation
 
@@ -163,6 +192,7 @@ Include in the delegation prompt:
 - Design artifacts for the CURRENT UNIT ONLY (not all units)
 - A 1-2 line summary of each inception-phase artifact with its file path (requirements summary, stories summary, app design summary) — the subagent can Read specific files if it needs full content
 - The approved code-generation-plan.md (full content)
+- The approved unit-test-instructions.md (full content)
 - Project workspace details (languages, frameworks, conventions from aidlc-state.md)
 - Instructions to execute each plan step sequentially and mark checkboxes as completed
 
@@ -224,11 +254,15 @@ Approval gate: strictly 2-option (Approve / Request Changes).
 This stage produces TypeScript/JavaScript code in the active Bolt
 worktree. Generated code lives at the workspace root (NEVER under
 the record dir); the planning, plan-approval, and summary artefacts
-(`code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md`)
-live under `<record>/construction/{unit-name}/code-generation/`.
+(`code-generation-plan.md`, `code-generation-questions.md`,
+`unit-test-instructions.md`, `code-summary.md`) live under
+`<record>/construction/{unit-name}/code-generation/`.
 
-The imported sensors check the code outputs:
+The imported sensors check the code outputs and per-unit markdown artefacts:
 
+- **`required-sections`** verifies each markdown artefact has the generic
+  document-shape floor (at least 2 H2 headings), including the per-unit unit
+  test instructions.
 - **`linter`** wraps the project's configured linter (eslint by default).
   Fires on every Write/Edit matching its `matches: "**/*.{ts,js}"` filter.
   Failure mode: lint violations land as `SENSOR_FAILED` audit rows with
@@ -239,10 +273,11 @@ The imported sensors check the code outputs:
 - **`traceability`** validates the per-Unit coverage table and verifies every
   `OK` target is an existing workspace-relative file.
 
-The two universal markdown-shape sensors (`required-sections`,
-`upstream-coverage`) are NOT imported here — code-generation produces
-code plus record artifacts, while those two checks are scoped to markdown
-content rather than the structured traceability file.
+`upstream-coverage` is intentionally NOT imported here. The stage consumes a
+broad, scope-dependent design set, while its load-bearing validation is the
+shape of the planning artefacts plus the lint, type, and traceability checks
+on generated code. The `required-sections` floor does not apply to the
+structured `traceability.json` file, which the `traceability` sensor owns.
 
 ## Learn
 

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -1200,8 +1200,9 @@ function readConstructionIteration(
 // signal, NOT on-disk artifact presence. A swarm unit builds inside an isolated
 // Bolt worktree and `aidlc-bolt complete --merge` consolidates only the AIDLC
 // metadata (state + audit + runtime-graph fragment) back to the main checkout;
-// the unit's produced artifacts (code-generation-plan.md / code-summary.md and
-// the generated source) are NOT copied into the main record tree by the swarm
+// the unit's produced artifacts (code-generation-plan.md,
+// unit-test-instructions.md, code-summary.md, and the generated source) are NOT
+// copied into the main record tree by the swarm
 // finalize flow. So unitCovered's disk check (the INLINE per-unit ledger) never
 // sees a swarm unit as covered, and the batch-advance signal must instead be the
 // `SWARM_UNIT_CONVERGED` audit rows `aidlc-swarm.ts finalize` writes from the

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.72";
+export const AIDLC_VERSION = "2.5.73";

--- a/dist/opencode/.aidlc/tools/data/stage-graph.json
+++ b/dist/opencode/.aidlc/tools/data/stage-graph.json
@@ -2031,6 +2031,7 @@
     "workspace_requires": true,
     "produces": [
       "code-generation-plan",
+      "unit-test-instructions",
       "code-summary",
       "traceability"
     ],
@@ -2076,6 +2077,7 @@
       "infrastructure-design"
     ],
     "sensors": [
+      "required-sections",
       "linter",
       "type-check",
       "traceability"
@@ -2094,7 +2096,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "inputs": "ALL prior design artifacts for this unit",
-    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+    "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",
@@ -2114,6 +2116,11 @@
       }
     ],
     "sensors_applicable": [
+      {
+        "id": "required-sections",
+        "path": ".aidlc/sensors/aidlc-required-sections.md",
+        "matches": "**/{aidlc-docs,intents}/**"
+      },
       {
         "id": "linter",
         "path": ".aidlc/sensors/aidlc-linter.md",
@@ -2145,7 +2152,6 @@
     "mode": "inline",
     "produces": [
       "build-instructions",
-      "unit-test-instructions",
       "integration-test-instructions",
       "performance-test-instructions",
       "security-test-instructions",
@@ -2156,6 +2162,10 @@
     "consumes": [
       {
         "artifact": "code-generation-plan",
+        "required": true
+      },
+      {
+        "artifact": "unit-test-instructions",
         "required": true
       },
       {
@@ -2182,7 +2192,7 @@
       "workshop"
     ],
     "inputs": "ALL code generation outputs across all units",
-    "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+    "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
     "rules_in_context": [
       {
         "path": "aidlc/spaces/default/memory/org.md",

--- a/docs/guide/14-artifacts-reference.md
+++ b/docs/guide/14-artifacts-reference.md
@@ -199,7 +199,7 @@ The four design stages (3.1-3.4) prune their artifacts to each unit's **kind** (
 | 3.2 NFR Requirements | `security-requirements.md`, `performance-requirements.md` | Per plan, per unit (by kind) |
 | 3.3 NFR Design | `security-design.md`, `performance-design.md` | Per plan, per unit (by kind) |
 | 3.4 Infrastructure Design | `deployment-architecture.md`, `infrastructure-services.md` | Per plan, per unit (by kind) |
-| 3.5 Code Generation | `code-generation-plan.md`, `code-generation-questions.md`, `code-summary.md` (code goes to workspace root) | Always, per unit |
+| 3.5 Code Generation | `code-generation-plan.md`, `code-generation-questions.md`, `unit-test-instructions.md`, `code-summary.md` (code goes to workspace root) | Always, per unit |
 | 3.6 Build and Test | `build-instructions.md`, `test-results.md` | Always, after all units |
 | 3.7 CI Pipeline | `ci-config.md`, `quality-gates.md` | Conditional, after all units |
 

--- a/docs/reference/04-stages/construction.md
+++ b/docs/reference/04-stages/construction.md
@@ -613,7 +613,7 @@ share infrastructure resources.
 | support_agents    | (none -- focused implementation)                                                                  |
 | mode              | subagent (Task tool subagent_type: aidlc-developer-agent)                                               |
 | Inputs            | ALL prior design artifacts for this unit                                                          |
-| Outputs           | application code (workspace root) + `<record>/construction/{unit-name}/code-generation/` -- code-generation-plan.md, code-generation-questions.md, code-summary.md |
+| Outputs           | application code (workspace root) + `<record>/construction/{unit-name}/code-generation/` -- code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md |
 
 ### Purpose
 
@@ -693,8 +693,26 @@ This stage has a **two-part structure**: planning followed by generation.
    Number each plan step sequentially (Step 1, Step 2, etc.) for clear
    execution ordering and traceability.
 
-3. **Plan Approval** -- Present the plan summary to the user and request
-   approval. First create or reset
+   Also create
+   `<record>/construction/{unit-name}/code-generation/unit-test-instructions.md`
+   before Plan Approval. Match the active test strategy:
+   - **Minimal**: Requirement-driven unit tests (1 test per requirement,
+     happy-path floor per component), approximately 5-15 tests total
+   - **Standard**: 5-8 tests per component, with key behavior coverage
+   - **Comprehensive**: 10-15 tests per component, with thorough coverage
+
+   Include test framework setup and configuration, how to run this unit's
+   tests, expected coverage targets, mocking/stubbing guidance, and test data
+   management. Every run command MUST be scoped to this unit using exact test
+   file paths or an exact unit filter. A bare project-wide command such as
+   `npm test` is not acceptable because Build and Test executes every unit's
+   commands.
+
+   Present the unit test instruction summary together with the plan summary.
+
+3. **Plan Approval** -- Request approval for both
+   `code-generation-plan.md` and `unit-test-instructions.md`. First create or
+   reset
    `<record>/construction/{unit-name}/code-generation/code-generation-questions.md`
    with a **Plan Approval** question and blank `[Answer]:`, then render it as a
    structured question and stop the turn:
@@ -702,8 +720,10 @@ This stage has a **two-part structure**: planning followed by generation.
    - "Request Changes" -- revise the plan
 
    Fill the tag only after the human responds. A request for changes is
-   recorded, the plan is revised, and the Plan Approval tag is reset to blank
-   before re-prompting. A forwarding-loop continuation is never approval.
+   recorded, both files are revised as needed, and the Plan Approval tag is
+   reset to blank before re-prompting. Any post-approval change to
+   `unit-test-instructions.md` reopens Plan Approval the same way a plan
+   change does. A forwarding-loop continuation is never approval.
 
 #### PART 2 -- Generation (Steps 4-7)
 
@@ -727,6 +747,7 @@ This stage has a **two-part structure**: planning followed by generation.
      (requirements summary, stories summary, app design summary) -- the
      subagent can Read specific files if it needs full content
    - The approved code-generation-plan.md (full content)
+   - The approved unit-test-instructions.md (full content)
    - Project workspace details (languages, frameworks, conventions from
      aidlc-state.md)
    - Instructions to execute each plan step sequentially and mark checkboxes
@@ -756,6 +777,7 @@ This stage has a **two-part structure**: planning followed by generation.
 |---------------------------|---------------------------------------------------------------------|
 | code-generation-plan.md   | Detailed plan with checkboxes, story traceability, step sequencing  |
 | code-generation-questions.md | Persisted Plan Approval question and explicit human answer       |
+| unit-test-instructions.md | Per-unit setup, scoped run commands, coverage, mocks, and test data |
 | code-summary.md           | Files created/modified, decisions, test coverage, plan deviations   |
 | (application code)        | All source code, tests, and config written to workspace root        |
 
@@ -781,6 +803,9 @@ Strictly 2-option: Approve / Request Changes.
 - **Mandatory test file inclusion**: Test files MUST be part of the code
   generation plan. Stage 3.6 (Build and Test) verifies and extends tests but
   does not create them from scratch.
+- **Unit-scoped execution**: Each per-unit test instruction file uses exact
+  test paths or an exact unit filter so the cross-unit execution stage does
+  not rerun the project-wide suite for every unit.
 - **Brownfield awareness**: In brownfield projects, the subagent modifies
   existing files in-place rather than creating duplicates.
 
@@ -801,19 +826,21 @@ Strictly 2-option: Approve / Request Changes.
 | support_agents    | aidlc-devsecops-agent                                                                                   |
 | mode              | inline                                                                                            |
 | Inputs            | ALL code generation outputs across all units                                                      |
-| Outputs           | `<record>/construction/build-and-test/` -- build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, plus conditional test instruction files |
+| Outputs           | `<record>/construction/build-and-test/` -- build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, plus conditional test instruction files |
 
 ### Purpose
 
-Generate test instructions across all test types, then actually execute the
-build and tests via Bash. This stage operates across ALL units -- it is NOT
-per-unit. The aidlc-quality-agent leads with the aidlc-devsecops-agent providing security
-testing expertise.
+Generate cross-unit test instructions, consume the per-unit unit test
+instructions, then actually execute the build and tests via Bash. This stage
+operates across ALL units -- it is NOT per-unit. The aidlc-quality-agent leads
+with the aidlc-devsecops-agent providing security testing expertise.
 
 ### Inputs
 
 - Code generation outputs across all units from
   `<record>/construction/*/code-generation/code-summary.md`
+- Per-unit test instructions from
+  `<record>/construction/*/code-generation/unit-test-instructions.md`
 - NFR requirements across units (if they exist) for performance and security
   testing needs
 
@@ -822,9 +849,10 @@ testing expertise.
 1. **Load Personas** -- Load aidlc-quality-agent (lead) persona and knowledge. Load
    aidlc-devsecops-agent persona and knowledge for security testing input.
 
-2. **Analyze Testing Requirements** -- Read code generation outputs across all
-   units. Review NFR requirements (if they exist) to identify performance and
-   security testing needs. Catalog all test types required.
+2. **Analyze Testing Requirements** -- Read code generation summaries and
+   per-unit test instructions across all units. Review NFR requirements (if
+   they exist) to identify performance and security testing needs. Catalog
+   all test types required.
 
 3. **Generate Build Instructions** -- Create
    `<record>/construction/build-and-test/build-instructions.md`:
@@ -834,50 +862,21 @@ testing expertise.
    - Build verification steps
    - Troubleshooting common build issues
 
-4. **Generate Unit Test Instructions** -- Create
-   `<record>/construction/build-and-test/unit-test-instructions.md`:
-   - Test framework setup and configuration
-   - How to run unit tests (commands, flags, filters)
-   - Expected test coverage targets
-   - Mocking/stubbing guidance
-   - Test data management
-
-5. **Generate Integration Test Instructions** -- Create
-   `<record>/construction/build-and-test/integration-test-instructions.md`:
-   - Test environment prerequisites (databases, services, queues)
-   - How to run integration tests
-   - Cross-unit interaction testing
-   - External dependency handling (stubs, test doubles, sandboxes)
-   - Test data setup and teardown
-
-6. **Generate Performance Test Instructions** (CONDITIONAL) -- IF NFR
-   performance requirements exist for any unit, create
-   `performance-test-instructions.md`:
-   - Load testing tools and configuration
-   - Performance test scenarios mapped to NFR targets
-   - Baseline measurements and benchmarks
-   - Stress and soak test procedures
-   - Performance regression detection
-
-7. **Generate Security Test Instructions** (CONDITIONAL) -- IF NFR security
-   requirements exist for any unit, create
-   `security-test-instructions.md`:
-   - Security scanning tools (SAST, DAST, dependency audit)
-   - Authentication/authorization test scenarios
-   - Input validation and injection testing
-   - Compliance verification steps
-   - Vulnerability assessment procedures
-
-8. **Generate Additional Test Types** (CONDITIONAL) -- As applicable based on
-   project architecture, create specifically named files:
-   - **contract-test-instructions.md**: For microservice APIs --
-     consumer-driven contracts, schema validation, API compatibility
-   - **e2e-test-instructions.md**: For UI-driven applications -- browser
-     automation, user journey tests, cross-browser verification
-   - **accessibility-test-instructions.md**: For user-facing interfaces --
-     WCAG compliance, screen reader testing, keyboard navigation
+4-8. **Generate Additional Test Instructions** -- Consult the active test
+   strategy and generate the matching cross-unit instruction files:
+   - **Minimal**: Generate no additional files. Unit tests are covered
+     per-unit by Code Generation.
+   - **Standard**: Generate `integration-test-instructions.md` for key
+     boundaries and cross-unit interactions.
+   - **Comprehensive**: Generate integration instructions, plus
+     `performance-test-instructions.md` when performance NFRs exist and
+     `security-test-instructions.md` when security NFRs exist.
+   - At any strategy, add specifically named contract, E2E, accessibility, or
+     other instruction files when the project context requires them.
 
    All files go in `<record>/construction/build-and-test/`.
+   Each file includes framework setup, run commands and filters, coverage
+   targets, and test data or environment setup.
 
 9. **Generate Build and Test Summary** -- Create
    `<record>/construction/build-and-test/build-and-test-summary.md`:
@@ -892,8 +891,11 @@ testing expertise.
 
     a. **Build**: Run the build commands from build-instructions.md via Bash.
        Capture output.
-    b. **Unit tests**: Run the unit test command from
-       unit-test-instructions.md via Bash. Capture pass/fail counts.
+    b. **Unit tests**: Collect commands from every per-unit
+       `code-generation/unit-test-instructions.md`, deduplicate identical
+       commands, and run each distinct command once. Commands should be
+       unit-scoped; if a file contains a project-wide command, run it once,
+       never once per unit. Report per-unit pass/fail without double counting.
     c. **Integration tests** (if applicable): Run integration test commands.
        Capture results.
     d. **Report results**: Create or update
@@ -925,8 +927,7 @@ testing expertise.
 | Artifact                          | Description                                                     | Condition          |
 |-----------------------------------|-----------------------------------------------------------------|--------------------|
 | build-instructions.md             | Dependency install, env setup, build commands, troubleshooting  | Always             |
-| unit-test-instructions.md         | Test framework setup, run commands, coverage targets, mocking   | Always             |
-| integration-test-instructions.md  | Prerequisites, cross-unit testing, external deps, data setup    | Always             |
+| integration-test-instructions.md  | Prerequisites, cross-unit testing, external deps, data setup    | Standard/Comprehensive |
 | performance-test-instructions.md  | Load testing, NFR scenarios, baselines, stress/soak tests       | If NFR perf exists |
 | security-test-instructions.md     | SAST/DAST, auth testing, injection testing, compliance          | If NFR sec exists  |
 | contract-test-instructions.md     | Consumer-driven contracts, schema validation, API compat        | If microservices   |

--- a/docs/reference/15-stage-definition.md
+++ b/docs/reference/15-stage-definition.md
@@ -144,8 +144,9 @@ the workspace root**, not just planning documents under the per-intent record di
 Why it exists: a stage's `produces[]` artifacts always resolve to markdown under
 the record dir (the only place the path resolver writes them). So a "do the
 produces exist?" check is satisfied by a `code-generation` stage that wrote its
-`code-generation-plan.md` and `code-summary.md` but never emitted a line of
-actual code (issue #366). `workspace_requires: true` closes that gap: the
+`code-generation-plan.md`, `unit-test-instructions.md`, and `code-summary.md`
+but never emitted a line of actual code (issue #366).
+`workspace_requires: true` closes that gap: the
 stage-completion artifact guard (`aidlc-state.ts` approve/advance/finalize/
 complete-workflow) additionally requires evidence of real source work outside
 the `aidlc/` workspace tree and the harness directory before the stage may

--- a/docs/reference/16-artifact-vocabulary.md
+++ b/docs/reference/16-artifact-vocabulary.md
@@ -131,9 +131,10 @@ The canonical names are split so the two never collide on the wire:
 
 - `build-test-results` — emitted by `build-and-test`. Pairs with
   sibling names in that stage: `build-instructions`,
-  `unit-test-instructions`, `integration-test-instructions`,
-  `performance-test-instructions`, `security-test-instructions`,
-  `build-and-test-summary`.
+  `integration-test-instructions`, `performance-test-instructions`,
+  `security-test-instructions`, `build-and-test-summary`.
+- `unit-test-instructions` is produced per-unit by `code-generation` and
+  consumed by `build-and-test`.
 - `load-test-results` — emitted by `performance-validation`. Pairs with
   `load-test-plan` already produced by the same stage.
 

--- a/tests/fixtures/designer-export/export.json
+++ b/tests/fixtures/designer-export/export.json
@@ -2032,6 +2032,7 @@
       "workspace_requires": true,
       "produces": [
         "code-generation-plan",
+        "unit-test-instructions",
         "code-summary",
         "traceability"
       ],
@@ -2077,6 +2078,7 @@
         "infrastructure-design"
       ],
       "sensors": [
+        "required-sections",
         "linter",
         "type-check",
         "traceability"
@@ -2095,7 +2097,7 @@
       "reviewer_max_iterations": 2,
       "review_class": "adversarial",
       "inputs": "ALL prior design artifacts for this unit",
-      "outputs": "application code + code-generation-plan.md, code-generation-questions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
+      "outputs": "application code + code-generation-plan.md, code-generation-questions.md, unit-test-instructions.md, code-summary.md, traceability.json (under this stage's per-unit record dir, engine-resolved)",
       "rules_in_context": [
         {
           "path": "aidlc/spaces/default/memory/org.md",
@@ -2115,6 +2117,11 @@
         }
       ],
       "sensors_applicable": [
+        {
+          "id": "required-sections",
+          "path": ".claude/sensors/aidlc-required-sections.md",
+          "matches": "**/{aidlc-docs,intents}/**"
+        },
         {
           "id": "linter",
           "path": ".claude/sensors/aidlc-linter.md",
@@ -2146,7 +2153,6 @@
       "mode": "inline",
       "produces": [
         "build-instructions",
-        "unit-test-instructions",
         "integration-test-instructions",
         "performance-test-instructions",
         "security-test-instructions",
@@ -2157,6 +2163,10 @@
       "consumes": [
         {
           "artifact": "code-generation-plan",
+          "required": true
+        },
+        {
+          "artifact": "unit-test-instructions",
           "required": true
         },
         {
@@ -2183,7 +2193,7 @@
         "workshop"
       ],
       "inputs": "ALL code generation outputs across all units",
-      "outputs": "build-instructions.md, unit-test-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
+      "outputs": "build-instructions.md, integration-test-instructions.md, performance-test-instructions.md, security-test-instructions.md, build-and-test-summary.md, test-results.md, cross-unit-traceability.md (under this stage's record dir, engine-resolved)",
       "rules_in_context": [
         {
           "path": "aidlc/spaces/default/memory/org.md",

--- a/tests/integration/t135-invoke-swarm.test.ts
+++ b/tests/integration/t135-invoke-swarm.test.ts
@@ -246,7 +246,12 @@ function logWorktreeReview(
   if (seedArtifacts) {
     const dir = join(seededRecordDir(wt), "construction", unit, "code-generation");
     mkdirSync(dir, { recursive: true });
-    for (const name of ["code-generation-plan", "code-summary", "traceability"]) {
+    for (const name of [
+      "code-generation-plan",
+      "unit-test-instructions",
+      "code-summary",
+      "traceability",
+    ]) {
       const artifact = join(dir, artifactFilename(name));
       const body =
         name === "traceability"

--- a/tests/integration/t185-stage-artifact-guard.test.ts
+++ b/tests/integration/t185-stage-artifact-guard.test.ts
@@ -380,13 +380,14 @@ describe("t185: stage-completion artifact guard (#366)", () => {
   describe("workspace_requires (code-generation)", () => {
     const UNIT = "user-auth";
 
-    // Move the pointer to code-generation, in-progress, and write its two
+    // Move the pointer to code-generation, in-progress, and write its three
     // per-unit produces[] docs under the record's construction/<unit>/ subtree
     // (satisfies layer 1) but NO source code.
     function stageCodeGenDocsOnly(): void {
       guarded(proj, ["set", "Current Stage=code-generation"]);
       guarded(proj, ["checkbox", "code-generation=in-progress"]);
       writeRecordDoc(proj, `construction/${UNIT}/code-generation/code-generation-plan.md`);
+      writeRecordDoc(proj, `construction/${UNIT}/code-generation/unit-test-instructions.md`);
       writeRecordDoc(proj, `construction/${UNIT}/code-generation/code-summary.md`);
     }
 

--- a/tests/integration/t89.test.ts
+++ b/tests/integration/t89.test.ts
@@ -134,17 +134,19 @@ afterEach(() => {
 // =========================================================================
 
 describe("t89 sensors_applicable resolution (in-process compileStageGraph)", () => {
-  // Case 1 (.sh:64-66): basic-import — code-generation resolves 3 sensors.
-  test("basic-import: code-generation has 3 resolved sensors", () => {
+  // Case 1 (.sh:64-66): basic-import - code-generation resolves 4 sensors.
+  test("basic-import: code-generation has 4 resolved sensors", () => {
     const { stages } = compileWithSensors(join(FIXTURES, "basic-import"));
-    expect(stageBySlug(stages, "code-generation").sensors_applicable).toHaveLength(3);
+    expect(stageBySlug(stages, "code-generation").sensors_applicable).toHaveLength(4);
   });
 
   // Case 2 (.sh:68-70): resolved entries carry id and .claude/... path.
   test("basic-import: first sensor id+path correct", () => {
     const { stages } = compileWithSensors(join(FIXTURES, "basic-import"));
     const first = stageBySlug(stages, "code-generation").sensors_applicable[0];
-    expect(`${first.id}|${first.path}`).toBe("linter|.claude/sensors/aidlc-linter.md");
+    expect(`${first.id}|${first.path}`).toBe(
+      "required-sections|.claude/sensors/aidlc-required-sections.md",
+    );
   });
 
   // Case 3 (.sh:72-75): matches glob copied verbatim from the manifest.
@@ -332,11 +334,11 @@ describe("t89 sensors_applicable resolution (in-process compileStageGraph)", () 
     expect(keys[idx + 1]).toBe("sensors_applicable");
   });
 
-  // Case 19 (.sh:230-241): per-stage matrix — code-generation=3, build-and-test=3,
+  // Case 19 (.sh:230-241): per-stage matrix - code-generation=4, build-and-test=3,
   // workspace-scaffold=0, functional-design=5.
-  test("per-stage matrix: CG=3, BT=3, WS=0, FD=5", () => {
+  test("per-stage matrix: CG=4, BT=3, WS=0, FD=5", () => {
     const { stages } = compileWithSensors(join(FIXTURES, "basic-import"));
-    expect(stageBySlug(stages, "code-generation").sensors_applicable.length).toBe(3);
+    expect(stageBySlug(stages, "code-generation").sensors_applicable.length).toBe(4);
     expect(stageBySlug(stages, "build-and-test").sensors_applicable.length).toBe(3);
     expect(stageBySlug(stages, "workspace-scaffold").sensors_applicable.length).toBe(0);
     expect(stageBySlug(stages, "functional-design").sensors_applicable.length).toBe(5);

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -919,6 +919,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t272-unit-major-code-gen.test.ts",
     "unit/t248-steering-content-delivery.test.ts",
     "unit/t278-per-unit-wave.test.ts",
+    "unit/t290-code-gen-unit-test-instructions-coverage.test.ts",
     "unit/t255-workspace-sync.test.ts",
     "unit/t27.test.ts",
     "unit/t29.test.ts",

--- a/tests/unit/t186-foreach-per-unit-iteration.test.ts
+++ b/tests/unit/t186-foreach-per-unit-iteration.test.ts
@@ -543,7 +543,12 @@ describe("t186 engine-driven per-unit for_each iteration (issue #368)", () => {
   // 13: a report arriving at an autonomous swarm's batch boundary must not
   // complete the whole stage. Only a valid DAG with current-run convergence
   // rows for every unit can receive the report-side disk-coverage exemption.
-  const CG_PRODUCES = ["code-generation-plan", "code-summary", "traceability"];
+  const CG_PRODUCES = [
+    "code-generation-plan",
+    "unit-test-instructions",
+    "code-summary",
+    "traceability",
+  ];
   test("13: autonomous multi-batch swarm refuses approval before every batch converges", () => {
     const proj = seedProject("code-generation", "on");
     // code-generation must be in-flight (not pending) for an approve to be valid;

--- a/tests/unit/t209-unit-major-iteration.test.ts
+++ b/tests/unit/t209-unit-major-iteration.test.ts
@@ -101,7 +101,12 @@ const PRODUCES: Record<string, string[]> = {
     "shared-infrastructure",
     "traceability",
   ],
-  "code-generation": ["code-generation-plan", "code-summary", "traceability"],
+  "code-generation": [
+    "code-generation-plan",
+    "unit-test-instructions",
+    "code-summary",
+    "traceability",
+  ],
 };
 // The walk's inner list in graph order: the four inline design stages, then
 // code-generation (mode: subagent, in the walk since the block filter was

--- a/tests/unit/t272-unit-major-code-gen.test.ts
+++ b/tests/unit/t272-unit-major-code-gen.test.ts
@@ -96,7 +96,12 @@ const PRODUCES: Record<string, string[]> = {
     "shared-infrastructure",
     "traceability",
   ],
-  "code-generation": ["code-generation-plan", "code-summary", "traceability"],
+  "code-generation": [
+    "code-generation-plan",
+    "unit-test-instructions",
+    "code-summary",
+    "traceability",
+  ],
 };
 // The widened walk block, graph order: design stages then code-generation.
 const BLOCK = [

--- a/tests/unit/t290-code-gen-unit-test-instructions-coverage.test.ts
+++ b/tests/unit/t290-code-gen-unit-test-instructions-coverage.test.ts
@@ -1,0 +1,240 @@
+// covers: subcommand:aidlc-orchestrate:next
+//
+// t290 - unit-test-instructions belongs to each code-generation unit. The
+// engine must require it for per-unit coverage under every test strategy, and
+// build-and-test must consume the artifact from a real producer.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  loadGraph,
+  producersOf,
+} from "../../dist/claude/.claude/tools/aidlc-graph.ts";
+import { artifactFilename } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
+import {
+  AIDLC_SRC,
+  cleanupTestProject,
+  createTestProject,
+  DEFAULT_RECORD_DIR,
+  DEFAULT_SPACE,
+  resetAidlcEnv,
+  runOrchestrateNext,
+  seedAidlcMemory,
+  seedBoltDag,
+  seededRecordDir,
+  seededStateFile,
+} from "../harness/fixtures.ts";
+
+resetAidlcEnv();
+
+const ORCH = join(AIDLC_SRC, "tools", "aidlc-orchestrate.ts");
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const RP = `aidlc/spaces/${DEFAULT_SPACE}/intents/${DEFAULT_RECORD_DIR}`;
+const TEST_STRATEGIES = ["Minimal", "Standard", "Comprehensive"] as const;
+const CG_PRODUCES = [
+  "code-generation-plan",
+  "unit-test-instructions",
+  "code-summary",
+  "traceability",
+] as const;
+
+interface Directive {
+  kind?: string;
+  stage?: string;
+  unit?: string;
+  produces?: string[];
+  [key: string]: unknown;
+}
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length > 0) cleanupTestProject(tempDirs.pop()!);
+});
+
+function constructionStateAtCodeGen(strategy: string): string {
+  return `# AI-DLC State Tracking
+
+## Project Information
+- **Project**: unit-test-instructions coverage test
+- **Project Type**: Greenfield
+- **Scope**: feature
+- **State Version**: 7
+- **Skeleton Stance**: on
+
+## Scope Configuration
+- **Stages to Execute**: all
+- **Stages to Skip**: none
+- **Depth**: Standard
+- **Test Strategy**: ${strategy}
+
+## Stage Progress
+
+### CONSTRUCTION PHASE
+- [x] functional-design — EXECUTE
+- [x] nfr-requirements — EXECUTE
+- [x] nfr-design — EXECUTE
+- [x] infrastructure-design — EXECUTE
+- [-] code-generation — EXECUTE
+- [ ] build-and-test — EXECUTE
+
+### INCEPTION PHASE
+- [x] application-design — EXECUTE
+
+## Current Status
+- **Lifecycle Phase**: CONSTRUCTION
+- **Current Stage**: code-generation
+- **Status**: Running
+`;
+}
+
+function seedProject(strategy: string): string {
+  const proj = createTestProject();
+  tempDirs.push(proj);
+  seedAidlcMemory(proj);
+  writeFileSync(seededStateFile(proj), constructionStateAtCodeGen(strategy));
+  seedBoltDag(proj, ["alpha", "beta"]);
+  return proj;
+}
+
+function realisticArtifact(name: string, unit: string): string {
+  if (name === "traceability") {
+    return `{"stage":"code-generation","unit":"${unit}","upstream_ids":[],"coverage":[]}\n`;
+  }
+  if (name === "unit-test-instructions") {
+    return `# Unit Test Instructions - ${unit}
+
+## Framework Setup
+
+Use Bun's test runner with the repository configuration.
+
+## Run This Unit
+
+\`bun test tests/unit/${unit}.test.ts\`
+
+## Coverage and Test Data
+
+Cover the unit's requirements with isolated fixtures and stub external services.
+`;
+  }
+  if (name === "code-generation-plan") {
+    return `# Code Generation Plan - ${unit}
+
+## Implementation Steps
+
+- [ ] Implement ${unit}.
+- [ ] Add unit-scoped tests.
+
+## Traceability
+
+- The implementation steps cover the ${unit} requirements.
+`;
+  }
+  return `# Code Summary - ${unit}
+
+## Files
+
+- Source and tests for ${unit}.
+
+## Test Coverage
+
+- Unit-scoped tests are present.
+`;
+}
+
+function coverUnit(proj: string, unit: string, names: readonly string[]): void {
+  const dir = join(seededRecordDir(proj), "construction", unit, "code-generation");
+  mkdirSync(dir, { recursive: true });
+  for (const name of names) {
+    writeFileSync(join(dir, artifactFilename(name)), realisticArtifact(name, unit));
+  }
+}
+
+function runNext(proj: string): Directive {
+  const env = { ...process.env };
+  delete env.AWS_AIDLC_DEFAULT_SCOPE;
+  const result = runOrchestrateNext(ORCH, proj, [], { env });
+  if (result.directive === null) {
+    throw new Error(
+      `runNext did not emit parseable JSON. status=${result.status}\n` +
+        `${result.stdout}\n${result.stderr}`,
+    );
+  }
+  return result.directive as Directive;
+}
+
+describe("t290 code-generation coverage requires per-unit test instructions", () => {
+  for (const strategy of TEST_STRATEGIES) {
+    test(`${strategy}: missing unit-test-instructions re-emits the unit`, () => {
+      const proj = seedProject(strategy);
+      coverUnit(proj, "alpha", ["code-generation-plan", "code-summary", "traceability"]);
+
+      const directive = runNext(proj);
+
+      expect(directive.kind).toBe("run-stage");
+      expect(directive.stage).toBe("code-generation");
+      expect(directive.unit).toBe("alpha");
+      expect(directive.produces).toContain(
+        `${RP}/construction/alpha/code-generation/unit-test-instructions.md`,
+      );
+    }, 30000);
+
+    test(`${strategy}: all four outputs advance to the next unit`, () => {
+      const proj = seedProject(strategy);
+      coverUnit(proj, "alpha", CG_PRODUCES);
+
+      const directive = runNext(proj);
+
+      expect(directive.kind).toBe("run-stage");
+      expect(directive.stage).toBe("code-generation");
+      expect(directive.unit).toBe("beta");
+    }, 30000);
+  }
+
+  test("build-and-test requires the artifact and code-generation produces it", () => {
+    const buildAndTest = loadGraph().find((stage) => stage.slug === "build-and-test");
+    expect(buildAndTest).toBeDefined();
+    expect(buildAndTest?.consumes).toContainEqual({
+      artifact: "unit-test-instructions",
+      required: true,
+    });
+    expect(producersOf("unit-test-instructions").map((stage) => stage.slug)).toEqual([
+      "code-generation",
+    ]);
+  });
+
+  test("stage prose pins unit scoping and deduplicated execution", () => {
+    const codeGeneration = readFileSync(
+      join(
+        REPO_ROOT,
+        "core",
+        "aidlc-common",
+        "stages",
+        "construction",
+        "code-generation.md",
+      ),
+      "utf-8",
+    );
+    const buildAndTest = readFileSync(
+      join(
+        REPO_ROOT,
+        "core",
+        "aidlc-common",
+        "stages",
+        "construction",
+        "build-and-test.md",
+      ),
+      "utf-8",
+    );
+
+    expect(codeGeneration).toContain(
+      "Every run command in this file MUST be scoped to this unit only",
+    );
+    expect(codeGeneration).toContain(
+      "A bare project-wide command like\n`npm test` is not acceptable",
+    );
+    expect(buildAndTest).toContain("deduplicate identical commands");
+    expect(buildAndTest).toContain("run each distinct command ONCE");
+    expect(buildAndTest).toContain("run it once, never N");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes https://github.com/awslabs/aidlc-workflows/issues/397

The `build-and-test` stage was generating `unit-test-instructions.md` (describing unit tests to write), but `code-generation` already includes unit test files in its plan and generates them during execution. This caused redundant duplication.

## Changes

- **`code-generation`**: Added `unit-test-instructions` to `produces:`. Added Step 4 (Generate Unit Test Instructions) between plan approval and code generation, so the instructions guide the subagent. Included in the delegation prompt context.
- **`build-and-test`**: Removed `unit-test-instructions` from `produces:`, added it to `consumes:`. Steps 4-8 now generate only integration/performance/security test instructions. Step 10 references the consumed artifact for execution.
- **Docs**: Updated `docs/reference/04-stages/construction.md` and `docs/reference/16-artifact-vocabulary.md` to reflect the moved artifact.
- **dist/**: Regenerated all harnesses (`bun scripts/package.ts --check` passes).
- **Fixture**: Regenerated `tests/fixtures/designer-export/export.json` (artifact count unchanged at 122).

## Test Results

All relevant tests pass (smoke, unit, integration graph/stage-consistency tests). Two pre-existing failures unrelated to this change (README badge version mismatch in t68, agents count in t66).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).