### PR TITLE
fix: record and read the per-intent memory path in learnings surface (2.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.2] - 2026-07-05
+
+Fixes the learnings gate returning zero candidates (or the wrong phase) once a project moved to the per-intent workspace layout. The runtime-graph row's `memory_path` was recorded without the active intent's record dir, and the learnings surface read the phase from the wrong path segment, so `learnings surface` looked for the diary in the wrong place and mislabeled its phase. Both the write side (runtime-graph compile and the state advance transition) and the read side (surface's phase extraction) now use the per-intent record path. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* `learnings surface` now finds a stage's captured learnings under the workspace layout instead of surfacing zero candidates: the runtime-graph `memory_path` it reads now includes the active intent's record dir.
+* The `phase` field in the `learnings surface` JSON is now correct under the workspace layout (it previously reported `spaces` for any per-intent project); the legacy flat layout still reports the right phase.
+
 ## [2.2.1] - 2026-07-04
 
 Stops help requests from accidentally creating intents. `/aidlc intent help` was parsed as "switch to an intent named help"; the failed switch died with an error inviting the agent to "describe what to build to start a new one", which a conductor mid-task read as an instruction and birthed an unwanted intent. Bare `/aidlc help` and `/aidlc -h` were worse: they fell into the freeform-description funnel and offered to birth an intent literally named "help" (or silently advanced the active stage). All help-shaped inputs now route to the help text. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.2.1-blue)
+![version](https://img.shields.io/badge/version-2.2.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-learnings.ts
+++ b/core/tools/aidlc-learnings.ts
@@ -194,7 +194,13 @@ function handleSurface(args: string[], projectDir: string): void {
   const raw = existsSync(memAbs) ? readFileSync(memAbs, "utf-8") : "";
   const entries = parseMemoryEntries(raw);
 
-  const phase = memRel.split("/")[1] ?? "";
+  // memory_path always ends `<prefix>/<phase>/<stageSlug>/memory.md` (see
+  // relativeMemoryPath), so the phase is the third-from-last segment regardless
+  // of prefix shape: the per-intent record dir, the bare space prefix, or the
+  // legacy flat `aidlc-docs` root all share that tail. Indexing from the front
+  // assumed the flat layout and yielded "spaces" under the workspace prefix.
+  const segs = memRel.split("/");
+  const phase = segs.at(-3) ?? "";
 
   const candidates: SurfaceCandidate[] = [];
   const parked: SurfaceParkedQuestion[] = [];

--- a/core/tools/aidlc-runtime.ts
+++ b/core/tools/aidlc-runtime.ts
@@ -354,6 +354,13 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
   const stages: RuntimeStage[] = [];
   const zeroEntryApprovedStages: { slug: string; completed_at: string }[] = [];
 
+  // The active intent's RELATIVE record-dir prefix (aidlc/spaces/<sp>/intents/
+  // <slug>-<id8>), so each row's memory_path resolves under the active intent
+  // rather than the bare space prefix. null -> the bare space record prefix (a
+  // pre-birth shell with no intent). Resolved once: the active intent is stable
+  // across a single compile.
+  const recordPrefix = relativeRecordDir(projectDir);
+
   for (const [slug, entry] of slugsByStartTime) {
     const phaseInfo = phaseMap.get(slug);
     if (!phaseInfo) continue; // unknown slug — skip rather than fail
@@ -367,7 +374,7 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
       started_at: entry.started_at,
       completed_at: entry.completed_at,
       agent: entry.agent || phaseInfo.agent,
-      memory_path: relativeMemoryPath(phaseInfo.phase, slug),
+      memory_path: relativeMemoryPath(phaseInfo.phase, slug, recordPrefix),
       memory_entries: memory.memory_entries,
       memory_breakdown: memory.memory_breakdown,
       sensor_firings: [],

--- a/core/tools/aidlc-state.ts
+++ b/core/tools/aidlc-state.ts
@@ -995,7 +995,7 @@ function handleAdvance(args: string[]): void {
       completed_count: completedCount,
       next_after: nextAfterNext ? nextAfterNext.slug : null,
       already_completed: alreadyMarkedCompleted,
-      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug),
+      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug, relativeRecordDir(pd)),
       timestamp,
     })
   );

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.1";
+export const AIDLC_VERSION = "2.2.2";

