### PR TITLE
test: tolerate legitimate greenfield RE-skip in workspace-journey codekb beat

### DIFF
--- a/tests/e2e/t-acp-kiro-journey-workspace.serial.test.ts
+++ b/tests/e2e/t-acp-kiro-journey-workspace.serial.test.ts
@@ -62,6 +62,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   activeSpace,
+  getField,
   listIntents,
   readIntentRegistry,
 } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
@@ -133,6 +134,29 @@ function activeRecordDir(root: string): string | undefined {
   return listIntents(root, activeSpace(root)).find((i) => i.active)?.dirName ?? undefined;
 }
 
+/** The RE codekb beat has TWO valid outcomes, and both keep the multi-repo journey
+ *  intact. Brownfield: reverse-engineering EXECUTEs and writes a per-repo codekb
+ *  store, so the codekbFiles asserts below hold. Greenfield: the engine stamps
+ *  reverse-engineering SKIP at intent birth (aidlc-utility.ts records it in the
+ *  Stages to Skip row), so no codekb is written and the asserts must not run (the
+ *  skip is the correct behaviour, not a flake). This reads the born intent's
+ *  aidlc-state.md and returns true only for that greenfield RE-skip: Project Type is
+ *  Greenfield AND the Stages to Skip row names the reverse-engineering slug. We match
+ *  the bare slug, never the row's human annotation (the engine writes it with an
+ *  em-dash phrase we deliberately avoid touching). A genuine brownfield RE failure
+ *  still falls through to the asserts and reds, as it should. */
+function greenfieldReSkip(recordDir: string): boolean {
+  let content: string;
+  try {
+    content = readFileSync(join(recordDir, "aidlc-state.md"), "utf-8");
+  } catch {
+    return false;
+  }
+  const projectType = (getField(content, "Project Type") ?? "").toLowerCase();
+  const stagesToSkip = getField(content, "Stages to Skip") ?? "";
+  return projectType === "greenfield" && stagesToSkip.includes("reverse-engineering");
+}
+
 /** Drive the reverse-engineering `--single` codekb turn and cancel it the moment
  *  BOTH repos' per-repo codekb has landed on disk — a DISK-CONDITION stop, not a
  *  tool-title one. A title stop (`/codekb/repo-b/…/`) is unreliable here: the
@@ -147,21 +171,28 @@ function activeRecordDir(root: string): string | undefined {
  *  codekbFiles), and `session/cancel` once both are present. The driver's awaited
  *  session/prompt then resolves with stopReason=cancelled. Falls through on the
  *  drive's own timeout (the budget) if the stage never produces both stores — a
- *  real failure the assertions below catch. */
+ *  real failure the assertions below catch.
+ *
+ *  Second cancel arm: a LEGITIMATE greenfield RE-skip. When the intent is greenfield
+ *  the engine stamped reverse-engineering SKIP at birth, so this `--single` run never
+ *  writes codekb and would otherwise burn the whole codekb budget (~20 min of live
+ *  Kiro credits) waiting for stores that will never appear. So we also cancel the
+ *  moment greenfieldReSkip becomes true on disk; the assertions below then take the
+ *  greenfield branch and accept the skip. The two arms are independent: either a
+ *  real both-repos landing OR a recorded greenfield skip ends the turn fast. */
 async function driveCodekbUntilBothRepos(
   session: AcpSession,
   root: string,
+  recordDir: string,
   timeoutMs: number,
 ): Promise<void> {
-  let bothPresent = false;
+  let done = false;
   const poll = setInterval(() => {
-    if (
-      !bothPresent &&
-      session.sessionId &&
-      codekbFiles(root, "repo-a").length > 0 &&
-      codekbFiles(root, "repo-b").length > 0
-    ) {
-      bothPresent = true;
+    if (done || !session.sessionId) return;
+    const bothRepos =
+      codekbFiles(root, "repo-a").length > 0 && codekbFiles(root, "repo-b").length > 0;
+    if (bothRepos || greenfieldReSkip(recordDir)) {
+      done = true;
       session.notify("session/cancel", { sessionId: session.sessionId });
     }
   }, 2000);
@@ -254,10 +285,19 @@ describe("t-acp-kiro-journey-workspace (live ACP multi-repo·intent·space journ
         // The RE stage writes both repos' codekb. Drive it and cancel the moment
         // BOTH repos' stores are on disk (a disk-condition stop — see
         // driveCodekbUntilBothRepos for why a tool-title stop flakes here). The
-        // on-disk assertions below are the proof.
-        await driveCodekbUntilBothRepos(conductor, root, CODEKB_DRIVE_MS);
-        expect(codekbFiles(root, "repo-a").length).toBeGreaterThan(0);
-        expect(codekbFiles(root, "repo-b").length).toBeGreaterThan(0);
+        // poller also fast-cancels on a legitimate greenfield RE-skip so a skip does
+        // not burn the codekb budget. The on-disk assertions below are the proof.
+        await driveCodekbUntilBothRepos(conductor, root, recordADir, CODEKB_DRIVE_MS);
+        if (greenfieldReSkip(recordADir)) {
+          // Greenfield: reverse-engineering was stamped SKIP at birth, so no per-repo
+          // codekb is expected. The recorded skip is the correct outcome; accept it
+          // and do NOT run the codekb asserts (permissive by design).
+          expect(greenfieldReSkip(recordADir)).toBe(true);
+        } else {
+          // Brownfield: reverse-engineering ran, so both repos got a codekb store.
+          expect(codekbFiles(root, "repo-a").length).toBeGreaterThan(0);
+          expect(codekbFiles(root, "repo-b").length).toBeGreaterThan(0);
+        }
 
         // A's birth emitted exactly one WORKFLOW_STARTED; the RE pass added stage
         // work but no second birth bled into A's shard.

--- a/tests/e2e/t-exec-codex-journey-workspace.serial.test.ts
+++ b/tests/e2e/t-exec-codex-journey-workspace.serial.test.ts
@@ -36,6 +36,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   activeSpace,
+  getField,
   listIntents,
   readIntentRegistry,
 } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
@@ -192,6 +193,29 @@ function activeRecordDir(root: string): string | undefined {
   return listIntents(root, activeSpace(root)).find((i) => i.active)?.dirName ?? undefined;
 }
 
+/** The RE codekb beat has TWO valid outcomes, and both keep the multi-repo journey
+ *  intact. Brownfield: reverse-engineering EXECUTEs and writes a per-repo codekb
+ *  store, so the codekbFiles asserts below hold. Greenfield: the engine stamps
+ *  reverse-engineering SKIP at intent birth (aidlc-utility.ts records it in the
+ *  Stages to Skip row), so no codekb is written and the asserts must not run (the
+ *  skip is the correct behaviour, not a flake). This reads the born intent's
+ *  aidlc-state.md and returns true only for that greenfield RE-skip: Project Type is
+ *  Greenfield AND the Stages to Skip row names the reverse-engineering slug. We match
+ *  the bare slug, never the row's human annotation (the engine writes it with an
+ *  em-dash phrase we deliberately avoid touching). A genuine brownfield RE failure
+ *  still falls through to the asserts and reds, as it should. */
+function greenfieldReSkip(recordDir: string): boolean {
+  let content: string;
+  try {
+    content = readFileSync(join(recordDir, "aidlc-state.md"), "utf-8");
+  } catch {
+    return false;
+  }
+  const projectType = (getField(content, "Project Type") ?? "").toLowerCase();
+  const stagesToSkip = getField(content, "Stages to Skip") ?? "";
+  return projectType === "greenfield" && stagesToSkip.includes("reverse-engineering");
+}
+
 /** Count WORKFLOW_STARTED events in a record's audit shards — exactly one for an
  *  intent's own birth; a SECOND means a foreign birth bled in. Per-session
  *  SessionStart/End hooks append SESSION_* events to the active intent, so raw
@@ -246,10 +270,20 @@ describe("t-exec-codex-journey-workspace (live codex-exec multi-repo·intent·sp
           CODEKB_EXEC_MS,
         );
         expect(r2.rc).toBe(0);
-        expect(codekbFiles(root, "repo-a").length).toBeGreaterThan(0);
-        expect(codekbFiles(root, "repo-b").length).toBeGreaterThan(0);
-
+        // Resolve A's record dir up front (hoisted above the codekb asserts) so we can
+        // read its state-file and tell which of the two valid RE outcomes applies.
         const recordADir = join(root, "aidlc", "spaces", "default", "intents", recordA as string);
+        if (greenfieldReSkip(recordADir)) {
+          // Greenfield: reverse-engineering was stamped SKIP at birth, so no per-repo
+          // codekb is expected. The recorded skip is the correct outcome; accept it and
+          // do NOT run the codekb asserts (permissive by design).
+          expect(greenfieldReSkip(recordADir)).toBe(true);
+        } else {
+          // Brownfield: reverse-engineering ran, so both repos got a codekb store.
+          expect(codekbFiles(root, "repo-a").length).toBeGreaterThan(0);
+          expect(codekbFiles(root, "repo-b").length).toBeGreaterThan(0);
+        }
+
         const stateABefore = readFileSync(join(recordADir, "aidlc-state.md"), "utf-8");
         expect(workflowStartedCount(recordADir)).toBe(1);
 

--- a/tests/integration/t-journey-workspace.sdk.test.ts
+++ b/tests/integration/t-journey-workspace.sdk.test.ts
@@ -72,6 +72,7 @@ import {
 import { driveAidlc } from "../harness/sdk-drive.ts";
 import {
   activeSpace,
+  getField,
   listIntents,
   readIntentRegistry,
 } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
@@ -148,6 +149,29 @@ function activeRecordDir(root: string): string | undefined {
   return listIntents(root, sp).find((i) => i.active)?.dirName ?? undefined;
 }
 
+/** The RE codekb beat has TWO valid outcomes, and both keep the multi-repo journey
+ *  intact. Brownfield: reverse-engineering EXECUTEs and writes a per-repo codekb
+ *  store, so the codekbFiles asserts below hold. Greenfield: the engine stamps
+ *  reverse-engineering SKIP at intent birth (aidlc-utility.ts records it in the
+ *  Stages to Skip row), so no codekb is written and the asserts must not run (the
+ *  skip is the correct behaviour, not a flake). This reads the born intent's
+ *  aidlc-state.md and returns true only for that greenfield RE-skip: Project Type is
+ *  Greenfield AND the Stages to Skip row names the reverse-engineering slug. We match
+ *  the bare slug, never the row's human annotation (the engine writes it with an
+ *  em-dash phrase we deliberately avoid touching). A genuine brownfield RE failure
+ *  still falls through to the asserts and reds, as it should. */
+function greenfieldReSkip(recordDir: string): boolean {
+  let content: string;
+  try {
+    content = readFileSync(join(recordDir, "aidlc-state.md"), "utf-8");
+  } catch {
+    return false;
+  }
+  const projectType = (getField(content, "Project Type") ?? "").toLowerCase();
+  const stagesToSkip = getField(content, "Stages to Skip") ?? "";
+  return projectType === "greenfield" && stagesToSkip.includes("reverse-engineering");
+}
+
 /** How many WORKFLOW_STARTED audit events the record's shards hold. An intent's
  *  birth emits exactly one; a SECOND would mean another intent's birth bled into
  *  this record — the collision the vision forbids. (Per-session SessionStart/End
@@ -219,10 +243,22 @@ describe("t-journey-workspace (live SDK multi-repo·intent·space journey)", () 
             timeoutMs: CODEKB_DRIVE_MS,
           },
         );
-        // Both repos got an independent codekb store (the multi-repo read the
-        // vision promises: an intent spanning two repos reads both folders).
-        expect(codekbFiles(root, "repo-a").length).toBeGreaterThan(0);
-        expect(codekbFiles(root, "repo-b").length).toBeGreaterThan(0);
+        // Resolve A's record dir up front (hoisted above the codekb asserts) so we
+        // can read its state-file and tell which of the two valid RE outcomes applies.
+        const recordADir = join(root, "aidlc", "spaces", "default", "intents", recordA as string);
+        if (greenfieldReSkip(recordADir)) {
+          // Greenfield: reverse-engineering was stamped SKIP at birth, so no per-repo
+          // codekb is expected here. The recorded skip is the correct outcome; accept
+          // it and do NOT run the codekb asserts. This branch is permissive by design
+          // (if the LLM writes codekb anyway despite the skip, the journey stays green).
+          expect(greenfieldReSkip(recordADir)).toBe(true);
+        } else {
+          // Brownfield: reverse-engineering ran, so both repos got an independent
+          // codekb store (the multi-repo read the vision promises: an intent spanning
+          // two repos reads both folders).
+          expect(codekbFiles(root, "repo-a").length).toBeGreaterThan(0);
+          expect(codekbFiles(root, "repo-b").length).toBeGreaterThan(0);
+        }
 
         // Snapshot A's WORKFLOW STATE before birthing B — the deterministic
         // isolation proof (B's birth must never touch A's aidlc-state.md). We do
@@ -233,7 +269,6 @@ describe("t-journey-workspace (live SDK multi-repo·intent·space journey)", () 
         // noise that is NOT a collision. The collision the vision forbids is B's
         // BIRTH bleeding into A; that surfaces as a SECOND WORKFLOW_STARTED in A's
         // shard, which we guard directly via workflowStartedCount().
-        const recordADir = join(root, "aidlc", "spaces", "default", "intents", recordA as string);
         const stateABefore = readFileSync(join(recordADir, "aidlc-state.md"), "utf-8");
         expect(workflowStartedCount(recordADir)).toBe(1);
 


### PR DESCRIPTION
Fixes #441 (the remaining half; the codekbFiles helper-path half already landed on v2 via the codekb-placement test fixes).

## What

The three workspace-journey legs (SDK integration, Kiro ACP e2e, Codex exec e2e) all assert their reverse-engineering beat wrote per-repo codekb for both sibling repos. That assertion assumes RE always runs, but the beat has two valid outcomes:

- Brownfield classification: RE executes and writes per-repo codekb; the existing asserts hold.
- Greenfield classification: the engine stamps RE SKIP at intent birth (recorded in the state file's Stages to Skip row), no codekb is ever produced by design, and the old asserts red on a correct skip. That is the flake: the fixture seeds each sibling repo with a tiny stub and live classification is non-deterministic, and the deterministic scanner only reads the workspace root (never the sibling repo dirs), so the live classifier is the deciding voice today.

Each leg now reads the born intent's state file via a shared greenfieldReSkip helper (Project Type is Greenfield AND the Stages to Skip row names the reverse-engineering slug) and branches: greenfield accepts the recorded skip, brownfield runs the two codekb asserts unchanged. A genuine brownfield RE failure still reds.

The ACP leg's driveCodekbUntilBothRepos poller also gains a second session/cancel arm: it fast-cancels the moment a greenfield RE-skip is on disk, so a legitimate skip no longer burns the full codekb budget (about 20 minutes of live Kiro credits) waiting for stores that will never appear.

## Interaction with the nested-workspace detection PR

The fix is valid in both merge orders relative to the depth-1 nested-scan fallback (PR #499): before it, the greenfield branch is the common path; after it, the fixture deterministically classifies Brownfield and the codekb asserts are the common path. Both branches stay live either way.

## Testing

Test-only change; no engine, fixture, or version edits (no version bump per the Changelog Policy).

- typecheck (both tsconfigs): clean
- smoke+unit (t177 fixture pin included): PASS, 2303 assertions, 0 failed
- deterministic e2e (filter ^t[0-9]): PASS, 129 assertions, 0 failed
- live SDK leg (t-journey-workspace.sdk): PASS, 1008s
- live Kiro ACP leg (AIDLC_KIRO_ACP_LIVE=1, t-acp-kiro-journey-workspace): PASS, 279s
- live Codex exec leg (AIDLC_CODEX_EXEC_LIVE=1, t-exec-codex-journey-workspace): PASS, 620s