### PR TITLE
fix: detect git submodules as a brownfield signal in workspace detection (2.2.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.10] - 2026-07-06
+
+Workspace detection now recognizes git submodules. A workspace whose code lives in uninitialized submodules (empty dirs plus a `.gitmodules` file) previously scanned as Greenfield, so reverse-engineering was auto-skipped and every design stage ran with zero code understanding. The scanner gains a sixth brownfield signal: a parseable `.gitmodules` with at least one submodule path entry classifies the workspace Brownfield. When submodule paths are uninitialized, the scan warns and names the remedy (`git submodule update --init --recursive`) at birth, in the doctor report, and on `detect`. Languages stay as scanned (Unknown is truthful until the submodules are fetched). **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* Workspace detection classifies a workspace with a parseable `.gitmodules` (at least one submodule path entry) as Brownfield, so reverse-engineering is no longer skipped for submodule-based projects.
+* The `WORKSPACE_SCANNED` audit event gains a `Submodules` field (`N declared, M uninitialized`) when submodules are present, and its `Details` names the `git submodule update --init --recursive` remedy when any submodule path is uninitialized. Projects without a `.gitmodules` produce a byte-identical event.
+* Birth stdout prints a one-line warning when submodule paths are uninitialized, telling you to fetch them before proceeding so reverse-engineering can read the code.
+* `/aidlc --doctor` gains an advisory `Submodules:` row: no `.gitmodules`, all initialized, uninitialized (names the count, the paths, and the remedy), or present-but-unparseable. Advisory only - it never flips doctor's exit code.
+* The read-only `detect` utility gains a `submodules` key in its `--json` payload and a `Submodules:` line in its human output when submodules are present.
 ## [2.2.9] - 2026-07-06
 
 Per-unit Construction stages no longer demand CONDITIONAL artifacts before a unit counts as covered. A new optional stage-frontmatter key `optional_produces:` names artifacts a stage writes only when the unit needs them - `functional-design`'s `frontend-components` (only when the unit has a UI) and `infrastructure-design`'s `shared-infrastructure` (only when units share infrastructure). Those names moved out of `produces:` into `optional_produces:`, so a backend-only unit completes without an N/A stub file and the stage gate is reachable. The conductor still gets the artifact's write path in the run-stage directive when the unit does produce it, and the artifact name stays in the vocabulary registry. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
@@ -73,6 +82,7 @@ Stops help requests from accidentally creating intents. `/aidlc intent help` was
 ||||||| parent of ef64a3e (fix: detect nested projects in workspace detection (2.2.7))
 ||||||| parent of 48f8b61 (fix: bound the compose-pending carve-out and guard recompose against autonomy (2.2.8))
 ||||||| parent of 4fd686b (fix: exempt optional produces from per-unit coverage so conditional artifacts can be skipped (2.2.9))
+||||||| parent of 4ad1db9 (fix: detect git submodules as a brownfield signal in workspace detection (2.2.10))
 
 ## [2.2.0] - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.2.9-blue)
+![version](https://img.shields.io/badge/version-2.2.10-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/stages/initialization/workspace-detection.md
+++ b/core/aidlc-common/stages/initialization/workspace-detection.md
@@ -50,6 +50,7 @@ Scan signals:
 - Build system files (Makefile, Dockerfile, docker-compose, CI/CD configs)
 - Package/dependency files (lock files, vendor directories)
 - Source code directories and their languages
+- Repo metadata (`.gitmodules` submodule declarations)
 - Test infrastructure (test directories, test config files, coverage config)
 - Documentation (README, docs/, wiki/)
 
@@ -69,6 +70,7 @@ Signals are evaluated at the root first; if none fires, the nested-project fallb
 - Application framework configuration detected (next.config, vite.config, angular.json, etc.)
 - Package manifest with application dependencies (package.json with non-dev deps, requirements.txt, Cargo.toml, go.mod, pom.xml, etc.)
 - Application source directories exist (src/, app/, lib/, pages/, components/)
+- A parseable `.gitmodules` at the workspace root with at least one submodule path entry (repo metadata declares code even when the submodule dirs are not yet initialized)
 
 **Greenfield** — ALL of these must be true:
 - No source code files in any recognized language
@@ -95,6 +97,15 @@ From the scan results, identify:
 1. Mark workspace-detection as `[x]` completed in `<record>/aidlc-state.md`
 2. Update Workspace State section with detected languages, frameworks, build system
 3. Append WORKSPACE_SCANNED event to `<record>/audit/<host>-<clone>.md` with scan results and classification
+
+### Step 6a: Relay the Submodule Warning (if present)
+
+When the birth output carries the uninitialized-submodules warning (the scanner
+found a `.gitmodules` whose submodule paths are empty/uninitialized), relay it to
+the user verbatim and tell them to run `git submodule update --init --recursive`
+before proceeding, since reverse-engineering needs the code on disk. Do NOT offer
+to run the command yourself, and do NOT block auto-proceed - this is an advisory
+relay only.
 
 ### Step 7: Auto-Proceed
 

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -633,6 +633,40 @@ function handleDoctor(projectDir: string): void {
     fix: `copy the workspace shell from \`dist/${harnessDir().replace(/^\./, "")}/\` into your project root`,
   });
 
+  // 5a. Git submodules - an uninitialized submodule leaves its dir empty, so the
+  // scanner would classify a submodule-only workspace greenfield and auto-skip
+  // reverse-engineering. This ADVISORY row surfaces the state and the remedy.
+  // pass:true always (an uninitialized submodule is a user-environment pre-flight
+  // state, not framework breakage, and doctor's exit code feeds CI/scripts): the
+  // detail lives in the LABEL because the renderer prints `fix` only on a FAILED
+  // row (mirrors the intent-registry advisory).
+  if (!existsSync(join(projectDir, ".gitmodules"))) {
+    results.push({
+      pass: true,
+      label: "Submodules: no .gitmodules at workspace root",
+    });
+  } else {
+    const submodules = scanSubmodules(projectDir);
+    const uninit = submodules.filter((s) => !s.initialized);
+    if (submodules.length === 0) {
+      results.push({
+        pass: true,
+        label:
+          "Submodules: .gitmodules present but no parseable submodule entries",
+      });
+    } else if (uninit.length === 0) {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, all initialized`,
+      });
+    } else {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, ${uninit.length} uninitialized (advisory) (${enumerateSubmodulePaths(uninit)}) - run \`${SUBMODULE_INIT_REMEDY}\` to fetch them so reverse-engineering can read the code`,
+      });
+    }
+  }
+
   // 6. Hook heartbeats
   // Three states:
   //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
@@ -1763,6 +1797,13 @@ function handleDoctor(projectDir: string): void {
 // Deterministic workspace scanner
 // ---------------------------------------------------------------------------
 
+interface SubmoduleEntry {
+  name: string;
+  path: string;          // as written in .gitmodules (validated relative)
+  url: string;           // "" when absent
+  initialized: boolean;  // existsSync(join(projectDir, path, ".git"))
+}
+
 interface ScanResult {
   projectType: string;   // "Greenfield" | "Brownfield"
   languages: string;     // e.g. "TypeScript, JavaScript"
@@ -1773,6 +1814,20 @@ interface ScanResult {
   // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
   // the `detect --json` payload, never in the state file.
   nestedRoot?: string;
+  submodules: SubmoduleEntry[]; // [] when no .gitmodules / none parseable
+}
+
+// The remedy naming the git command that fetches uninitialized submodules.
+// Shared by every warning surface so the wording never drifts.
+const SUBMODULE_INIT_REMEDY = "git submodule update --init --recursive";
+
+// Enumerate submodule paths for a warning string: at most 5, then "(+N more)".
+// Returns the bare comma-joined list (no parens) so each surface wraps it as
+// it needs. Caps the enumerated set to keep audit/stdout lines bounded.
+function enumerateSubmodulePaths(entries: SubmoduleEntry[]): string {
+  const paths = entries.map((e) => e.path);
+  if (paths.length <= 5) return paths.join(", ");
+  return `${paths.slice(0, 5).join(", ")} (+${paths.length - 5} more)`;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -2067,6 +2122,66 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   };
 }
 
+// Parse .gitmodules (ini-like) into submodule entries. Pure and exported for
+// direct unit testing. Line-oriented, tolerant: malformed content degrades to
+// whatever parses (total garbage yields []); it never throws. An entry with no
+// path is dropped, as is any path that is absolute or escapes the project via a
+// `..` segment (a caller joins path under projectDir and must not follow it out).
+export function parseGitmodules(
+  content: string
+): Array<{ name: string; path: string; url: string }> {
+  const entries: Array<{ name: string; path: string; url: string }> = [];
+  let current: { name: string; path: string; url: string } | null = null;
+  const finish = () => {
+    if (!current) return;
+    const p = current.path;
+    const isUnsafe =
+      p === "" ||
+      p.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(p) || // Windows drive-absolute
+      p.split(/[/\\]/).includes("..");
+    if (!isUnsafe) entries.push(current);
+    current = null;
+  };
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("[")) {
+      finish();
+      const m = line.match(/^\[submodule\s+"(.+)"\]$/);
+      current = m ? { name: m[1], path: "", url: "" } : null;
+      continue;
+    }
+    if (!current) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key === "path") current.path = value;
+    else if (key === "url") current.url = value;
+  }
+  finish();
+  return entries;
+}
+
+// Read + parse the workspace-root .gitmodules and probe each declared path for
+// initialization. A missing/unreadable file yields [] (the swallow idiom of the
+// scanner neighbors). `initialized` mirrors isGitRepoDir (aidlc-lib.ts): the dir
+// must exist AND hold a `.git` entry - so a missing dir, an empty dir, and a dir
+// without `.git` all classify uninitialized.
+function scanSubmodules(projectDir: string): SubmoduleEntry[] {
+  let content: string;
+  try {
+    content = readFileSync(join(projectDir, ".gitmodules"), "utf-8");
+  } catch {
+    return [];
+  }
+  return parseGitmodules(content).map((e) => ({
+    ...e,
+    initialized: existsSync(join(projectDir, e.path, ".git")),
+  }));
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -2136,11 +2251,20 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
+  // Repo metadata: a .gitmodules with >= 1 valid submodule path declares code,
+  // even when the submodule dirs are empty/uninitialized. Languages stay AS
+  // SCANNED (Unknown is truthful until the submodules are fetched). A root
+  // signal: folded in after the nested fallback so nested aggregation (and
+  // nestedRoot attribution) still runs when submodules are the only signal.
+  const submodules = scanSubmodules(projectDir);
+  if (submodules.length > 0) brownfield = true;
+
   const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
     frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
+    submodules,
   };
   if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
   return result;
