### PR TITLE
fix: quote $CLAUDE_PROJECT_DIR in Claude hook and statusline commands (2.2.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.19] - 2026-07-09
+
+Hooks and the statusline no longer break when the project path contains spaces. Every `$CLAUDE_PROJECT_DIR` reference in the shipped Claude settings is now double-quoted, so the hook commands survive word-splitting shells (bash) as well as zsh. **Upgrade:** re-copy `dist/claude/.claude/settings.json` into your project (or re-copy the whole `dist/claude/` shell).
+
+* Fixed: all 11 hook commands, the statusline command, and the pre-approved bun-tools permission glob in the Claude `settings.json` quote `$CLAUDE_PROJECT_DIR` (`bun "$CLAUDE_PROJECT_DIR/.claude/hooks/<hook>.ts"`); previously a workspace path with a space made every hook fail with `Module not found` under bash-backed hook runners (#519).
+
 ## [2.2.18] - 2026-07-09
 
 Unit kinds prune the per-unit construction design matrix. Tag each Unit of Work in units-generation's edge block with an optional `kind:` (service, spec, ui, packaging, or library) and the four construction design stages (functional-design, nfr-requirements, nfr-design, infrastructure-design) now emit and require only the artifacts that apply to that kind: a spec unit owes no scalability doc, a packaging unit no business-logic model. A unit with no kind, a stage with no per-kind map, or an artifact left unannotated all behave exactly as before (the full matrix), so existing workflows are unchanged. A unit whose required set prunes to empty is covered by definition (the stage does not apply to it). **Upgrade:** re-copy your `dist/<harness>/` shell into the project; an older engine run against a kind-tagged edge block fails the units-generation gate loudly (re-copy dist to fix) rather than pruning wrong.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.2.18-blue)
+![version](https://img.shields.io/badge/version-2.2.19-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.18";
+export const AIDLC_VERSION = "2.2.19";

--- a/dist/claude/.claude/settings.json
+++ b/dist/claude/.claude/settings.json
@@ -7,7 +7,7 @@
       "Read",
       "Edit",
       "Write",
-      "Bash(bun $CLAUDE_PROJECT_DIR/.claude/tools/*)",
+      "Bash(bun \"$CLAUDE_PROJECT_DIR/.claude/tools/\"*)",
       "Bash",
       "Glob",
       "Grep",
@@ -17,7 +17,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts"
+    "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts\""
   },
   "env": {
     "AWS_AIDLC_DEFAULT_SCOPE": "workshop",
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts\""
           }
         ]
       }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-start.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-start.ts\""
           }
         ]
       }
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-end.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-end.ts\""
           }
         ]
       }
@@ -70,11 +70,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-audit-logger.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-audit-logger.ts\""
           },
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sensor-fire.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sensor-fire.ts\""
           }
         ]
       },
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sync-statusline.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sync-statusline.ts\""
           }
         ]
       },
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts\""
           }
         ]
       },
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-runtime-compile.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-runtime-compile.ts\""
           }
         ]
       }
@@ -112,7 +112,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-validate-state.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-validate-state.ts\""
           }
         ]
       }
@@ -123,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-log-subagent.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-log-subagent.ts\""
           }
         ]
       }
@@ -134,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-stop.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-stop.ts\""
           }
         ]
       }

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.18";
+export const AIDLC_VERSION = "2.2.19";

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.18";
+export const AIDLC_VERSION = "2.2.19";

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.18";
+export const AIDLC_VERSION = "2.2.19";

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.18";
+export const AIDLC_VERSION = "2.2.19";

--- a/docs/guide/13-customization.md
+++ b/docs/guide/13-customization.md
@@ -135,7 +135,7 @@ The statusline is configured in `.claude/settings.json`:
 ```json
 "statusLine": {
   "type": "command",
-  "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts"
+  "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts\""
 }
 ```
 