--- a/dist/claude/.claude/tools/aidlc-learnings.ts
+++ b/dist/claude/.claude/tools/aidlc-learnings.ts
@@ -194,7 +194,13 @@ function handleSurface(args: string[], projectDir: string): void {
   const raw = existsSync(memAbs) ? readFileSync(memAbs, "utf-8") : "";
   const entries = parseMemoryEntries(raw);
 
-  const phase = memRel.split("/")[1] ?? "";
+  // memory_path always ends `<prefix>/<phase>/<stageSlug>/memory.md` (see
+  // relativeMemoryPath), so the phase is the third-from-last segment regardless
+  // of prefix shape: the per-intent record dir, the bare space prefix, or the
+  // legacy flat `aidlc-docs` root all share that tail. Indexing from the front
+  // assumed the flat layout and yielded "spaces" under the workspace prefix.
+  const segs = memRel.split("/");
+  const phase = segs.at(-3) ?? "";
 
   const candidates: SurfaceCandidate[] = [];
   const parked: SurfaceParkedQuestion[] = [];

--- a/dist/claude/.claude/tools/aidlc-runtime.ts
+++ b/dist/claude/.claude/tools/aidlc-runtime.ts
@@ -354,6 +354,13 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
   const stages: RuntimeStage[] = [];
   const zeroEntryApprovedStages: { slug: string; completed_at: string }[] = [];
 
+  // The active intent's RELATIVE record-dir prefix (aidlc/spaces/<sp>/intents/
+  // <slug>-<id8>), so each row's memory_path resolves under the active intent
+  // rather than the bare space prefix. null -> the bare space record prefix (a
+  // pre-birth shell with no intent). Resolved once: the active intent is stable
+  // across a single compile.
+  const recordPrefix = relativeRecordDir(projectDir);
+
   for (const [slug, entry] of slugsByStartTime) {
     const phaseInfo = phaseMap.get(slug);
     if (!phaseInfo) continue; // unknown slug — skip rather than fail
@@ -367,7 +374,7 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
       started_at: entry.started_at,
       completed_at: entry.completed_at,
       agent: entry.agent || phaseInfo.agent,
-      memory_path: relativeMemoryPath(phaseInfo.phase, slug),
+      memory_path: relativeMemoryPath(phaseInfo.phase, slug, recordPrefix),
       memory_entries: memory.memory_entries,
       memory_breakdown: memory.memory_breakdown,
       sensor_firings: [],

--- a/dist/claude/.claude/tools/aidlc-state.ts
+++ b/dist/claude/.claude/tools/aidlc-state.ts
@@ -995,7 +995,7 @@ function handleAdvance(args: string[]): void {
       completed_count: completedCount,
       next_after: nextAfterNext ? nextAfterNext.slug : null,
       already_completed: alreadyMarkedCompleted,
-      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug),
+      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug, relativeRecordDir(pd)),
       timestamp,
     })
   );

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.1";
+export const AIDLC_VERSION = "2.2.2";

