### PR TITLE
fix: detect nested projects in workspace detection (2.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.7] - 2026-07-05
+
+Workspace detection now finds projects nested in a container folder. A project whose source lives one folder down (e.g. `wordbook/`, `backend/`) was classified Greenfield because the scanner only looked at the workspace root plus a fixed source-dir list, so Reverse Engineering was skipped and no codebase understanding was produced. When no top-level signal fires, the scanner now falls back to a one-level-deep scan of each subdirectory (skipping the excluded, sample, and hidden dirs), so a nested codebase is detected as Brownfield. Starting an incremental workflow (`bugfix`, `refactor`, `security-patch`) on a workspace that still scans Greenfield now prints a one-line advisory pointing at fixing the Project Type or the layout; routing is unchanged, since an empty workspace has nothing to reverse-engineer. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* Workspace detection classifies a nested project (source in an arbitrarily-named subdirectory) as Brownfield instead of Greenfield, so Reverse Engineering runs. The fallback is depth-1 only and does not change classification for a normal top-level project. The detected subdirectory is surfaced as `Nested Root` in the `WORKSPACE_SCANNED` audit event and as `nestedRoot` in `/aidlc detect --json`.
+* Starting a `bugfix`, `refactor`, or `security-patch` workflow on a Greenfield-scanned workspace prints a stderr advisory (the scope targets existing code but none was found); it does not change routing or Project Type.
 ## [2.2.6] - 2026-07-05
 
 Approval options during Construction now name the real next stage instead of always saying Code Generation. The run-stage directive carries a computed `next_stage` field (the display name of the following in-scope stage, honouring the active scope and any recomposed EXECUTE/SKIP plan), and the harness question-rendering annexes render the Approve option's "Continue to ..." text from that field verbatim, showing "Complete workflow" on the final in-scope stage. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
@@ -49,6 +55,7 @@ Stops help requests from accidentally creating intents. `/aidlc intent help` was
 * The "Unknown intent" error from a failed `/aidlc intent <name>` switch no longer suggests describing new work; it points at the read-only `/aidlc intent` listing and explicitly says not to start a new workflow to recover. The "Unknown space" error likewise no longer instructs creating the missing space - creation stays a separate, deliberate move.
 * The orchestrator skill's second-intent CONFIRM step named the wrong binary (`aidlc-utility.ts next ...`, which dies with a usage error listing `intent-birth` - a guard-bypass temptation); it now names `aidlc-orchestrate.ts next` on all four harnesses.
 * The Codex orchestrator skill's forwarding loop now tells the conductor to drop the leading `$aidlc`/`/aidlc` invocation marker and forward the remaining text as separate arguments (observed live on Codex exec: the conductor echoed the whole slash line as one quoted token, which hid `intent help` from the router and dead-ended on a scope ask). The engine deliberately does NOT try to repair marker-prefixed input - a mangled echo lands in the scope-confirmation ask, a safe human gate.
+||||||| parent of ef64a3e (fix: detect nested projects in workspace detection (2.2.7))
 
 ## [2.2.0] - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.2.6-blue)