@@ -2430,6 +2554,11 @@ function handleIntentBirthStateBuild(
   });
 
   const scan = detectWorkspace(projectDir);
+  const uninitSubmodules = scan.submodules.filter((s) => !s.initialized);
+  const submoduleRemedy =
+    uninitSubmodules.length > 0
+      ? `${uninitSubmodules.length} uninitialized submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' to fetch them`
+      : "";
 
   appendAuditEvent(projectDir, "WORKSPACE_SCANNED", {
     "Project Type": scan.projectType,
@@ -2437,7 +2566,15 @@ function handleIntentBirthStateBuild(
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
     ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
-    Details: "Deterministic rule-based scan",
+    ...(scan.submodules.length > 0
+      ? {
+          Submodules: `${scan.submodules.length} declared, ${uninitSubmodules.length} uninitialized`,
+        }
+      : {}),
+    Details:
+      uninitSubmodules.length > 0
+        ? `Deterministic rule-based scan; ${submoduleRemedy}`
+        : "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
     Stage: "workspace-detection",
@@ -2673,6 +2810,10 @@ ${stageProgress}
   // cursor + the record dir were set by birthIntent above; the state file lives
   // under the born intent's record (resolved by writeStateFile's default).
   const bornDir = activeIntent(projectDir) ?? "(legacy flat record)";
+  const submoduleWarningLine =
+    uninitSubmodules.length > 0
+      ? `Warning: ${uninitSubmodules.length} uninitialized git submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' before proceeding so reverse-engineering can read the code.\n`
+      : "";
   process.stdout.write(
     `Intent born: ${bornDir} (space: ${activeSpace(projectDir)})
 State initialized: ${scope} scope, ${totalInScope} stages, ${effectiveDepth} depth
@@ -2680,7 +2821,7 @@ Project type: ${scan.projectType}
 Languages: ${scan.languages}
 Frameworks: ${scan.frameworks}
 Build System: ${scan.buildSystem}
-First post-init stage: ${firstPostInit} (${firstPostInitPhase})
+${submoduleWarningLine}First post-init stage: ${firstPostInit} (${firstPostInitPhase})
 `
   );
 }
@@ -2905,6 +3046,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
     ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
+    submodules: scan.submodules,
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2913,12 +3055,18 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
     return;
   }
+  const uninitCount = scan.submodules.filter((s) => !s.initialized).length;
+  const submoduleLine =
+    scan.submodules.length > 0
+      ? `Submodules: ${scan.submodules.length} declared, ${uninitCount} uninitialized\n`
+      : "";
   process.stdout.write(
     `Project type: ${payload.projectType}\n` +
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
       (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
+      submoduleLine +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.9";
+export const AIDLC_VERSION = "2.2.10";

--- a/dist/claude/.claude/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/claude/.claude/aidlc-common/stages/initialization/workspace-detection.md
@@ -50,6 +50,7 @@ Scan signals:
 - Build system files (Makefile, Dockerfile, docker-compose, CI/CD configs)
 - Package/dependency files (lock files, vendor directories)
 - Source code directories and their languages
+- Repo metadata (`.gitmodules` submodule declarations)
 - Test infrastructure (test directories, test config files, coverage config)
 - Documentation (README, docs/, wiki/)
 
@@ -69,6 +70,7 @@ Signals are evaluated at the root first; if none fires, the nested-project fallb
 - Application framework configuration detected (next.config, vite.config, angular.json, etc.)
 - Package manifest with application dependencies (package.json with non-dev deps, requirements.txt, Cargo.toml, go.mod, pom.xml, etc.)
 - Application source directories exist (src/, app/, lib/, pages/, components/)
+- A parseable `.gitmodules` at the workspace root with at least one submodule path entry (repo metadata declares code even when the submodule dirs are not yet initialized)
 
 **Greenfield** — ALL of these must be true:
 - No source code files in any recognized language
@@ -95,6 +97,15 @@ From the scan results, identify:
 1. Mark workspace-detection as `[x]` completed in `<record>/aidlc-state.md`
 2. Update Workspace State section with detected languages, frameworks, build system
 3. Append WORKSPACE_SCANNED event to `<record>/audit/<host>-<clone>.md` with scan results and classification
+
+### Step 6a: Relay the Submodule Warning (if present)
+
+When the birth output carries the uninitialized-submodules warning (the scanner
+found a `.gitmodules` whose submodule paths are empty/uninitialized), relay it to
+the user verbatim and tell them to run `git submodule update --init --recursive`
+before proceeding, since reverse-engineering needs the code on disk. Do NOT offer
+to run the command yourself, and do NOT block auto-proceed - this is an advisory
+relay only.
 
 ### Step 7: Auto-Proceed
 

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -633,6 +633,40 @@ function handleDoctor(projectDir: string): void {
     fix: `copy the workspace shell from \`dist/${harnessDir().replace(/^\./, "")}/\` into your project root`,
   });
 
+  // 5a. Git submodules - an uninitialized submodule leaves its dir empty, so the
+  // scanner would classify a submodule-only workspace greenfield and auto-skip
+  // reverse-engineering. This ADVISORY row surfaces the state and the remedy.
+  // pass:true always (an uninitialized submodule is a user-environment pre-flight
+  // state, not framework breakage, and doctor's exit code feeds CI/scripts): the
+  // detail lives in the LABEL because the renderer prints `fix` only on a FAILED
+  // row (mirrors the intent-registry advisory).
+  if (!existsSync(join(projectDir, ".gitmodules"))) {
+    results.push({
+      pass: true,
+      label: "Submodules: no .gitmodules at workspace root",
+    });
+  } else {
+    const submodules = scanSubmodules(projectDir);
+    const uninit = submodules.filter((s) => !s.initialized);
+    if (submodules.length === 0) {
+      results.push({
+        pass: true,
+        label:
+          "Submodules: .gitmodules present but no parseable submodule entries",
+      });
+    } else if (uninit.length === 0) {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, all initialized`,
+      });
+    } else {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, ${uninit.length} uninitialized (advisory) (${enumerateSubmodulePaths(uninit)}) - run \`${SUBMODULE_INIT_REMEDY}\` to fetch them so reverse-engineering can read the code`,
+      });
+    }
+  }
+
   // 6. Hook heartbeats
   // Three states:
   //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
@@ -1763,6 +1797,13 @@ function handleDoctor(projectDir: string): void {
 // Deterministic workspace scanner
 // ---------------------------------------------------------------------------
 
+interface SubmoduleEntry {
+  name: string;
+  path: string;          // as written in .gitmodules (validated relative)
+  url: string;           // "" when absent
+  initialized: boolean;  // existsSync(join(projectDir, path, ".git"))
+}
+
 interface ScanResult {
   projectType: string;   // "Greenfield" | "Brownfield"
   languages: string;     // e.g. "TypeScript, JavaScript"
@@ -1773,6 +1814,20 @@ interface ScanResult {
   // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
   // the `detect --json` payload, never in the state file.
   nestedRoot?: string;
+  submodules: SubmoduleEntry[]; // [] when no .gitmodules / none parseable
+}
+
+// The remedy naming the git command that fetches uninitialized submodules.
+// Shared by every warning surface so the wording never drifts.
+const SUBMODULE_INIT_REMEDY = "git submodule update --init --recursive";
+
+// Enumerate submodule paths for a warning string: at most 5, then "(+N more)".
+// Returns the bare comma-joined list (no parens) so each surface wraps it as
+// it needs. Caps the enumerated set to keep audit/stdout lines bounded.
+function enumerateSubmodulePaths(entries: SubmoduleEntry[]): string {
+  const paths = entries.map((e) => e.path);
+  if (paths.length <= 5) return paths.join(", ");
+  return `${paths.slice(0, 5).join(", ")} (+${paths.length - 5} more)`;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -2067,6 +2122,66 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   };
 }
 
+// Parse .gitmodules (ini-like) into submodule entries. Pure and exported for
+// direct unit testing. Line-oriented, tolerant: malformed content degrades to
+// whatever parses (total garbage yields []); it never throws. An entry with no
+// path is dropped, as is any path that is absolute or escapes the project via a
+// `..` segment (a caller joins path under projectDir and must not follow it out).
+export function parseGitmodules(
+  content: string
+): Array<{ name: string; path: string; url: string }> {
+  const entries: Array<{ name: string; path: string; url: string }> = [];
+  let current: { name: string; path: string; url: string } | null = null;
+  const finish = () => {
+    if (!current) return;
+    const p = current.path;
+    const isUnsafe =
+      p === "" ||
+      p.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(p) || // Windows drive-absolute
+      p.split(/[/\\]/).includes("..");
+    if (!isUnsafe) entries.push(current);
+    current = null;
+  };
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("[")) {
+      finish();
+      const m = line.match(/^\[submodule\s+"(.+)"\]$/);
+      current = m ? { name: m[1], path: "", url: "" } : null;
+      continue;
+    }
+    if (!current) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key === "path") current.path = value;
+    else if (key === "url") current.url = value;
+  }
+  finish();
+  return entries;
+}
+
+// Read + parse the workspace-root .gitmodules and probe each declared path for
+// initialization. A missing/unreadable file yields [] (the swallow idiom of the
+// scanner neighbors). `initialized` mirrors isGitRepoDir (aidlc-lib.ts): the dir
+// must exist AND hold a `.git` entry - so a missing dir, an empty dir, and a dir
+// without `.git` all classify uninitialized.
+function scanSubmodules(projectDir: string): SubmoduleEntry[] {
+  let content: string;
+  try {
+    content = readFileSync(join(projectDir, ".gitmodules"), "utf-8");
+  } catch {
+    return [];
+  }
+  return parseGitmodules(content).map((e) => ({
+    ...e,
+    initialized: existsSync(join(projectDir, e.path, ".git")),
+  }));
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -2136,11 +2251,20 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
+  // Repo metadata: a .gitmodules with >= 1 valid submodule path declares code,
+  // even when the submodule dirs are empty/uninitialized. Languages stay AS
+  // SCANNED (Unknown is truthful until the submodules are fetched). A root
+  // signal: folded in after the nested fallback so nested aggregation (and
+  // nestedRoot attribution) still runs when submodules are the only signal.
+  const submodules = scanSubmodules(projectDir);
+  if (submodules.length > 0) brownfield = true;
+
   const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
     frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
+    submodules,
   };
   if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
   return result;
