### PR TITLE
feat(unit-context-sync-extension): add coordination/unit-context-sync extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,10 @@ aws-aidlc-rule-details/
     │   └── baseline/
     │       ├── resiliency-baseline.md          # Baseline resiliency rules
     │       └── resiliency-baseline.opt-in.md   # Opt-in prompt
+    └── coordination/                  # Extension category
+        └── unit-context-sync/
+            ├── unit-context-sync.md          # Unit context sync rules
+            └── unit-context-sync.opt-in.md   # Opt-in prompt
 ```
 
 > [!IMPORTANT]

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/coordination/unit-context-sync/unit-context-sync.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/coordination/unit-context-sync/unit-context-sync.md
@@ -1,0 +1,119 @@
+# Unit Context Sync Rules
+
+## Overview
+These rules keep units of work aligned with one another while they are built during the Construction phase. When a system is split into multiple units, each unit is often built in a separate session or by a different person, so the units' contexts diverge and drift away from the assumptions agreed during Inception. Left unaddressed, that drift surfaces all at once at integration time and is expensive to reconcile — to the point where, for small systems, splitting into units can feel slower than not splitting at all.
+
+The rules keep humans and AI working as if they were in the same room after the split: the model surfaces where a human-to-human discussion is needed before a unit-boundary change spreads, and — once humans have decided — propagates that decision across the affected units together with its rationale, at the moment it is made rather than at merge time. Decisions and discussions stay with humans; the model carries detection and propagation.
+
+**Enforcement**: At each applicable stage of the Construction phase, the model MUST verify compliance with these rules before presenting the stage completion message to the user.
+
+### Blocking Coordination Finding Behavior
+A **blocking coordination finding** means:
+1. The finding MUST be listed in the stage completion message under a "Coordination Findings" section with the UCS rule ID and description
+2. The stage MUST NOT present the "Continue to Next Stage" option until all blocking findings are resolved
+3. The model MUST present only the "Request Changes" option with a clear explanation of what needs to change
+4. The finding MUST be logged in `aidlc-docs/audit.md` with the UCS rule ID, description, and stage context
+
+If a UCS rule is not applicable to the current project (e.g., the system is a single unit of work), mark it as **N/A** in the compliance summary — this is not a blocking finding.
+
+### Default Enforcement
+All rules in this document are **blocking** by default. If any rule's verification criteria are not met, it is a blocking coordination finding — follow the blocking finding behavior defined above.
+
+### Verification Criteria Format
+Verification items in this document are plain bullet points describing compliance checks. They are distinct from the `- [ ]` / `- [x]` progress-tracking checkboxes used in stage plan files. Each item should be evaluated as compliant or non-compliant during review.
+
+### Human Alignment Points (the model surfaces the need, humans align — the model MUST NOT substitute)
+This extension follows the AI-DLC principle that decisions belong to humans, not the model. For a change that affects a unit boundary, the model MUST decide only whether the change still has room for disagreement, and then act as below. The model MUST NOT settle a contested cross-unit change on the users' behalf, and MUST NOT treat its own record or propagation as a replacement for a human-to-human discussion.
+
+| Situation | Rule | What the model does |
+|---|---|---|
+| A unit-boundary change still open to disagreement (it affects another unit's commitments) | UCS-02 | Name the affected units and direct the responsible people to discuss it directly; hold propagation until they have decided |
+| A change humans have already discussed and decided, or one with no room for disagreement | UCS-03 | Propagate it across the affected units on the humans' behalf (draft the note, reflect it, sync it) |
+| Uncertain whether a discussion is needed | UCS-02 | Default to requiring discussion; never downgrade to "no discussion needed" without explicit human confirmation |
+
+---
+
+## Rule UCS-00: Declare the Cross-Unit Sync Method
+**Rule**: At the start of the Construction phase, the model MUST ask the user how unit-boundary records reach the other units and record the answer in `aidlc-docs/coordination/sync-mode.md`. The mode determines the propagation action stated in UCS-03. Supported modes:
+- `shared-fs` — all units read and write one shared filesystem; propagation is automatic
+- `git` — units share records through a version-control remote
+- `manual` — records are handed to the other units' members by hand
+- `other` — any team-specific method, described by the user
+
+**Verification**:
+- `aidlc-docs/coordination/sync-mode.md` exists and names exactly one mode before any unit records a cross-unit change
+- The recorded mode is the one UCS-03 references when stating its propagation action
+- The model asked the user for the mode and did not choose it on its own
+
+---
+
+## Rule UCS-01: Record Unit-Boundary Changes and Decisions With Intent
+**Rule**: When a contract between units (an API, schema, or other integration specification) changes, or a decision that affects a unit boundary is made during Construction, it MUST be recorded under `aidlc-docs/coordination/` before the stage proceeds. Contracts live in `aidlc-docs/coordination/contracts/`; decisions are indexed in `aidlc-docs/coordination/decisions/ledger.md` with a full record in `aidlc-docs/coordination/decisions/records/`. Each record MUST capture:
+- The decision or change, in plain language
+- The reason for it
+- The options that were considered and rejected, and why
+- The confidence/temperature: settled, contested, or provisional
+
+The human makes the decision; the model only records it. This complements `aidlc-docs/audit.md` (which remains the full interaction log) and does not replace it.
+
+**Verification**:
+- No unit-boundary contract changes without a corresponding record under `aidlc-docs/coordination/contracts/`
+- Every recorded decision states its reason, its rejected alternatives, and its confidence/temperature — not only the conclusion
+- The record attributes the decision to a human; the model did not author the decision itself
+- Each record references the related story or unit dependency so the change is traceable
+
+---
+
+## Rule UCS-02: Surface Cross-Unit Changes for Human Discussion
+**Rule**: When a recorded change affects another unit, the model MUST determine whether the change still has room for disagreement.
+- If it does — it affects another unit's commitments and needs agreement — the model MUST name the affected units, direct the responsible people to discuss it directly, and hold propagation until the humans confirm they have discussed and decided it.
+- If the humans have already discussed and decided it, or it has no room for disagreement, the model proceeds to UCS-03.
+
+The model MUST NOT downgrade a change to "no discussion needed" on its own; when uncertain it MUST default to requiring discussion. The model's record or propagation MUST NOT stand in for the human discussion.
+
+**Verification**:
+- Every cross-unit change is classified as "needs discussion" or "already decided / no room for disagreement"
+- Changes that need discussion name the specific affected units and are held from propagation until humans confirm a decision
+- No change is classified as "no discussion needed" without explicit human confirmation
+- The stage does not proceed while a cross-unit change is awaiting its human discussion
+
+---
+
+## Rule UCS-03: Propagate Decided Changes Across Affected Units
+**Rule**: For a change cleared by UCS-02 (already decided, or with no room for disagreement), the model MUST propagate it to the affected units on the humans' behalf, at the time it is decided rather than at integration time. The model MUST:
+- Produce a short note for each affected unit describing the change and its reason in that unit's terms
+- Reflect the change in the affected units' coordination records and context
+- State and carry out the propagation action for the declared sync mode:
+  - `shared-fs` — already shared; no action
+  - `git` — push the coordination records now to a location every unit reads, not only the unit's own feature branch
+  - `manual` — hand the record to the affected units' members now
+  - `other` — ensure the affected units can read the record before they pass the relevant stage
+
+The content propagated is what the humans decided, not a choice made by the model. The stage MUST NOT proceed until propagation for the declared mode is confirmed.
+
+**Verification**:
+- Every decided cross-unit change has a note targeted at each affected unit
+- The change is reflected in the affected units' coordination records
+- The propagation action matching the declared sync mode has been carried out (or is automatic for `shared-fs`)
+- Propagation happens when the change is decided, not deferred to integration or merge
+
+---
+
+## Rule UCS-04: Reconcile Against Prior Decisions Before Acting
+**Rule**: Before a unit acts on an assumption that crosses a unit boundary, the model MUST read the current coordination records (`aidlc-docs/coordination/contracts/` and `aidlc-docs/coordination/decisions/ledger.md`), refreshing them first if the declared sync mode requires it (`git`: pull; `manual`: obtain the latest handed-over records). If a relevant decision already exists, the model MUST follow it and cite its ID rather than re-deciding. If a recorded contract has changed, the consuming unit MUST reconcile with the change before its stage proceeds.
+
+**Verification**:
+- The coordination records were read — and refreshed per the sync mode — at the start of a unit's stage
+- Decisions already recorded are followed and cited by ID, not re-litigated
+- A unit that consumes a changed contract has reconciled with the change before proceeding
+- No cross-unit assumption is acted on while an unaddressed change to its contract exists in the records
+
+---
+
+## Enforcement Integration
+
+These rules apply during the Construction phase, where units of work are designed and built, and at integration. At each applicable stage:
+- Evaluate all UCS rule verification criteria against the unit-boundary changes and decisions produced
+- Include a "Coordination Compliance" section in the stage completion summary listing each rule as compliant, non-compliant, or N/A
+- If any rule is non-compliant, this is a blocking coordination finding — follow the blocking finding behavior defined in the Overview
+- When the system is built as a single unit of work, mark these rules N/A

--- a/aidlc-rules/aws-aidlc-rule-details/extensions/coordination/unit-context-sync/unit-context-sync.opt-in.md
+++ b/aidlc-rules/aws-aidlc-rule-details/extensions/coordination/unit-context-sync/unit-context-sync.opt-in.md
@@ -1,0 +1,20 @@
+# Unit Context Sync — Opt-In
+
+**Extension**: Unit Context Sync
+
+## Opt-In Prompt
+
+The following question is automatically included in the Requirements Analysis clarifying questions when this extension is loaded:
+
+```markdown
+## Question: Unit Context Sync
+When the system is split into multiple units of work, should units be kept aligned during Construction — surfacing where a human-to-human discussion is needed before a unit-boundary change spreads, and propagating human-made decisions across units as they happen?
+
+A) Yes — enforce all UCS rules as blocking constraints (recommended when units are built in parallel by more than one person or session)
+
+B) No — skip all UCS rules (suitable for a single unit, or one person building units one at a time)
+
+X) Other (please describe after [Answer]: tag below)
+
+[Answer]: 
+```


### PR DESCRIPTION
# Add `coordination/unit-context-sync` extension

> RFC discussion: #423

## Summary

Add an opt-in extension, **Unit Context Sync (UCS)**, under a new `coordination/` extension category. It keeps units of work aligned during the Construction phase after a system is split into multiple units built in parallel (by more than one person or session): the model surfaces where a human-to-human discussion is needed before a unit-boundary change spreads, records decisions with their rationale, propagates human-made decisions across units at decision time, and reconciles consuming units against prior decisions — instead of letting divergence surface all at once at integration time. The extension is sync-method-agnostic and marks itself N/A for single-unit projects (no overhead).

## Changes

1. New `aidlc-rules/aws-aidlc-rule-details/extensions/coordination/unit-context-sync/unit-context-sync.md` — rules UCS-00..04 (Overview, blocking-finding behavior, Human Alignment Points, and per-rule **Rule** + **Verification** sections).
2. New `.../unit-context-sync.opt-in.md` — opt-in prompt presented during Requirements Analysis.
3. `README.md` — add `coordination/` to the Built-in Extensions tree (+4 lines).

Out of PR scope by design (to honor CONTRIBUTING's "keep it agnostic"): the sync **infrastructure** (git / shared-fs / manual is the team's operational choice) and any enforcement **hooks**. UCS records timing and surfaces actions; it does not transport bytes itself.

## Context Impact

- **opt-in file** (loaded at workflow start for every project): 130 words (~170 tokens).
- **rules file** (loaded only after the user opts in): 1,599 words (~2,100 tokens); **zero** when opted out, and N/A for single-unit projects.
- This is the **smallest** of the current extensions (security 2,573 / property-based 2,649 / resiliency 3,889 words), so the always-on footprint is just the opt-in prompt.

## User experience

- **Before**: When a system is decomposed into units and built in parallel, each unit's session diverges; contract/assumption drift surfaces at integration and is expensive to reconcile. The workflow has no mechanism to surface "this needs a human-to-human discussion" or to carry a decision (and its rationale) across units when it is made.
- **After**: Opting in adds blocking coordination checks during Construction. A unit-boundary change that affects another unit is surfaced for human discussion and held (the stage shows a "Coordination Findings" section and offers only "Request Changes"); once humans decide, the decision is recorded with rationale/rejected-alternatives/temperature and propagated to all units at decision time; consuming units refresh and follow prior decisions by ID instead of re-deciding. Single-unit/sequential projects mark the rules N/A.

## Validation Results

- [x] **Opt-in wiring** — a fresh agent with **no knowledge of this extension**, following `core-workflow.md` from scratch on a different domain, autonomously scanned `extensions/` and presented the UCS opt-in verbatim alongside security/testing/resiliency in Requirements Analysis.
- [x] **UCS-00** — model asked for the sync method and recorded `git` in `aidlc-docs/coordination/sync-mode.md` (did not choose on its own).
- [x] **UCS-01** — decision recorded with reason, rejected alternatives, and temperature, attributed to a human (DEC-0001).
- [x] **UCS-02 (surface)** — a cross-unit decision was held as `contested` and the affected units named, unprompted.
- [x] **UCS-02 (blocking gate)** — a unit detected a real contract conflict and, at stage completion, withheld "Continue" and offered only "Request Changes" (see verbatim output below).
- [x] **UCS-03** — the decided change was propagated to the shared branch at decision time (per-unit notes included).
- [x] **UCS-04** — a consuming unit refreshed the records and followed a prior decision by ID, and later reconciled to a **changed** contract, without re-deciding.
- [x] **Safety valve** — for an ambiguous change, the model defaulted to "needs discussion" rather than self-downgrading to "no impact".
- [x] **markdownlint** 0 errors; diff limited to the 2 extension files + the README entry.

## With vs. without UCS (A/B — both arms actually run)

Same unit (fulfillment), same task (US-8/AC-5: remove an out-of-stock item and reduce the total), same Inception context — run twice in **isolated sessions**, the only difference being whether UCS is enabled. The conflict at issue: removing an item makes the captured amount less than the authorized amount, contradicting the recorded `XC-5` "authorized = captured = order total".

| | Without UCS (control, branch `control/no-ucs`) | With UCS (branch `feat/unit-fulfillment`) |
|---|---|---|
| Noticed the conflict? | Yes — a capable model spotted it | Yes |
| Where it was recorded | A prose "open / 未決" note **inside fulfillment's own design doc** (`business-logic-model.md`) — no ID, no temperature | A **shared** coordination record, **DEC-0002** (reason, rejected alternatives, temperature, human-attributed) |
| Stage gate | **Offered "Continue to Next Stage"** — advisory only; the stage can proceed with the conflict unresolved | **"Continue" withheld; "Request Changes" only** (blocking Coordination Finding) |
| Cross-unit propagation | None — the note stays in fulfillment's docs; other units' isolated sessions have no way to discover it | Decision propagated to the shared branch every unit reads, at decision time |
| Consumer reconcile | No mechanism — payment's isolated session keeps building `auth = capture` | payment refreshed and **reconciled to `XC-5 v2`, citing DEC-0002** (UCS-04) |

**Honest takeaway**: a capable model notices the conflict in *both* arms and (correctly) refuses to settle it unilaterally — so UCS's value is **not** "catching what a weaker model misses". Its value is converting an **advisory, unit-local, non-blocking note** (that a team can click past, and that the units which must act on it never see) into a **blocking, shared, structured, propagated, and reconciled** decision. The control arm demonstrates that the base workflow lets the stage proceed with the cross-unit conflict unresolved and invisible to its consumers.

## How it was tested (reproducible record)

**Setup**: Claude Code (Claude Opus 4.x), single machine. A full AI-DLC Inception produced 5 units (catalog/order/fulfillment/payment/notification) and boundary contracts. Construction ran in **mode = parallel**: one `git worktree` + feature branch per unit, each driven by an **isolated agent session** that could see only its own unit spec and the shared `aidlc-docs/coordination/` records (sync-mode `git`; the shared branch is `main`). The orchestrator role-played the human alignment/PO decisions. For the A/B above, an additional **control arm** (`control/no-ucs`) re-ran the identical fulfillment task with the UCS extension removed.

**What each unit session was told — and deliberately *not* told**: each session was instructed only to "do the functional design for unit X, follow the AI-DLC rules (UCS enabled, sync-mode=git)" plus its task. It was **not** told that a conflict existed, nor told to block, surface, or reconcile. All UCS behaviors below were the sessions following the rule text on their own.

**Artifacts produced** (in the run; not part of this diff):
- `coordination/sync-mode.md` = `git` (UCS-00).
- `decisions/DEC-0001` money representation (UCS-01) → propagated to `main` (UCS-03) → followed by payment via ID (UCS-04).
- `decisions/DEC-0002` partial-capture resolution; `contracts/XC-5` evolved v1→v2; payment reconciled (UCS-04 on a changed contract).
- `decisions/DEC-0003` (safety-valve probe) held as `contested`.
- git history across `main` + 4 feature branches shows decision-time propagation and consumer follow-up.

**Verbatim blocking stage-completion produced by the fulfillment session (UCS-02, translated from the run; emphasis original):**

```text
# Functional Design Complete - unit-fulfillment
... (design summary for US-8 / AC-5) ...