+![version](https://img.shields.io/badge/version-2.2.7-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/stages/initialization/workspace-detection.md
+++ b/core/aidlc-common/stages/initialization/workspace-detection.md
@@ -42,6 +42,8 @@ MANDATORY: Follow stage-protocol.md for state tracking and audit logging.
 
 The scanner walks the project directory one level deep plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`), excluding the harness directories (`.claude/`, `.kiro/`, `.codex/`), `aidlc/`, `node_modules/`, `.git/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`.
 
+Nested-project fallback: when NO top-level signal fires (the layout that would otherwise classify greenfield), the scanner then descends one level into each arbitrarily-named top-level subdirectory (skipping the excluded directories above, hidden dirs, and symlinks) and re-applies the same signal set rooted at that subdirectory. If any subdirectory looks brownfield, the workspace is classified brownfield and that subdirectory's languages/frameworks/build system are merged into the result. This catches a project whose source lives one container down (e.g. `wordbook/`, `backend/`) instead of at the root. The fallback is depth-1 only and never runs when the root already has a source signal.
+
 Scan signals:
 - Directory structure (top-level and key subdirectories)
 - Configuration files (package.json, pom.xml, build.gradle, Cargo.toml, pyproject.toml, etc.)
@@ -59,6 +61,8 @@ Scan signals:
 ### Step 3: Detect Project Type
 
 Classify based on the scanner's evidence:
+
+Signals are evaluated at the root first; if none fires, the nested-project fallback re-evaluates the same signals one level down (see Step 2).
 
 **Brownfield** — ANY of these indicators present:
 - Source code files exist (`.js`, `.ts`, `.jsx`, `.tsx`, `.py`, `.java`, `.go`, `.rs`, `.rb`, `.cs`, `.cpp`, `.c`, `.kt`, `.swift`, `.php`)

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -1764,6 +1764,9 @@ const LANG_BY_EXT: Record<string, string> = {
 };
 
 const SCAN_SOURCE_DIRS = ["src", "app", "lib", "pages", "components", "tests"];
+// Set view for the sweep-side skip in scanSignals: the depth-6 recurse there
+// is the SOLE counter for these dirs, so the file sweep must never enter them.
+const SCAN_SOURCE_DIR_SET: ReadonlySet<string> = new Set(SCAN_SOURCE_DIRS);
 const SCAN_EXCLUDE = new Set([
   ".claude",
   ".kiro",
@@ -1806,13 +1809,22 @@ const NESTED_SCAN_EXCLUDE = new Set([
   "example",
   "samples",
   "sample",
+  "demos",
+  "demo",
+  "reference",
+  "testdata",
+  "fixtures",
+  "templates",
   "scripts",
 ]);
 
+// skipDirs: directory names to skip at THIS level only (not propagated into
+// the recursion); the caller counts those dirs through a separate deeper call.
 function countFilesByLang(
   dir: string,
   counts: Record<string, number>,
-  maxDepth: number
+  maxDepth: number,
+  skipDirs?: ReadonlySet<string>
 ): void {
   if (maxDepth < 0) return;
   let entries: string[];
@@ -1833,6 +1845,7 @@ function countFilesByLang(
     // Don't follow symlinks — cycle protection.
     if (st.isSymbolicLink()) continue;
     if (st.isDirectory()) {
+      if (skipDirs?.has(entry)) continue;
       countFilesByLang(full, counts, maxDepth - 1);
     } else if (st.isFile()) {
       const dot = entry.lastIndexOf(".");
@@ -1959,8 +1972,11 @@ function hasNonDevDeps(projectDir: string): boolean {
 //       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
 //       skip, files only) PLUS a depth-6 recurse into each present
 //       SCAN_SOURCE_DIRS entry.
-//     - a nested container: 6, scanning the whole container one level in so a
-//       project under `wordbook/src/**` or `backend/server/**` is seen.
+//     - a nested container: 1, sweeping the container's own files plus one
+//       level of arbitrary subdirs so a project under `wordbook/**` or
+//       `backend/server/**` is seen. A present SCAN_SOURCE_DIRS entry is
+//       skipped by the sweep: the depth-6 recurse below is its only counter,
+//       so files directly under it are never counted twice.
 interface DirSignals {
   brownfield: boolean;
   langCounts: Record<string, number>;
@@ -1980,9 +1996,14 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
   // under dir (its recursion guard returns immediately at depth -1), matching
   // the base top-level file sweep. Any present known source dir is then
-  // recursed at the base depth cap.
+  // recursed at the base depth cap. The sweep itself never enters a
+  // SCAN_SOURCE_DIRS entry: at depth 1 (the nested-container scan) it would
+  // count the files directly under <dir>/src etc. that the depth-6 recurse
+  // below counts again, inflating that language and potentially flipping the
+  // reported primary. (At the root's depth 0 the skip is a no-op: the sweep
+  // never enters subdirs there.)
   const langCounts: Record<string, number> = {};
-  countFilesByLang(dir, langCounts, fileScanDepth);
+  countFilesByLang(dir, langCounts, fileScanDepth, SCAN_SOURCE_DIR_SET);
   for (const dirName of SCAN_SOURCE_DIRS) {
     if (entrySet.has(dirName)) {
       countFilesByLang(join(dir, dirName), langCounts, 6);

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -1734,6 +1734,11 @@ interface ScanResult {
   languages: string;     // e.g. "TypeScript, JavaScript"
   frameworks: string;    // e.g. "React, Vite"
   buildSystem: string;   // e.g. "npm (package.json)"
+  // Comma-joined top-level subdirectory name(s) the nested-project fallback
+  // classified Brownfield from. Absent when the root itself decided the verdict
+  // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
+  // the `detect --json` payload, never in the state file.
+  nestedRoot?: string;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -1771,6 +1776,37 @@ const SCAN_EXCLUDE = new Set([
   ".next",
   "target",
   "vendor",
+]);
+
+// Package/build manifests that mark a directory as an application (not just
+// scaffolding). Shared by the root scan and the nested-project fallback.
+const SOURCE_MANIFESTS = [
+  "requirements.txt",
+  "pyproject.toml",
+  "setup.py",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "composer.json",
+  "Gemfile",
+];
+
+// Top-level directories the nested-project fallback never descends into: they
+// commonly hold sample/snippet/boilerplate code that is not the project's own
+// source. The harness/VCS/build dirs in SCAN_EXCLUDE and SCAN_SOURCE_DIRS
+// (already scanned at the root) are skipped separately. Lowercased for a
+// case-insensitive match.
+const NESTED_SCAN_EXCLUDE = new Set([
+  "aidlc",
+  "docs",
+  "doc",
+  "examples",
+  "example",
+  "samples",
+  "sample",
+  "scripts",
 ]);
 
 function countFilesByLang(
@@ -1913,6 +1949,69 @@ function hasNonDevDeps(projectDir: string): boolean {
   }
 }
 
+// The signal evaluation for a single directory, used for both the workspace
+// root and (via the nested-project fallback) each depth-1 subdirectory. Returns
+// the raw brownfield signal plus the findings so the caller can aggregate.
+//
+//   fileScanDepth = the countFilesByLang depth for the SOURCE-FILE signal:
+//     - root: 0 for the top-level file sweep (files directly under dir; the
+//       inline top-level loop the base code ran is equivalent to
+//       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
+//       skip, files only) PLUS a depth-6 recurse into each present
+//       SCAN_SOURCE_DIRS entry.
+//     - a nested container: 6, scanning the whole container one level in so a
+//       project under `wordbook/src/**` or `backend/server/**` is seen.
+interface DirSignals {
+  brownfield: boolean;
+  langCounts: Record<string, number>;
+  frameworks: string[];
+  buildSystem: string;
+}
+
+function scanSignals(dir: string, fileScanDepth: number): DirSignals {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // dir doesn't exist yet (caller should scaffold first)
+  }
+  const entrySet = new Set(entries.filter((e) => !SCAN_EXCLUDE.has(e)));
+
+  // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
+  // under dir (its recursion guard returns immediately at depth -1), matching
+  // the base top-level file sweep. Any present known source dir is then
+  // recursed at the base depth cap.
+  const langCounts: Record<string, number> = {};
+  countFilesByLang(dir, langCounts, fileScanDepth);
+  for (const dirName of SCAN_SOURCE_DIRS) {
+    if (entrySet.has(dirName)) {
+      countFilesByLang(join(dir, dirName), langCounts, 6);
+    }
+  }
+
+  const frameworks = detectFrameworks(entrySet, dir);
+  const buildSystem = detectBuildSystem(entrySet, dir);
+
+  // Classification signals (mirror workspace-detection.md Step 3).
+  const hasSourceFiles = Object.keys(langCounts).length > 0;
+  const hasFrameworkConfig = frameworks.length > 0;
+  const hasNonDev = entrySet.has("package.json") && hasNonDevDeps(dir);
+  const hasOtherManifest = SOURCE_MANIFESTS.some((m) => entrySet.has(m));
+  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => entrySet.has(d));
+
+  return {
+    brownfield:
+      hasSourceFiles ||
+      hasFrameworkConfig ||
+      hasNonDev ||
+      hasOtherManifest ||
+      hasAppSourceDir,
+    langCounts,
+    frameworks,
+    buildSystem,
+  };
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -1922,37 +2021,51 @@ export function detectWorkspace(projectDir: string): ScanResult {
   }
   const topSet = new Set(topEntries.filter((e) => !SCAN_EXCLUDE.has(e)));
 
-  // Count source files by language across top-level files + known source dirs
-  const langCounts: Record<string, number> = {};
+  // Root scan (depth 0 for the top-level file sweep, byte-identical to the
+  // base inline loop plus the SCAN_SOURCE_DIRS recurse, both inside scanSignals).
+  const root = scanSignals(projectDir, 0);
+  const langCounts = { ...root.langCounts };
+  const frameworks = [...root.frameworks];
+  let buildSystem = root.buildSystem;
+  let brownfield = root.brownfield;
+  const nestedHits: string[] = [];
 
-  // Top-level files only (no recursion at this depth)
-  for (const entry of topSet) {
-    const full = join(projectDir, entry);
-    let st: import("node:fs").Stats;
-    try {
-      st = lstatSync(full);
-    } catch {
-      continue;
-    }
-    if (st.isSymbolicLink()) continue;
-    if (st.isFile()) {
-      const dot = entry.lastIndexOf(".");
-      if (dot > 0) {
-        const ext = entry.slice(dot).toLowerCase();
-        const lang = LANG_BY_EXT[ext];
-        if (lang) langCounts[lang] = (langCounts[lang] || 0) + 1;
+  // Nested-project fallback: only when the root itself shows NO brownfield
+  // signal. Scan each arbitrarily-named depth-1 subdirectory with the same
+  // signal set (source files one level in via scanSignals(.., 1)), skipping
+  // dot-dirs, NESTED_SCAN_EXCLUDE, the SCAN_SOURCE_DIRS entries already scanned
+  // at the root, symlinks, and non-dirs. Aggregate every hit: languages merged,
+  // frameworks unioned, first non-Unknown build system kept.
+  if (!brownfield) {
+    for (const entry of [...topSet].sort()) {
+      if (entry.startsWith(".")) continue;
+      if (NESTED_SCAN_EXCLUDE.has(entry.toLowerCase())) continue;
+      if (SCAN_SOURCE_DIRS.includes(entry)) continue;
+      const full = join(projectDir, entry);
+      let st: import("node:fs").Stats;
+      try {
+        st = lstatSync(full);
+      } catch {
+        continue;
       }
+      if (st.isSymbolicLink() || !st.isDirectory()) continue;
+
+      const sub = scanSignals(full, 1);
+      if (!sub.brownfield) continue;
+
+      brownfield = true;
+      nestedHits.push(entry);
+      for (const [lang, n] of Object.entries(sub.langCounts)) {
+        langCounts[lang] = (langCounts[lang] || 0) + n;
+      }
+      for (const fw of sub.frameworks) {
+        if (!frameworks.includes(fw)) frameworks.push(fw);
+      }
+      if (buildSystem === "Unknown") buildSystem = sub.buildSystem;
     }
   }
 
-  // Recurse into known source dirs if present (capped depth)
-  for (const dirName of SCAN_SOURCE_DIRS) {
-    if (topSet.has(dirName)) {
-      countFilesByLang(join(projectDir, dirName), langCounts, 6);
-    }
-  }
-
-  // Language list: primary = highest count; secondary = >= 20% of primary count
+  // Language list: primary = highest count; secondary = >= 20% of primary count.
   const sortedLangs = Object.entries(langCounts).sort((a, b) => b[1] - a[1]);
   let languages: string;
   if (sortedLangs.length === 0) {
@@ -1968,41 +2081,14 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
-  const frameworks = detectFrameworks(topSet, projectDir);
-  const frameworksStr = frameworks.length > 0 ? frameworks.join(", ") : "Unknown";
-  const buildSystem = detectBuildSystem(topSet, projectDir);
-
-  // Classification (mirrors workspace-detection.md:66-78)
-  const hasSourceFiles = Object.keys(langCounts).length > 0;
-  const hasFrameworkConfig = frameworks.length > 0;
-  const hasNonDev = topSet.has("package.json") && hasNonDevDeps(projectDir);
-  const hasOtherManifest = [
-    "requirements.txt",
-    "pyproject.toml",
-    "setup.py",
-    "Cargo.toml",
-    "go.mod",
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "composer.json",
-    "Gemfile",
-  ].some((m) => topSet.has(m));
-  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => topSet.has(d));
-
-  const brownfield =
-    hasSourceFiles ||
-    hasFrameworkConfig ||
-    hasNonDev ||
-    hasOtherManifest ||
-    hasAppSourceDir;
-
-  return {
+  const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
-    frameworks: frameworksStr,
+    frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
   };
+  if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -2295,6 +2381,7 @@ function handleIntentBirthStateBuild(
     Languages: scan.languages,
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
+    ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
     Details: "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
@@ -2342,6 +2429,18 @@ function handleIntentBirthStateBuild(
         const idx = executeStages.indexOf(reStage.number);
         if (idx >= 0) executeStages.splice(idx, 1);
         skipStages.push(`${reStage.number} (reverse-engineering — greenfield)`);
+      }
+      // Advisory: the incremental scopes presume existing code, so a greenfield
+      // scan is a likely misread (source nested past the depth-1 fallback, or a
+      // wrong scope). We do NOT override routing (an empty workspace genuinely
+      // has nothing to reverse-engineer); we point the user at the fix.
+      if (["bugfix", "refactor", "security-patch"].includes(scope)) {
+        process.stderr.write(
+          `Note: scope "${scope}" usually targets existing code, but the workspace scanned as Greenfield ` +
+            `so Reverse Engineering will be skipped. If this project has a codebase the scanner missed, ` +
+            `edit "Project Type" to Brownfield in the intent's aidlc-state.md, or move the source so it is ` +
+            `detected (top-level or one folder down), then re-run.\n`,
+        );
       }
     }
   }
@@ -2750,6 +2849,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     languages: scan.languages,
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
+    ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2763,6 +2863,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
+      (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.6";
+export const AIDLC_VERSION = "2.2.7";

--- a/dist/claude/.claude/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/claude/.claude/aidlc-common/stages/initialization/workspace-detection.md
@@ -42,6 +42,8 @@ MANDATORY: Follow stage-protocol.md for state tracking and audit logging.
 
 The scanner walks the project directory one level deep plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`), excluding the harness directories (`.claude/`, `.kiro/`, `.codex/`), `aidlc/`, `node_modules/`, `.git/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`.
 
+Nested-project fallback: when NO top-level signal fires (the layout that would otherwise classify greenfield), the scanner then descends one level into each arbitrarily-named top-level subdirectory (skipping the excluded directories above, hidden dirs, and symlinks) and re-applies the same signal set rooted at that subdirectory. If any subdirectory looks brownfield, the workspace is classified brownfield and that subdirectory's languages/frameworks/build system are merged into the result. This catches a project whose source lives one container down (e.g. `wordbook/`, `backend/`) instead of at the root. The fallback is depth-1 only and never runs when the root already has a source signal.
+
 Scan signals:
 - Directory structure (top-level and key subdirectories)
 - Configuration files (package.json, pom.xml, build.gradle, Cargo.toml, pyproject.toml, etc.)
@@ -59,6 +61,8 @@ Scan signals:
 ### Step 3: Detect Project Type
 
 Classify based on the scanner's evidence:
+
+Signals are evaluated at the root first; if none fires, the nested-project fallback re-evaluates the same signals one level down (see Step 2).
 
 **Brownfield** — ANY of these indicators present:
 - Source code files exist (`.js`, `.ts`, `.jsx`, `.tsx`, `.py`, `.java`, `.go`, `.rs`, `.rb`, `.cs`, `.cpp`, `.c`, `.kt`, `.swift`, `.php`)

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -1764,6 +1764,9 @@ const LANG_BY_EXT: Record<string, string> = {
 };
 
 const SCAN_SOURCE_DIRS = ["src", "app", "lib", "pages", "components", "tests"];
+// Set view for the sweep-side skip in scanSignals: the depth-6 recurse there
+// is the SOLE counter for these dirs, so the file sweep must never enter them.
+const SCAN_SOURCE_DIR_SET: ReadonlySet<string> = new Set(SCAN_SOURCE_DIRS);
 const SCAN_EXCLUDE = new Set([
   ".claude",
   ".kiro",
@@ -1806,13 +1809,22 @@ const NESTED_SCAN_EXCLUDE = new Set([
   "example",
   "samples",
   "sample",
+  "demos",
+  "demo",
+  "reference",
+  "testdata",
+  "fixtures",
+  "templates",
   "scripts",
 ]);
 
+// skipDirs: directory names to skip at THIS level only (not propagated into
+// the recursion); the caller counts those dirs through a separate deeper call.
 function countFilesByLang(
   dir: string,
   counts: Record<string, number>,
-  maxDepth: number
+  maxDepth: number,
+  skipDirs?: ReadonlySet<string>
 ): void {
   if (maxDepth < 0) return;
   let entries: string[];
@@ -1833,6 +1845,7 @@ function countFilesByLang(
     // Don't follow symlinks — cycle protection.
     if (st.isSymbolicLink()) continue;
     if (st.isDirectory()) {
+      if (skipDirs?.has(entry)) continue;
       countFilesByLang(full, counts, maxDepth - 1);
     } else if (st.isFile()) {
       const dot = entry.lastIndexOf(".");
@@ -1959,8 +1972,11 @@ function hasNonDevDeps(projectDir: string): boolean {
 //       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
 //       skip, files only) PLUS a depth-6 recurse into each present
 //       SCAN_SOURCE_DIRS entry.
-//     - a nested container: 6, scanning the whole container one level in so a
-//       project under `wordbook/src/**` or `backend/server/**` is seen.
+//     - a nested container: 1, sweeping the container's own files plus one
+//       level of arbitrary subdirs so a project under `wordbook/**` or
+//       `backend/server/**` is seen. A present SCAN_SOURCE_DIRS entry is
+//       skipped by the sweep: the depth-6 recurse below is its only counter,
+//       so files directly under it are never counted twice.
 interface DirSignals {
   brownfield: boolean;
   langCounts: Record<string, number>;
@@ -1980,9 +1996,14 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
   // under dir (its recursion guard returns immediately at depth -1), matching
   // the base top-level file sweep. Any present known source dir is then
-  // recursed at the base depth cap.
+  // recursed at the base depth cap. The sweep itself never enters a
+  // SCAN_SOURCE_DIRS entry: at depth 1 (the nested-container scan) it would
+  // count the files directly under <dir>/src etc. that the depth-6 recurse
+  // below counts again, inflating that language and potentially flipping the
+  // reported primary. (At the root's depth 0 the skip is a no-op: the sweep
+  // never enters subdirs there.)
   const langCounts: Record<string, number> = {};
-  countFilesByLang(dir, langCounts, fileScanDepth);
+  countFilesByLang(dir, langCounts, fileScanDepth, SCAN_SOURCE_DIR_SET);
   for (const dirName of SCAN_SOURCE_DIRS) {
     if (entrySet.has(dirName)) {
       countFilesByLang(join(dir, dirName), langCounts, 6);

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -1734,6 +1734,11 @@ interface ScanResult {
   languages: string;     // e.g. "TypeScript, JavaScript"
   frameworks: string;    // e.g. "React, Vite"
   buildSystem: string;   // e.g. "npm (package.json)"
+  // Comma-joined top-level subdirectory name(s) the nested-project fallback
+  // classified Brownfield from. Absent when the root itself decided the verdict
+  // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
+  // the `detect --json` payload, never in the state file.
+  nestedRoot?: string;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -1771,6 +1776,37 @@ const SCAN_EXCLUDE = new Set([
   ".next",
   "target",
   "vendor",
+]);
+
+// Package/build manifests that mark a directory as an application (not just
+// scaffolding). Shared by the root scan and the nested-project fallback.
+const SOURCE_MANIFESTS = [
+  "requirements.txt",
+  "pyproject.toml",
+  "setup.py",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "composer.json",
+  "Gemfile",
+];
+
+// Top-level directories the nested-project fallback never descends into: they
+// commonly hold sample/snippet/boilerplate code that is not the project's own
+// source. The harness/VCS/build dirs in SCAN_EXCLUDE and SCAN_SOURCE_DIRS
+// (already scanned at the root) are skipped separately. Lowercased for a
+// case-insensitive match.
+const NESTED_SCAN_EXCLUDE = new Set([
+  "aidlc",
+  "docs",
+  "doc",
+  "examples",
+  "example",
+  "samples",
+  "sample",
+  "scripts",
 ]);
 
 function countFilesByLang(
@@ -1913,6 +1949,69 @@ function hasNonDevDeps(projectDir: string): boolean {
   }
 }
 
+// The signal evaluation for a single directory, used for both the workspace
+// root and (via the nested-project fallback) each depth-1 subdirectory. Returns
+// the raw brownfield signal plus the findings so the caller can aggregate.
+//
+//   fileScanDepth = the countFilesByLang depth for the SOURCE-FILE signal:
+//     - root: 0 for the top-level file sweep (files directly under dir; the
+//       inline top-level loop the base code ran is equivalent to
+//       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
+//       skip, files only) PLUS a depth-6 recurse into each present
+//       SCAN_SOURCE_DIRS entry.
+//     - a nested container: 6, scanning the whole container one level in so a
+//       project under `wordbook/src/**` or `backend/server/**` is seen.
+interface DirSignals {
+  brownfield: boolean;
+  langCounts: Record<string, number>;
+  frameworks: string[];
+  buildSystem: string;
+}
+
+function scanSignals(dir: string, fileScanDepth: number): DirSignals {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // dir doesn't exist yet (caller should scaffold first)
+  }
+  const entrySet = new Set(entries.filter((e) => !SCAN_EXCLUDE.has(e)));
+
+  // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
+  // under dir (its recursion guard returns immediately at depth -1), matching
+  // the base top-level file sweep. Any present known source dir is then
+  // recursed at the base depth cap.
+  const langCounts: Record<string, number> = {};
+  countFilesByLang(dir, langCounts, fileScanDepth);
+  for (const dirName of SCAN_SOURCE_DIRS) {
+    if (entrySet.has(dirName)) {
+      countFilesByLang(join(dir, dirName), langCounts, 6);
+    }
+  }
+
+  const frameworks = detectFrameworks(entrySet, dir);
+  const buildSystem = detectBuildSystem(entrySet, dir);
+
+  // Classification signals (mirror workspace-detection.md Step 3).
+  const hasSourceFiles = Object.keys(langCounts).length > 0;
+  const hasFrameworkConfig = frameworks.length > 0;
+  const hasNonDev = entrySet.has("package.json") && hasNonDevDeps(dir);
+  const hasOtherManifest = SOURCE_MANIFESTS.some((m) => entrySet.has(m));
+  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => entrySet.has(d));
+
+  return {
+    brownfield:
+      hasSourceFiles ||
+      hasFrameworkConfig ||
+      hasNonDev ||
+      hasOtherManifest ||
+      hasAppSourceDir,
+    langCounts,
+    frameworks,
+    buildSystem,
+  };
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -1922,37 +2021,51 @@ export function detectWorkspace(projectDir: string): ScanResult {
   }
   const topSet = new Set(topEntries.filter((e) => !SCAN_EXCLUDE.has(e)));
 
-  // Count source files by language across top-level files + known source dirs
-  const langCounts: Record<string, number> = {};
+  // Root scan (depth 0 for the top-level file sweep, byte-identical to the
+  // base inline loop plus the SCAN_SOURCE_DIRS recurse, both inside scanSignals).
+  const root = scanSignals(projectDir, 0);
+  const langCounts = { ...root.langCounts };
+  const frameworks = [...root.frameworks];
+  let buildSystem = root.buildSystem;
+  let brownfield = root.brownfield;
+  const nestedHits: string[] = [];
 
-  // Top-level files only (no recursion at this depth)
-  for (const entry of topSet) {
-    const full = join(projectDir, entry);
-    let st: import("node:fs").Stats;
-    try {
-      st = lstatSync(full);
-    } catch {
-      continue;
-    }
-    if (st.isSymbolicLink()) continue;
-    if (st.isFile()) {
-      const dot = entry.lastIndexOf(".");
-      if (dot > 0) {
-        const ext = entry.slice(dot).toLowerCase();
-        const lang = LANG_BY_EXT[ext];
-        if (lang) langCounts[lang] = (langCounts[lang] || 0) + 1;
+  // Nested-project fallback: only when the root itself shows NO brownfield
+  // signal. Scan each arbitrarily-named depth-1 subdirectory with the same
+  // signal set (source files one level in via scanSignals(.., 1)), skipping
+  // dot-dirs, NESTED_SCAN_EXCLUDE, the SCAN_SOURCE_DIRS entries already scanned
+  // at the root, symlinks, and non-dirs. Aggregate every hit: languages merged,
+  // frameworks unioned, first non-Unknown build system kept.
+  if (!brownfield) {
+    for (const entry of [...topSet].sort()) {
+      if (entry.startsWith(".")) continue;
+      if (NESTED_SCAN_EXCLUDE.has(entry.toLowerCase())) continue;
+      if (SCAN_SOURCE_DIRS.includes(entry)) continue;
+      const full = join(projectDir, entry);
+      let st: import("node:fs").Stats;
+      try {
+        st = lstatSync(full);
+      } catch {
+        continue;
       }
+      if (st.isSymbolicLink() || !st.isDirectory()) continue;
+
+      const sub = scanSignals(full, 1);
+      if (!sub.brownfield) continue;
+
+      brownfield = true;
+      nestedHits.push(entry);
+      for (const [lang, n] of Object.entries(sub.langCounts)) {
+        langCounts[lang] = (langCounts[lang] || 0) + n;
+      }
+      for (const fw of sub.frameworks) {
+        if (!frameworks.includes(fw)) frameworks.push(fw);
+      }
+      if (buildSystem === "Unknown") buildSystem = sub.buildSystem;
     }
   }
 
-  // Recurse into known source dirs if present (capped depth)
-  for (const dirName of SCAN_SOURCE_DIRS) {
-    if (topSet.has(dirName)) {
-      countFilesByLang(join(projectDir, dirName), langCounts, 6);
-    }
-  }
-
-  // Language list: primary = highest count; secondary = >= 20% of primary count
+  // Language list: primary = highest count; secondary = >= 20% of primary count.
   const sortedLangs = Object.entries(langCounts).sort((a, b) => b[1] - a[1]);
   let languages: string;
   if (sortedLangs.length === 0) {
@@ -1968,41 +2081,14 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
-  const frameworks = detectFrameworks(topSet, projectDir);
-  const frameworksStr = frameworks.length > 0 ? frameworks.join(", ") : "Unknown";
-  const buildSystem = detectBuildSystem(topSet, projectDir);
-
-  // Classification (mirrors workspace-detection.md:66-78)
-  const hasSourceFiles = Object.keys(langCounts).length > 0;
-  const hasFrameworkConfig = frameworks.length > 0;
-  const hasNonDev = topSet.has("package.json") && hasNonDevDeps(projectDir);
-  const hasOtherManifest = [
-    "requirements.txt",
-    "pyproject.toml",
-    "setup.py",
-    "Cargo.toml",
-    "go.mod",
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "composer.json",
-    "Gemfile",
-  ].some((m) => topSet.has(m));
-  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => topSet.has(d));
-
-  const brownfield =
-    hasSourceFiles ||
-    hasFrameworkConfig ||
-    hasNonDev ||
-    hasOtherManifest ||
-    hasAppSourceDir;
-
-  return {
+  const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
-    frameworks: frameworksStr,
+    frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
   };
+  if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -2295,6 +2381,7 @@ function handleIntentBirthStateBuild(
     Languages: scan.languages,
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
+    ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
     Details: "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
@@ -2342,6 +2429,18 @@ function handleIntentBirthStateBuild(
         const idx = executeStages.indexOf(reStage.number);
         if (idx >= 0) executeStages.splice(idx, 1);
         skipStages.push(`${reStage.number} (reverse-engineering — greenfield)`);
+      }
+      // Advisory: the incremental scopes presume existing code, so a greenfield
+      // scan is a likely misread (source nested past the depth-1 fallback, or a
+      // wrong scope). We do NOT override routing (an empty workspace genuinely
+      // has nothing to reverse-engineer); we point the user at the fix.
+      if (["bugfix", "refactor", "security-patch"].includes(scope)) {
+        process.stderr.write(
+          `Note: scope "${scope}" usually targets existing code, but the workspace scanned as Greenfield ` +
+            `so Reverse Engineering will be skipped. If this project has a codebase the scanner missed, ` +
+            `edit "Project Type" to Brownfield in the intent's aidlc-state.md, or move the source so it is ` +
+            `detected (top-level or one folder down), then re-run.\n`,
+        );
       }
     }
   }
@@ -2750,6 +2849,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     languages: scan.languages,
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
+    ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2763,6 +2863,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
+      (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.6";
+export const AIDLC_VERSION = "2.2.7";

--- a/dist/codex/.codex/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/codex/.codex/aidlc-common/stages/initialization/workspace-detection.md
@@ -42,6 +42,8 @@ MANDATORY: Follow stage-protocol.md for state tracking and audit logging.
 
 The scanner walks the project directory one level deep plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`), excluding the harness directories (`.claude/`, `.kiro/`, `.codex/`), `aidlc/`, `node_modules/`, `.git/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`.
 
+Nested-project fallback: when NO top-level signal fires (the layout that would otherwise classify greenfield), the scanner then descends one level into each arbitrarily-named top-level subdirectory (skipping the excluded directories above, hidden dirs, and symlinks) and re-applies the same signal set rooted at that subdirectory. If any subdirectory looks brownfield, the workspace is classified brownfield and that subdirectory's languages/frameworks/build system are merged into the result. This catches a project whose source lives one container down (e.g. `wordbook/`, `backend/`) instead of at the root. The fallback is depth-1 only and never runs when the root already has a source signal.
+
 Scan signals:
 - Directory structure (top-level and key subdirectories)
 - Configuration files (package.json, pom.xml, build.gradle, Cargo.toml, pyproject.toml, etc.)
@@ -59,6 +61,8 @@ Scan signals:
 ### Step 3: Detect Project Type
 
 Classify based on the scanner's evidence:
+
+Signals are evaluated at the root first; if none fires, the nested-project fallback re-evaluates the same signals one level down (see Step 2).
 
 **Brownfield** — ANY of these indicators present:
 - Source code files exist (`.js`, `.ts`, `.jsx`, `.tsx`, `.py`, `.java`, `.go`, `.rs`, `.rb`, `.cs`, `.cpp`, `.c`, `.kt`, `.swift`, `.php`)

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -1764,6 +1764,9 @@ const LANG_BY_EXT: Record<string, string> = {
 };
 
 const SCAN_SOURCE_DIRS = ["src", "app", "lib", "pages", "components", "tests"];
+// Set view for the sweep-side skip in scanSignals: the depth-6 recurse there
+// is the SOLE counter for these dirs, so the file sweep must never enter them.
+const SCAN_SOURCE_DIR_SET: ReadonlySet<string> = new Set(SCAN_SOURCE_DIRS);
 const SCAN_EXCLUDE = new Set([
   ".claude",
   ".kiro",
@@ -1806,13 +1809,22 @@ const NESTED_SCAN_EXCLUDE = new Set([
   "example",
   "samples",
   "sample",
+  "demos",
+  "demo",
+  "reference",
+  "testdata",
+  "fixtures",
+  "templates",
   "scripts",
 ]);
 
+// skipDirs: directory names to skip at THIS level only (not propagated into
+// the recursion); the caller counts those dirs through a separate deeper call.
 function countFilesByLang(
   dir: string,
   counts: Record<string, number>,
-  maxDepth: number
+  maxDepth: number,
+  skipDirs?: ReadonlySet<string>
 ): void {
   if (maxDepth < 0) return;
   let entries: string[];
@@ -1833,6 +1845,7 @@ function countFilesByLang(
     // Don't follow symlinks — cycle protection.
     if (st.isSymbolicLink()) continue;
     if (st.isDirectory()) {
+      if (skipDirs?.has(entry)) continue;
       countFilesByLang(full, counts, maxDepth - 1);
     } else if (st.isFile()) {
       const dot = entry.lastIndexOf(".");
@@ -1959,8 +1972,11 @@ function hasNonDevDeps(projectDir: string): boolean {
 //       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
 //       skip, files only) PLUS a depth-6 recurse into each present
 //       SCAN_SOURCE_DIRS entry.
-//     - a nested container: 6, scanning the whole container one level in so a
-//       project under `wordbook/src/**` or `backend/server/**` is seen.
+//     - a nested container: 1, sweeping the container's own files plus one
+//       level of arbitrary subdirs so a project under `wordbook/**` or
+//       `backend/server/**` is seen. A present SCAN_SOURCE_DIRS entry is
+//       skipped by the sweep: the depth-6 recurse below is its only counter,
+//       so files directly under it are never counted twice.
 interface DirSignals {
   brownfield: boolean;
   langCounts: Record<string, number>;
@@ -1980,9 +1996,14 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
   // under dir (its recursion guard returns immediately at depth -1), matching
   // the base top-level file sweep. Any present known source dir is then
-  // recursed at the base depth cap.
+  // recursed at the base depth cap. The sweep itself never enters a
+  // SCAN_SOURCE_DIRS entry: at depth 1 (the nested-container scan) it would
+  // count the files directly under <dir>/src etc. that the depth-6 recurse
+  // below counts again, inflating that language and potentially flipping the
+  // reported primary. (At the root's depth 0 the skip is a no-op: the sweep
+  // never enters subdirs there.)
   const langCounts: Record<string, number> = {};
-  countFilesByLang(dir, langCounts, fileScanDepth);
+  countFilesByLang(dir, langCounts, fileScanDepth, SCAN_SOURCE_DIR_SET);
   for (const dirName of SCAN_SOURCE_DIRS) {
     if (entrySet.has(dirName)) {
       countFilesByLang(join(dir, dirName), langCounts, 6);

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -1734,6 +1734,11 @@ interface ScanResult {
   languages: string;     // e.g. "TypeScript, JavaScript"
   frameworks: string;    // e.g. "React, Vite"
   buildSystem: string;   // e.g. "npm (package.json)"
+  // Comma-joined top-level subdirectory name(s) the nested-project fallback
+  // classified Brownfield from. Absent when the root itself decided the verdict
+  // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
+  // the `detect --json` payload, never in the state file.
+  nestedRoot?: string;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -1771,6 +1776,37 @@ const SCAN_EXCLUDE = new Set([
   ".next",
   "target",
   "vendor",
+]);
+
+// Package/build manifests that mark a directory as an application (not just
+// scaffolding). Shared by the root scan and the nested-project fallback.
+const SOURCE_MANIFESTS = [
+  "requirements.txt",
+  "pyproject.toml",
+  "setup.py",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "composer.json",
+  "Gemfile",
+];
+
+// Top-level directories the nested-project fallback never descends into: they
+// commonly hold sample/snippet/boilerplate code that is not the project's own
+// source. The harness/VCS/build dirs in SCAN_EXCLUDE and SCAN_SOURCE_DIRS
+// (already scanned at the root) are skipped separately. Lowercased for a
+// case-insensitive match.
+const NESTED_SCAN_EXCLUDE = new Set([
+  "aidlc",
+  "docs",
+  "doc",
+  "examples",
+  "example",
+  "samples",
+  "sample",
+  "scripts",
 ]);
 
 function countFilesByLang(
@@ -1913,6 +1949,69 @@ function hasNonDevDeps(projectDir: string): boolean {
   }
 }
 
+// The signal evaluation for a single directory, used for both the workspace
+// root and (via the nested-project fallback) each depth-1 subdirectory. Returns
+// the raw brownfield signal plus the findings so the caller can aggregate.
+//
+//   fileScanDepth = the countFilesByLang depth for the SOURCE-FILE signal:
+//     - root: 0 for the top-level file sweep (files directly under dir; the
+//       inline top-level loop the base code ran is equivalent to
+//       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
+//       skip, files only) PLUS a depth-6 recurse into each present
+//       SCAN_SOURCE_DIRS entry.
+//     - a nested container: 6, scanning the whole container one level in so a
+//       project under `wordbook/src/**` or `backend/server/**` is seen.
+interface DirSignals {
+  brownfield: boolean;
+  langCounts: Record<string, number>;
+  frameworks: string[];
+  buildSystem: string;
+}
+
+function scanSignals(dir: string, fileScanDepth: number): DirSignals {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // dir doesn't exist yet (caller should scaffold first)
+  }
+  const entrySet = new Set(entries.filter((e) => !SCAN_EXCLUDE.has(e)));
+
+  // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
+  // under dir (its recursion guard returns immediately at depth -1), matching
+  // the base top-level file sweep. Any present known source dir is then
+  // recursed at the base depth cap.
+  const langCounts: Record<string, number> = {};
+  countFilesByLang(dir, langCounts, fileScanDepth);
+  for (const dirName of SCAN_SOURCE_DIRS) {
+    if (entrySet.has(dirName)) {
+      countFilesByLang(join(dir, dirName), langCounts, 6);
+    }
+  }
+
+  const frameworks = detectFrameworks(entrySet, dir);
+  const buildSystem = detectBuildSystem(entrySet, dir);
+
+  // Classification signals (mirror workspace-detection.md Step 3).
+  const hasSourceFiles = Object.keys(langCounts).length > 0;
+  const hasFrameworkConfig = frameworks.length > 0;
+  const hasNonDev = entrySet.has("package.json") && hasNonDevDeps(dir);
+  const hasOtherManifest = SOURCE_MANIFESTS.some((m) => entrySet.has(m));
+  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => entrySet.has(d));
+
+  return {
+    brownfield:
+      hasSourceFiles ||
+      hasFrameworkConfig ||
+      hasNonDev ||
+      hasOtherManifest ||
+      hasAppSourceDir,
+    langCounts,
+    frameworks,
+    buildSystem,
+  };
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -1922,37 +2021,51 @@ export function detectWorkspace(projectDir: string): ScanResult {
   }
   const topSet = new Set(topEntries.filter((e) => !SCAN_EXCLUDE.has(e)));
 
-  // Count source files by language across top-level files + known source dirs
-  const langCounts: Record<string, number> = {};
+  // Root scan (depth 0 for the top-level file sweep, byte-identical to the
+  // base inline loop plus the SCAN_SOURCE_DIRS recurse, both inside scanSignals).
+  const root = scanSignals(projectDir, 0);
+  const langCounts = { ...root.langCounts };
+  const frameworks = [...root.frameworks];
+  let buildSystem = root.buildSystem;
+  let brownfield = root.brownfield;
+  const nestedHits: string[] = [];
 
-  // Top-level files only (no recursion at this depth)
-  for (const entry of topSet) {
-    const full = join(projectDir, entry);
-    let st: import("node:fs").Stats;
-    try {
-      st = lstatSync(full);
-    } catch {
-      continue;
-    }
-    if (st.isSymbolicLink()) continue;
-    if (st.isFile()) {
-      const dot = entry.lastIndexOf(".");
-      if (dot > 0) {
-        const ext = entry.slice(dot).toLowerCase();
-        const lang = LANG_BY_EXT[ext];
-        if (lang) langCounts[lang] = (langCounts[lang] || 0) + 1;
+  // Nested-project fallback: only when the root itself shows NO brownfield
+  // signal. Scan each arbitrarily-named depth-1 subdirectory with the same
+  // signal set (source files one level in via scanSignals(.., 1)), skipping
+  // dot-dirs, NESTED_SCAN_EXCLUDE, the SCAN_SOURCE_DIRS entries already scanned
+  // at the root, symlinks, and non-dirs. Aggregate every hit: languages merged,
+  // frameworks unioned, first non-Unknown build system kept.
+  if (!brownfield) {
+    for (const entry of [...topSet].sort()) {
+      if (entry.startsWith(".")) continue;
+      if (NESTED_SCAN_EXCLUDE.has(entry.toLowerCase())) continue;
+      if (SCAN_SOURCE_DIRS.includes(entry)) continue;
+      const full = join(projectDir, entry);
+      let st: import("node:fs").Stats;
+      try {
+        st = lstatSync(full);
+      } catch {
+        continue;
       }
+      if (st.isSymbolicLink() || !st.isDirectory()) continue;
+
+      const sub = scanSignals(full, 1);
+      if (!sub.brownfield) continue;
+
+      brownfield = true;
+      nestedHits.push(entry);
+      for (const [lang, n] of Object.entries(sub.langCounts)) {
+        langCounts[lang] = (langCounts[lang] || 0) + n;
+      }
+      for (const fw of sub.frameworks) {
+        if (!frameworks.includes(fw)) frameworks.push(fw);
+      }
+      if (buildSystem === "Unknown") buildSystem = sub.buildSystem;
     }
   }
 
-  // Recurse into known source dirs if present (capped depth)
-  for (const dirName of SCAN_SOURCE_DIRS) {
-    if (topSet.has(dirName)) {
-      countFilesByLang(join(projectDir, dirName), langCounts, 6);
-    }
-  }
-
-  // Language list: primary = highest count; secondary = >= 20% of primary count
+  // Language list: primary = highest count; secondary = >= 20% of primary count.
   const sortedLangs = Object.entries(langCounts).sort((a, b) => b[1] - a[1]);
   let languages: string;
   if (sortedLangs.length === 0) {
@@ -1968,41 +2081,14 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
-  const frameworks = detectFrameworks(topSet, projectDir);
-  const frameworksStr = frameworks.length > 0 ? frameworks.join(", ") : "Unknown";
-  const buildSystem = detectBuildSystem(topSet, projectDir);
-
-  // Classification (mirrors workspace-detection.md:66-78)
-  const hasSourceFiles = Object.keys(langCounts).length > 0;
-  const hasFrameworkConfig = frameworks.length > 0;
-  const hasNonDev = topSet.has("package.json") && hasNonDevDeps(projectDir);
-  const hasOtherManifest = [
-    "requirements.txt",
-    "pyproject.toml",
-    "setup.py",
-    "Cargo.toml",
-    "go.mod",
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "composer.json",
-    "Gemfile",
-  ].some((m) => topSet.has(m));
-  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => topSet.has(d));
-
-  const brownfield =
-    hasSourceFiles ||
-    hasFrameworkConfig ||
-    hasNonDev ||
-    hasOtherManifest ||
-    hasAppSourceDir;
-
-  return {
+  const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
-    frameworks: frameworksStr,
+    frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
   };
+  if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -2295,6 +2381,7 @@ function handleIntentBirthStateBuild(
     Languages: scan.languages,
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
+    ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
     Details: "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
@@ -2342,6 +2429,18 @@ function handleIntentBirthStateBuild(
         const idx = executeStages.indexOf(reStage.number);
         if (idx >= 0) executeStages.splice(idx, 1);
         skipStages.push(`${reStage.number} (reverse-engineering — greenfield)`);
+      }
+      // Advisory: the incremental scopes presume existing code, so a greenfield
+      // scan is a likely misread (source nested past the depth-1 fallback, or a
+      // wrong scope). We do NOT override routing (an empty workspace genuinely
+      // has nothing to reverse-engineer); we point the user at the fix.
+      if (["bugfix", "refactor", "security-patch"].includes(scope)) {
+        process.stderr.write(
+          `Note: scope "${scope}" usually targets existing code, but the workspace scanned as Greenfield ` +
+            `so Reverse Engineering will be skipped. If this project has a codebase the scanner missed, ` +
+            `edit "Project Type" to Brownfield in the intent's aidlc-state.md, or move the source so it is ` +
+            `detected (top-level or one folder down), then re-run.\n`,
+        );
       }
     }
   }
@@ -2750,6 +2849,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     languages: scan.languages,
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
+    ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2763,6 +2863,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
+      (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.6";
+export const AIDLC_VERSION = "2.2.7";

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/initialization/workspace-detection.md
@@ -42,6 +42,8 @@ MANDATORY: Follow stage-protocol.md for state tracking and audit logging.
 
 The scanner walks the project directory one level deep plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`), excluding the harness directories (`.claude/`, `.kiro/`, `.codex/`), `aidlc/`, `node_modules/`, `.git/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`.
 
+Nested-project fallback: when NO top-level signal fires (the layout that would otherwise classify greenfield), the scanner then descends one level into each arbitrarily-named top-level subdirectory (skipping the excluded directories above, hidden dirs, and symlinks) and re-applies the same signal set rooted at that subdirectory. If any subdirectory looks brownfield, the workspace is classified brownfield and that subdirectory's languages/frameworks/build system are merged into the result. This catches a project whose source lives one container down (e.g. `wordbook/`, `backend/`) instead of at the root. The fallback is depth-1 only and never runs when the root already has a source signal.
+
 Scan signals:
 - Directory structure (top-level and key subdirectories)
 - Configuration files (package.json, pom.xml, build.gradle, Cargo.toml, pyproject.toml, etc.)
@@ -59,6 +61,8 @@ Scan signals:
 ### Step 3: Detect Project Type
 
 Classify based on the scanner's evidence:
+
+Signals are evaluated at the root first; if none fires, the nested-project fallback re-evaluates the same signals one level down (see Step 2).
 
 **Brownfield** — ANY of these indicators present:
 - Source code files exist (`.js`, `.ts`, `.jsx`, `.tsx`, `.py`, `.java`, `.go`, `.rs`, `.rb`, `.cs`, `.cpp`, `.c`, `.kt`, `.swift`, `.php`)

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -1764,6 +1764,9 @@ const LANG_BY_EXT: Record<string, string> = {
 };
 
 const SCAN_SOURCE_DIRS = ["src", "app", "lib", "pages", "components", "tests"];
+// Set view for the sweep-side skip in scanSignals: the depth-6 recurse there
+// is the SOLE counter for these dirs, so the file sweep must never enter them.
+const SCAN_SOURCE_DIR_SET: ReadonlySet<string> = new Set(SCAN_SOURCE_DIRS);
 const SCAN_EXCLUDE = new Set([
   ".claude",
   ".kiro",
@@ -1806,13 +1809,22 @@ const NESTED_SCAN_EXCLUDE = new Set([
   "example",
   "samples",
   "sample",
+  "demos",
+  "demo",
+  "reference",
+  "testdata",
+  "fixtures",
+  "templates",
   "scripts",
 ]);
 
+// skipDirs: directory names to skip at THIS level only (not propagated into
+// the recursion); the caller counts those dirs through a separate deeper call.
 function countFilesByLang(
   dir: string,
   counts: Record<string, number>,
-  maxDepth: number
+  maxDepth: number,
+  skipDirs?: ReadonlySet<string>
 ): void {
   if (maxDepth < 0) return;
   let entries: string[];
@@ -1833,6 +1845,7 @@ function countFilesByLang(
     // Don't follow symlinks — cycle protection.
     if (st.isSymbolicLink()) continue;
     if (st.isDirectory()) {
+      if (skipDirs?.has(entry)) continue;
       countFilesByLang(full, counts, maxDepth - 1);
     } else if (st.isFile()) {
       const dot = entry.lastIndexOf(".");
@@ -1959,8 +1972,11 @@ function hasNonDevDeps(projectDir: string): boolean {
 //       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
 //       skip, files only) PLUS a depth-6 recurse into each present
 //       SCAN_SOURCE_DIRS entry.
-//     - a nested container: 6, scanning the whole container one level in so a
-//       project under `wordbook/src/**` or `backend/server/**` is seen.
+//     - a nested container: 1, sweeping the container's own files plus one
+//       level of arbitrary subdirs so a project under `wordbook/**` or
+//       `backend/server/**` is seen. A present SCAN_SOURCE_DIRS entry is
+//       skipped by the sweep: the depth-6 recurse below is its only counter,
+//       so files directly under it are never counted twice.
 interface DirSignals {
   brownfield: boolean;
   langCounts: Record<string, number>;
@@ -1980,9 +1996,14 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
   // under dir (its recursion guard returns immediately at depth -1), matching
   // the base top-level file sweep. Any present known source dir is then
-  // recursed at the base depth cap.
+  // recursed at the base depth cap. The sweep itself never enters a
+  // SCAN_SOURCE_DIRS entry: at depth 1 (the nested-container scan) it would
+  // count the files directly under <dir>/src etc. that the depth-6 recurse
+  // below counts again, inflating that language and potentially flipping the
+  // reported primary. (At the root's depth 0 the skip is a no-op: the sweep
+  // never enters subdirs there.)
   const langCounts: Record<string, number> = {};
-  countFilesByLang(dir, langCounts, fileScanDepth);
+  countFilesByLang(dir, langCounts, fileScanDepth, SCAN_SOURCE_DIR_SET);
   for (const dirName of SCAN_SOURCE_DIRS) {
     if (entrySet.has(dirName)) {
       countFilesByLang(join(dir, dirName), langCounts, 6);

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -1734,6 +1734,11 @@ interface ScanResult {
   languages: string;     // e.g. "TypeScript, JavaScript"
   frameworks: string;    // e.g. "React, Vite"
   buildSystem: string;   // e.g. "npm (package.json)"
+  // Comma-joined top-level subdirectory name(s) the nested-project fallback
+  // classified Brownfield from. Absent when the root itself decided the verdict
+  // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
+  // the `detect --json` payload, never in the state file.
+  nestedRoot?: string;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -1771,6 +1776,37 @@ const SCAN_EXCLUDE = new Set([
   ".next",
   "target",
   "vendor",
+]);
+
+// Package/build manifests that mark a directory as an application (not just
+// scaffolding). Shared by the root scan and the nested-project fallback.
+const SOURCE_MANIFESTS = [
+  "requirements.txt",
+  "pyproject.toml",
+  "setup.py",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "composer.json",
+  "Gemfile",
+];
+
+// Top-level directories the nested-project fallback never descends into: they
+// commonly hold sample/snippet/boilerplate code that is not the project's own
+// source. The harness/VCS/build dirs in SCAN_EXCLUDE and SCAN_SOURCE_DIRS
+// (already scanned at the root) are skipped separately. Lowercased for a
+// case-insensitive match.
+const NESTED_SCAN_EXCLUDE = new Set([
+  "aidlc",
+  "docs",
+  "doc",
+  "examples",
+  "example",
+  "samples",
+  "sample",
+  "scripts",
 ]);
 
 function countFilesByLang(
@@ -1913,6 +1949,69 @@ function hasNonDevDeps(projectDir: string): boolean {
   }
 }
 
+// The signal evaluation for a single directory, used for both the workspace
+// root and (via the nested-project fallback) each depth-1 subdirectory. Returns
+// the raw brownfield signal plus the findings so the caller can aggregate.
+//
+//   fileScanDepth = the countFilesByLang depth for the SOURCE-FILE signal:
+//     - root: 0 for the top-level file sweep (files directly under dir; the
+//       inline top-level loop the base code ran is equivalent to
+//       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
+//       skip, files only) PLUS a depth-6 recurse into each present
+//       SCAN_SOURCE_DIRS entry.
+//     - a nested container: 6, scanning the whole container one level in so a
+//       project under `wordbook/src/**` or `backend/server/**` is seen.
+interface DirSignals {
+  brownfield: boolean;
+  langCounts: Record<string, number>;
+  frameworks: string[];
+  buildSystem: string;
+}
+
+function scanSignals(dir: string, fileScanDepth: number): DirSignals {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // dir doesn't exist yet (caller should scaffold first)
+  }
+  const entrySet = new Set(entries.filter((e) => !SCAN_EXCLUDE.has(e)));
+
+  // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
+  // under dir (its recursion guard returns immediately at depth -1), matching
+  // the base top-level file sweep. Any present known source dir is then
+  // recursed at the base depth cap.
+  const langCounts: Record<string, number> = {};
+  countFilesByLang(dir, langCounts, fileScanDepth);
+  for (const dirName of SCAN_SOURCE_DIRS) {
+    if (entrySet.has(dirName)) {
+      countFilesByLang(join(dir, dirName), langCounts, 6);
+    }
+  }
+
+  const frameworks = detectFrameworks(entrySet, dir);
+  const buildSystem = detectBuildSystem(entrySet, dir);
+
+  // Classification signals (mirror workspace-detection.md Step 3).
+  const hasSourceFiles = Object.keys(langCounts).length > 0;
+  const hasFrameworkConfig = frameworks.length > 0;
+  const hasNonDev = entrySet.has("package.json") && hasNonDevDeps(dir);
+  const hasOtherManifest = SOURCE_MANIFESTS.some((m) => entrySet.has(m));
+  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => entrySet.has(d));
+
+  return {
+    brownfield:
+      hasSourceFiles ||
+      hasFrameworkConfig ||
+      hasNonDev ||
+      hasOtherManifest ||
+      hasAppSourceDir,
+    langCounts,
+    frameworks,
+    buildSystem,
+  };
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -1922,37 +2021,51 @@ export function detectWorkspace(projectDir: string): ScanResult {
   }
   const topSet = new Set(topEntries.filter((e) => !SCAN_EXCLUDE.has(e)));
 
-  // Count source files by language across top-level files + known source dirs
-  const langCounts: Record<string, number> = {};
+  // Root scan (depth 0 for the top-level file sweep, byte-identical to the
+  // base inline loop plus the SCAN_SOURCE_DIRS recurse, both inside scanSignals).
+  const root = scanSignals(projectDir, 0);
+  const langCounts = { ...root.langCounts };
+  const frameworks = [...root.frameworks];
+  let buildSystem = root.buildSystem;
+  let brownfield = root.brownfield;
+  const nestedHits: string[] = [];
 
-  // Top-level files only (no recursion at this depth)
-  for (const entry of topSet) {
-    const full = join(projectDir, entry);
-    let st: import("node:fs").Stats;
-    try {
-      st = lstatSync(full);
-    } catch {
-      continue;
-    }
-    if (st.isSymbolicLink()) continue;
-    if (st.isFile()) {
-      const dot = entry.lastIndexOf(".");
-      if (dot > 0) {
-        const ext = entry.slice(dot).toLowerCase();
-        const lang = LANG_BY_EXT[ext];
-        if (lang) langCounts[lang] = (langCounts[lang] || 0) + 1;
+  // Nested-project fallback: only when the root itself shows NO brownfield
+  // signal. Scan each arbitrarily-named depth-1 subdirectory with the same
+  // signal set (source files one level in via scanSignals(.., 1)), skipping
+  // dot-dirs, NESTED_SCAN_EXCLUDE, the SCAN_SOURCE_DIRS entries already scanned
+  // at the root, symlinks, and non-dirs. Aggregate every hit: languages merged,
+  // frameworks unioned, first non-Unknown build system kept.
+  if (!brownfield) {
+    for (const entry of [...topSet].sort()) {
+      if (entry.startsWith(".")) continue;
+      if (NESTED_SCAN_EXCLUDE.has(entry.toLowerCase())) continue;
+      if (SCAN_SOURCE_DIRS.includes(entry)) continue;
+      const full = join(projectDir, entry);
+      let st: import("node:fs").Stats;
+      try {
+        st = lstatSync(full);
+      } catch {
+        continue;
       }
+      if (st.isSymbolicLink() || !st.isDirectory()) continue;
+
+      const sub = scanSignals(full, 1);
+      if (!sub.brownfield) continue;
+
+      brownfield = true;
+      nestedHits.push(entry);
+      for (const [lang, n] of Object.entries(sub.langCounts)) {
+        langCounts[lang] = (langCounts[lang] || 0) + n;
+      }
+      for (const fw of sub.frameworks) {
+        if (!frameworks.includes(fw)) frameworks.push(fw);
+      }
+      if (buildSystem === "Unknown") buildSystem = sub.buildSystem;
     }
   }
 
-  // Recurse into known source dirs if present (capped depth)
-  for (const dirName of SCAN_SOURCE_DIRS) {
-    if (topSet.has(dirName)) {
-      countFilesByLang(join(projectDir, dirName), langCounts, 6);
-    }
-  }
-
-  // Language list: primary = highest count; secondary = >= 20% of primary count
+  // Language list: primary = highest count; secondary = >= 20% of primary count.
   const sortedLangs = Object.entries(langCounts).sort((a, b) => b[1] - a[1]);
   let languages: string;
   if (sortedLangs.length === 0) {
@@ -1968,41 +2081,14 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
-  const frameworks = detectFrameworks(topSet, projectDir);
-  const frameworksStr = frameworks.length > 0 ? frameworks.join(", ") : "Unknown";
-  const buildSystem = detectBuildSystem(topSet, projectDir);
-
-  // Classification (mirrors workspace-detection.md:66-78)
-  const hasSourceFiles = Object.keys(langCounts).length > 0;
-  const hasFrameworkConfig = frameworks.length > 0;
-  const hasNonDev = topSet.has("package.json") && hasNonDevDeps(projectDir);
-  const hasOtherManifest = [
-    "requirements.txt",
-    "pyproject.toml",
-    "setup.py",
-    "Cargo.toml",
-    "go.mod",
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "composer.json",
-    "Gemfile",
-  ].some((m) => topSet.has(m));
-  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => topSet.has(d));
-
-  const brownfield =
-    hasSourceFiles ||
-    hasFrameworkConfig ||
-    hasNonDev ||
-    hasOtherManifest ||
-    hasAppSourceDir;
-
-  return {
+  const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
-    frameworks: frameworksStr,
+    frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
   };
+  if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -2295,6 +2381,7 @@ function handleIntentBirthStateBuild(
     Languages: scan.languages,
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
+    ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
     Details: "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
@@ -2342,6 +2429,18 @@ function handleIntentBirthStateBuild(
         const idx = executeStages.indexOf(reStage.number);
         if (idx >= 0) executeStages.splice(idx, 1);
         skipStages.push(`${reStage.number} (reverse-engineering — greenfield)`);
+      }
+      // Advisory: the incremental scopes presume existing code, so a greenfield
+      // scan is a likely misread (source nested past the depth-1 fallback, or a
+      // wrong scope). We do NOT override routing (an empty workspace genuinely
+      // has nothing to reverse-engineer); we point the user at the fix.
+      if (["bugfix", "refactor", "security-patch"].includes(scope)) {
+        process.stderr.write(
+          `Note: scope "${scope}" usually targets existing code, but the workspace scanned as Greenfield ` +
+            `so Reverse Engineering will be skipped. If this project has a codebase the scanner missed, ` +
+            `edit "Project Type" to Brownfield in the intent's aidlc-state.md, or move the source so it is ` +
+            `detected (top-level or one folder down), then re-run.\n`,
+        );
       }
     }
   }
@@ -2750,6 +2849,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     languages: scan.languages,
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
+    ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2763,6 +2863,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
+      (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.6";
+export const AIDLC_VERSION = "2.2.7";

--- a/dist/kiro/.kiro/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/initialization/workspace-detection.md
@@ -42,6 +42,8 @@ MANDATORY: Follow stage-protocol.md for state tracking and audit logging.
 
 The scanner walks the project directory one level deep plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`), excluding the harness directories (`.claude/`, `.kiro/`, `.codex/`), `aidlc/`, `node_modules/`, `.git/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`.
 
+Nested-project fallback: when NO top-level signal fires (the layout that would otherwise classify greenfield), the scanner then descends one level into each arbitrarily-named top-level subdirectory (skipping the excluded directories above, hidden dirs, and symlinks) and re-applies the same signal set rooted at that subdirectory. If any subdirectory looks brownfield, the workspace is classified brownfield and that subdirectory's languages/frameworks/build system are merged into the result. This catches a project whose source lives one container down (e.g. `wordbook/`, `backend/`) instead of at the root. The fallback is depth-1 only and never runs when the root already has a source signal.
+
 Scan signals:
 - Directory structure (top-level and key subdirectories)
 - Configuration files (package.json, pom.xml, build.gradle, Cargo.toml, pyproject.toml, etc.)
@@ -59,6 +61,8 @@ Scan signals:
 ### Step 3: Detect Project Type
 
 Classify based on the scanner's evidence:
+
+Signals are evaluated at the root first; if none fires, the nested-project fallback re-evaluates the same signals one level down (see Step 2).
 
 **Brownfield** — ANY of these indicators present:
 - Source code files exist (`.js`, `.ts`, `.jsx`, `.tsx`, `.py`, `.java`, `.go`, `.rs`, `.rb`, `.cs`, `.cpp`, `.c`, `.kt`, `.swift`, `.php`)

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -1764,6 +1764,9 @@ const LANG_BY_EXT: Record<string, string> = {
 };
 
 const SCAN_SOURCE_DIRS = ["src", "app", "lib", "pages", "components", "tests"];
+// Set view for the sweep-side skip in scanSignals: the depth-6 recurse there
+// is the SOLE counter for these dirs, so the file sweep must never enter them.
+const SCAN_SOURCE_DIR_SET: ReadonlySet<string> = new Set(SCAN_SOURCE_DIRS);
 const SCAN_EXCLUDE = new Set([
   ".claude",
   ".kiro",
@@ -1806,13 +1809,22 @@ const NESTED_SCAN_EXCLUDE = new Set([
   "example",
   "samples",
   "sample",
+  "demos",
+  "demo",
+  "reference",
+  "testdata",
+  "fixtures",
+  "templates",
   "scripts",
 ]);
 
+// skipDirs: directory names to skip at THIS level only (not propagated into
+// the recursion); the caller counts those dirs through a separate deeper call.
 function countFilesByLang(
   dir: string,
   counts: Record<string, number>,
-  maxDepth: number
+  maxDepth: number,
+  skipDirs?: ReadonlySet<string>
 ): void {
   if (maxDepth < 0) return;
   let entries: string[];
@@ -1833,6 +1845,7 @@ function countFilesByLang(
     // Don't follow symlinks — cycle protection.
     if (st.isSymbolicLink()) continue;
     if (st.isDirectory()) {
+      if (skipDirs?.has(entry)) continue;
       countFilesByLang(full, counts, maxDepth - 1);
     } else if (st.isFile()) {
       const dot = entry.lastIndexOf(".");
@@ -1959,8 +1972,11 @@ function hasNonDevDeps(projectDir: string): boolean {
 //       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
 //       skip, files only) PLUS a depth-6 recurse into each present
 //       SCAN_SOURCE_DIRS entry.
-//     - a nested container: 6, scanning the whole container one level in so a
-//       project under `wordbook/src/**` or `backend/server/**` is seen.
+//     - a nested container: 1, sweeping the container's own files plus one
+//       level of arbitrary subdirs so a project under `wordbook/**` or
+//       `backend/server/**` is seen. A present SCAN_SOURCE_DIRS entry is
+//       skipped by the sweep: the depth-6 recurse below is its only counter,
+//       so files directly under it are never counted twice.
 interface DirSignals {
   brownfield: boolean;
   langCounts: Record<string, number>;
@@ -1980,9 +1996,14 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
   // under dir (its recursion guard returns immediately at depth -1), matching
   // the base top-level file sweep. Any present known source dir is then
-  // recursed at the base depth cap.
+  // recursed at the base depth cap. The sweep itself never enters a
+  // SCAN_SOURCE_DIRS entry: at depth 1 (the nested-container scan) it would
+  // count the files directly under <dir>/src etc. that the depth-6 recurse
+  // below counts again, inflating that language and potentially flipping the
+  // reported primary. (At the root's depth 0 the skip is a no-op: the sweep
+  // never enters subdirs there.)
   const langCounts: Record<string, number> = {};
-  countFilesByLang(dir, langCounts, fileScanDepth);
+  countFilesByLang(dir, langCounts, fileScanDepth, SCAN_SOURCE_DIR_SET);
   for (const dirName of SCAN_SOURCE_DIRS) {
     if (entrySet.has(dirName)) {
       countFilesByLang(join(dir, dirName), langCounts, 6);

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -1734,6 +1734,11 @@ interface ScanResult {
   languages: string;     // e.g. "TypeScript, JavaScript"
   frameworks: string;    // e.g. "React, Vite"
   buildSystem: string;   // e.g. "npm (package.json)"
+  // Comma-joined top-level subdirectory name(s) the nested-project fallback
+  // classified Brownfield from. Absent when the root itself decided the verdict
+  // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
+  // the `detect --json` payload, never in the state file.
+  nestedRoot?: string;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -1771,6 +1776,37 @@ const SCAN_EXCLUDE = new Set([
   ".next",
   "target",
   "vendor",
+]);
+
+// Package/build manifests that mark a directory as an application (not just
+// scaffolding). Shared by the root scan and the nested-project fallback.
+const SOURCE_MANIFESTS = [
+  "requirements.txt",
+  "pyproject.toml",
+  "setup.py",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "composer.json",
+  "Gemfile",
+];
+
+// Top-level directories the nested-project fallback never descends into: they
+// commonly hold sample/snippet/boilerplate code that is not the project's own
+// source. The harness/VCS/build dirs in SCAN_EXCLUDE and SCAN_SOURCE_DIRS
+// (already scanned at the root) are skipped separately. Lowercased for a
+// case-insensitive match.
+const NESTED_SCAN_EXCLUDE = new Set([
+  "aidlc",
+  "docs",
+  "doc",
+  "examples",
+  "example",
+  "samples",
+  "sample",
+  "scripts",
 ]);
 
 function countFilesByLang(
@@ -1913,6 +1949,69 @@ function hasNonDevDeps(projectDir: string): boolean {
   }
 }
 
+// The signal evaluation for a single directory, used for both the workspace
+// root and (via the nested-project fallback) each depth-1 subdirectory. Returns
+// the raw brownfield signal plus the findings so the caller can aggregate.
+//
+//   fileScanDepth = the countFilesByLang depth for the SOURCE-FILE signal:
+//     - root: 0 for the top-level file sweep (files directly under dir; the
+//       inline top-level loop the base code ran is equivalent to
+//       countFilesByLang(dir, counts, 0), same SCAN_EXCLUDE filter + symlink
+//       skip, files only) PLUS a depth-6 recurse into each present
+//       SCAN_SOURCE_DIRS entry.
+//     - a nested container: 6, scanning the whole container one level in so a
+//       project under `wordbook/src/**` or `backend/server/**` is seen.
+interface DirSignals {
+  brownfield: boolean;
+  langCounts: Record<string, number>;
+  frameworks: string[];
+  buildSystem: string;
+}
+
+function scanSignals(dir: string, fileScanDepth: number): DirSignals {
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    // dir doesn't exist yet (caller should scaffold first)
+  }
+  const entrySet = new Set(entries.filter((e) => !SCAN_EXCLUDE.has(e)));
+
+  // Source-file count. countFilesByLang(dir, counts, 0) counts files directly
+  // under dir (its recursion guard returns immediately at depth -1), matching
+  // the base top-level file sweep. Any present known source dir is then
+  // recursed at the base depth cap.
+  const langCounts: Record<string, number> = {};
+  countFilesByLang(dir, langCounts, fileScanDepth);
+  for (const dirName of SCAN_SOURCE_DIRS) {
+    if (entrySet.has(dirName)) {
+      countFilesByLang(join(dir, dirName), langCounts, 6);
+    }
+  }
+
+  const frameworks = detectFrameworks(entrySet, dir);
+  const buildSystem = detectBuildSystem(entrySet, dir);
+
+  // Classification signals (mirror workspace-detection.md Step 3).
+  const hasSourceFiles = Object.keys(langCounts).length > 0;
+  const hasFrameworkConfig = frameworks.length > 0;
+  const hasNonDev = entrySet.has("package.json") && hasNonDevDeps(dir);
+  const hasOtherManifest = SOURCE_MANIFESTS.some((m) => entrySet.has(m));
+  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => entrySet.has(d));
+
+  return {
+    brownfield:
+      hasSourceFiles ||
+      hasFrameworkConfig ||
+      hasNonDev ||
+      hasOtherManifest ||
+      hasAppSourceDir,
+    langCounts,
+    frameworks,
+    buildSystem,
+  };
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -1922,37 +2021,51 @@ export function detectWorkspace(projectDir: string): ScanResult {
   }
   const topSet = new Set(topEntries.filter((e) => !SCAN_EXCLUDE.has(e)));
 
-  // Count source files by language across top-level files + known source dirs
-  const langCounts: Record<string, number> = {};
+  // Root scan (depth 0 for the top-level file sweep, byte-identical to the
+  // base inline loop plus the SCAN_SOURCE_DIRS recurse, both inside scanSignals).
+  const root = scanSignals(projectDir, 0);
+  const langCounts = { ...root.langCounts };
+  const frameworks = [...root.frameworks];
+  let buildSystem = root.buildSystem;
+  let brownfield = root.brownfield;
+  const nestedHits: string[] = [];
 
-  // Top-level files only (no recursion at this depth)
-  for (const entry of topSet) {
-    const full = join(projectDir, entry);
-    let st: import("node:fs").Stats;
-    try {
-      st = lstatSync(full);
-    } catch {
-      continue;
-    }
-    if (st.isSymbolicLink()) continue;
-    if (st.isFile()) {
-      const dot = entry.lastIndexOf(".");
-      if (dot > 0) {
-        const ext = entry.slice(dot).toLowerCase();
-        const lang = LANG_BY_EXT[ext];
-        if (lang) langCounts[lang] = (langCounts[lang] || 0) + 1;
+  // Nested-project fallback: only when the root itself shows NO brownfield
+  // signal. Scan each arbitrarily-named depth-1 subdirectory with the same
+  // signal set (source files one level in via scanSignals(.., 1)), skipping
+  // dot-dirs, NESTED_SCAN_EXCLUDE, the SCAN_SOURCE_DIRS entries already scanned
+  // at the root, symlinks, and non-dirs. Aggregate every hit: languages merged,
+  // frameworks unioned, first non-Unknown build system kept.
+  if (!brownfield) {
+    for (const entry of [...topSet].sort()) {
+      if (entry.startsWith(".")) continue;
+      if (NESTED_SCAN_EXCLUDE.has(entry.toLowerCase())) continue;
+      if (SCAN_SOURCE_DIRS.includes(entry)) continue;
+      const full = join(projectDir, entry);
+      let st: import("node:fs").Stats;
+      try {
+        st = lstatSync(full);
+      } catch {
+        continue;
       }
+      if (st.isSymbolicLink() || !st.isDirectory()) continue;
+
+      const sub = scanSignals(full, 1);
+      if (!sub.brownfield) continue;
+
+      brownfield = true;
+      nestedHits.push(entry);
+      for (const [lang, n] of Object.entries(sub.langCounts)) {
+        langCounts[lang] = (langCounts[lang] || 0) + n;
+      }
+      for (const fw of sub.frameworks) {
+        if (!frameworks.includes(fw)) frameworks.push(fw);
+      }
+      if (buildSystem === "Unknown") buildSystem = sub.buildSystem;
     }
   }
 
-  // Recurse into known source dirs if present (capped depth)
-  for (const dirName of SCAN_SOURCE_DIRS) {
-    if (topSet.has(dirName)) {
-      countFilesByLang(join(projectDir, dirName), langCounts, 6);
-    }
-  }
-
-  // Language list: primary = highest count; secondary = >= 20% of primary count
+  // Language list: primary = highest count; secondary = >= 20% of primary count.
   const sortedLangs = Object.entries(langCounts).sort((a, b) => b[1] - a[1]);
   let languages: string;
   if (sortedLangs.length === 0) {
@@ -1968,41 +2081,14 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
-  const frameworks = detectFrameworks(topSet, projectDir);
-  const frameworksStr = frameworks.length > 0 ? frameworks.join(", ") : "Unknown";
-  const buildSystem = detectBuildSystem(topSet, projectDir);
-
-  // Classification (mirrors workspace-detection.md:66-78)
-  const hasSourceFiles = Object.keys(langCounts).length > 0;
-  const hasFrameworkConfig = frameworks.length > 0;
-  const hasNonDev = topSet.has("package.json") && hasNonDevDeps(projectDir);
-  const hasOtherManifest = [
-    "requirements.txt",
-    "pyproject.toml",
-    "setup.py",
-    "Cargo.toml",
-    "go.mod",
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "composer.json",
-    "Gemfile",
-  ].some((m) => topSet.has(m));
-  const hasAppSourceDir = SCAN_SOURCE_DIRS.some((d) => topSet.has(d));
-
-  const brownfield =
-    hasSourceFiles ||
-    hasFrameworkConfig ||
-    hasNonDev ||
-    hasOtherManifest ||
-    hasAppSourceDir;
-
-  return {
+  const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
-    frameworks: frameworksStr,
+    frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
   };
+  if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -2295,6 +2381,7 @@ function handleIntentBirthStateBuild(
     Languages: scan.languages,
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
+    ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
     Details: "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
@@ -2342,6 +2429,18 @@ function handleIntentBirthStateBuild(
         const idx = executeStages.indexOf(reStage.number);
         if (idx >= 0) executeStages.splice(idx, 1);
         skipStages.push(`${reStage.number} (reverse-engineering — greenfield)`);
+      }
+      // Advisory: the incremental scopes presume existing code, so a greenfield
+      // scan is a likely misread (source nested past the depth-1 fallback, or a
+      // wrong scope). We do NOT override routing (an empty workspace genuinely
+      // has nothing to reverse-engineer); we point the user at the fix.
+      if (["bugfix", "refactor", "security-patch"].includes(scope)) {
+        process.stderr.write(
+          `Note: scope "${scope}" usually targets existing code, but the workspace scanned as Greenfield ` +
+            `so Reverse Engineering will be skipped. If this project has a codebase the scanner missed, ` +
+            `edit "Project Type" to Brownfield in the intent's aidlc-state.md, or move the source so it is ` +
+            `detected (top-level or one folder down), then re-run.\n`,
+        );
       }
     }
   }
@@ -2750,6 +2849,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     languages: scan.languages,
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
+    ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2763,6 +2863,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
+      (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.6";
+export const AIDLC_VERSION = "2.2.7";

--- a/docs/guide/02-your-first-workflow.md
+++ b/docs/guide/02-your-first-workflow.md
@@ -48,7 +48,7 @@ Space-level dirs ensured:
 
 ### Stage 0.2: Workspace Detection
 
-A deterministic rule-based scanner walks one level deep into the project plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`). It classifies greenfield vs brownfield based on source files, framework configs, and package manifests.
+A deterministic rule-based scanner walks one level deep into the project plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`). It classifies greenfield vs brownfield based on source files, framework configs, and package manifests. When no top-level signal fires, it also descends one level into each arbitrarily-named subdirectory, so a project whose source lives in a container folder (e.g. `wordbook/`, `backend/`) is still detected as brownfield.
 
 ### Stage 0.3: State Initialization
 

--- a/docs/reference/04-stages/initialization.md
+++ b/docs/reference/04-stages/initialization.md
@@ -81,7 +81,7 @@ All three stages run inside a single deterministic `bun .claude/tools/aidlc-util
 | Mode | Auto-proceed (no approval gate) |
 
 ### Steps
-1. Walk the project directory one level deep, plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`) if present
+1. Walk the project directory one level deep, plus known source directories (`src/`, `app/`, `lib/`, `pages/`, `components/`, `tests/`) if present. When no top-level signal fires, fall back to scanning one level into each arbitrarily-named subdirectory with the same signal set, so a project nested in a container folder (e.g. `wordbook/`) is detected instead of misclassified greenfield
 2. Count files by extension to determine primary/secondary languages
 3. Detect frameworks via known config filenames (Next.js, Vite, Angular, Nuxt, Remix, Gatsby, Astro, Svelte, NestJS) and React via `package.json` dependencies
 4. Detect build system via manifest + lockfile (npm/yarn/pnpm/bun/poetry/uv/hatch/pip/cargo/go/maven/gradle/composer/bundler)

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -3454,6 +3454,10 @@
         {
           "file": "tests/integration/t71-stage-workspace-detection-brownfield.test.ts",
           "mechanism": "sdk"
+        },
+        {
+          "file": "tests/unit/t203-nested-workspace-detection.test.ts",
+          "mechanism": "cli"
         }
       ],
       "status": "covered"

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -839,6 +839,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t199-learnings-memory-path.test.ts",
     "unit/t201-swarm-batch-advance.test.ts",
     "unit/t202-gate-next-stage.test.ts",
+    "unit/t203-nested-workspace-detection.test.ts",
     "unit/t17.test.ts",
     "unit/t18.test.ts",
     "unit/t19.test.ts",

--- a/tests/unit/t203-nested-workspace-detection.test.ts
+++ b/tests/unit/t203-nested-workspace-detection.test.ts
@@ -1,0 +1,206 @@
+// covers: stage:initialization/workspace-detection
+//
+// t203: nested-project workspace detection + the greenfield advisory for
+// incremental scopes. Mechanism: none for the detectWorkspace cases (pure
+// in-process over hand-built temp trees), cli for the advisory cases (they
+// spawn the real intent-birth tool to observe its stderr). Technique:
+// known-answer.
+//
+// TWO fixes are pinned here.
+//
+//   1. detectWorkspace NESTED-PROJECT FALLBACK (#462). The scanner classified a
+//      project Greenfield whenever its source lived one level down in an
+//      arbitrarily-named container (e.g. wordbook/), because every signal was
+//      root-relative and the recursion allowlist was a fixed six-name set. When
+//      no top-level signal fires, the scanner now re-applies the same signal set
+//      one level into each depth-1 subdirectory (skipping dot-dirs,
+//      NESTED_SCAN_EXCLUDE, the SCAN_SOURCE_DIRS entries already scanned at the
+//      root, symlinks, and non-dirs), aggregates every hit, and records the hit
+//      dir(s) in ScanResult.nestedRoot. Root behavior is byte-identical for a
+//      normal top-level layout, so the fallback never runs then.
+//
+//   2. The GREENFIELD ADVISORY (#438). An incremental scope (bugfix/refactor/
+//      security-patch) presumes existing code. We do NOT override routing (an
+//      empty workspace genuinely has nothing to reverse-engineer, and forcing
+//      Brownfield would break the greenfield RE-skip pins). Instead intent-birth
+//      writes a one-line stderr advisory when such a scope scans Greenfield,
+//      pointing the user at fixing Project Type or the layout. Routing is
+//      unchanged: reverse-engineering still greenfield-SKIPs.
+//
+// detectWorkspace is a pure function of the directory tree, so each detection
+// case builds a FRESH mkdtemp dir, writes the signal files inline, and reads the
+// classified ScanResult back in-process. The advisory cases spawn the shipped
+// intent-birth tool against a scaffolded temp project and read its stderr. All
+// temp dirs are removed in afterAll. NOTHING is written under tests/fixtures/**.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTestProject } from "../harness/fixtures.ts";
+import { detectWorkspace } from "../../dist/claude/.claude/tools/aidlc-utility.ts";
+
+const BUN = process.execPath;
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const UTIL = join(REPO_ROOT, "dist", "claude", ".claude", "tools", "aidlc-utility.ts");
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+});
+
+/** A fresh empty temp dir (no scaffold; detectWorkspace scans the bare tree). */
+function tmp(): string {
+  const d = mkdtempSync(join(tmpdir(), "aidlc-t203-"));
+  tempDirs.push(d);
+  return d;
+}
+
+/** Write a file, creating parent dirs. Path segments are joined under `root`. */
+function put(root: string, rel: string[], body: string): void {
+  const full = join(root, ...rel);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, body, "utf-8");
+}
+
+const PKG_REACT = JSON.stringify({ name: "x", dependencies: { react: "^18.0.0" } });
+
+describe("t203 nested-project detection (the depth-1 fallback)", () => {
+  test("nested wordbook/package.json + src -> Brownfield with nestedRoot", () => {
+    const d = tmp();
+    put(d, ["wordbook", "package.json"], PKG_REACT);
+    put(d, ["wordbook", "src", "app.ts"], "export const app = 1;\n");
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Brownfield");
+    expect(scan.nestedRoot).toBe("wordbook");
+    // The nested subdir's findings merge into the result.
+    expect(scan.languages).toContain("TypeScript");
+    expect(scan.frameworks).toContain("React");
+  });
+
+  test("deep backend/server/main.go -> Brownfield with nestedRoot", () => {
+    const d = tmp();
+    put(d, ["backend", "server", "main.go"], "package main\n");
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Brownfield");
+    expect(scan.nestedRoot).toBe("backend");
+    expect(scan.languages).toContain("Go");
+  });
+
+  test("manifest-only svc/go.mod -> Brownfield (manifest signal, no source files)", () => {
+    const d = tmp();
+    put(d, ["svc", "go.mod"], "module x\n");
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Brownfield");
+    expect(scan.nestedRoot).toBe("svc");
+  });
+
+  test("empty dir -> Greenfield, no nestedRoot", () => {
+    const d = tmp();
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Greenfield");
+    expect(scan.nestedRoot).toBeUndefined();
+    expect(scan.languages).toBe("Unknown");
+  });
+
+  test("top-level project (root src/) unchanged: Brownfield, no nestedRoot (fallback does not fire)", () => {
+    const d = tmp();
+    put(d, ["src", "app.ts"], "export const app = 1;\n");
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Brownfield");
+    expect(scan.nestedRoot).toBeUndefined();
+    expect(scan.languages).toContain("TypeScript");
+  });
+
+  test("excluded-dirs-only (docs, examples, scripts, .github) -> Greenfield (no false positive)", () => {
+    const d = tmp();
+    for (const dir of ["docs", "examples", "scripts", ".github"]) {
+      put(d, [dir, "sample.py"], "print(1)\n");
+    }
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Greenfield");
+    expect(scan.nestedRoot).toBeUndefined();
+  });
+
+  test("two nested repos -> Brownfield, both recorded in nestedRoot (sorted)", () => {
+    const d = tmp();
+    for (const repo of ["web", "api"]) {
+      put(d, [repo, "src", "m.ts"], "export const z = 1;\n");
+    }
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Brownfield");
+    expect(scan.nestedRoot).toBe("api, web");
+  });
+
+  test("a symlinked subdirectory is skipped by the fallback", () => {
+    const d = tmp();
+    const real = tmp();
+    put(real, ["src", "a.ts"], "export const q = 1;\n");
+    symlinkSync(real, join(d, "linked"));
+    expect(detectWorkspace(d).projectType).toBe("Greenfield");
+  });
+});
+
+// P4: intent-birth writes state into the born intent's per-intent record dir.
+function recordDirOf(p: string): string {
+  const spaceCursor = join(p, "aidlc", "active-space");
+  const space = existsSync(spaceCursor)
+    ? readFileSync(spaceCursor, "utf-8").trim() || "default"
+    : "default";
+  const intentsDir = join(p, "aidlc", "spaces", space, "intents");
+  const intentCursor = join(intentsDir, "active-intent");
+  if (existsSync(intentCursor)) {
+    const rec = readFileSync(intentCursor, "utf-8").trim();
+    if (rec && existsSync(join(intentsDir, rec, "aidlc-state.md"))) {
+      return join(intentsDir, rec);
+    }
+  }
+  return join(p, "aidlc-docs");
+}
+
+/** Birth a scope on a bare (empty, Greenfield) scaffolded project. */
+function birth(scope: string): { stderr: string; stateFile: string } {
+  const p = createTestProject();
+  tempDirs.push(p);
+  const r = spawnSync(
+    BUN,
+    [UTIL, "intent-birth", "--scope", scope, "--project-dir", p],
+    { encoding: "utf-8" },
+  );
+  expect(r.status).toBe(0);
+  const sp = join(recordDirOf(p), "aidlc-state.md");
+  return { stderr: r.stderr ?? "", stateFile: existsSync(sp) ? readFileSync(sp, "utf-8") : "" };
+}
+
+describe("t203 greenfield advisory (incremental scopes, no routing override)", () => {
+  test("bugfix on an empty workspace stays Greenfield, RE SKIP, and emits the stderr advisory", () => {
+    const { stderr, stateFile } = birth("bugfix");
+    // Routing is UNCHANGED: still Greenfield, reverse-engineering still SKIPs.
+    expect(stateFile).toContain("- **Project Type**: Greenfield");
+    // The greenfield RE-skip annotation in the Stages-to-Skip row. The shipped
+    // annotation joins slug and reason with an em dash, so match the two ends
+    // rather than transcribing the punctuation.
+    expect(stateFile).toMatch(/\(reverse-engineering .* greenfield\)/);
+    expect(stateFile).toMatch(/- \[ \] reverse-engineering .* SKIP/);
+    // The advisory fired on stderr (not stdout).
+    expect(stderr).toContain('scope "bugfix"');
+    expect(stderr.toLowerCase()).toContain("greenfield");
+    expect(stderr).toContain("Project Type");
+  });
+
+  test("poc on an empty workspace stays Greenfield and emits NO advisory (not an incremental scope)", () => {
+    const { stderr, stateFile } = birth("poc");
+    expect(stateFile).toContain("- **Project Type**: Greenfield");
+    expect(stderr).not.toContain("usually targets existing code");
+  });
+});