@@ -2430,6 +2554,11 @@ function handleIntentBirthStateBuild(
   });
 
   const scan = detectWorkspace(projectDir);
+  const uninitSubmodules = scan.submodules.filter((s) => !s.initialized);
+  const submoduleRemedy =
+    uninitSubmodules.length > 0
+      ? `${uninitSubmodules.length} uninitialized submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' to fetch them`
+      : "";
 
   appendAuditEvent(projectDir, "WORKSPACE_SCANNED", {
     "Project Type": scan.projectType,
@@ -2437,7 +2566,15 @@ function handleIntentBirthStateBuild(
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
     ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
-    Details: "Deterministic rule-based scan",
+    ...(scan.submodules.length > 0
+      ? {
+          Submodules: `${scan.submodules.length} declared, ${uninitSubmodules.length} uninitialized`,
+        }
+      : {}),
+    Details:
+      uninitSubmodules.length > 0
+        ? `Deterministic rule-based scan; ${submoduleRemedy}`
+        : "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
     Stage: "workspace-detection",
@@ -2673,6 +2810,10 @@ ${stageProgress}
   // cursor + the record dir were set by birthIntent above; the state file lives
   // under the born intent's record (resolved by writeStateFile's default).
   const bornDir = activeIntent(projectDir) ?? "(legacy flat record)";
+  const submoduleWarningLine =
+    uninitSubmodules.length > 0
+      ? `Warning: ${uninitSubmodules.length} uninitialized git submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' before proceeding so reverse-engineering can read the code.\n`
+      : "";
   process.stdout.write(
     `Intent born: ${bornDir} (space: ${activeSpace(projectDir)})
 State initialized: ${scope} scope, ${totalInScope} stages, ${effectiveDepth} depth
@@ -2680,7 +2821,7 @@ Project type: ${scan.projectType}
 Languages: ${scan.languages}
 Frameworks: ${scan.frameworks}
 Build System: ${scan.buildSystem}
-First post-init stage: ${firstPostInit} (${firstPostInitPhase})
+${submoduleWarningLine}First post-init stage: ${firstPostInit} (${firstPostInitPhase})
 `
   );
 }
@@ -2905,6 +3046,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
     ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
+    submodules: scan.submodules,
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2913,12 +3055,18 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
     return;
   }
+  const uninitCount = scan.submodules.filter((s) => !s.initialized).length;
+  const submoduleLine =
+    scan.submodules.length > 0
+      ? `Submodules: ${scan.submodules.length} declared, ${uninitCount} uninitialized\n`
+      : "";
   process.stdout.write(
     `Project type: ${payload.projectType}\n` +
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
       (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
+      submoduleLine +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.9";
+export const AIDLC_VERSION = "2.2.10";

--- a/dist/codex/.codex/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/codex/.codex/aidlc-common/stages/initialization/workspace-detection.md
@@ -50,6 +50,7 @@ Scan signals:
 - Build system files (Makefile, Dockerfile, docker-compose, CI/CD configs)
 - Package/dependency files (lock files, vendor directories)
 - Source code directories and their languages
+- Repo metadata (`.gitmodules` submodule declarations)
 - Test infrastructure (test directories, test config files, coverage config)
 - Documentation (README, docs/, wiki/)
 
@@ -69,6 +70,7 @@ Signals are evaluated at the root first; if none fires, the nested-project fallb
 - Application framework configuration detected (next.config, vite.config, angular.json, etc.)
 - Package manifest with application dependencies (package.json with non-dev deps, requirements.txt, Cargo.toml, go.mod, pom.xml, etc.)
 - Application source directories exist (src/, app/, lib/, pages/, components/)
+- A parseable `.gitmodules` at the workspace root with at least one submodule path entry (repo metadata declares code even when the submodule dirs are not yet initialized)
 
 **Greenfield** — ALL of these must be true:
 - No source code files in any recognized language
@@ -95,6 +97,15 @@ From the scan results, identify:
 1. Mark workspace-detection as `[x]` completed in `<record>/aidlc-state.md`
 2. Update Workspace State section with detected languages, frameworks, build system
 3. Append WORKSPACE_SCANNED event to `<record>/audit/<host>-<clone>.md` with scan results and classification
+
+### Step 6a: Relay the Submodule Warning (if present)
+
+When the birth output carries the uninitialized-submodules warning (the scanner
+found a `.gitmodules` whose submodule paths are empty/uninitialized), relay it to
+the user verbatim and tell them to run `git submodule update --init --recursive`
+before proceeding, since reverse-engineering needs the code on disk. Do NOT offer
+to run the command yourself, and do NOT block auto-proceed - this is an advisory
+relay only.
 
 ### Step 7: Auto-Proceed
 

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -633,6 +633,40 @@ function handleDoctor(projectDir: string): void {
     fix: `copy the workspace shell from \`dist/${harnessDir().replace(/^\./, "")}/\` into your project root`,
   });
 
+  // 5a. Git submodules - an uninitialized submodule leaves its dir empty, so the
+  // scanner would classify a submodule-only workspace greenfield and auto-skip
+  // reverse-engineering. This ADVISORY row surfaces the state and the remedy.
+  // pass:true always (an uninitialized submodule is a user-environment pre-flight
+  // state, not framework breakage, and doctor's exit code feeds CI/scripts): the
+  // detail lives in the LABEL because the renderer prints `fix` only on a FAILED
+  // row (mirrors the intent-registry advisory).
+  if (!existsSync(join(projectDir, ".gitmodules"))) {
+    results.push({
+      pass: true,
+      label: "Submodules: no .gitmodules at workspace root",
+    });
+  } else {
+    const submodules = scanSubmodules(projectDir);
+    const uninit = submodules.filter((s) => !s.initialized);
+    if (submodules.length === 0) {
+      results.push({
+        pass: true,
+        label:
+          "Submodules: .gitmodules present but no parseable submodule entries",
+      });
+    } else if (uninit.length === 0) {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, all initialized`,
+      });
+    } else {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, ${uninit.length} uninitialized (advisory) (${enumerateSubmodulePaths(uninit)}) - run \`${SUBMODULE_INIT_REMEDY}\` to fetch them so reverse-engineering can read the code`,
+      });
+    }
+  }
+
   // 6. Hook heartbeats
   // Three states:
   //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
@@ -1763,6 +1797,13 @@ function handleDoctor(projectDir: string): void {
 // Deterministic workspace scanner
 // ---------------------------------------------------------------------------
 
+interface SubmoduleEntry {
+  name: string;
+  path: string;          // as written in .gitmodules (validated relative)
+  url: string;           // "" when absent
+  initialized: boolean;  // existsSync(join(projectDir, path, ".git"))
+}
+
 interface ScanResult {
   projectType: string;   // "Greenfield" | "Brownfield"
   languages: string;     // e.g. "TypeScript, JavaScript"
@@ -1773,6 +1814,20 @@ interface ScanResult {
   // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
   // the `detect --json` payload, never in the state file.
   nestedRoot?: string;
+  submodules: SubmoduleEntry[]; // [] when no .gitmodules / none parseable
+}
+
+// The remedy naming the git command that fetches uninitialized submodules.
+// Shared by every warning surface so the wording never drifts.
+const SUBMODULE_INIT_REMEDY = "git submodule update --init --recursive";
+
+// Enumerate submodule paths for a warning string: at most 5, then "(+N more)".
+// Returns the bare comma-joined list (no parens) so each surface wraps it as
+// it needs. Caps the enumerated set to keep audit/stdout lines bounded.
+function enumerateSubmodulePaths(entries: SubmoduleEntry[]): string {
+  const paths = entries.map((e) => e.path);
+  if (paths.length <= 5) return paths.join(", ");
+  return `${paths.slice(0, 5).join(", ")} (+${paths.length - 5} more)`;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -2067,6 +2122,66 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   };
 }
 
+// Parse .gitmodules (ini-like) into submodule entries. Pure and exported for
+// direct unit testing. Line-oriented, tolerant: malformed content degrades to
+// whatever parses (total garbage yields []); it never throws. An entry with no
+// path is dropped, as is any path that is absolute or escapes the project via a
+// `..` segment (a caller joins path under projectDir and must not follow it out).
+export function parseGitmodules(
+  content: string
+): Array<{ name: string; path: string; url: string }> {
+  const entries: Array<{ name: string; path: string; url: string }> = [];
+  let current: { name: string; path: string; url: string } | null = null;
+  const finish = () => {
+    if (!current) return;
+    const p = current.path;
+    const isUnsafe =
+      p === "" ||
+      p.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(p) || // Windows drive-absolute
+      p.split(/[/\\]/).includes("..");
+    if (!isUnsafe) entries.push(current);
+    current = null;
+  };
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("[")) {
+      finish();
+      const m = line.match(/^\[submodule\s+"(.+)"\]$/);
+      current = m ? { name: m[1], path: "", url: "" } : null;
+      continue;
+    }
+    if (!current) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key === "path") current.path = value;
+    else if (key === "url") current.url = value;
+  }
+  finish();
+  return entries;
+}
+
+// Read + parse the workspace-root .gitmodules and probe each declared path for
+// initialization. A missing/unreadable file yields [] (the swallow idiom of the
+// scanner neighbors). `initialized` mirrors isGitRepoDir (aidlc-lib.ts): the dir
+// must exist AND hold a `.git` entry - so a missing dir, an empty dir, and a dir
+// without `.git` all classify uninitialized.
+function scanSubmodules(projectDir: string): SubmoduleEntry[] {
+  let content: string;
+  try {
+    content = readFileSync(join(projectDir, ".gitmodules"), "utf-8");
+  } catch {
+    return [];
+  }
+  return parseGitmodules(content).map((e) => ({
+    ...e,
+    initialized: existsSync(join(projectDir, e.path, ".git")),
+  }));
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -2136,11 +2251,20 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
+  // Repo metadata: a .gitmodules with >= 1 valid submodule path declares code,
+  // even when the submodule dirs are empty/uninitialized. Languages stay AS
+  // SCANNED (Unknown is truthful until the submodules are fetched). A root
+  // signal: folded in after the nested fallback so nested aggregation (and
+  // nestedRoot attribution) still runs when submodules are the only signal.
+  const submodules = scanSubmodules(projectDir);
+  if (submodules.length > 0) brownfield = true;
+
   const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
     frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
+    submodules,
   };
   if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
   return result;