> Coordination Findings (UCS):
> - UCS-04: COMPLIANT — refreshed coordination; followed DEC-0001 by ID (no re-decision).
> - UCS-01: COMPLIANT — recorded CF-1 as DEC-0002 (contested): reason, options, temperature, human-attributed.
> - UCS-02: BLOCKING FINDING (unresolved) — CF-1: US-8 (remove item, reduce total) conflicts with
>   XC-5 (settled) "authorized = captured = order total"; left as-is this overcharges the customer.
>   XC-5 is owned by unit-order / unit-payment, so fulfillment cannot settle it.
>   Affected units: unit-order / unit-payment, and the PO — please discuss and decide the capture policy.
> - UCS-03: HELD — contested, not propagated to main until UCS-02 is resolved.

> WHAT'S NEXT?
> A blocking coordination finding (CF-1 / DEC-0002, UCS-02) is unresolved.
> The "Continue to Next Stage" option is withheld until the responsible humans resolve it.
> You may:  Request Changes
```

(A maintainer can reproduce the same behaviors with the platform-agnostic recipe below; we can also attach the full session transcripts/records on request.)

## Benefits

- Catches cross-unit drift at the moment of decision, not at integration — turning integration from reconciliation into confirmation.
- Keeps decision authority with humans: the model surfaces and propagates, it does not settle contested cross-unit changes.
- Produces a durable, ID-referenced decision record (rationale + rejected alternatives + temperature) that consuming units follow instead of re-deciding.
- Useful even for a single sequential agent (decision reuse across units over time); N/A and zero-overhead when there is one unit.

## Test Plan (reviewer-verifiable recipe)

Platform-agnostic. Install the rules (incl. this extension) for your platform, then start an AI-DLC workflow on a **greenfield** project intended to be split into **≥2 units built in parallel**.

1. **Opt-in wiring** — In Requirements Analysis, confirm a **`## Question: Unit Context Sync`** appears among the clarifying questions, alongside security/testing/resiliency. Choose **A (Yes)**.
2. **UCS-00** — At Construction start, confirm the model **asks** for the cross-unit sync method and records it in `aidlc-docs/coordination/sync-mode.md` (it must not choose on its own).
3. **UCS-01** — Make a unit-boundary decision (e.g., how money / IDs / order-status are represented). Confirm it is recorded under `aidlc-docs/coordination/decisions/` with reason, rejected alternatives, and temperature, attributed to a human.
4. **UCS-02 (surface + block)** — Have one unit attempt a change to a contract another unit owns/consumes. Confirm the model classifies it as "needs discussion", **names the affected units**, holds propagation, and at stage completion presents a **"Coordination Findings"** blocking section offering **only "Request Changes"**.
5. **UCS-03** — After humans decide, confirm the model propagates the decision to a location every unit reads (git: push to the shared branch) with a per-unit note, at decision time.
6. **UCS-04** — In a consuming unit's session, confirm the model refreshes the coordination records and **follows the existing decision by ID** (does not re-decide), and reconciles with a **changed** contract before proceeding.
7. **Safety valve** — Introduce an **ambiguous** change; confirm the model defaults to "needs discussion" rather than self-downgrading to "no impact".

**Platform/model tested**: Claude Code (Claude Opus 4.x), single machine; sync-mode `git`; units built in parallel via separate `git worktree`s + isolated agent sessions coordinating only through git-shared `aidlc-docs/coordination/` records.

## Checklist

- [x] I have reviewed the contributing guidelines
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
