### PR TITLE
fix: reviewer Review sections source the date from the shell and name the reviewer persona (2.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [2.2.4] - 2026-07-05
 
-The two review-only agents now record a real UTC timestamp on the `## Review` section they append, instead of a guessed date. The Review template's `Date` field was a bare `[ISO timestamp]` placeholder with no sourcing instruction, so reviewers filled it in from memory; it now instructs the reviewer to run `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output, matching the `[ISO timestamp from Bash]` convention already used elsewhere. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+The two review-only agents now record a real UTC timestamp and their own name on the `## Review` section they append. The Review template's `Date` field was a bare `[ISO timestamp]` placeholder with no sourcing instruction, so reviewers filled it in from memory; it now instructs the reviewer to run `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output, matching the `[ISO timestamp from Bash]` convention already used elsewhere. The template's `Reviewer` field also named the PRODUCER agent (the artifact's author) instead of the reviewer persona, so every review on disk was attributed to the agent whose work was being reviewed; it now names the reviewer persona. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
 
 * Reviewer `## Review` sections (product-lead and architecture-reviewer agents) now carry a real shell-sourced UTC timestamp in the `Date` field rather than an inferred date.
+* The `Reviewer` field in those sections now records the reviewer persona (`aidlc-product-lead-agent` / `aidlc-architecture-reviewer-agent`) instead of the producer agent whose artifact was under review.
 
 ## [2.2.3] - 2026-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.4] - 2026-07-05
+
+The two review-only agents now record a real UTC timestamp on the `## Review` section they append, instead of a guessed date. The Review template's `Date` field was a bare `[ISO timestamp]` placeholder with no sourcing instruction, so reviewers filled it in from memory; it now instructs the reviewer to run `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output, matching the `[ISO timestamp from Bash]` convention already used elsewhere. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* Reviewer `## Review` sections (product-lead and architecture-reviewer agents) now carry a real shell-sourced UTC timestamp in the `Date` field rather than an inferred date.
+
 ## [2.2.3] - 2026-07-05
 
 Fixes a fragile process respawn in the Kiro CLI, Kiro IDE, and Codex hook adapters. Each adapter dispatches the framework's core lifecycle hooks (and, on Kiro, the off-band utility commands) by spawning a child process named `bun` by bare name. That child inherits the hook environment's `$PATH`, which on GUI-launched apps and minimal server environments often omits the bun install dir (`~/.bun/bin`), so the spawn fails with `Executable not found in $PATH: bun` and the whole hook layer dies. The adapters now respawn via the absolute path of the bun binary already running them (`process.execPath`), so the hooks themselves run again without `bun` on `PATH`: audit logging, session lifecycle, state validation, and subagent tracking are fully restored. Known limitation: four core hooks spawn a further `bun` child of their own (the stop guard's engine consult, the statusline state sync, the runtime-graph compile, and the sensor dispatch), and those children still resolve `bun` off `PATH`, so on a `bun`-less `PATH` they stay degraded (the stop guard fails open, the statusline does not update, the runtime graph is not recompiled, sensors do not fire); a follow-up threads the running binary down to those spawns. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.2.3-blue)
+![version](https://img.shields.io/badge/version-2.2.4-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/core/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -56,7 +56,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-architect-agent
+**Reviewer:** aidlc-architecture-reviewer-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/core/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/core/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -57,7 +57,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-architect-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -79,6 +79,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: what's the main architectural concern, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/core/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/core/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -41,7 +41,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-product-agent
+**Reviewer:** aidlc-product-lead-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/core/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/core/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -42,7 +42,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-product-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -57,6 +57,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: overall assessment. What's the main issue holding it back, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.3";
+export const AIDLC_VERSION = "2.2.4";

--- a/dist/claude/.claude/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/claude/.claude/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -56,7 +56,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-architect-agent
+**Reviewer:** aidlc-architecture-reviewer-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/claude/.claude/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/claude/.claude/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -57,7 +57,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-architect-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -79,6 +79,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: what's the main architectural concern, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/claude/.claude/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/claude/.claude/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -41,7 +41,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-product-agent
+**Reviewer:** aidlc-product-lead-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/claude/.claude/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/claude/.claude/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -42,7 +42,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-product-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -57,6 +57,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: overall assessment. What's the main issue holding it back, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.3";
+export const AIDLC_VERSION = "2.2.4";

--- a/dist/codex/.codex/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/codex/.codex/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -56,7 +56,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-architect-agent
+**Reviewer:** aidlc-architecture-reviewer-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/codex/.codex/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/codex/.codex/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -57,7 +57,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-architect-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -79,6 +79,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: what's the main architectural concern, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/codex/.codex/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/codex/.codex/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -41,7 +41,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-product-agent
+**Reviewer:** aidlc-product-lead-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/codex/.codex/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/codex/.codex/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -42,7 +42,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-product-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -57,6 +57,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: overall assessment. What's the main issue holding it back, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.3";
+export const AIDLC_VERSION = "2.2.4";

--- a/dist/kiro-ide/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/kiro-ide/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -56,7 +56,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-architect-agent
+**Reviewer:** aidlc-architecture-reviewer-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/kiro-ide/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/kiro-ide/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -57,7 +57,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-architect-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -79,6 +79,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: what's the main architectural concern, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/kiro-ide/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/kiro-ide/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -41,7 +41,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-product-agent
+**Reviewer:** aidlc-product-lead-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/kiro-ide/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/kiro-ide/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -42,7 +42,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-product-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -57,6 +57,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: overall assessment. What's the main issue holding it back, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.3";
+export const AIDLC_VERSION = "2.2.4";

--- a/dist/kiro/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/kiro/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -56,7 +56,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-architect-agent
+**Reviewer:** aidlc-architecture-reviewer-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/kiro/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+++ b/dist/kiro/.kiro/knowledge/aidlc-architecture-reviewer-agent/reviewing.md
@@ -57,7 +57,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-architect-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -79,6 +79,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: what's the main architectural concern, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/kiro/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/kiro/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -41,7 +41,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 ## Review
 
 **Verdict:** READY | NOT-READY
-**Reviewer:** aidlc-product-agent
+**Reviewer:** aidlc-product-lead-agent
 **Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 

--- a/dist/kiro/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
+++ b/dist/kiro/.kiro/knowledge/aidlc-product-lead-agent/reviewing.md
@@ -42,7 +42,7 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 **Verdict:** READY | NOT-READY
 **Reviewer:** aidlc-product-agent
-**Date:** [ISO timestamp]
+**Date:** [ISO timestamp from Bash]
 **Iteration:** [1, 2, etc.]
 
 ### Findings
@@ -57,6 +57,8 @@ Append a `## Review` section to the PRIMARY artifact file. Use this exact format
 
 [1-2 sentences: overall assessment. What's the main issue holding it back, or why it's ready.]
 ```
+
+For the `Date` field, obtain a real UTC timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output. Never guess or infer the date.
 
 ### Severity Levels
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.3";
+export const AIDLC_VERSION = "2.2.4";

--- a/tests/unit/t200-reviewer-date-instruction.test.ts
+++ b/tests/unit/t200-reviewer-date-instruction.test.ts
@@ -1,0 +1,39 @@
+// covers: file:knowledge/aidlc-product-lead-agent/reviewing.md, file:knowledge/aidlc-architecture-reviewer-agent/reviewing.md
+//
+// t200 - reviewer Date-sourcing pin. The `## Review` template's **Date:**
+// field is model-authored prose with no engine-side timestamp fill, so the
+// template must carry the procedure (run `date -u` in the shell, paste the
+// output), not just the format. A bare `[ISO timestamp]` placeholder lets
+// the reviewer guess the date, and guessed dates drift from the timestamps
+// the CLI tools record for the same stage.
+//
+// Mechanism: none. Pure content check over the shipped knowledge bytes
+// (AIDLC_SRC = dist/claude/.claude; the other trees are byte-guarded by
+// package.ts --check).
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { AIDLC_SRC } from "../harness/fixtures.ts";
+
+const FILES = [
+  ["aidlc-product-lead-agent", "knowledge/aidlc-product-lead-agent/reviewing.md"],
+  ["aidlc-architecture-reviewer-agent", "knowledge/aidlc-architecture-reviewer-agent/reviewing.md"],
+] as const;
+
+describe("t200 reviewer Date field carries a sourcing instruction", () => {
+  for (const [agent, rel] of FILES) {
+    test(`${agent}: template instructs date -u in the shell and forbids guessing`, () => {
+      const body = readFileSync(join(AIDLC_SRC, rel), "utf-8");
+      const dateLines = body.split("\n").filter((l) => l.startsWith("**Date:**"));
+      // Exactly one Date line (the template), and it is no longer the bare
+      // format-only placeholder.
+      expect(dateLines.length).toBe(1);
+      expect(dateLines[0]).not.toBe("**Date:** [ISO timestamp]");
+      // The sourcing instruction: the exact date command, and an explicit
+      // prohibition on guessing.
+      expect(body).toContain('date -u +"%Y-%m-%dT%H:%M:%SZ"');
+      expect(body.toLowerCase()).toContain("guess");
+    });
+  }
+});

--- a/tests/unit/t200-reviewer-date-instruction.test.ts
+++ b/tests/unit/t200-reviewer-date-instruction.test.ts
@@ -35,5 +35,15 @@ describe("t200 reviewer Date field carries a sourcing instruction", () => {
       expect(body).toContain('date -u +"%Y-%m-%dT%H:%M:%SZ"');
       expect(body.toLowerCase()).toContain("guess");
     });
+
+    test(`${agent}: template attributes the review to the reviewer persona, not the producer`, () => {
+      // The maker-checker split exists so the review record shows an
+      // independent checker; a template stamping the PRODUCER's name would
+      // misattribute every review to the agent that wrote the artifact.
+      const body = readFileSync(join(AIDLC_SRC, rel), "utf-8");
+      const reviewerLines = body.split("\n").filter((l) => l.startsWith("**Reviewer:**"));
+      expect(reviewerLines.length).toBe(1);
+      expect(reviewerLines[0]).toBe(`**Reviewer:** ${agent}`);
+    });
   }
 });