@@ -2430,6 +2554,11 @@ function handleIntentBirthStateBuild(
   });
 
   const scan = detectWorkspace(projectDir);
+  const uninitSubmodules = scan.submodules.filter((s) => !s.initialized);
+  const submoduleRemedy =
+    uninitSubmodules.length > 0
+      ? `${uninitSubmodules.length} uninitialized submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' to fetch them`
+      : "";
 
   appendAuditEvent(projectDir, "WORKSPACE_SCANNED", {
     "Project Type": scan.projectType,
@@ -2437,7 +2566,15 @@ function handleIntentBirthStateBuild(
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
     ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
-    Details: "Deterministic rule-based scan",
+    ...(scan.submodules.length > 0
+      ? {
+          Submodules: `${scan.submodules.length} declared, ${uninitSubmodules.length} uninitialized`,
+        }
+      : {}),
+    Details:
+      uninitSubmodules.length > 0
+        ? `Deterministic rule-based scan; ${submoduleRemedy}`
+        : "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
     Stage: "workspace-detection",
@@ -2673,6 +2810,10 @@ ${stageProgress}
   // cursor + the record dir were set by birthIntent above; the state file lives
   // under the born intent's record (resolved by writeStateFile's default).
   const bornDir = activeIntent(projectDir) ?? "(legacy flat record)";
+  const submoduleWarningLine =
+    uninitSubmodules.length > 0
+      ? `Warning: ${uninitSubmodules.length} uninitialized git submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' before proceeding so reverse-engineering can read the code.\n`
+      : "";
   process.stdout.write(
     `Intent born: ${bornDir} (space: ${activeSpace(projectDir)})
 State initialized: ${scope} scope, ${totalInScope} stages, ${effectiveDepth} depth
@@ -2680,7 +2821,7 @@ Project type: ${scan.projectType}
 Languages: ${scan.languages}
 Frameworks: ${scan.frameworks}
 Build System: ${scan.buildSystem}
-First post-init stage: ${firstPostInit} (${firstPostInitPhase})
+${submoduleWarningLine}First post-init stage: ${firstPostInit} (${firstPostInitPhase})
 `
   );
 }
@@ -2905,6 +3046,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
     ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
+    submodules: scan.submodules,
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2913,12 +3055,18 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
     return;
   }
+  const uninitCount = scan.submodules.filter((s) => !s.initialized).length;
+  const submoduleLine =
+    scan.submodules.length > 0
+      ? `Submodules: ${scan.submodules.length} declared, ${uninitCount} uninitialized\n`
+      : "";
   process.stdout.write(
     `Project type: ${payload.projectType}\n` +
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
       (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
+      submoduleLine +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.9";
+export const AIDLC_VERSION = "2.2.10";

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/initialization/workspace-detection.md
@@ -50,6 +50,7 @@ Scan signals:
 - Build system files (Makefile, Dockerfile, docker-compose, CI/CD configs)
 - Package/dependency files (lock files, vendor directories)
 - Source code directories and their languages
+- Repo metadata (`.gitmodules` submodule declarations)
 - Test infrastructure (test directories, test config files, coverage config)
 - Documentation (README, docs/, wiki/)
 
@@ -69,6 +70,7 @@ Signals are evaluated at the root first; if none fires, the nested-project fallb
 - Application framework configuration detected (next.config, vite.config, angular.json, etc.)
 - Package manifest with application dependencies (package.json with non-dev deps, requirements.txt, Cargo.toml, go.mod, pom.xml, etc.)
 - Application source directories exist (src/, app/, lib/, pages/, components/)
+- A parseable `.gitmodules` at the workspace root with at least one submodule path entry (repo metadata declares code even when the submodule dirs are not yet initialized)
 
 **Greenfield** — ALL of these must be true:
 - No source code files in any recognized language
@@ -95,6 +97,15 @@ From the scan results, identify:
 1. Mark workspace-detection as `[x]` completed in `<record>/aidlc-state.md`
 2. Update Workspace State section with detected languages, frameworks, build system
 3. Append WORKSPACE_SCANNED event to `<record>/audit/<host>-<clone>.md` with scan results and classification
+
+### Step 6a: Relay the Submodule Warning (if present)
+
+When the birth output carries the uninitialized-submodules warning (the scanner
+found a `.gitmodules` whose submodule paths are empty/uninitialized), relay it to
+the user verbatim and tell them to run `git submodule update --init --recursive`
+before proceeding, since reverse-engineering needs the code on disk. Do NOT offer
+to run the command yourself, and do NOT block auto-proceed - this is an advisory
+relay only.
 
 ### Step 7: Auto-Proceed
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -633,6 +633,40 @@ function handleDoctor(projectDir: string): void {
     fix: `copy the workspace shell from \`dist/${harnessDir().replace(/^\./, "")}/\` into your project root`,
   });
 
+  // 5a. Git submodules - an uninitialized submodule leaves its dir empty, so the
+  // scanner would classify a submodule-only workspace greenfield and auto-skip
+  // reverse-engineering. This ADVISORY row surfaces the state and the remedy.
+  // pass:true always (an uninitialized submodule is a user-environment pre-flight
+  // state, not framework breakage, and doctor's exit code feeds CI/scripts): the
+  // detail lives in the LABEL because the renderer prints `fix` only on a FAILED
+  // row (mirrors the intent-registry advisory).
+  if (!existsSync(join(projectDir, ".gitmodules"))) {
+    results.push({
+      pass: true,
+      label: "Submodules: no .gitmodules at workspace root",
+    });
+  } else {
+    const submodules = scanSubmodules(projectDir);
+    const uninit = submodules.filter((s) => !s.initialized);
+    if (submodules.length === 0) {
+      results.push({
+        pass: true,
+        label:
+          "Submodules: .gitmodules present but no parseable submodule entries",
+      });
+    } else if (uninit.length === 0) {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, all initialized`,
+      });
+    } else {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, ${uninit.length} uninitialized (advisory) (${enumerateSubmodulePaths(uninit)}) - run \`${SUBMODULE_INIT_REMEDY}\` to fetch them so reverse-engineering can read the code`,
+      });
+    }
+  }
+
   // 6. Hook heartbeats
   // Three states:
   //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
@@ -1763,6 +1797,13 @@ function handleDoctor(projectDir: string): void {
 // Deterministic workspace scanner
 // ---------------------------------------------------------------------------
 
+interface SubmoduleEntry {
+  name: string;
+  path: string;          // as written in .gitmodules (validated relative)
+  url: string;           // "" when absent
+  initialized: boolean;  // existsSync(join(projectDir, path, ".git"))
+}
+
 interface ScanResult {
   projectType: string;   // "Greenfield" | "Brownfield"
   languages: string;     // e.g. "TypeScript, JavaScript"
@@ -1773,6 +1814,20 @@ interface ScanResult {
   // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
   // the `detect --json` payload, never in the state file.
   nestedRoot?: string;
+  submodules: SubmoduleEntry[]; // [] when no .gitmodules / none parseable
+}
+
+// The remedy naming the git command that fetches uninitialized submodules.
+// Shared by every warning surface so the wording never drifts.
+const SUBMODULE_INIT_REMEDY = "git submodule update --init --recursive";
+
+// Enumerate submodule paths for a warning string: at most 5, then "(+N more)".
+// Returns the bare comma-joined list (no parens) so each surface wraps it as
+// it needs. Caps the enumerated set to keep audit/stdout lines bounded.
+function enumerateSubmodulePaths(entries: SubmoduleEntry[]): string {
+  const paths = entries.map((e) => e.path);
+  if (paths.length <= 5) return paths.join(", ");
+  return `${paths.slice(0, 5).join(", ")} (+${paths.length - 5} more)`;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -2067,6 +2122,66 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   };
 }
 
+// Parse .gitmodules (ini-like) into submodule entries. Pure and exported for
+// direct unit testing. Line-oriented, tolerant: malformed content degrades to
+// whatever parses (total garbage yields []); it never throws. An entry with no
+// path is dropped, as is any path that is absolute or escapes the project via a
+// `..` segment (a caller joins path under projectDir and must not follow it out).
+export function parseGitmodules(
+  content: string
+): Array<{ name: string; path: string; url: string }> {
+  const entries: Array<{ name: string; path: string; url: string }> = [];
+  let current: { name: string; path: string; url: string } | null = null;
+  const finish = () => {
+    if (!current) return;
+    const p = current.path;
+    const isUnsafe =
+      p === "" ||
+      p.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(p) || // Windows drive-absolute
+      p.split(/[/\\]/).includes("..");
+    if (!isUnsafe) entries.push(current);
+    current = null;
+  };
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("[")) {
+      finish();
+      const m = line.match(/^\[submodule\s+"(.+)"\]$/);
+      current = m ? { name: m[1], path: "", url: "" } : null;
+      continue;
+    }
+    if (!current) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key === "path") current.path = value;
+    else if (key === "url") current.url = value;
+  }
+  finish();
+  return entries;
+}
+
+// Read + parse the workspace-root .gitmodules and probe each declared path for
+// initialization. A missing/unreadable file yields [] (the swallow idiom of the
+// scanner neighbors). `initialized` mirrors isGitRepoDir (aidlc-lib.ts): the dir
+// must exist AND hold a `.git` entry - so a missing dir, an empty dir, and a dir
+// without `.git` all classify uninitialized.
+function scanSubmodules(projectDir: string): SubmoduleEntry[] {
+  let content: string;
+  try {
+    content = readFileSync(join(projectDir, ".gitmodules"), "utf-8");
+  } catch {
+    return [];
+  }
+  return parseGitmodules(content).map((e) => ({
+    ...e,
+    initialized: existsSync(join(projectDir, e.path, ".git")),
+  }));
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -2136,11 +2251,20 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
+  // Repo metadata: a .gitmodules with >= 1 valid submodule path declares code,
+  // even when the submodule dirs are empty/uninitialized. Languages stay AS
+  // SCANNED (Unknown is truthful until the submodules are fetched). A root
+  // signal: folded in after the nested fallback so nested aggregation (and
+  // nestedRoot attribution) still runs when submodules are the only signal.
+  const submodules = scanSubmodules(projectDir);
+  if (submodules.length > 0) brownfield = true;
+
   const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
     frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
+    submodules,
   };
   if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
   return result;