--- a/dist/codex/.codex/tools/aidlc-learnings.ts
+++ b/dist/codex/.codex/tools/aidlc-learnings.ts
@@ -194,7 +194,13 @@ function handleSurface(args: string[], projectDir: string): void {
   const raw = existsSync(memAbs) ? readFileSync(memAbs, "utf-8") : "";
   const entries = parseMemoryEntries(raw);
 
-  const phase = memRel.split("/")[1] ?? "";
+  // memory_path always ends `<prefix>/<phase>/<stageSlug>/memory.md` (see
+  // relativeMemoryPath), so the phase is the third-from-last segment regardless
+  // of prefix shape: the per-intent record dir, the bare space prefix, or the
+  // legacy flat `aidlc-docs` root all share that tail. Indexing from the front
+  // assumed the flat layout and yielded "spaces" under the workspace prefix.
+  const segs = memRel.split("/");
+  const phase = segs.at(-3) ?? "";
 
   const candidates: SurfaceCandidate[] = [];
   const parked: SurfaceParkedQuestion[] = [];

--- a/dist/codex/.codex/tools/aidlc-runtime.ts
+++ b/dist/codex/.codex/tools/aidlc-runtime.ts
@@ -354,6 +354,13 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
   const stages: RuntimeStage[] = [];
   const zeroEntryApprovedStages: { slug: string; completed_at: string }[] = [];
 
+  // The active intent's RELATIVE record-dir prefix (aidlc/spaces/<sp>/intents/
+  // <slug>-<id8>), so each row's memory_path resolves under the active intent
+  // rather than the bare space prefix. null -> the bare space record prefix (a
+  // pre-birth shell with no intent). Resolved once: the active intent is stable
+  // across a single compile.
+  const recordPrefix = relativeRecordDir(projectDir);
+
   for (const [slug, entry] of slugsByStartTime) {
     const phaseInfo = phaseMap.get(slug);
     if (!phaseInfo) continue; // unknown slug — skip rather than fail
@@ -367,7 +374,7 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
       started_at: entry.started_at,
       completed_at: entry.completed_at,
       agent: entry.agent || phaseInfo.agent,
-      memory_path: relativeMemoryPath(phaseInfo.phase, slug),
+      memory_path: relativeMemoryPath(phaseInfo.phase, slug, recordPrefix),
       memory_entries: memory.memory_entries,
       memory_breakdown: memory.memory_breakdown,
       sensor_firings: [],

--- a/dist/codex/.codex/tools/aidlc-state.ts
+++ b/dist/codex/.codex/tools/aidlc-state.ts
@@ -995,7 +995,7 @@ function handleAdvance(args: string[]): void {
       completed_count: completedCount,
       next_after: nextAfterNext ? nextAfterNext.slug : null,
       already_completed: alreadyMarkedCompleted,
-      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug),
+      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug, relativeRecordDir(pd)),
       timestamp,
     })
   );

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.1";
+export const AIDLC_VERSION = "2.2.2";

--- a/dist/kiro-ide/.kiro/tools/aidlc-learnings.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-learnings.ts
@@ -194,7 +194,13 @@ function handleSurface(args: string[], projectDir: string): void {
   const raw = existsSync(memAbs) ? readFileSync(memAbs, "utf-8") : "";
   const entries = parseMemoryEntries(raw);
 
-  const phase = memRel.split("/")[1] ?? "";
+  // memory_path always ends `<prefix>/<phase>/<stageSlug>/memory.md` (see
+  // relativeMemoryPath), so the phase is the third-from-last segment regardless
+  // of prefix shape: the per-intent record dir, the bare space prefix, or the
+  // legacy flat `aidlc-docs` root all share that tail. Indexing from the front
+  // assumed the flat layout and yielded "spaces" under the workspace prefix.
+  const segs = memRel.split("/");
+  const phase = segs.at(-3) ?? "";
 
   const candidates: SurfaceCandidate[] = [];
   const parked: SurfaceParkedQuestion[] = [];

--- a/dist/kiro-ide/.kiro/tools/aidlc-runtime.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-runtime.ts
@@ -354,6 +354,13 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
   const stages: RuntimeStage[] = [];
   const zeroEntryApprovedStages: { slug: string; completed_at: string }[] = [];
 
+  // The active intent's RELATIVE record-dir prefix (aidlc/spaces/<sp>/intents/
+  // <slug>-<id8>), so each row's memory_path resolves under the active intent
+  // rather than the bare space prefix. null -> the bare space record prefix (a
+  // pre-birth shell with no intent). Resolved once: the active intent is stable
+  // across a single compile.
+  const recordPrefix = relativeRecordDir(projectDir);
+
   for (const [slug, entry] of slugsByStartTime) {
     const phaseInfo = phaseMap.get(slug);
     if (!phaseInfo) continue; // unknown slug — skip rather than fail
@@ -367,7 +374,7 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
       started_at: entry.started_at,
       completed_at: entry.completed_at,
       agent: entry.agent || phaseInfo.agent,
-      memory_path: relativeMemoryPath(phaseInfo.phase, slug),
+      memory_path: relativeMemoryPath(phaseInfo.phase, slug, recordPrefix),
       memory_entries: memory.memory_entries,
       memory_breakdown: memory.memory_breakdown,
       sensor_firings: [],

--- a/dist/kiro-ide/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-state.ts
@@ -995,7 +995,7 @@ function handleAdvance(args: string[]): void {
       completed_count: completedCount,
       next_after: nextAfterNext ? nextAfterNext.slug : null,
       already_completed: alreadyMarkedCompleted,
-      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug),
+      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug, relativeRecordDir(pd)),
       timestamp,
     })
   );

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.1";
+export const AIDLC_VERSION = "2.2.2";

