### PR TITLE
docs: explain how to provide input documents to the agent (#250)

### DIFF
--- a/docs/writing-inputs/inputs-quickstart.md
+++ b/docs/writing-inputs/inputs-quickstart.md
@@ -4,6 +4,18 @@ AI-DLC (AI-Driven Development Life Cycle) is a structured workflow that guides a
 
 ---
 
+## How to Provide These Documents to the Agent
+
+There is no required location for your input documents. Place them anywhere in your project
+and reference them in your initial request to the agent — for example,
+`read ./vision.md and ./tech-env.md and start the AI-DLC workflow`. You can also paste a
+document's contents directly into the chat.
+
+AI-DLC does not enforce a folder convention, so use whatever location fits your project.
+The agent uses what you reference or paste as the primary input to the Inception Phase.
+
+---
+
 ## What You Need to Provide
 
 ### 1. Vision Document -- what to build and why

--- a/docs/writing-inputs/vision-document-guide.md
+++ b/docs/writing-inputs/vision-document-guide.md
@@ -6,6 +6,16 @@ A Vision Document defines the **business goals**, **target outcomes**, and **sco
 
 A well-written Vision Document reduces ambiguity during Requirements Analysis, improves User Story quality, and prevents scope creep during Construction.
 
+## How to Provide This Document to the Agent
+
+There is no required location for your Vision Document. Place it anywhere in your project
+and reference it in your initial request to the agent — for example,
+`read ./vision.md and start the AI-DLC workflow`. You can also paste the document's
+contents directly into the chat.
+
+AI-DLC does not enforce a folder convention, so use whatever location fits your project.
+The agent uses what you reference or paste as the primary input to the Inception Phase.
+
 ## When to Write a Vision Document
 
 - Before starting any new project or major initiative


### PR DESCRIPTION
# Summary

Closes #250.

The `writing-inputs` guides explain *what* a Vision Document and Technical Environment Document are and *how* they feed each AI-DLC stage, but never tell the user the mechanical step of **how to hand a document to the agent** or where to place it. As reported in #250, a user who asked "where do I put a vision document?" got a confused, non-definitive answer.

This adds the missing instruction, matching the fix @leandrodamascena outlined in the issue thread.

## Changes

Add a short **"How to Provide … to the Agent"** section near the top of both:

- `docs/writing-inputs/vision-document-guide.md`
- `docs/writing-inputs/inputs-quickstart.md`

The section states the intended flow: place the document anywhere in your project and reference it in your initial request (e.g. `read ./vision.md and start the AI-DLC workflow`), or paste its contents into chat — no enforced folder convention.

Docs-only and additive; no rules, code, or behavioral change. (The issue also floated a tweak to `requirements-analysis.md`, but its Step 4 already instructs the agent to use "existing requirements documents (search workspace if mentioned)" and "pasted content or file references", so the genuine remaining gap was the user-facing docs.)

## User experience

- **Before:** The guides describe the documents thoroughly but never say where to put one or how the agent picks it up; users are left guessing and the agent gives non-definitive answers.
- **After:** Both entry-point docs state up front how to provide an input document — reference it by path in the initial request, or paste it — and that no specific folder is required.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- `markdownlint-cli2` (the repo's CI lint, `.markdownlint-cli2.yaml`) passes on both files with 0 errors.
- The CI multiple-choice-separator check (issue #246) passes — no `A) `-style consecutive lines introduced.
- Render both files and confirm the new section appears near the top and reads correctly.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