@@ -2430,6 +2554,11 @@ function handleIntentBirthStateBuild(
   });
 
   const scan = detectWorkspace(projectDir);
+  const uninitSubmodules = scan.submodules.filter((s) => !s.initialized);
+  const submoduleRemedy =
+    uninitSubmodules.length > 0
+      ? `${uninitSubmodules.length} uninitialized submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' to fetch them`
+      : "";
 
   appendAuditEvent(projectDir, "WORKSPACE_SCANNED", {
     "Project Type": scan.projectType,
@@ -2437,7 +2566,15 @@ function handleIntentBirthStateBuild(
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
     ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
-    Details: "Deterministic rule-based scan",
+    ...(scan.submodules.length > 0
+      ? {
+          Submodules: `${scan.submodules.length} declared, ${uninitSubmodules.length} uninitialized`,
+        }
+      : {}),
+    Details:
+      uninitSubmodules.length > 0
+        ? `Deterministic rule-based scan; ${submoduleRemedy}`
+        : "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
     Stage: "workspace-detection",
@@ -2673,6 +2810,10 @@ ${stageProgress}
   // cursor + the record dir were set by birthIntent above; the state file lives
   // under the born intent's record (resolved by writeStateFile's default).
   const bornDir = activeIntent(projectDir) ?? "(legacy flat record)";
+  const submoduleWarningLine =
+    uninitSubmodules.length > 0
+      ? `Warning: ${uninitSubmodules.length} uninitialized git submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' before proceeding so reverse-engineering can read the code.\n`
+      : "";
   process.stdout.write(
     `Intent born: ${bornDir} (space: ${activeSpace(projectDir)})
 State initialized: ${scope} scope, ${totalInScope} stages, ${effectiveDepth} depth
@@ -2680,7 +2821,7 @@ Project type: ${scan.projectType}
 Languages: ${scan.languages}
 Frameworks: ${scan.frameworks}
 Build System: ${scan.buildSystem}
-First post-init stage: ${firstPostInit} (${firstPostInitPhase})
+${submoduleWarningLine}First post-init stage: ${firstPostInit} (${firstPostInitPhase})
 `
   );
 }
@@ -2905,6 +3046,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
     ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
+    submodules: scan.submodules,
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2913,12 +3055,18 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
     return;
   }
+  const uninitCount = scan.submodules.filter((s) => !s.initialized).length;
+  const submoduleLine =
+    scan.submodules.length > 0
+      ? `Submodules: ${scan.submodules.length} declared, ${uninitCount} uninitialized\n`
+      : "";
   process.stdout.write(
     `Project type: ${payload.projectType}\n` +
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
       (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
+      submoduleLine +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.9";
+export const AIDLC_VERSION = "2.2.10";

--- a/dist/kiro/.kiro/aidlc-common/stages/initialization/workspace-detection.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/initialization/workspace-detection.md
@@ -50,6 +50,7 @@ Scan signals:
 - Build system files (Makefile, Dockerfile, docker-compose, CI/CD configs)
 - Package/dependency files (lock files, vendor directories)
 - Source code directories and their languages
+- Repo metadata (`.gitmodules` submodule declarations)
 - Test infrastructure (test directories, test config files, coverage config)
 - Documentation (README, docs/, wiki/)
 
@@ -69,6 +70,7 @@ Signals are evaluated at the root first; if none fires, the nested-project fallb
 - Application framework configuration detected (next.config, vite.config, angular.json, etc.)
 - Package manifest with application dependencies (package.json with non-dev deps, requirements.txt, Cargo.toml, go.mod, pom.xml, etc.)
 - Application source directories exist (src/, app/, lib/, pages/, components/)
+- A parseable `.gitmodules` at the workspace root with at least one submodule path entry (repo metadata declares code even when the submodule dirs are not yet initialized)
 
 **Greenfield** — ALL of these must be true:
 - No source code files in any recognized language
@@ -95,6 +97,15 @@ From the scan results, identify:
 1. Mark workspace-detection as `[x]` completed in `<record>/aidlc-state.md`
 2. Update Workspace State section with detected languages, frameworks, build system
 3. Append WORKSPACE_SCANNED event to `<record>/audit/<host>-<clone>.md` with scan results and classification
+
+### Step 6a: Relay the Submodule Warning (if present)
+
+When the birth output carries the uninitialized-submodules warning (the scanner
+found a `.gitmodules` whose submodule paths are empty/uninitialized), relay it to
+the user verbatim and tell them to run `git submodule update --init --recursive`
+before proceeding, since reverse-engineering needs the code on disk. Do NOT offer
+to run the command yourself, and do NOT block auto-proceed - this is an advisory
+relay only.
 
 ### Step 7: Auto-Proceed
 

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -633,6 +633,40 @@ function handleDoctor(projectDir: string): void {
     fix: `copy the workspace shell from \`dist/${harnessDir().replace(/^\./, "")}/\` into your project root`,
   });
 
+  // 5a. Git submodules - an uninitialized submodule leaves its dir empty, so the
+  // scanner would classify a submodule-only workspace greenfield and auto-skip
+  // reverse-engineering. This ADVISORY row surfaces the state and the remedy.
+  // pass:true always (an uninitialized submodule is a user-environment pre-flight
+  // state, not framework breakage, and doctor's exit code feeds CI/scripts): the
+  // detail lives in the LABEL because the renderer prints `fix` only on a FAILED
+  // row (mirrors the intent-registry advisory).
+  if (!existsSync(join(projectDir, ".gitmodules"))) {
+    results.push({
+      pass: true,
+      label: "Submodules: no .gitmodules at workspace root",
+    });
+  } else {
+    const submodules = scanSubmodules(projectDir);
+    const uninit = submodules.filter((s) => !s.initialized);
+    if (submodules.length === 0) {
+      results.push({
+        pass: true,
+        label:
+          "Submodules: .gitmodules present but no parseable submodule entries",
+      });
+    } else if (uninit.length === 0) {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, all initialized`,
+      });
+    } else {
+      results.push({
+        pass: true,
+        label: `Submodules: ${submodules.length} declared, ${uninit.length} uninitialized (advisory) (${enumerateSubmodulePaths(uninit)}) - run \`${SUBMODULE_INIT_REMEDY}\` to fetch them so reverse-engineering can read the code`,
+      });
+    }
+  }
+
   // 6. Hook heartbeats
   // Three states:
   //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