--- a/dist/kiro/.kiro/tools/aidlc-learnings.ts
+++ b/dist/kiro/.kiro/tools/aidlc-learnings.ts
@@ -194,7 +194,13 @@ function handleSurface(args: string[], projectDir: string): void {
   const raw = existsSync(memAbs) ? readFileSync(memAbs, "utf-8") : "";
   const entries = parseMemoryEntries(raw);
 
-  const phase = memRel.split("/")[1] ?? "";
+  // memory_path always ends `<prefix>/<phase>/<stageSlug>/memory.md` (see
+  // relativeMemoryPath), so the phase is the third-from-last segment regardless
+  // of prefix shape: the per-intent record dir, the bare space prefix, or the
+  // legacy flat `aidlc-docs` root all share that tail. Indexing from the front
+  // assumed the flat layout and yielded "spaces" under the workspace prefix.
+  const segs = memRel.split("/");
+  const phase = segs.at(-3) ?? "";
 
   const candidates: SurfaceCandidate[] = [];
   const parked: SurfaceParkedQuestion[] = [];

--- a/dist/kiro/.kiro/tools/aidlc-runtime.ts
+++ b/dist/kiro/.kiro/tools/aidlc-runtime.ts
@@ -354,6 +354,13 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
   const stages: RuntimeStage[] = [];
   const zeroEntryApprovedStages: { slug: string; completed_at: string }[] = [];
 
+  // The active intent's RELATIVE record-dir prefix (aidlc/spaces/<sp>/intents/
+  // <slug>-<id8>), so each row's memory_path resolves under the active intent
+  // rather than the bare space prefix. null -> the bare space record prefix (a
+  // pre-birth shell with no intent). Resolved once: the active intent is stable
+  // across a single compile.
+  const recordPrefix = relativeRecordDir(projectDir);
+
   for (const [slug, entry] of slugsByStartTime) {
     const phaseInfo = phaseMap.get(slug);
     if (!phaseInfo) continue; // unknown slug — skip rather than fail
@@ -367,7 +374,7 @@ function compile(opts: CompileOptions): { skipped?: string; written?: string } {
       started_at: entry.started_at,
       completed_at: entry.completed_at,
       agent: entry.agent || phaseInfo.agent,
-      memory_path: relativeMemoryPath(phaseInfo.phase, slug),
+      memory_path: relativeMemoryPath(phaseInfo.phase, slug, recordPrefix),
       memory_entries: memory.memory_entries,
       memory_breakdown: memory.memory_breakdown,
       sensor_firings: [],

--- a/dist/kiro/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro/.kiro/tools/aidlc-state.ts
@@ -995,7 +995,7 @@ function handleAdvance(args: string[]): void {
       completed_count: completedCount,
       next_after: nextAfterNext ? nextAfterNext.slug : null,
       already_completed: alreadyMarkedCompleted,
-      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug),
+      memory_path: relativeMemoryPath(nextStage.phase, nextStage.slug, relativeRecordDir(pd)),
       timestamp,
     })
   );

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.1";
+export const AIDLC_VERSION = "2.2.2";

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -3924,6 +3924,10 @@
           "mechanism": "cli"
         },
         {
+          "file": "tests/unit/t199-learnings-memory-path.test.ts",
+          "mechanism": "cli"
+        },
+        {
           "file": "tests/unit/t97.test.ts",
           "mechanism": "cli"
         }
