### PR TITLE
docs(readme): add OpenAI Codex to Platform-Specific Setup index

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ AI-DLC is an intelligent software development workflow that adapts to your needs
 - [Cline](#cline)
 - [Claude Code](#claude-code)
 - [GitHub Copilot](#github-copilot)
+- [OpenAI Codex](#openai-codex)
 
 ---
 


### PR DESCRIPTION
## Summary

The Platform-Specific Setup index in the README was missing an entry for the OpenAI Codex section, even though the section itself already exists further down in the file. This adds the missing index link.

## Changes

- Add `- [OpenAI Codex](#openai-codex)` to the Platform-Specific Setup index, after GitHub Copilot.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).