@@ -1763,6 +1797,13 @@ function handleDoctor(projectDir: string): void {
 // Deterministic workspace scanner
 // ---------------------------------------------------------------------------
 
+interface SubmoduleEntry {
+  name: string;
+  path: string;          // as written in .gitmodules (validated relative)
+  url: string;           // "" when absent
+  initialized: boolean;  // existsSync(join(projectDir, path, ".git"))
+}
+
 interface ScanResult {
   projectType: string;   // "Greenfield" | "Brownfield"
   languages: string;     // e.g. "TypeScript, JavaScript"
@@ -1773,6 +1814,20 @@ interface ScanResult {
   // (the common case). Surfaced only in the WORKSPACE_SCANNED audit event and
   // the `detect --json` payload, never in the state file.
   nestedRoot?: string;
+  submodules: SubmoduleEntry[]; // [] when no .gitmodules / none parseable
+}
+
+// The remedy naming the git command that fetches uninitialized submodules.
+// Shared by every warning surface so the wording never drifts.
+const SUBMODULE_INIT_REMEDY = "git submodule update --init --recursive";
+
+// Enumerate submodule paths for a warning string: at most 5, then "(+N more)".
+// Returns the bare comma-joined list (no parens) so each surface wraps it as
+// it needs. Caps the enumerated set to keep audit/stdout lines bounded.
+function enumerateSubmodulePaths(entries: SubmoduleEntry[]): string {
+  const paths = entries.map((e) => e.path);
+  if (paths.length <= 5) return paths.join(", ");
+  return `${paths.slice(0, 5).join(", ")} (+${paths.length - 5} more)`;
 }
 
 const LANG_BY_EXT: Record<string, string> = {
@@ -2067,6 +2122,66 @@ function scanSignals(dir: string, fileScanDepth: number): DirSignals {
   };
 }
 
+// Parse .gitmodules (ini-like) into submodule entries. Pure and exported for
+// direct unit testing. Line-oriented, tolerant: malformed content degrades to
+// whatever parses (total garbage yields []); it never throws. An entry with no
+// path is dropped, as is any path that is absolute or escapes the project via a
+// `..` segment (a caller joins path under projectDir and must not follow it out).
+export function parseGitmodules(
+  content: string
+): Array<{ name: string; path: string; url: string }> {
+  const entries: Array<{ name: string; path: string; url: string }> = [];
+  let current: { name: string; path: string; url: string } | null = null;
+  const finish = () => {
+    if (!current) return;
+    const p = current.path;
+    const isUnsafe =
+      p === "" ||
+      p.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(p) || // Windows drive-absolute
+      p.split(/[/\\]/).includes("..");
+    if (!isUnsafe) entries.push(current);
+    current = null;
+  };
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#") || line.startsWith(";")) continue;
+    if (line.startsWith("[")) {
+      finish();
+      const m = line.match(/^\[submodule\s+"(.+)"\]$/);
+      current = m ? { name: m[1], path: "", url: "" } : null;
+      continue;
+    }
+    if (!current) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key === "path") current.path = value;
+    else if (key === "url") current.url = value;
+  }
+  finish();
+  return entries;
+}
+
+// Read + parse the workspace-root .gitmodules and probe each declared path for
+// initialization. A missing/unreadable file yields [] (the swallow idiom of the
+// scanner neighbors). `initialized` mirrors isGitRepoDir (aidlc-lib.ts): the dir
+// must exist AND hold a `.git` entry - so a missing dir, an empty dir, and a dir
+// without `.git` all classify uninitialized.
+function scanSubmodules(projectDir: string): SubmoduleEntry[] {
+  let content: string;
+  try {
+    content = readFileSync(join(projectDir, ".gitmodules"), "utf-8");
+  } catch {
+    return [];
+  }
+  return parseGitmodules(content).map((e) => ({
+    ...e,
+    initialized: existsSync(join(projectDir, e.path, ".git")),
+  }));
+}
+
 export function detectWorkspace(projectDir: string): ScanResult {
   let topEntries: string[] = [];
   try {
@@ -2136,11 +2251,20 @@ export function detectWorkspace(projectDir: string): ScanResult {
     languages = [primary, ...extras].join(", ");
   }
 
+  // Repo metadata: a .gitmodules with >= 1 valid submodule path declares code,
+  // even when the submodule dirs are empty/uninitialized. Languages stay AS
+  // SCANNED (Unknown is truthful until the submodules are fetched). A root
+  // signal: folded in after the nested fallback so nested aggregation (and
+  // nestedRoot attribution) still runs when submodules are the only signal.
+  const submodules = scanSubmodules(projectDir);
+  if (submodules.length > 0) brownfield = true;
+
   const result: ScanResult = {
     projectType: brownfield ? "Brownfield" : "Greenfield",
     languages,
     frameworks: frameworks.length > 0 ? frameworks.join(", ") : "Unknown",
     buildSystem,
+    submodules,
   };
   if (nestedHits.length > 0) result.nestedRoot = nestedHits.join(", ");
   return result;
@@ -2430,6 +2554,11 @@ function handleIntentBirthStateBuild(
   });
 
   const scan = detectWorkspace(projectDir);
+  const uninitSubmodules = scan.submodules.filter((s) => !s.initialized);
+  const submoduleRemedy =
+    uninitSubmodules.length > 0
+      ? `${uninitSubmodules.length} uninitialized submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' to fetch them`
+      : "";
 
   appendAuditEvent(projectDir, "WORKSPACE_SCANNED", {
     "Project Type": scan.projectType,
@@ -2437,7 +2566,15 @@ function handleIntentBirthStateBuild(
     Frameworks: scan.frameworks,
     "Build System": scan.buildSystem,
     ...(scan.nestedRoot ? { "Nested Root": scan.nestedRoot } : {}),
-    Details: "Deterministic rule-based scan",
+    ...(scan.submodules.length > 0
+      ? {
+          Submodules: `${scan.submodules.length} declared, ${uninitSubmodules.length} uninitialized`,
+        }
+      : {}),
+    Details:
+      uninitSubmodules.length > 0
+        ? `Deterministic rule-based scan; ${submoduleRemedy}`
+        : "Deterministic rule-based scan",
   });
   appendAuditEvent(projectDir, "STAGE_COMPLETED", {
     Stage: "workspace-detection",
@@ -2673,6 +2810,10 @@ ${stageProgress}
   // cursor + the record dir were set by birthIntent above; the state file lives
   // under the born intent's record (resolved by writeStateFile's default).
   const bornDir = activeIntent(projectDir) ?? "(legacy flat record)";
+  const submoduleWarningLine =
+    uninitSubmodules.length > 0
+      ? `Warning: ${uninitSubmodules.length} uninitialized git submodule path(s) (${enumerateSubmodulePaths(uninitSubmodules)}) - run '${SUBMODULE_INIT_REMEDY}' before proceeding so reverse-engineering can read the code.\n`
+      : "";
   process.stdout.write(
     `Intent born: ${bornDir} (space: ${activeSpace(projectDir)})
 State initialized: ${scope} scope, ${totalInScope} stages, ${effectiveDepth} depth
@@ -2680,7 +2821,7 @@ Project type: ${scan.projectType}
 Languages: ${scan.languages}
 Frameworks: ${scan.frameworks}
 Build System: ${scan.buildSystem}
-First post-init stage: ${firstPostInit} (${firstPostInitPhase})
+${submoduleWarningLine}First post-init stage: ${firstPostInit} (${firstPostInitPhase})
 `
   );
 }
@@ -2905,6 +3046,7 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     frameworks: scan.frameworks,
     buildSystem: scan.buildSystem,
     ...(scan.nestedRoot ? { nestedRoot: scan.nestedRoot } : {}),
+    submodules: scan.submodules,
     scopesDir: scopesDir(),
     scopeGridPath: scopeGridPath(),
     scopes: [...validScopes()],
@@ -2913,12 +3055,18 @@ function handleDetect(projectDir: string, flags: Record<string, string>): void {
     process.stdout.write(`${JSON.stringify(payload)}\n`);
     return;
   }
+  const uninitCount = scan.submodules.filter((s) => !s.initialized).length;
+  const submoduleLine =
+    scan.submodules.length > 0
+      ? `Submodules: ${scan.submodules.length} declared, ${uninitCount} uninitialized\n`
+      : "";
   process.stdout.write(
     `Project type: ${payload.projectType}\n` +
       `Languages: ${payload.languages}\n` +
       `Frameworks: ${payload.frameworks}\n` +
       `Build system: ${payload.buildSystem}\n` +
       (scan.nestedRoot ? `Nested root: ${scan.nestedRoot}\n` : "") +
+      submoduleLine +
       `Scopes dir: ${payload.scopesDir}\n` +
       `Scope grid: ${payload.scopeGridPath}\n` +
       `Valid scopes: ${payload.scopes.join(", ")}\n`,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.9";
+export const AIDLC_VERSION = "2.2.10";

--- a/docs/guide/12-cli-commands.md
+++ b/docs/guide/12-cli-commands.md
@@ -224,6 +224,7 @@ Validate that all of this implementation's prerequisites, configuration, and sta
 | Hook presence | Every hook `settings.json` wires (its `hooks` blocks + the `statusLine` command — all 11 framework hooks) exists in `.claude/hooks/`; a wired-but-missing hook fails loudly. Sourcing the expected roster from `settings.json` means adding a hook there auto-checks it |
 | Project structure | `.claude/settings.json` exists (file presence only, no content validation) |
 | Workspace shell | `.claude/` + `aidlc/spaces/default/memory/` are present (the shipped shell) |
+| Submodules | If a `.gitmodules` is present, reports how many submodule paths are declared and how many are uninitialized, naming `git submodule update --init --recursive` when any are (advisory - never fails) |
 | Env scope | `AWS_AIDLC_DEFAULT_SCOPE` (if set) names a valid scope |
 | Hook heartbeats | `.aidlc-hooks-health/` contains recent timestamps from hook executions |
 | State drift | the active intent's `aidlc-state.md` matches the last `WORKFLOW_COMPLETED` in the audit |
@@ -251,6 +252,7 @@ Validate that all of this implementation's prerequisites, configuration, and sta
 ✓ settings.json present
 ✓ AWS_AIDLC_DEFAULT_SCOPE (unset — no project default)
 ✓ workspace shell ready (.claude/ + aidlc/spaces/default/memory/)
+✓ Submodules: no .gitmodules at workspace root
 ✓ Hook heartbeats: not yet fired (first workflow stage will populate)
 ✓ State matches last audit event (no drift)
 ✓ Cycle detection: 0 cycles
@@ -432,7 +434,7 @@ Run any of them with `bun .claude/tools/<tool>.ts <subcommand>`.
 
 ### `aidlc-utility detect` - read-only workspace scan
 
-`bun .claude/tools/aidlc-utility.ts detect --json` prints the workspace scan (project type, languages, frameworks, build system) plus the resolved scopes dir and scope-grid path. Pure read; the composer runs it to learn where scope data lives on the current harness.
+`bun .claude/tools/aidlc-utility.ts detect --json` prints the workspace scan (project type, languages, frameworks, build system, and a `submodules` array of any declared git submodules with their initialized state) plus the resolved scopes dir and scope-grid path. Pure read; the composer runs it to learn where scope data lives on the current harness.
 
 ### `aidlc-utility recompose` - in-flight plan flips
 

--- a/docs/reference/04-stages/initialization.md
+++ b/docs/reference/04-stages/initialization.md
@@ -85,8 +85,9 @@ All three stages run inside a single deterministic `bun .claude/tools/aidlc-util
 2. Count files by extension to determine primary/secondary languages
 3. Detect frameworks via known config filenames (Next.js, Vite, Angular, Nuxt, Remix, Gatsby, Astro, Svelte, NestJS) and React via `package.json` dependencies
 4. Detect build system via manifest + lockfile (npm/yarn/pnpm/bun/poetry/uv/hatch/pip/cargo/go/maven/gradle/composer/bundler)
-5. Classify greenfield vs brownfield using the rules in `stages/initialization/workspace-detection.md`
-6. Append `STAGE_STARTED` + `WORKSPACE_SCANNED` + `STAGE_COMPLETED` events
+5. Read `.gitmodules` (if present) for declared submodule paths, probing each for initialization
+6. Classify greenfield vs brownfield using the rules in `stages/initialization/workspace-detection.md`
+7. Append `STAGE_STARTED` + `WORKSPACE_SCANNED` + `STAGE_COMPLETED` events
 
 ### Inputs
 - Project filesystem (read-only scan)
@@ -101,6 +102,7 @@ All three stages run inside a single deterministic `bun .claude/tools/aidlc-util
 - Symbolic links are not followed (cycle protection via `lstatSync`)
 - Excludes `.claude/`, `<record>/`, `node_modules/`, `.git/`, `dist/`, `build/`, `.next/`, `target/`, `vendor/`
 - `package.json` with only `devDependencies` is treated as tooling/scaffolding and does not alone cause brownfield classification
+- A parseable `.gitmodules` with at least one submodule path entry is a brownfield signal (repo metadata declares code even when the submodule dirs are uninitialized). When submodule paths are uninitialized, the scan warns and names `git submodule update --init --recursive` - surfaced in the `WORKSPACE_SCANNED` event (`Submodules` field + `Details` remedy) and on birth stdout so the conductor can relay it; languages stay as scanned
 
 ---
 

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -4540,6 +4540,10 @@
           "mechanism": "cli"
         },
         {
+          "file": "tests/unit/t212-doctor-submodules.test.ts",
+          "mechanism": "cli"
+        },
+        {
           "file": "tests/unit/t27.test.ts",
           "mechanism": "cli"
         },
@@ -4689,6 +4693,10 @@
         },
         {
           "file": "tests/unit/t191-composed-scope-write.test.ts",
+          "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t211-detect-submodules.test.ts",
           "mechanism": "cli"
         }
       ],

--- a/tests/fixtures/docs-legacy-refs.json
+++ b/tests/fixtures/docs-legacy-refs.json
@@ -51,6 +51,16 @@
       "file": "docs/reference/07-sensor-system.md",
       "text": "| `aidlc-upstream-coverage.md` | `**/{aidlc-docs,intents}/**` |",
       "why": "shipped upstream-coverage sensor matches-glob value"
+    },
+    {
+      "file": "docs/guide/12-cli-commands.md",
+      "text": "| Submodules | If a `.gitmodules` is present, reports how many submodule paths are declared and how many are uninitialized, naming `git submodule update --init --recursive` when any are (advisory - never fails) |",
+      "why": "the `--init` is part of the canonical `git submodule update --init --recursive` remedy (the doctor Submodules row names it), NOT the retired aidlc `--init` command"
+    },
+    {
+      "file": "docs/reference/04-stages/initialization.md",
+      "text": "- A parseable `.gitmodules` with at least one submodule path entry is a brownfield signal (repo metadata declares code even when the submodule dirs are uninitialized). When submodule paths are uninitialized, the scan warns and names `git submodule update --init --recursive` - surfaced in the `WORKSPACE_SCANNED` event (`Submodules` field + `Details` remedy) and on birth stdout so the conductor can relay it; languages stay as scanned",
+      "why": "the `--init` is part of the canonical `git submodule update --init --recursive` remedy the workspace-detection scanner names, NOT the retired aidlc `--init` command"
     }
   ]
 }

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -842,6 +842,8 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t203-nested-workspace-detection.test.ts",
     "unit/t204-compose-marker-doctor.test.ts",
     "unit/t206-optional-produces-coverage.test.ts",