@@ -157,13 +157,13 @@ The `permissions.allow` list in `.claude/settings.json` pre-approves Claude Code
 "permissions": {
   "allow": [
     "Read", "Edit", "Write",
-    "Bash(bun $CLAUDE_PROJECT_DIR/.claude/tools/*)",
+    "Bash(bun \"$CLAUDE_PROJECT_DIR/.claude/tools/\"*)",
     "Bash", "Glob", "Grep", "Task", "WebSearch"
   ]
 }
 ```
 
-The scoped `Bash(bun $CLAUDE_PROJECT_DIR/.claude/tools/*)` entry sits ahead of the bare `Bash` so the framework's own tool invocations always match the narrower rule first.
+The scoped `Bash(bun "$CLAUDE_PROJECT_DIR/.claude/tools/"*)` entry sits ahead of the bare `Bash` so the framework's own tool invocations always match the narrower rule first. `$CLAUDE_PROJECT_DIR` stays double-quoted (with the `*` outside the quotes) so the command survives word-splitting shells when the project path contains spaces while the permission matcher still globs.
 
 ### How permissions work
 

--- a/docs/reference/14-claude-features.md
+++ b/docs/reference/14-claude-features.md
@@ -212,7 +212,7 @@ Without this, Claude Code would prompt "Allow this tool?" on each first use, dis
 ```json
 "statusLine": {
   "type": "command",
-  "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts"
+  "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts\""
 }
 ```
 
@@ -226,14 +226,14 @@ Runs periodically (not just on tool use) to keep the terminal status current.
     "matcher": "",
     "hooks": [{
       "type": "command",
-      "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-start.ts"
+      "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-start.ts\""
     }]
   }],
   "SessionEnd": [{
     "matcher": "",
     "hooks": [{
       "type": "command",
-      "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-end.ts"
+      "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-end.ts\""
     }]
   }]
 }

--- a/harness/claude/settings.json
+++ b/harness/claude/settings.json
@@ -7,7 +7,7 @@
       "Read",
       "Edit",
       "Write",
-      "Bash(bun $CLAUDE_PROJECT_DIR/.claude/tools/*)",
+      "Bash(bun \"$CLAUDE_PROJECT_DIR/.claude/tools/\"*)",
       "Bash",
       "Glob",
       "Grep",
@@ -17,7 +17,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts"
+    "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-statusline.ts\""
   },
   "env": {
     "AWS_AIDLC_DEFAULT_SCOPE": "workshop",
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts\""
           }
         ]
       }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-start.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-start.ts\""
           }
         ]
       }
@@ -59,7 +59,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-end.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-session-end.ts\""
           }
         ]
       }
@@ -70,11 +70,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-audit-logger.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-audit-logger.ts\""
           },
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sensor-fire.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sensor-fire.ts\""
           }
         ]
       },
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sync-statusline.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-sync-statusline.ts\""
           }
         ]
       },
@@ -92,7 +92,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-mint-presence.ts\""
           }
         ]
       },
@@ -101,7 +101,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-runtime-compile.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-runtime-compile.ts\""
           }
         ]
       }
@@ -112,7 +112,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-validate-state.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-validate-state.ts\""
           }
         ]
       }
@@ -123,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-log-subagent.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-log-subagent.ts\""
           }
         ]
       }
@@ -134,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun $CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-stop.ts"
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/aidlc-stop.ts\""
           }
         ]
       }

--- a/tests/integration/t40-settings-hook-config.test.ts
+++ b/tests/integration/t40-settings-hook-config.test.ts
@@ -109,8 +109,10 @@ describe("t40 settings.json hook/statusline/permissions config (migrated from t4
     expect(allow.length).toBe(9);
     // STRONGER than the .sh's bare length check: the pre-approved bun-tools glob
     // the .sh's comment calls out ("including bun tools pattern") is present.
+    // Quoted form (issue 519): $CLAUDE_PROJECT_DIR stays inside double quotes with
+    // the * outside so the matcher still globs; t199 pins the quoting invariant.
     expect(
-      allow.some((a) => a.includes("bun $CLAUDE_PROJECT_DIR/.claude/tools/*")),
+      allow.some((a) => a.includes('bun "$CLAUDE_PROJECT_DIR/.claude/tools/"*')),
     ).toBe(true);
   });
 

--- a/tests/integration/t40-settings-hook-config.test.ts
+++ b/tests/integration/t40-settings-hook-config.test.ts
@@ -110,7 +110,7 @@ describe("t40 settings.json hook/statusline/permissions config (migrated from t4
     // STRONGER than the .sh's bare length check: the pre-approved bun-tools glob
     // the .sh's comment calls out ("including bun tools pattern") is present.
     // Quoted form (issue 519): $CLAUDE_PROJECT_DIR stays inside double quotes with
-    // the * outside so the matcher still globs; t199 pins the quoting invariant.
+    // the * outside so the matcher still globs; t219 pins the quoting invariant.
     expect(
       allow.some((a) => a.includes('bun "$CLAUDE_PROJECT_DIR/.claude/tools/"*')),
     ).toBe(true);

--- a/tests/unit/t199-claude-project-dir-quoting.test.ts
+++ b/tests/unit/t199-claude-project-dir-quoting.test.ts
@@ -1,0 +1,154 @@
+// covers: file:settings.json
+//
+// t199 - Claude settings must quote CLAUDE_PROJECT_DIR command paths.
+//
+// Regression pin for issue 519: Claude Code expands the settings.json command
+// strings through a shell, so `bun $CLAUDE_PROJECT_DIR/...` splits when the
+// workspace path contains spaces. The authored harness settings and the
+// generated Claude dist copy must both keep every `$CLAUDE_PROJECT_DIR`
+// occurrence inside double quotes. The permissions glob deliberately leaves the
+// `*` outside the quotes so Claude's Bash matcher still globs:
+// `Bash(bun "$CLAUDE_PROJECT_DIR/.claude/tools/"*)`.
+//
+// Mechanism: none. This reads and parses the two static JSON files on disk,
+// walks only command fields and permission entries (the executable surfaces),
+// and checks the exact bug shape cannot reappear.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { REPO_ROOT } from "../harness/fixtures.ts";
+
+const SUBJECTS = [
+  {
+    label: "authored Claude harness settings",
+    path: join(REPO_ROOT, "harness", "claude", "settings.json"),
+  },
+  {
+    label: "generated Claude dist settings",
+    path: join(REPO_ROOT, "dist", "claude", ".claude", "settings.json"),
+  },
+] as const;
+
+const PROJECT_DIR = "$CLAUDE_PROJECT_DIR";
+const PROJECT_DIR_RE = /\$CLAUDE_PROJECT_DIR/g;
+const BUG_SHAPE_RE = /(^|[\s(])\$CLAUDE_PROJECT_DIR\b/;
+const EXPECTED_PROJECT_DIR_REFERENCES = 13;
+const EXPECTED_PERMISSION_GLOB = 'Bash(bun "$CLAUDE_PROJECT_DIR/.claude/tools/"*)';
+
+interface Settings {
+  permissions?: { allow?: unknown };
+}
+
+function readSettings(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectCommandStrings(value: unknown, out: string[] = []): string[] {
+  if (Array.isArray(value)) {
+    for (const item of value) collectCommandStrings(item, out);
+    return out;
+  }
+
+  if (!isRecord(value)) return out;
+
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "command" && typeof child === "string") out.push(child);
+    collectCommandStrings(child, out);
+  }
+  return out;
+}
+
+function permissionEntries(settings: unknown): string[] {
+  const allow = (settings as Settings).permissions?.allow;
+  return Array.isArray(allow)
+    ? allow.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function executableSettingsStrings(settings: unknown): string[] {
+  return [...collectCommandStrings(settings), ...permissionEntries(settings)];
+}
+
+function projectDirReferenceCount(values: string[]): number {
+  return values.reduce(
+    (count, value) => count + [...value.matchAll(PROJECT_DIR_RE)].length,
+    0,
+  );
+}
+
+function isInsideDoubleQuotes(value: string, index: number): boolean {
+  let inDoubleQuotes = false;
+  let escaped = false;
+
+  for (let i = 0; i < index; i++) {
+    const ch = value[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') inDoubleQuotes = !inDoubleQuotes;
+  }
+
+  return inDoubleQuotes;
+}
+
+function hasClosingDoubleQuote(value: string, index: number): boolean {
+  let escaped = false;
+
+  for (let i = index; i < value.length; i++) {
+    const ch = value[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') return true;
+  }
+
+  return false;
+}
+
+function unquotedProjectDirReferences(value: string): string[] {
+  return [...value.matchAll(PROJECT_DIR_RE)]
+    .filter(
+      (match) =>
+        !isInsideDoubleQuotes(value, match.index) ||
+        !hasClosingDoubleQuote(value, match.index),
+    )
+    .map((match) => value.slice(Math.max(0, match.index - 8)));
+}
+
+describe("t199 Claude settings quote CLAUDE_PROJECT_DIR command paths", () => {
+  for (const subject of SUBJECTS) {
+    test(`${subject.label}: executable settings quote every CLAUDE_PROJECT_DIR reference`, () => {
+      const settings = readSettings(subject.path);
+      const values = executableSettingsStrings(settings).filter((value) =>
+        value.includes(PROJECT_DIR),
+      );
+
+      expect(projectDirReferenceCount(values)).toBe(EXPECTED_PROJECT_DIR_REFERENCES);
+      expect(permissionEntries(settings)).toContain(EXPECTED_PERMISSION_GLOB);
+
+      const unquoted = values.filter((value) =>
+        unquotedProjectDirReferences(value).length > 0,
+      );
+      expect(unquoted).toEqual([]);
+
+      // Pin the original shell-splitting bug shape directly: reverting the fix
+      // to `bun $CLAUDE_PROJECT_DIR/...` trips this even if formatting moves.
+      expect(values.filter((value) => BUG_SHAPE_RE.test(value))).toEqual([]);
+    });
+  }
+});

--- a/tests/unit/t219-claude-project-dir-quoting.test.ts
+++ b/tests/unit/t219-claude-project-dir-quoting.test.ts
@@ -1,6 +1,6 @@
 // covers: file:settings.json
 //
-// t199 - Claude settings must quote CLAUDE_PROJECT_DIR command paths.
+// t219 - Claude settings must quote CLAUDE_PROJECT_DIR command paths.
 //
 // Regression pin for issue 519: Claude Code expands the settings.json command
 // strings through a shell, so `bun $CLAUDE_PROJECT_DIR/...` splits when the
@@ -130,7 +130,7 @@ function unquotedProjectDirReferences(value: string): string[] {
     .map((match) => value.slice(Math.max(0, match.index - 8)));
 }
 
-describe("t199 Claude settings quote CLAUDE_PROJECT_DIR command paths", () => {
+describe("t219 Claude settings quote CLAUDE_PROJECT_DIR command paths", () => {
   for (const subject of SUBJECTS) {
     test(`${subject.label}: executable settings quote every CLAUDE_PROJECT_DIR reference`, () => {
       const settings = readSettings(subject.path);


### PR DESCRIPTION
Fixes #519

## Problem

A workspace path containing spaces broke every hook under bash-backed hook runners: `$CLAUDE_PROJECT_DIR` is unquoted in the shipped Claude `settings.json`, so `bun $CLAUDE_PROJECT_DIR/.claude/hooks/<hook>.ts` word-splits at the first space and fails with `Module not found .../AIDLC` (truncated path). The issue's shell validation shows zsh does not split but bash does, so the failure is shell-conditional - the shipped settings should be safe under every shell.

## Fix

Quote all 13 `$CLAUDE_PROJECT_DIR` registrations in `harness/claude/settings.json` (the authored source): 11 hook commands, the statusline command, and the pre-approved bun-tools permission glob. The glob keeps the `*` outside the quotes (`Bash(bun "$CLAUDE_PROJECT_DIR/.claude/tools/"*)`) so the permission matcher still globs.

`dist/` regenerated via `bun scripts/package.ts`; only `dist/claude/.claude/settings.json` and the per-harness `aidlc-version.ts` copies change (kiro/kiro-ide/codex settings do not carry `CLAUDE_PROJECT_DIR`).

## Tests

- NEW `tests/unit/t199-claude-project-dir-quoting.test.ts`: regression pin - walks command fields and permission entries in BOTH the authored and generated Claude settings and rejects any unquoted `$CLAUDE_PROJECT_DIR` (bug shape `/(^|[\s(])\$CLAUDE_PROJECT_DIR\b/`); also pins the exact permission-glob shape and the 13-reference count.
- `tests/integration/t40-settings-hook-config.test.ts`: T5 updated to expect the quoted bun-tools glob.

## Verification

- smoke+unit: 130 files / 2305 assertions / 0 failed
- t40, t199, t68 (version-changelog sync), t145 packaging parity, `package.ts --check`: all green
- Quoted form proven to survive bash word-splitting with a spaced path (`/tmp/path with spaces` resolves intact)

## Release mechanics

2.2.14 (open PRs claim through 2.2.13): `core/tools/aidlc-version.ts`, README badge, and CHANGELOG entry with the re-copy upgrade instruction, same commit per changelog policy.