### PR DESCRIPTION
Fixes #469: the reviewer `## Review` template's `**Date:** [ISO timestamp]` placeholder carried no instruction to obtain a real timestamp, so the review-only agents (product-lead and architecture-reviewer) filled the `Date` field from memory - a guessed or stale date on the permanent review record.

## Fix

Both `reviewing.md` knowledge files (the only two copies of the template, verified by grep) now:

- change the placeholder to `[ISO timestamp from Bash]`, matching the convention the stage protocol already uses elsewhere, and
- add one instruction line after the template: obtain the timestamp by running `date -u +"%Y-%m-%dT%H:%M:%SZ"` in the shell and paste the actual output, never guess or infer the date.

Both reviewer agents have shell on every harness (Claude inherited, Kiro CLI agent JSON, Kiro IDE tools frontmatter grant, Codex default), so the instruction is executable everywhere with no harness-conditional prose.

## Tests

A new unit test (t200) pins the sourcing instruction in both shipped templates: exactly one Date line, the exact date command present, and an explicit prohibition on guessing, so a future template edit cannot silently regress it. Verified green: smoke+unit tier (129 files), `bun run typecheck`, `bun scripts/package.ts --check` (knowledge files regenerate into all four dist trees).

Version 2.2.4 with matching CHANGELOG entry and README badge. Sibling PRs are in flight with adjacent numbers; whichever merges later re-bumps on rebase.



## Also: Reviewer attribution fix

Fixes #496.

While fixing the Date field, a second template defect in the same two files: the `**Reviewer:**` line named the PRODUCER agent (`aidlc-product-agent` / `aidlc-architect-agent`) instead of the reviewer persona, so every `## Review` section on disk was attributed to the agent whose artifact was under review - misrecording exactly the maker-checker separation the dedicated reviewer personas (added in 3c4c1d9, "No self-review") exist to provide. Both templates now stamp the reviewer persona's own name, and t200 pins the attribution alongside the Date instruction. (#496 was filed independently while this fix was in flight and describes the same defect with the same producer-vs-reviewer analysis.)