--- a/tests/unit/t203-nested-workspace-detection.test.ts
+++ b/tests/unit/t203-nested-workspace-detection.test.ts
@@ -83,9 +83,31 @@ describe("t203 nested-project detection (the depth-1 fallback)", () => {
     const scan = detectWorkspace(d);
     expect(scan.projectType).toBe("Brownfield");
     expect(scan.nestedRoot).toBe("wordbook");
-    // The nested subdir's findings merge into the result.
-    expect(scan.languages).toContain("TypeScript");
+    // The nested subdir's findings merge into the result. Pinned EXACT so a
+    // count inflation (each file seen once and only once) cannot hide.
+    expect(scan.languages).toBe("TypeScript");
     expect(scan.frameworks).toContain("React");
+  });
+
+  test("nested source-dir files are counted ONCE: 4 top-level .py beat 3 .ts under src/", () => {
+    // Regression pin for the depth-1 double count: the container file sweep
+    // used to enter <sub>/src at depth 1 AND the SCAN_SOURCE_DIRS recurse
+    // counted it again, doubling TypeScript (3 -> 6) past Python (4) and
+    // flipping the reported primary language. The same layout at the root
+    // already reported Python; nested must agree.
+    const d = tmp();
+    for (const f of ["a", "b", "c", "e"]) {
+      put(d, ["engine", `${f}.py`], "print(1)\n");
+    }
+    for (const f of ["x", "y", "z"]) {
+      put(d, ["engine", "src", `${f}.ts`], "export const v = 1;\n");
+    }
+    const scan = detectWorkspace(d);
+    expect(scan.projectType).toBe("Brownfield");
+    expect(scan.nestedRoot).toBe("engine");
+    // Python (4) primary, TypeScript (3) secondary (>= 20% threshold). The
+    // doubled count would report "TypeScript, Python".
+    expect(scan.languages).toBe("Python, TypeScript");
   });
 
   test("deep backend/server/main.go -> Brownfield with nestedRoot", () => {
@@ -94,7 +116,7 @@ describe("t203 nested-project detection (the depth-1 fallback)", () => {
     const scan = detectWorkspace(d);
     expect(scan.projectType).toBe("Brownfield");
     expect(scan.nestedRoot).toBe("backend");
-    expect(scan.languages).toContain("Go");
+    expect(scan.languages).toBe("Go");
   });
 
   test("manifest-only svc/go.mod -> Brownfield (manifest signal, no source files)", () => {
@@ -119,12 +141,23 @@ describe("t203 nested-project detection (the depth-1 fallback)", () => {
     const scan = detectWorkspace(d);
     expect(scan.projectType).toBe("Brownfield");
     expect(scan.nestedRoot).toBeUndefined();
-    expect(scan.languages).toContain("TypeScript");
+    expect(scan.languages).toBe("TypeScript");
   });
 
-  test("excluded-dirs-only (docs, examples, scripts, .github) -> Greenfield (no false positive)", () => {
+  test("excluded-dirs-only (docs, examples, demo, fixtures, ...) -> Greenfield (no false positive)", () => {
     const d = tmp();
-    for (const dir of ["docs", "examples", "scripts", ".github"]) {
+    for (const dir of [
+      "docs",
+      "examples",
+      "scripts",
+      ".github",
+      "demo",
+      "demos",
+      "reference",
+      "testdata",
+      "fixtures",
+      "templates",
+    ]) {
       put(d, [dir, "sample.py"], "print(1)\n");
     }
     const scan = detectWorkspace(d);
@@ -197,6 +230,16 @@ describe("t203 greenfield advisory (incremental scopes, no routing override)", (
     expect(stderr.toLowerCase()).toContain("greenfield");
     expect(stderr).toContain("Project Type");
   });
+
+  test.each(["refactor", "security-patch"])(
+    "%s on an empty workspace also emits the advisory (all three incremental scopes covered)",
+    (scope: string) => {
+      const { stderr, stateFile } = birth(scope);
+      expect(stateFile).toContain("- **Project Type**: Greenfield");
+      expect(stderr).toContain(`scope "${scope}"`);
+      expect(stderr).toContain("usually targets existing code");
+    },
+  );
 
   test("poc on an empty workspace stays Greenfield and emits NO advisory (not an incremental scope)", () => {
     const { stderr, stateFile } = birth("poc");


### PR DESCRIPTION
Fixes #462 and addresses #438: a project nested in an arbitrarily named folder (e.g. `wordbook/`) was classified Greenfield because `detectWorkspace` scanned only top-level files plus a fixed source-dir allowlist - so Reverse Engineering was skipped and the workflow treated an existing codebase as a fresh one. The bugfix scope hit this hardest (#438): its whole premise is existing code, yet a misread scan silently skipped RE.

## Fix

- **Nested-scan fallback**: the signal evaluation is extracted into a helper applied first at the root (byte-identical behavior for every existing layout, verified against the pinned scanner contract tests). When ALL root signals miss - the exact condition that used to mean Greenfield - the scanner re-applies the full five-signal set (manifests, framework configs, non-dev deps, source dirs, shallow source-file counts) one level down per non-hidden top-level directory, excluding dot-dirs, common non-source dirs (docs, examples, samples, scripts), and the aidlc workspace root. Any hit classifies Brownfield; multiple hits aggregate languages and frameworks. The winning subdirectories are recorded in a new optional `nestedRoot` field surfaced in the WORKSPACE_SCANNED audit event and `detect --json` (no state-file change).
- **Incremental-scope advisory** (#438): when the scan still reads Greenfield and the scope is bugfix, refactor, or security-patch, intent birth prints a one-line stderr note that the scope usually targets existing code, RE will be skipped, and how to correct it (fix the layout or edit Project Type in aidlc-state.md). Deliberately NOT a forced Brownfield or a routing override: an empty directory genuinely has nothing to reverse-engineer, and the existing scope-runner pins encode that semantics.

## Tests

New `tests/unit/t203-nested-workspace-detection.test.ts` (10 cases): nested project, deep container with no manifests, manifest-only nested project, empty dir unchanged, top-level unchanged, excluded-dirs-only stays Greenfield, two nested repos both recorded, symlink skipped, bugfix advisory fires on Greenfield, non-incremental scope does not. All named pins re-verified green including the live SDK detection pair (t70 greenfield / t71 brownfield) and t130 scope-runners. Adversarial review of the first cut caught a scope-override that would have broken those pins; the shipped version is the corrected design.

Known interaction, deliberately untouched: the workspace-journey test fixture seeds tiny stub repos at depth 1, so that fixture now classifies Brownfield - no journey test pins Project Type (verified), and the fixture's separate flake is tracked in #441.

Version 2.2.7; sibling PRs hold adjacent numbers and whichever merges later re-bumps on rebase.