+    "unit/t211-detect-submodules.test.ts",
+    "unit/t212-doctor-submodules.test.ts",
     "unit/t17.test.ts",
     "unit/t18.test.ts",
     "unit/t19.test.ts",

--- a/tests/unit/t211-detect-submodules.test.ts
+++ b/tests/unit/t211-detect-submodules.test.ts
@@ -1,0 +1,263 @@
+// covers: subcommand:aidlc-utility:intent-birth
+//
+// The workspace scanner's SIXTH brownfield signal: a parseable .gitmodules at
+// the workspace root with >= 1 valid submodule path entry classifies the
+// workspace Brownfield, even when the submodule dirs are empty/uninitialized.
+// Before this, a submodule-only workspace scanned Greenfield -> reverse-
+// engineering auto-skipped -> every design stage ran blind.
+//
+// Two mechanisms, one covers id (intent-birth, mechanism cli):
+//  - CLI-boundary cases spawn `bun aidlc-utility.ts intent-birth --scope poc
+//    --project-dir <p>` (t20's pattern) and read the state file / audit shard /
+//    stdout — the observable contract of the birth pipeline (scan -> state +
+//    audit + stdout warning).
+//  - parseGitmodules unit cases import the pure exported parser in-process from
+//    the dist tool (t37's idiom) — STRONGER than a stringified grep.
+//
+// poc's scope grid has reverse-engineering = EXECUTE, so a Brownfield birth
+// keeps RE in scope and the greenfield->SKIP flip must NOT fire; a Greenfield
+// birth (no .gitmodules) flips RE to SKIP with the "greenfield" annotation.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { cleanupTestProject, createTestProject } from "../harness/fixtures.ts";
+import { parseGitmodules } from "../../dist/claude/.claude/tools/aidlc-utility.ts";
+
+const BUN = process.execPath; // the bun running this test
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const TOOL = join(REPO_ROOT, "dist", "claude", ".claude", "tools", "aidlc-utility.ts");
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const d of tempDirs) cleanupTestProject(d);
+});
+
+/** Fresh bare temp project (createTestProject scaffolds the workspace shell). */
+function proj(): string {
+  const p = createTestProject();
+  tempDirs.push(p);
+  return p;
+}
+
+interface CliResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Spawn `bun aidlc-utility.ts intent-birth --scope poc --project-dir <p>`. */
+function birth(p: string): CliResult {
+  const res = spawnSync(
+    BUN,
+    [TOOL, "intent-birth", "--scope", "poc", "--project-dir", p],
+    { encoding: "utf-8" },
+  );
+  return {
+    status: res.status ?? -1,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+// Resolve the born intent's record dir from the active-space + active-intent
+// cursors (mirrors t20's recordDirOf).
+function recordDirOf(p: string): string {
+  const spaceCursor = join(p, "aidlc", "active-space");
+  const space = existsSync(spaceCursor)
+    ? readFileSync(spaceCursor, "utf-8").trim() || "default"
+    : "default";
+  const intentsDir = join(p, "aidlc", "spaces", space, "intents");
+  const intentCursor = join(intentsDir, "active-intent");
+  if (existsSync(intentCursor)) {
+    const rec = readFileSync(intentCursor, "utf-8").trim();
+    if (rec && existsSync(join(intentsDir, rec, "aidlc-state.md"))) {
+      return join(intentsDir, rec);
+    }
+  }
+  return join(p, "aidlc-docs");
+}
+
+function stateContent(p: string): string {
+  const f = join(recordDirOf(p), "aidlc-state.md");
+  return existsSync(f) ? readFileSync(f, "utf-8") : "";
+}
+
+function stateField(p: string, key: string): string {
+  const re = new RegExp(`^- \\*\\*${key}\\*\\*: (.*)$`, "m");
+  const m = stateContent(p).match(re);
+  return m ? m[1] : "";
+}
+
+function readAudit(p: string): string {
+  const auditDir = join(recordDirOf(p), "audit");
+  if (!existsSync(auditDir)) return "";
+  return readdirSync(auditDir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => readFileSync(join(auditDir, f), "utf-8"))
+    .join("\n");
+}
+
+const GITMODULES_TWO = `[submodule "services/api"]
+\tpath = services/api
+\turl = https://example.com/api.git
+[submodule "services/web"]
+\tpath = services/web
+\turl = https://example.com/web.git
+`;
+
+describe("t211 aidlc-utility intent-birth — git submodules as a brownfield signal", () => {
+  // --- Case 1: .gitmodules + empty dirs -> Brownfield, RE stays EXECUTE, warned ---
+  test("1: uninitialized submodules classify Brownfield with warning + RE EXECUTE", () => {
+    const p = proj();
+    writeFileSync(join(p, ".gitmodules"), GITMODULES_TWO, "utf-8");
+    const r = birth(p);
+    expect(r.status).toBe(0);
+
+    // Brownfield classification, languages truthfully Unknown (dirs empty).
+    expect(stateField(p, "Project Type")).toBe("Brownfield");
+    expect(stateField(p, "Languages")).toBe("Unknown");
+
+    // RE stays EXECUTE — the greenfield->SKIP flip must NOT have fired.
+    expect(stateContent(p)).toContain("- [ ] reverse-engineering — EXECUTE");
+    expect(stateField(p, "Stages to Skip")).not.toContain(
+      "reverse-engineering — greenfield",
+    );
+
+    // Audit WORKSPACE_SCANNED carries the Submodules field + the remedy.
+    const audit = readAudit(p);
+    expect(audit).toContain("**Event**: WORKSPACE_SCANNED");
+    expect(audit).toContain("**Submodules**: 2 declared, 2 uninitialized");
+    expect(audit).toContain(
+      "git submodule update --init --recursive",
+    );
+
+    // Birth stdout carries the warning line naming the remedy + paths.
+    expect(r.stdout).toContain(
+      "Warning: 2 uninitialized git submodule path(s) (services/api, services/web)",
+    );
+    expect(r.stdout).toContain("git submodule update --init --recursive");
+  });
+
+  // --- Case 2: no .gitmodules -> Greenfield unchanged, RE flips to SKIP ---
+  test("2: no .gitmodules keeps Greenfield + RE SKIP (byte-stable no-submodule path)", () => {
+    const p = proj();
+    const r = birth(p);
+    expect(r.status).toBe(0);
+
+    expect(stateField(p, "Project Type")).toBe("Greenfield");
+    // Greenfield flip fires: RE annotated greenfield in Stages-to-Skip.
+    expect(stateField(p, "Stages to Skip")).toContain(
+      "reverse-engineering — greenfield",
+    );
+
+    // No submodule surfaces: audit event has no Submodules field, no remedy,
+    // and stdout carries no warning line.
+    const audit = readAudit(p);
+    expect(audit).toContain("**Event**: WORKSPACE_SCANNED");
+    expect(audit).not.toContain("**Submodules**:");
+    expect(audit).not.toContain("git submodule update");
+    expect(r.stdout).not.toContain("Warning:");
+    // The no-submodule Details stays byte-identical to the original event.
+    expect(audit).toContain("**Details**: Deterministic rule-based scan\n");
+  });
+
+  // --- Case 3: malformed .gitmodules -> degrade to no-signal, never crash ---
+  test("3: malformed .gitmodules degrades to Greenfield, exit 0, no warning", () => {
+    const p = proj();
+    writeFileSync(
+      join(p, ".gitmodules"),
+      "this is not valid ini @#$%\n=headerless\n[core]\nfoo=bar\n",
+      "utf-8",
+    );
+    const r = birth(p);
+    expect(r.status).toBe(0);
+    expect(stateField(p, "Project Type")).toBe("Greenfield");
+    expect(readAudit(p)).not.toContain("**Submodules**:");
+    expect(r.stdout).not.toContain("Warning:");
+  });
+
+  // --- Case 4: .gitmodules + INITIALIZED dirs -> Brownfield, no warning ---
+  test("4: initialized submodules classify Brownfield with no uninitialized warning", () => {
+    const p = proj();
+    writeFileSync(join(p, ".gitmodules"), GITMODULES_TWO, "utf-8");
+    // The submodule shape: a dir holding a `.git` entry (file for a submodule).
+    for (const sub of ["services/api", "services/web"]) {
+      mkdirSync(join(p, sub), { recursive: true });
+      writeFileSync(join(p, sub, ".git"), "gitdir: ../../.git/modules/x\n", "utf-8");
+    }
+    const r = birth(p);
+    expect(r.status).toBe(0);
+    expect(stateField(p, "Project Type")).toBe("Brownfield");
+
+    const audit = readAudit(p);
+    expect(audit).toContain("**Submodules**: 2 declared, 0 uninitialized");
+    // No remedy in Details, no stdout warning when all are initialized.
+    expect(audit).toContain("**Details**: Deterministic rule-based scan\n");
+    expect(audit).not.toContain("git submodule update");
+    expect(r.stdout).not.toContain("Warning:");
+  });
+
+  // --- Case 5: parseGitmodules unit cases (pure, in-process) ---
+  describe("5: parseGitmodules parser", () => {
+    test("multi-entry parse keeps name/path/url", () => {
+      const out = parseGitmodules(GITMODULES_TWO);
+      expect(out).toEqual([
+        { name: "services/api", path: "services/api", url: "https://example.com/api.git" },
+        { name: "services/web", path: "services/web", url: "https://example.com/web.git" },
+      ]);
+    });
+
+    test("comments and unknown keys tolerated; url optional", () => {
+      const out = parseGitmodules(
+        `# a comment
+; another comment
+[submodule "lib"]
+\tpath = lib/foo
+\tbranch = main
+`,
+      );
+      expect(out).toEqual([{ name: "lib", path: "lib/foo", url: "" }]);
+    });
+
+    test("entry without a path is dropped", () => {
+      const out = parseGitmodules(
+        `[submodule "nopath"]
+\turl = https://example.com/x.git
+`,
+      );
+      expect(out).toEqual([]);
+    });
+
+    test("absolute and ..-traversal paths are dropped", () => {
+      const out = parseGitmodules(
+        `[submodule "abs"]
+\tpath = /etc/passwd
+[submodule "up"]
+\tpath = ../../escape
+[submodule "ok"]
+\tpath = pkg/ok
+`,
+      );
+      expect(out).toEqual([{ name: "ok", path: "pkg/ok", url: "" }]);
+    });
+
+    test("non-submodule sections are ignored", () => {
+      const out = parseGitmodules(
+        `[core]
+\tbare = false
+[submodule "real"]
+\tpath = real
+`,
+      );
+      expect(out).toEqual([{ name: "real", path: "real", url: "" }]);
+    });
+
+    test("total garbage yields []", () => {
+      expect(parseGitmodules("!!! not ini at all\n\n???")).toEqual([]);
+      expect(parseGitmodules("")).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/t212-doctor-submodules.test.ts
+++ b/tests/unit/t212-doctor-submodules.test.ts
@@ -1,0 +1,94 @@
+// covers: subcommand:aidlc-utility:doctor
+//
+// The doctor's Submodules advisory row (added alongside the workspace-detection
+// submodule signal). Four states, all pass:true (an uninitialized submodule is a
+// user-environment pre-flight state, not framework breakage, and doctor's exit
+// code feeds CI/scripts):
+//   - no .gitmodules            -> "no .gitmodules at workspace root"
+//   - uninitialized entries     -> advisory naming count + paths + the remedy
+//   - all initialized           -> "N declared, all initialized"
+//   - present but unparseable   -> "no parseable submodule entries"
+//
+// Follows t83's spawn-and-grep-stdout pattern. Asserts on the report LABEL text,
+// never on doctor's exit code — a bare temp project fails unrelated checks
+// (hooks, shell), so the exit code is not a submodule observable.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { AIDLC_SRC, cleanupTestProject, createTestProject } from "../harness/fixtures.ts";
+
+const BUN = process.execPath; // the bun running this test
+const UTIL = join(AIDLC_SRC, "tools", "aidlc-utility.ts");
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length) cleanupTestProject(created.pop());
+});
+
+function proj(): string {
+  const p = createTestProject();
+  created.push(p);
+  return p;
+}
+
+/** `bun UTIL doctor --project-dir <proj>` captured 2>&1, exit code swallowed. */
+function runDoctor(proj: string): string {
+  const res = spawnSync(BUN, [UTIL, "doctor", "--project-dir", proj], {
+    encoding: "utf-8",
+    env: { ...process.env },
+  });
+  return `${res.stdout ?? ""}${res.stderr ?? ""}`;
+}
+
+const GITMODULES_TWO = `[submodule "services/api"]
+\tpath = services/api
+\turl = https://example.com/api.git
+[submodule "services/web"]
+\tpath = services/web
+\turl = https://example.com/web.git
+`;
+
+describe("t212 aidlc-utility doctor — Submodules advisory row", () => {
+  test("1: no .gitmodules -> 'no .gitmodules at workspace root' row", () => {
+    const out = runDoctor(proj());
+    expect(out).toContain("Submodules: no .gitmodules at workspace root");
+  }, 30000);
+
+  test("2: uninitialized entries -> advisory naming count, paths, remedy", () => {
+    const p = proj();
+    writeFileSync(join(p, ".gitmodules"), GITMODULES_TWO, "utf-8");
+    const out = runDoctor(p);
+    expect(out).toContain("Submodules: 2 declared, 2 uninitialized (advisory)");
+    expect(out).toContain("services/api, services/web");
+    expect(out).toContain("git submodule update --init --recursive");
+    // Advisory renders as a passing row (✓), never a failed (✗) one.
+    expect(out).toContain("✓  Submodules: 2 declared, 2 uninitialized");
+  }, 30000);
+
+  test("3: all initialized -> 'all initialized' row", () => {
+    const p = proj();
+    writeFileSync(join(p, ".gitmodules"), GITMODULES_TWO, "utf-8");
+    for (const sub of ["services/api", "services/web"]) {
+      mkdirSync(join(p, sub), { recursive: true });
+      writeFileSync(join(p, sub, ".git"), "gitdir: ../../.git/modules/x\n", "utf-8");
+    }
+    const out = runDoctor(p);
+    expect(out).toContain("Submodules: 2 declared, all initialized");
+  }, 30000);
+
+  test("4: malformed .gitmodules -> 'no parseable submodule entries' row, no crash", () => {
+    const p = proj();
+    writeFileSync(
+      join(p, ".gitmodules"),
+      "this is not valid ini @#$%\n=headerless\n[core]\nfoo=bar\n",
+      "utf-8",
+    );
+    const out = runDoctor(p);
+    expect(out).toContain(
+      "Submodules: .gitmodules present but no parseable submodule entries",
+    );
+  }, 30000);
+});


### PR DESCRIPTION
Closes #504.

## What

Workspace detection now recognizes git submodules as evidence of existing code, so a multi-repo workspace whose code lives in submodules no longer misclassifies as Greenfield (which silently skipped Reverse Engineering).

- `detectWorkspace()` gains a sixth brownfield signal: a parseable `.gitmodules` at the workspace root with at least one valid `path` entry. New exported `parseGitmodules()` (line-oriented, drops absolute/`..`/pathless entries, malformed input degrades to no-signal, never throws) plus a submodule scan that probes each declared path for a `.git` entry.
- When declared submodules are uninitialized (path missing, empty, or lacking `.git`), the scan says so explicitly and carries the remedy: `git submodule update --init --recursive`. Surfaces: the `WORKSPACE_SCANNED` audit event (new `Submodules` field), the intent-birth stdout block, `detect --json` (additive `submodules` key), and a new advisory (never-failing) `--doctor` row.
- `workspace-detection.md` stage prose gains the sixth Brownfield bullet and a conductor note to relay the warning verbatim (no auto-init offer; initializing touches the network and stays a human decision).
- Projects without `.gitmodules` take a byte-identical code path (empirically verified: origin/v2 vs this branch produce identical birth stdout and `WORKSPACE_SCANNED` events on a bare project).

Version 2.2.10, CHANGELOG entry, README badge. Tests t211 (detection, warning payload, RE stays EXECUTE, malformed degrade, greenfield byte-stability, parser units) and t212 (all four doctor row states).

## Why

The brownfield signal list only looked for files (extensions, manifests, framework configs, source dirs). An uninitialized submodule is an empty directory, so a workspace declaring all its code via `.gitmodules` scanned as `Greenfield, Languages: Unknown`, reverse-engineering was flipped to SKIP during state build, and every design stage ran with zero code understanding. The first agent to need real code then had to discover and init the submodule itself mid-stage, unaudited and too late to inform design.

Sibling blind spots stay open and compose with this fix: #462 (source nested in arbitrarily-named dirs, a directory-walk fix) and #438 (bugfix-scope default). This change is additive metadata detection only.

## Verification

- Deterministic tiers green: smoke+unit (131 files, 2317 assertions, 0 failed), integration incl every `WORKSPACE_SCANNED`-asserting test (t18/t20/t70/t71/t111), t68 version sync, t174 legacy-refs.
- `bun scripts/package.ts --check` clean (all 4 dist trees), `bun run typecheck` clean, coverage registry regen produces zero diff.
- Adversarial verification pass: 15 hostile `.gitmodules` inputs (absolute paths, `..` escapes, CRLF, garbage, file-as-path) all degrade to no-signal without throwing; live end-to-end drive of birth/detect/doctor on a temp fixture.
- Known cosmetic edges (non-blocking): duplicate `[submodule]` sections double-count in the warning text; a quoted `path = "with spaces"` value reads as uninitialized (false warning only, classification unaffected); key matching is case-sensitive (degrades to no-signal).

Draft until the branch soaks a full pre-merge live gate alongside its four sibling PRs (2.2.9-2.2.13 series); whoever merges later re-bumps per the CHANGELOG conflict-trap policy.
