### PR TITLE
test: fix two codekb-placement test assertions to match shipped engine behavior

### DIFF
--- a/tests/e2e/t-exec-codex-journey-workspace.serial.test.ts
+++ b/tests/e2e/t-exec-codex-journey-workspace.serial.test.ts
@@ -165,12 +165,27 @@ function execCodex(
   return { rc: r.status ?? -1, out: `${r.stdout ?? ""}\n${r.stderr ?? ""}` };
 }
 
+// The engine resolves the per-repo codekb store to the SPACE-LEVEL sibling of
+// intents (aidlc/spaces/<space>/codekb/<repo>/ - the dir codekb-path prints, the
+// codekb-determinism placement fix), but the live RE subagent occasionally still
+// writes the bare workspace-root form aidlc/codekb/<repo>/. Either is a valid
+// per-repo store for this beat's promise; accept BOTH, only absence is a fail
+// (matching the SDK t-journey-workspace.sdk sibling helper verbatim, and the ACP
+// t-acp-kiro-journey-workspace sibling modulo candidate order).
 function codekbFiles(root: string, repo: string): string[] {
-  try {
-    return readdirSync(join(root, "aidlc", "codekb", repo)).filter((f) => f.endsWith(".md"));
-  } catch {
-    return [];
+  const candidates = [
+    join(root, "aidlc", "spaces", activeSpace(root), "codekb", repo),
+    join(root, "aidlc", "codekb", repo),
+  ];
+  for (const dir of candidates) {
+    try {
+      const md = readdirSync(dir).filter((f) => f.endsWith(".md"));
+      if (md.length > 0) return md;
+    } catch {
+      /* try the next candidate */
+    }
   }
+  return [];
 }
 
 function activeRecordDir(root: string): string | undefined {

--- a/tests/integration/t72-stage-reverse-engineering.test.ts
+++ b/tests/integration/t72-stage-reverse-engineering.test.ts
@@ -92,6 +92,26 @@ function codekbReDir(proj: string): string {
   return existsSync(spaceScoped) ? spaceScoped : bare;
 }
 
+// The 9 RE artifact stems the architect synthesises (reverse-engineering.md
+// produces:). The anti-scatter check below tests for THESE in the old per-intent
+// record location - NOT the directory's mere existence, because the RE stage's
+// own "Learn" ritual legitimately writes its stage diary memory.md into
+// <record>/<phase>/<stage>/ (reverse-engineering.md "the memory.md file stays in
+// the artefact directory as part of the stage's permanent record"). That diary
+// materializes the reverse-engineering/ directory by design; only a scattered RE
+// ARTIFACT there is a placement regression. Mirrors t183's stem-filtered check.
+const RE_STEMS = [
+  "business-overview",
+  "architecture",
+  "code-structure",
+  "api-documentation",
+  "component-inventory",
+  "technology-stack",
+  "dependencies",
+  "code-quality-assessment",
+  "reverse-engineering-timestamp",
+];
+
 // ---------------------------------------------------------------------------
 // Timeout budget — the .sh set AIDLC_TEST_TIMEOUT=900 (RE is a HEAVY multi-agent
 // stage). Honour it. The driver aborts ~15s before bun's per-test cap so a stuck
@@ -144,11 +164,20 @@ describe("t72 /aidlc reverse-engineering brownfield (sdk)", () => {
         // .sh test 1: the RE artifact directory was created. RE now writes to the
         // SPACE-LEVEL per-repo codekb store, NOT the per-intent record dir (the
         // codekb-determinism placement fix). Enumerate that dir; also assert RE
-        // did NOT scatter artifacts into the old record-dir location.
+        // did NOT scatter ARTIFACTS into the old record-dir location.
         const reDir = codekbReDir(proj);
         expect(existsSync(reDir) && statSync(reDir).isDirectory()).toBe(true);
+        // Anti-scatter: no RE artifact (by stem) landed in the per-intent record
+        // dir. We do NOT assert the dir is absent - the stage's by-design diary
+        // memory.md lives there (see RE_STEMS comment); only a scattered ARTIFACT
+        // is a regression. (Mirrors t183's stem-filtered placement check.)
         const oldRecordReDir = join(seededRecordDir(proj), "inception", "reverse-engineering");
-        expect(existsSync(oldRecordReDir)).toBe(false);
+        const scatteredArtifacts = existsSync(oldRecordReDir)
+          ? readdirSync(oldRecordReDir).filter((f) =>
+              RE_STEMS.includes(f.replace(/\.md$/, "")),
+            )
+          : [];
+        expect(scatteredArtifacts).toEqual([]);
 
         // .sh test 2: >= 4 .md artifacts (the .sh's assert_gt 3).
         const reFiles = readdirSync(reDir).filter((f) => f.endsWith(".md"));


### PR DESCRIPTION
## What

Two reverse-engineering codekb-placement tests asserted the OLD placement
behavior and failed on a fully-correct run. The codekb-determinism placement fix
is already shipped and correct on `v2` (the engine resolves the per-repo store to
the space-level `aidlc/spaces/<space>/codekb/<repo>/`, the `codekb-path` verb
prints it, and the reverse-engineering stage prose defers to the tool). Both
failures are test-side; there is no engine change here.

## Fixes (test-only)

- **t72** (`tests/integration/t72-stage-reverse-engineering.test.ts`): the
  anti-scatter check forbade the whole `<record>/inception/reverse-engineering/`
  directory, but the RE stage's own Learn ritual legitimately writes its stage
  diary `memory.md` there (the file "stays in the artefact directory as part of
  the stage's permanent record"). Replaced the directory-existence check with a
  stem-filtered one (no RE artifact landed in the record dir), tolerating the
  by-design `memory.md`. Mirrors the technique in t183.

- **t-exec-codex** (`tests/e2e/t-exec-codex-journey-workspace.serial.test.ts`):
  the file-local `codekbFiles` helper globbed only the bare `aidlc/codekb/<repo>/`,
  but the engine writes the space-level `aidlc/spaces/<space>/codekb/<repo>/`.
  Widened it to check both candidate dirs, matching the SDK
  (`t-journey-workspace.sdk`) and ACP (`t-acp-kiro-journey-workspace`) sibling
  helpers.

## Verification

- `bun run typecheck` clean on both tsconfigs.
- **t72 re-run live (Claude SDK): 1 pass / 0 fail.** The trace confirmed the RE
  agent ran `codekb-path`, wrote all 9 artifacts to the space-level codekb dir,
  and wrote only `memory.md` to the record dir.
- **t-exec-codex helper widen proven** via a preserved-workspace repro: given the
  full RE time, codex runs `codekb-path`, resolves the space-level dir, and writes
  9 artifacts per repo there (zero to the bare path) - which the old bare-only
  helper never checked. Note this test is the existing "Flaky-LLM-tier (watched)"
  live journey: a zero-write run is codex ending its turn early on a low-effort
  pass, a flake to re-run rather than a code defect; the widen makes the test pass
  whenever codex completes the writes.

Test-only; no version bump (per the Changelog Policy).