@@ -3985,6 +3989,10 @@
         },
         {
           "file": "tests/unit/t133-bolt-dag-compile.test.ts",
+          "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t199-learnings-memory-path.test.ts",
           "mechanism": "cli"
         }
       ],

--- a/tests/integration/t99-learnings-gate-flow.test.ts
+++ b/tests/integration/t99-learnings-gate-flow.test.ts
@@ -225,6 +225,9 @@ describe("t99 §13 learning-gate end-to-end (migrated from t99-learnings-gate-fl
     // STRONGER than the .sh's "3:1" string: assert the two array LENGTHS directly.
     expect(j.candidates.length).toBe(3);
     expect(j.parked_open_questions.length).toBe(1);
+    // The fixture memory_path carries the per-intent record dir, so the phase
+    // must be the real one, not a prefix segment like "spaces".
+    expect(j.phase).toBe("inception");
   }, TIMEOUT);
 
   test("Case 1: project pick lands as a practice in project.md [.sh 2]", () => {

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -836,6 +836,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t191-composed-scope-write.test.ts",
     "unit/t194-recompose.test.ts",
     "unit/t198-compose-surfaces.test.ts",
+    "unit/t199-learnings-memory-path.test.ts",
     "unit/t17.test.ts",
     "unit/t18.test.ts",
     "unit/t19.test.ts",

--- a/tests/unit/t100-memory-template-lifecycle.test.ts
+++ b/tests/unit/t100-memory-template-lifecycle.test.ts
@@ -68,6 +68,7 @@ import {
   AIDLC_SRC,
   cleanupTestProject,
   createTestProject,
+  DEFAULT_RECORD_DIR,
   DEFAULT_SPACE,
   FIXTURES_DIR,
   resetAidlcEnv,
@@ -76,11 +77,12 @@ import {
 
 resetAidlcEnv();
 
-// P9: advance/approve emit memory_path against the BARE space record prefix
-// (relativeMemoryPath called with no recordPrefix -> relativeSpaceRecordPrefix);
-// the flat aidlc-docs/ prefix is retired. `advance` does not thread the active
-// intent's record dir, so the row carries the bare-space prefix.
-const RP = `aidlc/spaces/${DEFAULT_SPACE}/intents`;
+// advance/approve emit memory_path against the ACTIVE INTENT's record prefix
+// (relativeMemoryPath threaded relativeRecordDir(pd) -> aidlc/spaces/<sp>/intents/
+// <slug>-<id8>); the flat aidlc-docs/ prefix is retired. midIdeationProject seeds
+// the active-intent cursor at DEFAULT_RECORD_DIR (via createTestProject), so the
+// row carries the per-intent record dir.
+const RP = `aidlc/spaces/${DEFAULT_SPACE}/intents/${DEFAULT_RECORD_DIR}`;
 
 const BUN = process.execPath; // the bun running this test
 const TOOL = join(AIDLC_SRC, "tools", "aidlc-state.ts");

--- a/tests/unit/t199-learnings-memory-path.test.ts
+++ b/tests/unit/t199-learnings-memory-path.test.ts
@@ -1,0 +1,222 @@
+// covers: subcommand:aidlc-runtime:compile, subcommand:aidlc-learnings:surface
+//
+// t199 - the per-intent memory path is recorded (write side) and read (read
+// side) across the workspace layout.
+//
+// Mechanism: cli. Both sides are exercised by spawning the shipped tools through
+// the bun runtime: `aidlc-runtime compile` writes the runtime-graph.json rows,
+// `aidlc-learnings surface` reads a row's memory_path and derives the phase. The
+// process boundary plus the bytes on disk are the subject; an in-process twin
+// would lose the record-cursor resolution the tools do against the project tree.
+//
+// TWO DEFECTS PINNED (both made `learnings surface` dead under the workspace
+// layout):
+//   WRITE SIDE - compile recorded memory_path as `<bare-space-prefix>/<phase>/
+//     <slug>/memory.md`, dropping the active intent's record dir
+//     (aidlc/spaces/<sp>/intents/<slug>-<id8>). The state advance transition had
+//     the same 2-arg relativeMemoryPath call. surface then join()'d that against
+//     projectDir and missed the real diary, surfacing zero candidates.
+//   READ SIDE - surface extracted the phase as memRel.split("/")[1], which under
+//     the workspace prefix is "spaces", not the real phase. The robust extraction
+//     is the third-from-last segment: memory_path always ends
+//     `<prefix>/<phase>/<stageSlug>/memory.md` regardless of prefix shape.
+//
+// The legacy flat path `aidlc-docs/<phase>/<slug>/memory.md` shares that tail, so
+// the read-side fix degrades correctly there too - the third case pins it.
+//
+// Source under test (dist/claude/.claude/tools/):
+//   aidlc-runtime.ts compile      - the runtime-graph row's memory_path.
+//   aidlc-learnings.ts surface    - the phase extraction + diary read.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  AIDLC_SRC,
+  createTestProject,
+  DEFAULT_RECORD_DIR,
+  DEFAULT_SPACE,
+  seededAuditShard,
+  seededRecordDir,
+  seededStateFile,
+} from "../harness/fixtures.ts";
+
+const BUN = process.execPath; // the bun running this test
+const RUNTIME_TS = join(AIDLC_SRC, "tools", "aidlc-runtime.ts");
+const LEARNINGS_TS = join(AIDLC_SRC, "tools", "aidlc-learnings.ts");
+
+// The active intent's RELATIVE record prefix a seeded workspace project resolves
+// (createTestProject seeds the active-intent cursor at DEFAULT_RECORD_DIR).
+const RP = `aidlc/spaces/${DEFAULT_SPACE}/intents/${DEFAULT_RECORD_DIR}`;
+
+const projects: string[] = [];
+afterAll(() => {
+  for (const p of projects) rmSync(p, { recursive: true, force: true });
+});
+
+/** A minimal audit shard: one WORKFLOW_STARTED + one STAGE_STARTED for a stage
+ *  whose phase the stage-graph knows (user-stories -> inception). */
+function auditShard(): string {
+  return [
+    "# AI-DLC Audit Log",
+    "",
+    "## Workflow Started",
+    "**Timestamp**: 2026-05-28T08:00:00Z",
+    "**Event**: WORKFLOW_STARTED",
+    "**Workflow ID**: t199",
+    "**Scope**: feature",
+    "",
+    "---",
+    "",
+    "## Stage Started",
+    "**Timestamp**: 2026-05-28T08:01:00Z",
+    "**Event**: STAGE_STARTED",
+    "**Stage**: user-stories",
+    "**Agent**: aidlc-product-agent",
+    "",
+    "---",
+    "",
+  ].join("\n");
+}
+
+/** Seed a per-intent workspace project with the state + audit compile needs. */
+function mkWorkspaceProject(): string {
+  const pd = createTestProject();
+  projects.push(pd);
+  const rec = seededRecordDir(pd);
+  mkdirSync(rec, { recursive: true });
+  writeFileSync(
+    seededStateFile(pd),
+    "# AI-DLC State Tracking\n- **Current Stage**: user-stories\n- **Scope**: feature\n",
+  );
+  const shard = seededAuditShard(pd);
+  mkdirSync(join(rec, "audit"), { recursive: true });
+  writeFileSync(shard, auditShard());
+  return pd;
+}
+
+/** memory.md with one Interpretations entry so surface yields a candidate only
+ *  when it resolved the diary at the right path. */
+function memoryDiary(): string {
+  // parseMemoryEntryLine counts any non-empty line under a heading as one entry
+  // (a canonical `<ts> - <text>` bullet is parsed further, a bare line degrades
+  // to a raw entry), so this single bullet yields exactly one candidate.
+  return [
+    "## Interpretations",
+    "- Reused the existing auth module; saved a rewrite this stage",
+    "",
+  ].join("\n");
+}
+
+const TIMEOUT = 30000;
+
+describe("t199 per-intent memory path (write + read)", () => {
+  // ===========================================================================
+  // WRITE SIDE - compile records memory_path WITH the per-intent record dir.
+  // ===========================================================================
+  test("compile records a memory_path that includes the per-intent record dir", () => {
+    const pd = mkWorkspaceProject();
+    const r = spawnSync(BUN, [RUNTIME_TS, "--project-dir", pd, "compile"], {
+      encoding: "utf-8",
+    });
+    expect(r.status).toBe(0);
+    const graph = JSON.parse(
+      readFileSync(join(seededRecordDir(pd), "runtime-graph.json"), "utf-8"),
+    );
+    const row = graph.stages.find(
+      (s: { stage_slug: string }) => s.stage_slug === "user-stories",
+    );
+    expect(row).toBeDefined();
+    // The row's memory_path carries the active intent's record dir, not the bare
+    // space prefix - so join(projectDir, memory_path) points at the real diary.
+    expect(row.memory_path).toBe(`${RP}/inception/user-stories/memory.md`);
+  }, TIMEOUT);
+
+  // ===========================================================================
+  // READ SIDE - surface finds the diary + derives the phase under the workspace
+  // layout. Drives the write side first so the row is real, then seeds the diary
+  // at the recorded path.
+  // ===========================================================================
+  test("surface finds the diary and reports the correct phase under the workspace layout", () => {
+    const pd = mkWorkspaceProject();
+    expect(
+      spawnSync(BUN, [RUNTIME_TS, "--project-dir", pd, "compile"], {
+        encoding: "utf-8",
+      }).status,
+    ).toBe(0);
+    // Seed memory.md at the per-intent record path the row now records.
+    const diaryDir = join(seededRecordDir(pd), "inception", "user-stories");
+    mkdirSync(diaryDir, { recursive: true });
+    writeFileSync(join(diaryDir, "memory.md"), memoryDiary());
+
+    const s = spawnSync(
+      BUN,
+      [LEARNINGS_TS, "surface", "--slug", "user-stories", "--project-dir", pd],
+      { encoding: "utf-8" },
+    );
+    expect(s.status).toBe(0);
+    const out = JSON.parse(s.stdout);
+    // The phase is the real one (inception), NOT "spaces" (the old front-index bug).
+    expect(out.phase).toBe("inception");
+    // The diary was resolved: one Interpretations entry -> one candidate.
+    expect(out.candidates.length).toBe(1);
+  }, TIMEOUT);
+
+  // ===========================================================================
+  // LEGACY FLAT LAYOUT - a hand-written flat memory_path still degrades
+  // correctly: the phase is extracted right and no crash. Seeds the flat
+  // aidlc-docs/ shape directly (a pre-workspace project awaiting migration).
+  // ===========================================================================
+  test("surface extracts the right phase from a legacy flat memory_path", () => {
+    const pd = mkWorkspaceProject();
+    // Overwrite the runtime-graph with a flat-layout row (no per-intent prefix).
+    const rec = seededRecordDir(pd);
+    writeFileSync(
+      join(rec, "runtime-graph.json"),
+      JSON.stringify({
+        workflow_id: "w1",
+        scope: "feature",
+        started_at: "2026-05-28T08:00:00Z",
+        stages: [
+          {
+            stage_slug: "user-stories",
+            memory_path: "aidlc-docs/inception/user-stories/memory.md",
+          },
+        ],
+      }),
+    );
+    // Seed the diary at the flat path (relative to projectDir, per surface's join).
+    const flatDir = join(pd, "aidlc-docs", "inception", "user-stories");
+    mkdirSync(flatDir, { recursive: true });
+    writeFileSync(join(flatDir, "memory.md"), memoryDiary());
+
+    const s = spawnSync(
+      BUN,
+      [LEARNINGS_TS, "surface", "--slug", "user-stories", "--project-dir", pd],
+      { encoding: "utf-8" },
+    );
+    expect(s.status).toBe(0);
+    const out = JSON.parse(s.stdout);
+    expect(out.phase).toBe("inception");
+    expect(out.candidates.length).toBe(1);
+  }, TIMEOUT);
+
+  // A guard-rail: the runtime-graph.json must exist where surface reads it (the
+  // seeded record root), proving compile wrote to the per-intent record dir.
+  test("compile writes runtime-graph.json under the per-intent record dir", () => {
+    const pd = mkWorkspaceProject();
+    expect(
+      spawnSync(BUN, [RUNTIME_TS, "--project-dir", pd, "compile"], {
+        encoding: "utf-8",
+      }).status,
+    ).toBe(0);
+    expect(existsSync(join(seededRecordDir(pd), "runtime-graph.json"))).toBe(true);
+  }, TIMEOUT);
+});


### PR DESCRIPTION
Fixes #455 and #468: `learnings surface` was dead under the per-intent workspace layout - it surfaced zero candidates and reported the wrong phase. Two related defects, one on each side of the runtime graph.

## Write side (#468)

The runtime-graph row's `memory_path` was recorded without the active intent's record dir. Both `aidlc-runtime.ts compile` and the `aidlc-state.ts advance` transition called `relativeMemoryPath` with two args, so the `recordPrefix` defaulted to the bare space prefix (`aidlc/spaces/<sp>/intents`) and dropped the `intents/<slug>-<id8>` segment. `surface` then `join()`'d that path against the project dir and opened a nonexistent diary. Both call sites now thread `relativeRecordDir(projectDir)`, the same pattern the orchestrator already uses; a pre-birth shell with no active intent still falls back to the bare space root.

## Read side (#455)

`surface` extracted the phase as `memory_path.split("/")[1]`, which under the workspace prefix is `"spaces"`, never the real phase. `memory_path` always ends `<prefix>/<phase>/<stageSlug>/memory.md` regardless of prefix shape (per-intent record dir, bare space prefix, or the legacy flat `aidlc-docs` root), so the extraction now takes the third-from-last segment. The legacy flat layout keeps working, pinned by a test case.

## Tests

- New `tests/unit/t199-learnings-memory-path.test.ts` pins both sides through the shipped tools' CLI surface: the compile row carries the per-intent record dir, `surface` finds the diary and reports the correct phase under the workspace layout, and the legacy flat path still degrades correctly.
- `t100` pinned the old bare-space advance shape and is updated to expect the per-intent record dir.
- `t99` (integration, learnings gate flow) additionally asserts the surfaced `phase` is the real phase end to end under the workspace layout.
- Verified green: smoke+unit tier (130 files, t84 flake re-run green alone), integration `t99-learnings-gate-flow`, `bun run typecheck`, `bun scripts/package.ts --check`.

Version 2.2.2 with matching CHANGELOG entry and README badge. If a sibling PR takes 2.2.2 first, this re-bumps on rebase.

