### PR TITLE
feat(tools): add `upgrade` subcommand for in-place AI-DLC install upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.40] - 2026-08-03
+
+Adds an `upgrade` utility subcommand that replaces the manual "download the release zip and `cp -r dist/<harness>/` into your project" recipe every prior `## [N.N.N]` entry has documented. One command fetches the newest tag in the installed major series from the upstream tags API (not `releases/latest`, which answers the v1 line for this repo), auto-detects the harness (`.claude` / `.kiro` / `.codex` / `.aidlc`), and copies new files in — PRESERVING any file whose local bytes differ from the incoming upstream file (the user-modification signal). No backup dir is created — commit your harness dir or take a snapshot yourself before running upgrade if you want rollback insurance. Windows requires Git Bash or WSL (uses system `tar`).
+
+* NEW `aidlc-utility upgrade`: runs the upgrade. Reports installed vs latest, prints `up to date` / `ahead of upstream` and exits when no work is needed. Otherwise: downloads the tarball to /tmp, copies added + byte-identical upstream files into the harness dir, and preserves user-modified files (naming each one).
+* NEW `aidlc-utility upgrade --dry-run`: same discovery + download + diff, but writes nothing. Prints the per-file counts (added / unchanged / kept-local) and lists the user-modified files that would be preserved. Useful before letting a script mutate a live install.
+* The installed version is read from the target project's `.claude/tools/aidlc-version.ts` (or `.kiro/...` / `.codex/...` / `.aidlc/...`), not from the tool binary's own compiled-in constant, so `upgrade` reports the truth for the install being operated on even when the tool binary lives elsewhere.
+* Cross-major upgrades are refused deliberately: a 2.x install is never auto-offered a 3.x jump — the pick keeps to `v<installed-major>.*` tags. Pre-release tags (`-rc1`, etc.) are also filtered out.
+* Auto-detects the target harness by looking for `.claude/` / `.kiro/` / `.codex/` / `.aidlc/` under the project. Errors clearly if none exist ("install AI-DLC first") or if multiple are present ("pick one with `--harness <name>`").
+
 ## [2.5.36] - 2026-08-03
 
 Adds an optional declared workspace manifest for multi-repo teams. AI-DLC already auto-discovers sibling code repos on disk at intent birth; this release lets a team also declare that expected set in a `repos.json` file at the workspace root and reconcile it with a new `aidlc-workspace-sync` tool that clones missing repos, maintains a managed `.gitignore` block, and generates a VSCode multi-root workspace. The manifest is a convenience layer only: disk discovery remains the runtime source of truth, so a repo works the moment it is cloned whether or not it is declared. `--doctor` gains three advisory rows about manifest state. **Upgrade:** re-copy your `dist/<harness>/` shell to pick up the new tool; without `repos.json`, sync stays dormant and doctor adds only the advisory workspace-records row.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The deterministic engine — state machine, audit log, and the referee that coor
 
 ## Recommended Model
 
-This release works better with `Claude Opus 4.8`. We are sharpening it for previous model versions. 
+This release works better with `Claude Opus 4.8`. We are sharpening it for previous model versions.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.36-blue)
+![version](https://img.shields.io/badge/version-2.5.40-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-upgrade.ts
+++ b/core/tools/aidlc-upgrade.ts
@@ -1,0 +1,391 @@
+// aidlc-upgrade.ts — the AI-DLC install upgrader.
+//
+// ONE entry point:
+//   • upgrade(projectDir, { dryRun }) — figures out the target harness dir,
+//     reads that install's aidlc-version.ts (NOT the imported constant — the
+//     tool binary may live elsewhere), fetches the newest upstream tag in the
+//     same major series, and either dry-runs the diff or applies the upgrade.
+//     PRESERVES any file whose local bytes differ from the incoming upstream
+//     file (user modification). No backup dir is created — users who want a
+//     snapshot should commit their harness dir (or copy it) themselves before
+//     running upgrade. Standard Unix "trust your VCS" default.
+//
+// WHY tags, not GitHub Releases: this repo cuts v2 as tags on the v2 branch
+// (v2.1.7, v2.2.0, ...) but the "latest release" API answers the v1.x line.
+// Tags in the installed major series are the honest answer to "what should I
+// upgrade to today."
+//
+// WHY read the target's aidlc-version.ts, not the imported AIDLC_VERSION: the
+// import binds this file's version at build time. That's correct if a user
+// runs the tool from inside their install (the tool IS the install). It is
+// wrong if the tool binary lives elsewhere (a scenario surfaced during live
+// testing). Reading the target's aidlc-version.ts makes the command answer
+// for the install, not for itself.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { AIDLC_VERSION } from "./aidlc-version.ts";
+
+const UPSTREAM_OWNER = "awslabs";
+const UPSTREAM_REPO = "aidlc-workflows";
+const TAGS_URL = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tags?per_page=100`;
+const RELEASE_NOTES_BASE = `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/tag`;
+
+const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string }> = [
+  { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
+  { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
+  { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+];
+
+export interface UpgradeOptions {
+  dryRun?: boolean;
+  harnessOverride?: string;
+  // Injected in tests. Real callers leave these unset.
+  fetchTagsFn?: () => Promise<string[]>;
+  downloadTarballFn?: (tag: string, destDir: string) => Promise<string>;
+  installedVersionOverride?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Version + tag helpers
+// -----------------------------------------------------------------------------
+
+function parseSemver(tag: string): [number, number, number] | null {
+  // Accept "v2.2.10" and "2.2.10". Reject pre-releases (v2.2.10-rc1).
+  const m = tag.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+async function defaultFetchTags(): Promise<string[]> {
+  const res = await fetch(TAGS_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API returned ${res.status} fetching tags. Try again in a minute, or download the release manually from https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases`
+    );
+  }
+  const list = (await res.json()) as Array<{ name: string }>;
+  return list.map((t) => t.name);
+}
+
+async function defaultDownloadTarball(tag: string, destDir: string): Promise<string> {
+  const url = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tarball/${tag}`;
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Failed to download tarball for ${tag}: HTTP ${res.status}`);
+  }
+  const tarballPath = join(destDir, "release.tar.gz");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  writeFileSync(tarballPath, buf);
+  const extractDir = join(destDir, "extracted");
+  mkdirSync(extractDir, { recursive: true });
+  const tar = spawnSync("tar", ["-xzf", tarballPath, "-C", extractDir, "--strip-components=1"], {
+    encoding: "utf-8",
+  });
+  if (tar.status !== 0) {
+    throw new Error(
+      `tar extraction failed for ${tag}: ${tar.stderr || tar.stdout || "unknown error"}. Is 'tar' installed and on PATH?`
+    );
+  }
+  return extractDir;
+}
+
+function pickLatestMatchingMajor(tags: string[], installed: string): string | null {
+  const inst = parseSemver(installed);
+  if (!inst) return null;
+  const candidates = tags
+    .map((t) => ({ tag: t, ver: parseSemver(t) }))
+    .filter((c): c is { tag: string; ver: [number, number, number] } => c.ver !== null)
+    .filter((c) => c.ver[0] === inst[0]);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => compareSemver(b.ver, a.ver));
+  return candidates[0].tag;
+}
+
+// -----------------------------------------------------------------------------
+// Harness detection + installed-version reader
+// -----------------------------------------------------------------------------
+
+interface DetectedHarness {
+  harnessDir: string;
+  distSubpath: string;
+  label: string;
+}
+
+function detectHarness(projectDir: string, override?: string): DetectedHarness {
+  const present = HARNESSES.filter((h) => existsSync(join(projectDir, h.dir)));
+  if (override) {
+    const match = HARNESSES.find((h) => h.dir === override || h.dir === `.${override}`);
+    if (!match) {
+      throw new Error(
+        `Unknown --harness "${override}". Valid values: ${HARNESSES.map((h) => h.dir).join(", ")}`
+      );
+    }
+    if (!existsSync(join(projectDir, match.dir))) {
+      throw new Error(
+        `Requested --harness ${match.dir} but ${join(projectDir, match.dir)} does not exist. Install AI-DLC into this project first.`
+      );
+    }
+    return { harnessDir: join(projectDir, match.dir), distSubpath: match.distSubpath, label: match.label };
+  }
+  if (present.length === 0) {
+    throw new Error(
+      `No AI-DLC harness dir found in ${projectDir}. Expected one of: ${HARNESSES.map((h) => h.dir).join(", ")}. Install AI-DLC into this project first.`
+    );
+  }
+  if (present.length > 1) {
+    throw new Error(
+      `Multiple harness dirs present (${present.map((h) => h.dir).join(", ")}). Pick one with --harness <name>.`
+    );
+  }
+  const [only] = present;
+  return { harnessDir: join(projectDir, only.dir), distSubpath: only.distSubpath, label: only.label };
+}
+
+// Read the INSTALLED version from the target harness dir's aidlc-version.ts.
+// We deliberately do not import AIDLC_VERSION here: the tool binary that
+// invokes this code may live elsewhere (a downloaded tool copy, a different
+// install), and its imported constant tells us nothing about what's installed
+// in the target project.
+export function readInstalledVersion(harnessDir: string): string {
+  const versionFile = join(harnessDir, "tools", "aidlc-version.ts");
+  if (!existsSync(versionFile)) {
+    // The install exists (we detected the harness dir), but the version file
+    // is absent. That's an unusually broken install; fall back to the tool's
+    // own version constant so we still produce SOMETHING truthful.
+    return AIDLC_VERSION;
+  }
+  const src = readFileSync(versionFile, "utf-8");
+  const m = src.match(/AIDLC_VERSION\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/);
+  if (!m) return AIDLC_VERSION;
+  return m[1];
+}
+
+// -----------------------------------------------------------------------------
+// File walk + hash
+// -----------------------------------------------------------------------------
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function walk(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const p = join(cur, name);
+      let st: Stats;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(p);
+      else if (st.isFile()) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+interface DiffResult {
+  added: string[];
+  unchanged: string[];
+  kept: string[]; // user-modified — do not overwrite
+}
+
+function diffTrees(localRoot: string, upstreamRoot: string): DiffResult {
+  const res: DiffResult = { added: [], unchanged: [], kept: [] };
+  for (const upAbs of walk(upstreamRoot)) {
+    const rel = relative(upstreamRoot, upAbs).split(sep).join("/");
+    const localAbs = join(localRoot, rel);
+    const upBuf = readFileSync(upAbs);
+    if (!existsSync(localAbs)) {
+      res.added.push(rel);
+      continue;
+    }
+    const localBuf = readFileSync(localAbs);
+    if (upBuf.equals(localBuf)) res.unchanged.push(rel);
+    else res.kept.push(rel);
+  }
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+// Public entry point
+// -----------------------------------------------------------------------------
+
+export interface UpgradeReport {
+  installed: string;
+  latest: string | null;
+  harnessLabel: string | null;
+  harnessDir: string | null;
+  reason:
+    | "no-upstream-version"
+    | "up-to-date"
+    | "ahead-of-upstream"
+    | "dry-run"
+    | "applied";
+  dryRun: boolean;
+  applied: boolean;
+  filesWritten: number;
+  filesKept: number;
+  diff: DiffResult | null;
+  releaseNotesUrl: string | null;
+}
+
+export async function upgrade(projectDir: string, opts: UpgradeOptions = {}): Promise<UpgradeReport> {
+  const dryRun = !!opts.dryRun;
+  const fetchTags = opts.fetchTagsFn ?? defaultFetchTags;
+  const download = opts.downloadTarballFn ?? defaultDownloadTarball;
+
+  // Step 1: figure out installed version. Prefer the target harness's file
+  // (that's the source of truth for THIS project), fall back to injected
+  // override for tests that don't stage a harness dir.
+  let installed = opts.installedVersionOverride;
+  let harness: DetectedHarness | null = null;
+  try {
+    harness = detectHarness(projectDir, opts.harnessOverride);
+    if (!installed) installed = readInstalledVersion(harness.harnessDir);
+  } catch (err) {
+    // If we cannot detect a harness AND no override was given, we cannot
+    // report an installed version — surface the underlying error.
+    if (!installed) throw err;
+  }
+  installed = installed as string;
+
+  // Step 2: fetch upstream tags and pick the latest matching-major tag.
+  const tags = await fetchTags();
+  const latest = pickLatestMatchingMajor(tags, installed);
+
+  const empty: Omit<UpgradeReport, "installed" | "latest" | "reason"> = {
+    harnessLabel: harness?.label ?? null,
+    harnessDir: harness?.harnessDir ?? null,
+    dryRun,
+    applied: false,
+    filesWritten: 0,
+    filesKept: 0,
+    diff: null,
+    releaseNotesUrl: null,
+  };
+
+  if (!latest) {
+    return { ...empty, installed, latest: null, reason: "no-upstream-version" };
+  }
+
+  const cmp = compareSemver(
+    parseSemver(installed) as [number, number, number],
+    parseSemver(latest) as [number, number, number]
+  );
+  const releaseNotesUrl = `${RELEASE_NOTES_BASE}/${latest}`;
+
+  if (cmp === 0) {
+    return { ...empty, installed, latest, reason: "up-to-date", releaseNotesUrl };
+  }
+  if (cmp > 0) {
+    return { ...empty, installed, latest, reason: "ahead-of-upstream", releaseNotesUrl };
+  }
+
+  // Step 3: upgrade is possible. Download + diff + (maybe) apply.
+  if (!harness) {
+    // Should not reach here (detectHarness would have thrown earlier), but
+    // keep the invariant explicit.
+    throw new Error("upgrade: harness not detected");
+  }
+  const tmpRoot = mkdtempSync(join(tmpdir(), "aidlc-upgrade-"));
+  try {
+    const extractDir = await download(latest, tmpRoot);
+    const upstreamHarness = join(extractDir, harness.distSubpath);
+    if (!existsSync(upstreamHarness)) {
+      throw new Error(
+        `Upstream tarball for ${latest} does not contain ${harness.distSubpath}. This tag may predate the current dist layout — file an issue at https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/issues.`
+      );
+    }
+    const diff = diffTrees(harness.harnessDir, upstreamHarness);
+
+    if (dryRun) {
+      return {
+        installed,
+        latest,
+        harnessLabel: harness.label,
+        harnessDir: harness.harnessDir,
+        reason: "dry-run",
+        dryRun: true,
+        applied: false,
+        filesWritten: 0,
+        filesKept: diff.kept.length,
+        diff,
+        releaseNotesUrl,
+      };
+    }
+
+    // Real apply. Copy added + byte-identical upstream files in; skip files
+    // the user has modified (their bytes differ). No backup dir is created —
+    // users who want a snapshot should commit their .claude/ or take one
+    // themselves before running upgrade.
+    let written = 0;
+    for (const rel of [...diff.added, ...diff.unchanged]) {
+      const src = join(upstreamHarness, ...rel.split("/"));
+      const dst = join(harness.harnessDir, ...rel.split("/"));
+      mkdirSync(dirName(dst), { recursive: true });
+      cpSync(src, dst);
+      written++;
+    }
+    return {
+      installed,
+      latest,
+      harnessLabel: harness.label,
+      harnessDir: harness.harnessDir,
+      reason: "applied",
+      dryRun: false,
+      applied: true,
+      filesWritten: written,
+      filesKept: diff.kept.length,
+      diff,
+      releaseNotesUrl,
+    };
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+function dirName(p: string): string {
+  const idx = p.lastIndexOf(sep);
+  if (idx === -1) return ".";
+  return p.slice(0, idx);
+}
+
+// Test-only exposure for pure helpers.
+export const _test = { sha256, diffTrees, pickLatestMatchingMajor, parseSemver, readInstalledVersion };

--- a/core/tools/aidlc-upgrade.ts
+++ b/core/tools/aidlc-upgrade.ts
@@ -49,6 +49,7 @@ const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string
   { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
   { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
   { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+  { dir: ".aidlc", distSubpath: "dist/opencode/.aidlc", label: "opencode" },
 ];
 
 export interface UpgradeOptions {

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -117,6 +117,7 @@ import {
   _resetStageGraphForTests,
 } from "./aidlc-lib.ts";
 import { validateStageFrontmatter } from "./aidlc-stage-schema.ts";
+import { upgrade, type UpgradeReport } from "./aidlc-upgrade.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
@@ -148,9 +149,6 @@ const NO_STATE_FILE_MESSAGE =
   "No state file found. Start a workflow first by describing what to build (/aidlc \"build the auth service\").";
 const INIT_TRANSITION_MESSAGE =
   "init now lays down the project data tree and is not yet available in this release. To start work, describe what to build: /aidlc \"build the auth service\".";
-const UPGRADE_UNAVAILABLE_MESSAGE =
-  "upgrade is not available in this install; it arrives with the packaged binary distribution.";
-
 let errorArgs: string[] = [];
 let errorProjectDirArg: string | undefined;
 
@@ -228,6 +226,9 @@ Utilities:
   --depth <level>   Override depth (minimal, standard, comprehensive)
   --test-strategy <level>  Override test strategy (minimal, standard, comprehensive)
   --version         Show the framework version
+  upgrade           Download the latest AI-DLC release and apply it (backs up
+                    first, preserves any files you have modified)
+  upgrade --dry-run Show what an upgrade would change without writing anything
   --help            Show this help message
 
 Other:
@@ -932,6 +933,82 @@ async function handlePluginSync(projectDir: string): Promise<void> {
   }
 
   process.stdout.write(`plugin sync complete: ${composePaths.length} plugin(s)\n`);
+}
+
+// ---------------------------------------------------------------------------
+// upgrade
+// ---------------------------------------------------------------------------
+
+// One subcommand, one flag:
+//   `upgrade`            → downloads the latest matching-major upstream tag,
+//                           backs up the harness dir, copies new files in,
+//                           PRESERVES any file the user has modified.
+//   `upgrade --dry-run`  → same discovery + download + diff, but no writes.
+// Auto-detects the harness by looking for .claude/.kiro/.codex under the
+// project dir; --harness <name> forces a specific pick when ambiguous.
+async function handleUpgrade(projectDir: string, flags: Record<string, string>): Promise<void> {
+  const dryRun = flags["dry-run"] !== undefined || flags.check !== undefined;
+  const override = flags.harness;
+  try {
+    const report = await upgrade(projectDir, { dryRun, harnessOverride: override });
+    printUpgrade(report);
+  } catch (err) {
+    die(`upgrade failed: ${(err as Error).message}`);
+  }
+}
+
+function printUpgrade(r: UpgradeReport): void {
+  if (r.reason === "no-upstream-version") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed\n` +
+      `Could not resolve a latest upstream version. Try again in a minute, or download manually from https://github.com/awslabs/aidlc-workflows/releases\n`
+    );
+    return;
+  }
+  if (r.reason === "up-to-date") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — up to date (matches upstream ${r.latest}).\n`
+    );
+    return;
+  }
+  if (r.reason === "ahead-of-upstream") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — ahead of upstream (latest published: ${r.latest}).\n` +
+      `You are on an unreleased build. Nothing to upgrade to.\n`
+    );
+    return;
+  }
+  if (r.reason === "dry-run") {
+    const d = r.diff;
+    process.stdout.write(
+      `aidlc ${r.installed} installed — would upgrade to ${r.latest} on ${r.harnessLabel}\n` +
+      `  harness dir: ${r.harnessDir}\n` +
+      `  added:       ${d?.added.length ?? 0} files\n` +
+      `  unchanged:   ${d?.unchanged.length ?? 0} files (safe to overwrite)\n` +
+      `  kept local:  ${d?.kept.length ?? 0} files (user-modified — will NOT be overwritten)\n`
+    );
+    if (d && d.kept.length > 0) {
+      process.stdout.write(`\nUser-modified files that would be kept as-is:\n`);
+      for (const rel of d.kept) process.stdout.write(`  ${rel}\n`);
+    }
+    process.stdout.write(`\nDry run — no files were changed. Run \`upgrade\` (without --dry-run) to apply.\n`);
+    return;
+  }
+  // reason === "applied"
+  process.stdout.write(
+    `aidlc upgraded ${r.installed} → ${r.latest} on ${r.harnessLabel}\n` +
+    `  harness dir:  ${r.harnessDir}\n` +
+    `  files written: ${r.filesWritten}\n` +
+    `  files kept (user-modified, not overwritten): ${r.filesKept}\n`
+  );
+  if (r.diff && r.diff.kept.length > 0) {
+    process.stdout.write(`\nUser-modified files preserved:\n`);
+    for (const rel of r.diff.kept) process.stdout.write(`  ${rel}\n`);
+    process.stdout.write(
+      `\nTo take the upstream copy for one of these, delete the local file and re-run \`upgrade\`.\n`
+    );
+  }
+  process.stdout.write(`\nRelease notes: ${r.releaseNotesUrl}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -3999,10 +4076,6 @@ function handleStateInit(_projectDir: string, _flags: Record<string, string>): v
   );
 }
 
-function handleUpgrade(): void {
-  die(UPGRADE_UNAVAILABLE_MESSAGE);
-}
-
 // ---------------------------------------------------------------------------
 // intent / space — the verb families + the deterministic query layer
 // ---------------------------------------------------------------------------
@@ -5614,7 +5687,7 @@ export async function main(argv: string[]): Promise<void> {
       handleStateInit(projectDir, flags);
       break;
     case "upgrade":
-      handleUpgrade();
+      await handleUpgrade(projectDir, flags);
       break;
     case "scope-change":
       handleScopeChange(projectDir, flags);

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.36";
+export const AIDLC_VERSION = "2.5.40";

--- a/dist/claude/.claude/tools/aidlc-upgrade.ts
+++ b/dist/claude/.claude/tools/aidlc-upgrade.ts
@@ -1,0 +1,391 @@
+// aidlc-upgrade.ts — the AI-DLC install upgrader.
+//
+// ONE entry point:
+//   • upgrade(projectDir, { dryRun }) — figures out the target harness dir,
+//     reads that install's aidlc-version.ts (NOT the imported constant — the
+//     tool binary may live elsewhere), fetches the newest upstream tag in the
+//     same major series, and either dry-runs the diff or applies the upgrade.
+//     PRESERVES any file whose local bytes differ from the incoming upstream
+//     file (user modification). No backup dir is created — users who want a
+//     snapshot should commit their harness dir (or copy it) themselves before
+//     running upgrade. Standard Unix "trust your VCS" default.
+//
+// WHY tags, not GitHub Releases: this repo cuts v2 as tags on the v2 branch
+// (v2.1.7, v2.2.0, ...) but the "latest release" API answers the v1.x line.
+// Tags in the installed major series are the honest answer to "what should I
+// upgrade to today."
+//
+// WHY read the target's aidlc-version.ts, not the imported AIDLC_VERSION: the
+// import binds this file's version at build time. That's correct if a user
+// runs the tool from inside their install (the tool IS the install). It is
+// wrong if the tool binary lives elsewhere (a scenario surfaced during live
+// testing). Reading the target's aidlc-version.ts makes the command answer
+// for the install, not for itself.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { AIDLC_VERSION } from "./aidlc-version.ts";
+
+const UPSTREAM_OWNER = "awslabs";
+const UPSTREAM_REPO = "aidlc-workflows";
+const TAGS_URL = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tags?per_page=100`;
+const RELEASE_NOTES_BASE = `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/tag`;
+
+const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string }> = [
+  { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
+  { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
+  { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+];
+
+export interface UpgradeOptions {
+  dryRun?: boolean;
+  harnessOverride?: string;
+  // Injected in tests. Real callers leave these unset.
+  fetchTagsFn?: () => Promise<string[]>;
+  downloadTarballFn?: (tag: string, destDir: string) => Promise<string>;
+  installedVersionOverride?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Version + tag helpers
+// -----------------------------------------------------------------------------
+
+function parseSemver(tag: string): [number, number, number] | null {
+  // Accept "v2.2.10" and "2.2.10". Reject pre-releases (v2.2.10-rc1).
+  const m = tag.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+async function defaultFetchTags(): Promise<string[]> {
+  const res = await fetch(TAGS_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API returned ${res.status} fetching tags. Try again in a minute, or download the release manually from https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases`
+    );
+  }
+  const list = (await res.json()) as Array<{ name: string }>;
+  return list.map((t) => t.name);
+}
+
+async function defaultDownloadTarball(tag: string, destDir: string): Promise<string> {
+  const url = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tarball/${tag}`;
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Failed to download tarball for ${tag}: HTTP ${res.status}`);
+  }
+  const tarballPath = join(destDir, "release.tar.gz");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  writeFileSync(tarballPath, buf);
+  const extractDir = join(destDir, "extracted");
+  mkdirSync(extractDir, { recursive: true });
+  const tar = spawnSync("tar", ["-xzf", tarballPath, "-C", extractDir, "--strip-components=1"], {
+    encoding: "utf-8",
+  });
+  if (tar.status !== 0) {
+    throw new Error(
+      `tar extraction failed for ${tag}: ${tar.stderr || tar.stdout || "unknown error"}. Is 'tar' installed and on PATH?`
+    );
+  }
+  return extractDir;
+}
+
+function pickLatestMatchingMajor(tags: string[], installed: string): string | null {
+  const inst = parseSemver(installed);
+  if (!inst) return null;
+  const candidates = tags
+    .map((t) => ({ tag: t, ver: parseSemver(t) }))
+    .filter((c): c is { tag: string; ver: [number, number, number] } => c.ver !== null)
+    .filter((c) => c.ver[0] === inst[0]);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => compareSemver(b.ver, a.ver));
+  return candidates[0].tag;
+}
+
+// -----------------------------------------------------------------------------
+// Harness detection + installed-version reader
+// -----------------------------------------------------------------------------
+
+interface DetectedHarness {
+  harnessDir: string;
+  distSubpath: string;
+  label: string;
+}
+
+function detectHarness(projectDir: string, override?: string): DetectedHarness {
+  const present = HARNESSES.filter((h) => existsSync(join(projectDir, h.dir)));
+  if (override) {
+    const match = HARNESSES.find((h) => h.dir === override || h.dir === `.${override}`);
+    if (!match) {
+      throw new Error(
+        `Unknown --harness "${override}". Valid values: ${HARNESSES.map((h) => h.dir).join(", ")}`
+      );
+    }
+    if (!existsSync(join(projectDir, match.dir))) {
+      throw new Error(
+        `Requested --harness ${match.dir} but ${join(projectDir, match.dir)} does not exist. Install AI-DLC into this project first.`
+      );
+    }
+    return { harnessDir: join(projectDir, match.dir), distSubpath: match.distSubpath, label: match.label };
+  }
+  if (present.length === 0) {
+    throw new Error(
+      `No AI-DLC harness dir found in ${projectDir}. Expected one of: ${HARNESSES.map((h) => h.dir).join(", ")}. Install AI-DLC into this project first.`
+    );
+  }
+  if (present.length > 1) {
+    throw new Error(
+      `Multiple harness dirs present (${present.map((h) => h.dir).join(", ")}). Pick one with --harness <name>.`
+    );
+  }
+  const [only] = present;
+  return { harnessDir: join(projectDir, only.dir), distSubpath: only.distSubpath, label: only.label };
+}
+
+// Read the INSTALLED version from the target harness dir's aidlc-version.ts.
+// We deliberately do not import AIDLC_VERSION here: the tool binary that
+// invokes this code may live elsewhere (a downloaded tool copy, a different
+// install), and its imported constant tells us nothing about what's installed
+// in the target project.
+export function readInstalledVersion(harnessDir: string): string {
+  const versionFile = join(harnessDir, "tools", "aidlc-version.ts");
+  if (!existsSync(versionFile)) {
+    // The install exists (we detected the harness dir), but the version file
+    // is absent. That's an unusually broken install; fall back to the tool's
+    // own version constant so we still produce SOMETHING truthful.
+    return AIDLC_VERSION;
+  }
+  const src = readFileSync(versionFile, "utf-8");
+  const m = src.match(/AIDLC_VERSION\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/);
+  if (!m) return AIDLC_VERSION;
+  return m[1];
+}
+
+// -----------------------------------------------------------------------------
+// File walk + hash
+// -----------------------------------------------------------------------------
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function walk(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const p = join(cur, name);
+      let st: Stats;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(p);
+      else if (st.isFile()) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+interface DiffResult {
+  added: string[];
+  unchanged: string[];
+  kept: string[]; // user-modified — do not overwrite
+}
+
+function diffTrees(localRoot: string, upstreamRoot: string): DiffResult {
+  const res: DiffResult = { added: [], unchanged: [], kept: [] };
+  for (const upAbs of walk(upstreamRoot)) {
+    const rel = relative(upstreamRoot, upAbs).split(sep).join("/");
+    const localAbs = join(localRoot, rel);
+    const upBuf = readFileSync(upAbs);
+    if (!existsSync(localAbs)) {
+      res.added.push(rel);
+      continue;
+    }
+    const localBuf = readFileSync(localAbs);
+    if (upBuf.equals(localBuf)) res.unchanged.push(rel);
+    else res.kept.push(rel);
+  }
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+// Public entry point
+// -----------------------------------------------------------------------------
+
+export interface UpgradeReport {
+  installed: string;
+  latest: string | null;
+  harnessLabel: string | null;
+  harnessDir: string | null;
+  reason:
+    | "no-upstream-version"
+    | "up-to-date"
+    | "ahead-of-upstream"
+    | "dry-run"
+    | "applied";
+  dryRun: boolean;
+  applied: boolean;
+  filesWritten: number;
+  filesKept: number;
+  diff: DiffResult | null;
+  releaseNotesUrl: string | null;
+}
+
+export async function upgrade(projectDir: string, opts: UpgradeOptions = {}): Promise<UpgradeReport> {
+  const dryRun = !!opts.dryRun;
+  const fetchTags = opts.fetchTagsFn ?? defaultFetchTags;
+  const download = opts.downloadTarballFn ?? defaultDownloadTarball;
+
+  // Step 1: figure out installed version. Prefer the target harness's file
+  // (that's the source of truth for THIS project), fall back to injected
+  // override for tests that don't stage a harness dir.
+  let installed = opts.installedVersionOverride;
+  let harness: DetectedHarness | null = null;
+  try {
+    harness = detectHarness(projectDir, opts.harnessOverride);
+    if (!installed) installed = readInstalledVersion(harness.harnessDir);
+  } catch (err) {
+    // If we cannot detect a harness AND no override was given, we cannot
+    // report an installed version — surface the underlying error.
+    if (!installed) throw err;
+  }
+  installed = installed as string;
+
+  // Step 2: fetch upstream tags and pick the latest matching-major tag.
+  const tags = await fetchTags();
+  const latest = pickLatestMatchingMajor(tags, installed);
+
+  const empty: Omit<UpgradeReport, "installed" | "latest" | "reason"> = {
+    harnessLabel: harness?.label ?? null,
+    harnessDir: harness?.harnessDir ?? null,
+    dryRun,
+    applied: false,
+    filesWritten: 0,
+    filesKept: 0,
+    diff: null,
+    releaseNotesUrl: null,
+  };
+
+  if (!latest) {
+    return { ...empty, installed, latest: null, reason: "no-upstream-version" };
+  }
+
+  const cmp = compareSemver(
+    parseSemver(installed) as [number, number, number],
+    parseSemver(latest) as [number, number, number]
+  );
+  const releaseNotesUrl = `${RELEASE_NOTES_BASE}/${latest}`;
+
+  if (cmp === 0) {
+    return { ...empty, installed, latest, reason: "up-to-date", releaseNotesUrl };
+  }
+  if (cmp > 0) {
+    return { ...empty, installed, latest, reason: "ahead-of-upstream", releaseNotesUrl };
+  }
+
+  // Step 3: upgrade is possible. Download + diff + (maybe) apply.
+  if (!harness) {
+    // Should not reach here (detectHarness would have thrown earlier), but
+    // keep the invariant explicit.
+    throw new Error("upgrade: harness not detected");
+  }
+  const tmpRoot = mkdtempSync(join(tmpdir(), "aidlc-upgrade-"));
+  try {
+    const extractDir = await download(latest, tmpRoot);
+    const upstreamHarness = join(extractDir, harness.distSubpath);
+    if (!existsSync(upstreamHarness)) {
+      throw new Error(
+        `Upstream tarball for ${latest} does not contain ${harness.distSubpath}. This tag may predate the current dist layout — file an issue at https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/issues.`
+      );
+    }
+    const diff = diffTrees(harness.harnessDir, upstreamHarness);
+
+    if (dryRun) {
+      return {
+        installed,
+        latest,
+        harnessLabel: harness.label,
+        harnessDir: harness.harnessDir,
+        reason: "dry-run",
+        dryRun: true,
+        applied: false,
+        filesWritten: 0,
+        filesKept: diff.kept.length,
+        diff,
+        releaseNotesUrl,
+      };
+    }
+
+    // Real apply. Copy added + byte-identical upstream files in; skip files
+    // the user has modified (their bytes differ). No backup dir is created —
+    // users who want a snapshot should commit their .claude/ or take one
+    // themselves before running upgrade.
+    let written = 0;
+    for (const rel of [...diff.added, ...diff.unchanged]) {
+      const src = join(upstreamHarness, ...rel.split("/"));
+      const dst = join(harness.harnessDir, ...rel.split("/"));
+      mkdirSync(dirName(dst), { recursive: true });
+      cpSync(src, dst);
+      written++;
+    }
+    return {
+      installed,
+      latest,
+      harnessLabel: harness.label,
+      harnessDir: harness.harnessDir,
+      reason: "applied",
+      dryRun: false,
+      applied: true,
+      filesWritten: written,
+      filesKept: diff.kept.length,
+      diff,
+      releaseNotesUrl,
+    };
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+function dirName(p: string): string {
+  const idx = p.lastIndexOf(sep);
+  if (idx === -1) return ".";
+  return p.slice(0, idx);
+}
+
+// Test-only exposure for pure helpers.
+export const _test = { sha256, diffTrees, pickLatestMatchingMajor, parseSemver, readInstalledVersion };

--- a/dist/claude/.claude/tools/aidlc-upgrade.ts
+++ b/dist/claude/.claude/tools/aidlc-upgrade.ts
@@ -49,6 +49,7 @@ const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string
   { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
   { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
   { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+  { dir: ".aidlc", distSubpath: "dist/opencode/.aidlc", label: "opencode" },
 ];
 
 export interface UpgradeOptions {

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -117,6 +117,7 @@ import {
   _resetStageGraphForTests,
 } from "./aidlc-lib.ts";
 import { validateStageFrontmatter } from "./aidlc-stage-schema.ts";
+import { upgrade, type UpgradeReport } from "./aidlc-upgrade.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
@@ -148,9 +149,6 @@ const NO_STATE_FILE_MESSAGE =
   "No state file found. Start a workflow first by describing what to build (/aidlc \"build the auth service\").";
 const INIT_TRANSITION_MESSAGE =
   "init now lays down the project data tree and is not yet available in this release. To start work, describe what to build: /aidlc \"build the auth service\".";
-const UPGRADE_UNAVAILABLE_MESSAGE =
-  "upgrade is not available in this install; it arrives with the packaged binary distribution.";
-
 let errorArgs: string[] = [];
 let errorProjectDirArg: string | undefined;
 
@@ -228,6 +226,9 @@ Utilities:
   --depth <level>   Override depth (minimal, standard, comprehensive)
   --test-strategy <level>  Override test strategy (minimal, standard, comprehensive)
   --version         Show the framework version
+  upgrade           Download the latest AI-DLC release and apply it (backs up
+                    first, preserves any files you have modified)
+  upgrade --dry-run Show what an upgrade would change without writing anything
   --help            Show this help message
 
 Other:
@@ -932,6 +933,82 @@ async function handlePluginSync(projectDir: string): Promise<void> {
   }
 
   process.stdout.write(`plugin sync complete: ${composePaths.length} plugin(s)\n`);
+}
+
+// ---------------------------------------------------------------------------
+// upgrade
+// ---------------------------------------------------------------------------
+
+// One subcommand, one flag:
+//   `upgrade`            → downloads the latest matching-major upstream tag,
+//                           backs up the harness dir, copies new files in,
+//                           PRESERVES any file the user has modified.
+//   `upgrade --dry-run`  → same discovery + download + diff, but no writes.
+// Auto-detects the harness by looking for .claude/.kiro/.codex under the
+// project dir; --harness <name> forces a specific pick when ambiguous.
+async function handleUpgrade(projectDir: string, flags: Record<string, string>): Promise<void> {
+  const dryRun = flags["dry-run"] !== undefined || flags.check !== undefined;
+  const override = flags.harness;
+  try {
+    const report = await upgrade(projectDir, { dryRun, harnessOverride: override });
+    printUpgrade(report);
+  } catch (err) {
+    die(`upgrade failed: ${(err as Error).message}`);
+  }
+}
+
+function printUpgrade(r: UpgradeReport): void {
+  if (r.reason === "no-upstream-version") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed\n` +
+      `Could not resolve a latest upstream version. Try again in a minute, or download manually from https://github.com/awslabs/aidlc-workflows/releases\n`
+    );
+    return;
+  }
+  if (r.reason === "up-to-date") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — up to date (matches upstream ${r.latest}).\n`
+    );
+    return;
+  }
+  if (r.reason === "ahead-of-upstream") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — ahead of upstream (latest published: ${r.latest}).\n` +
+      `You are on an unreleased build. Nothing to upgrade to.\n`
+    );
+    return;
+  }
+  if (r.reason === "dry-run") {
+    const d = r.diff;
+    process.stdout.write(
+      `aidlc ${r.installed} installed — would upgrade to ${r.latest} on ${r.harnessLabel}\n` +
+      `  harness dir: ${r.harnessDir}\n` +
+      `  added:       ${d?.added.length ?? 0} files\n` +
+      `  unchanged:   ${d?.unchanged.length ?? 0} files (safe to overwrite)\n` +
+      `  kept local:  ${d?.kept.length ?? 0} files (user-modified — will NOT be overwritten)\n`
+    );
+    if (d && d.kept.length > 0) {
+      process.stdout.write(`\nUser-modified files that would be kept as-is:\n`);
+      for (const rel of d.kept) process.stdout.write(`  ${rel}\n`);
+    }
+    process.stdout.write(`\nDry run — no files were changed. Run \`upgrade\` (without --dry-run) to apply.\n`);
+    return;
+  }
+  // reason === "applied"
+  process.stdout.write(
+    `aidlc upgraded ${r.installed} → ${r.latest} on ${r.harnessLabel}\n` +
+    `  harness dir:  ${r.harnessDir}\n` +
+    `  files written: ${r.filesWritten}\n` +
+    `  files kept (user-modified, not overwritten): ${r.filesKept}\n`
+  );
+  if (r.diff && r.diff.kept.length > 0) {
+    process.stdout.write(`\nUser-modified files preserved:\n`);
+    for (const rel of r.diff.kept) process.stdout.write(`  ${rel}\n`);
+    process.stdout.write(
+      `\nTo take the upstream copy for one of these, delete the local file and re-run \`upgrade\`.\n`
+    );
+  }
+  process.stdout.write(`\nRelease notes: ${r.releaseNotesUrl}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -3999,10 +4076,6 @@ function handleStateInit(_projectDir: string, _flags: Record<string, string>): v
   );
 }
 
-function handleUpgrade(): void {
-  die(UPGRADE_UNAVAILABLE_MESSAGE);
-}
-
 // ---------------------------------------------------------------------------
 // intent / space — the verb families + the deterministic query layer
 // ---------------------------------------------------------------------------
@@ -5614,7 +5687,7 @@ export async function main(argv: string[]): Promise<void> {
       handleStateInit(projectDir, flags);
       break;
     case "upgrade":
-      handleUpgrade();
+      await handleUpgrade(projectDir, flags);
       break;
     case "scope-change":
       handleScopeChange(projectDir, flags);

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.36";
+export const AIDLC_VERSION = "2.5.40";

--- a/dist/codex/.codex/tools/aidlc-upgrade.ts
+++ b/dist/codex/.codex/tools/aidlc-upgrade.ts
@@ -1,0 +1,391 @@
+// aidlc-upgrade.ts — the AI-DLC install upgrader.
+//
+// ONE entry point:
+//   • upgrade(projectDir, { dryRun }) — figures out the target harness dir,
+//     reads that install's aidlc-version.ts (NOT the imported constant — the
+//     tool binary may live elsewhere), fetches the newest upstream tag in the
+//     same major series, and either dry-runs the diff or applies the upgrade.
+//     PRESERVES any file whose local bytes differ from the incoming upstream
+//     file (user modification). No backup dir is created — users who want a
+//     snapshot should commit their harness dir (or copy it) themselves before
+//     running upgrade. Standard Unix "trust your VCS" default.
+//
+// WHY tags, not GitHub Releases: this repo cuts v2 as tags on the v2 branch
+// (v2.1.7, v2.2.0, ...) but the "latest release" API answers the v1.x line.
+// Tags in the installed major series are the honest answer to "what should I
+// upgrade to today."
+//
+// WHY read the target's aidlc-version.ts, not the imported AIDLC_VERSION: the
+// import binds this file's version at build time. That's correct if a user
+// runs the tool from inside their install (the tool IS the install). It is
+// wrong if the tool binary lives elsewhere (a scenario surfaced during live
+// testing). Reading the target's aidlc-version.ts makes the command answer
+// for the install, not for itself.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { AIDLC_VERSION } from "./aidlc-version.ts";
+
+const UPSTREAM_OWNER = "awslabs";
+const UPSTREAM_REPO = "aidlc-workflows";
+const TAGS_URL = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tags?per_page=100`;
+const RELEASE_NOTES_BASE = `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/tag`;
+
+const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string }> = [
+  { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
+  { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
+  { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+];
+
+export interface UpgradeOptions {
+  dryRun?: boolean;
+  harnessOverride?: string;
+  // Injected in tests. Real callers leave these unset.
+  fetchTagsFn?: () => Promise<string[]>;
+  downloadTarballFn?: (tag: string, destDir: string) => Promise<string>;
+  installedVersionOverride?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Version + tag helpers
+// -----------------------------------------------------------------------------
+
+function parseSemver(tag: string): [number, number, number] | null {
+  // Accept "v2.2.10" and "2.2.10". Reject pre-releases (v2.2.10-rc1).
+  const m = tag.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+async function defaultFetchTags(): Promise<string[]> {
+  const res = await fetch(TAGS_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API returned ${res.status} fetching tags. Try again in a minute, or download the release manually from https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases`
+    );
+  }
+  const list = (await res.json()) as Array<{ name: string }>;
+  return list.map((t) => t.name);
+}
+
+async function defaultDownloadTarball(tag: string, destDir: string): Promise<string> {
+  const url = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tarball/${tag}`;
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Failed to download tarball for ${tag}: HTTP ${res.status}`);
+  }
+  const tarballPath = join(destDir, "release.tar.gz");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  writeFileSync(tarballPath, buf);
+  const extractDir = join(destDir, "extracted");
+  mkdirSync(extractDir, { recursive: true });
+  const tar = spawnSync("tar", ["-xzf", tarballPath, "-C", extractDir, "--strip-components=1"], {
+    encoding: "utf-8",
+  });
+  if (tar.status !== 0) {
+    throw new Error(
+      `tar extraction failed for ${tag}: ${tar.stderr || tar.stdout || "unknown error"}. Is 'tar' installed and on PATH?`
+    );
+  }
+  return extractDir;
+}
+
+function pickLatestMatchingMajor(tags: string[], installed: string): string | null {
+  const inst = parseSemver(installed);
+  if (!inst) return null;
+  const candidates = tags
+    .map((t) => ({ tag: t, ver: parseSemver(t) }))
+    .filter((c): c is { tag: string; ver: [number, number, number] } => c.ver !== null)
+    .filter((c) => c.ver[0] === inst[0]);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => compareSemver(b.ver, a.ver));
+  return candidates[0].tag;
+}
+
+// -----------------------------------------------------------------------------
+// Harness detection + installed-version reader
+// -----------------------------------------------------------------------------
+
+interface DetectedHarness {
+  harnessDir: string;
+  distSubpath: string;
+  label: string;
+}
+
+function detectHarness(projectDir: string, override?: string): DetectedHarness {
+  const present = HARNESSES.filter((h) => existsSync(join(projectDir, h.dir)));
+  if (override) {
+    const match = HARNESSES.find((h) => h.dir === override || h.dir === `.${override}`);
+    if (!match) {
+      throw new Error(
+        `Unknown --harness "${override}". Valid values: ${HARNESSES.map((h) => h.dir).join(", ")}`
+      );
+    }
+    if (!existsSync(join(projectDir, match.dir))) {
+      throw new Error(
+        `Requested --harness ${match.dir} but ${join(projectDir, match.dir)} does not exist. Install AI-DLC into this project first.`
+      );
+    }
+    return { harnessDir: join(projectDir, match.dir), distSubpath: match.distSubpath, label: match.label };
+  }
+  if (present.length === 0) {
+    throw new Error(
+      `No AI-DLC harness dir found in ${projectDir}. Expected one of: ${HARNESSES.map((h) => h.dir).join(", ")}. Install AI-DLC into this project first.`
+    );
+  }
+  if (present.length > 1) {
+    throw new Error(
+      `Multiple harness dirs present (${present.map((h) => h.dir).join(", ")}). Pick one with --harness <name>.`
+    );
+  }
+  const [only] = present;
+  return { harnessDir: join(projectDir, only.dir), distSubpath: only.distSubpath, label: only.label };
+}
+
+// Read the INSTALLED version from the target harness dir's aidlc-version.ts.
+// We deliberately do not import AIDLC_VERSION here: the tool binary that
+// invokes this code may live elsewhere (a downloaded tool copy, a different
+// install), and its imported constant tells us nothing about what's installed
+// in the target project.
+export function readInstalledVersion(harnessDir: string): string {
+  const versionFile = join(harnessDir, "tools", "aidlc-version.ts");
+  if (!existsSync(versionFile)) {
+    // The install exists (we detected the harness dir), but the version file
+    // is absent. That's an unusually broken install; fall back to the tool's
+    // own version constant so we still produce SOMETHING truthful.
+    return AIDLC_VERSION;
+  }
+  const src = readFileSync(versionFile, "utf-8");
+  const m = src.match(/AIDLC_VERSION\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/);
+  if (!m) return AIDLC_VERSION;
+  return m[1];
+}
+
+// -----------------------------------------------------------------------------
+// File walk + hash
+// -----------------------------------------------------------------------------
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function walk(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const p = join(cur, name);
+      let st: Stats;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(p);
+      else if (st.isFile()) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+interface DiffResult {
+  added: string[];
+  unchanged: string[];
+  kept: string[]; // user-modified — do not overwrite
+}
+
+function diffTrees(localRoot: string, upstreamRoot: string): DiffResult {
+  const res: DiffResult = { added: [], unchanged: [], kept: [] };
+  for (const upAbs of walk(upstreamRoot)) {
+    const rel = relative(upstreamRoot, upAbs).split(sep).join("/");
+    const localAbs = join(localRoot, rel);
+    const upBuf = readFileSync(upAbs);
+    if (!existsSync(localAbs)) {
+      res.added.push(rel);
+      continue;
+    }
+    const localBuf = readFileSync(localAbs);
+    if (upBuf.equals(localBuf)) res.unchanged.push(rel);
+    else res.kept.push(rel);
+  }
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+// Public entry point
+// -----------------------------------------------------------------------------
+
+export interface UpgradeReport {
+  installed: string;
+  latest: string | null;
+  harnessLabel: string | null;
+  harnessDir: string | null;
+  reason:
+    | "no-upstream-version"
+    | "up-to-date"
+    | "ahead-of-upstream"
+    | "dry-run"
+    | "applied";
+  dryRun: boolean;
+  applied: boolean;
+  filesWritten: number;
+  filesKept: number;
+  diff: DiffResult | null;
+  releaseNotesUrl: string | null;
+}
+
+export async function upgrade(projectDir: string, opts: UpgradeOptions = {}): Promise<UpgradeReport> {
+  const dryRun = !!opts.dryRun;
+  const fetchTags = opts.fetchTagsFn ?? defaultFetchTags;
+  const download = opts.downloadTarballFn ?? defaultDownloadTarball;
+
+  // Step 1: figure out installed version. Prefer the target harness's file
+  // (that's the source of truth for THIS project), fall back to injected
+  // override for tests that don't stage a harness dir.
+  let installed = opts.installedVersionOverride;
+  let harness: DetectedHarness | null = null;
+  try {
+    harness = detectHarness(projectDir, opts.harnessOverride);
+    if (!installed) installed = readInstalledVersion(harness.harnessDir);
+  } catch (err) {
+    // If we cannot detect a harness AND no override was given, we cannot
+    // report an installed version — surface the underlying error.
+    if (!installed) throw err;
+  }
+  installed = installed as string;
+
+  // Step 2: fetch upstream tags and pick the latest matching-major tag.
+  const tags = await fetchTags();
+  const latest = pickLatestMatchingMajor(tags, installed);
+
+  const empty: Omit<UpgradeReport, "installed" | "latest" | "reason"> = {
+    harnessLabel: harness?.label ?? null,
+    harnessDir: harness?.harnessDir ?? null,
+    dryRun,
+    applied: false,
+    filesWritten: 0,
+    filesKept: 0,
+    diff: null,
+    releaseNotesUrl: null,
+  };
+
+  if (!latest) {
+    return { ...empty, installed, latest: null, reason: "no-upstream-version" };
+  }
+
+  const cmp = compareSemver(
+    parseSemver(installed) as [number, number, number],
+    parseSemver(latest) as [number, number, number]
+  );
+  const releaseNotesUrl = `${RELEASE_NOTES_BASE}/${latest}`;
+
+  if (cmp === 0) {
+    return { ...empty, installed, latest, reason: "up-to-date", releaseNotesUrl };
+  }
+  if (cmp > 0) {
+    return { ...empty, installed, latest, reason: "ahead-of-upstream", releaseNotesUrl };
+  }
+
+  // Step 3: upgrade is possible. Download + diff + (maybe) apply.
+  if (!harness) {
+    // Should not reach here (detectHarness would have thrown earlier), but
+    // keep the invariant explicit.
+    throw new Error("upgrade: harness not detected");
+  }
+  const tmpRoot = mkdtempSync(join(tmpdir(), "aidlc-upgrade-"));
+  try {
+    const extractDir = await download(latest, tmpRoot);
+    const upstreamHarness = join(extractDir, harness.distSubpath);
+    if (!existsSync(upstreamHarness)) {
+      throw new Error(
+        `Upstream tarball for ${latest} does not contain ${harness.distSubpath}. This tag may predate the current dist layout — file an issue at https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/issues.`
+      );
+    }
+    const diff = diffTrees(harness.harnessDir, upstreamHarness);
+
+    if (dryRun) {
+      return {
+        installed,
+        latest,
+        harnessLabel: harness.label,
+        harnessDir: harness.harnessDir,
+        reason: "dry-run",
+        dryRun: true,
+        applied: false,
+        filesWritten: 0,
+        filesKept: diff.kept.length,
+        diff,
+        releaseNotesUrl,
+      };
+    }
+
+    // Real apply. Copy added + byte-identical upstream files in; skip files
+    // the user has modified (their bytes differ). No backup dir is created —
+    // users who want a snapshot should commit their .claude/ or take one
+    // themselves before running upgrade.
+    let written = 0;
+    for (const rel of [...diff.added, ...diff.unchanged]) {
+      const src = join(upstreamHarness, ...rel.split("/"));
+      const dst = join(harness.harnessDir, ...rel.split("/"));
+      mkdirSync(dirName(dst), { recursive: true });
+      cpSync(src, dst);
+      written++;
+    }
+    return {
+      installed,
+      latest,
+      harnessLabel: harness.label,
+      harnessDir: harness.harnessDir,
+      reason: "applied",
+      dryRun: false,
+      applied: true,
+      filesWritten: written,
+      filesKept: diff.kept.length,
+      diff,
+      releaseNotesUrl,
+    };
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+function dirName(p: string): string {
+  const idx = p.lastIndexOf(sep);
+  if (idx === -1) return ".";
+  return p.slice(0, idx);
+}
+
+// Test-only exposure for pure helpers.
+export const _test = { sha256, diffTrees, pickLatestMatchingMajor, parseSemver, readInstalledVersion };

--- a/dist/codex/.codex/tools/aidlc-upgrade.ts
+++ b/dist/codex/.codex/tools/aidlc-upgrade.ts
@@ -49,6 +49,7 @@ const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string
   { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
   { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
   { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+  { dir: ".aidlc", distSubpath: "dist/opencode/.aidlc", label: "opencode" },
 ];
 
 export interface UpgradeOptions {

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -117,6 +117,7 @@ import {
   _resetStageGraphForTests,
 } from "./aidlc-lib.ts";
 import { validateStageFrontmatter } from "./aidlc-stage-schema.ts";
+import { upgrade, type UpgradeReport } from "./aidlc-upgrade.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
@@ -148,9 +149,6 @@ const NO_STATE_FILE_MESSAGE =
   "No state file found. Start a workflow first by describing what to build (/aidlc \"build the auth service\").";
 const INIT_TRANSITION_MESSAGE =
   "init now lays down the project data tree and is not yet available in this release. To start work, describe what to build: /aidlc \"build the auth service\".";
-const UPGRADE_UNAVAILABLE_MESSAGE =
-  "upgrade is not available in this install; it arrives with the packaged binary distribution.";
-
 let errorArgs: string[] = [];
 let errorProjectDirArg: string | undefined;
 
@@ -228,6 +226,9 @@ Utilities:
   --depth <level>   Override depth (minimal, standard, comprehensive)
   --test-strategy <level>  Override test strategy (minimal, standard, comprehensive)
   --version         Show the framework version
+  upgrade           Download the latest AI-DLC release and apply it (backs up
+                    first, preserves any files you have modified)
+  upgrade --dry-run Show what an upgrade would change without writing anything
   --help            Show this help message
 
 Other:
@@ -932,6 +933,82 @@ async function handlePluginSync(projectDir: string): Promise<void> {
   }
 
   process.stdout.write(`plugin sync complete: ${composePaths.length} plugin(s)\n`);
+}
+
+// ---------------------------------------------------------------------------
+// upgrade
+// ---------------------------------------------------------------------------
+
+// One subcommand, one flag:
+//   `upgrade`            → downloads the latest matching-major upstream tag,
+//                           backs up the harness dir, copies new files in,
+//                           PRESERVES any file the user has modified.
+//   `upgrade --dry-run`  → same discovery + download + diff, but no writes.
+// Auto-detects the harness by looking for .claude/.kiro/.codex under the
+// project dir; --harness <name> forces a specific pick when ambiguous.
+async function handleUpgrade(projectDir: string, flags: Record<string, string>): Promise<void> {
+  const dryRun = flags["dry-run"] !== undefined || flags.check !== undefined;
+  const override = flags.harness;
+  try {
+    const report = await upgrade(projectDir, { dryRun, harnessOverride: override });
+    printUpgrade(report);
+  } catch (err) {
+    die(`upgrade failed: ${(err as Error).message}`);
+  }
+}
+
+function printUpgrade(r: UpgradeReport): void {
+  if (r.reason === "no-upstream-version") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed\n` +
+      `Could not resolve a latest upstream version. Try again in a minute, or download manually from https://github.com/awslabs/aidlc-workflows/releases\n`
+    );
+    return;
+  }
+  if (r.reason === "up-to-date") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — up to date (matches upstream ${r.latest}).\n`
+    );
+    return;
+  }
+  if (r.reason === "ahead-of-upstream") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — ahead of upstream (latest published: ${r.latest}).\n` +
+      `You are on an unreleased build. Nothing to upgrade to.\n`
+    );
+    return;
+  }
+  if (r.reason === "dry-run") {
+    const d = r.diff;
+    process.stdout.write(
+      `aidlc ${r.installed} installed — would upgrade to ${r.latest} on ${r.harnessLabel}\n` +
+      `  harness dir: ${r.harnessDir}\n` +
+      `  added:       ${d?.added.length ?? 0} files\n` +
+      `  unchanged:   ${d?.unchanged.length ?? 0} files (safe to overwrite)\n` +
+      `  kept local:  ${d?.kept.length ?? 0} files (user-modified — will NOT be overwritten)\n`
+    );
+    if (d && d.kept.length > 0) {
+      process.stdout.write(`\nUser-modified files that would be kept as-is:\n`);
+      for (const rel of d.kept) process.stdout.write(`  ${rel}\n`);
+    }
+    process.stdout.write(`\nDry run — no files were changed. Run \`upgrade\` (without --dry-run) to apply.\n`);
+    return;
+  }
+  // reason === "applied"
+  process.stdout.write(
+    `aidlc upgraded ${r.installed} → ${r.latest} on ${r.harnessLabel}\n` +
+    `  harness dir:  ${r.harnessDir}\n` +
+    `  files written: ${r.filesWritten}\n` +
+    `  files kept (user-modified, not overwritten): ${r.filesKept}\n`
+  );
+  if (r.diff && r.diff.kept.length > 0) {
+    process.stdout.write(`\nUser-modified files preserved:\n`);
+    for (const rel of r.diff.kept) process.stdout.write(`  ${rel}\n`);
+    process.stdout.write(
+      `\nTo take the upstream copy for one of these, delete the local file and re-run \`upgrade\`.\n`
+    );
+  }
+  process.stdout.write(`\nRelease notes: ${r.releaseNotesUrl}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -3999,10 +4076,6 @@ function handleStateInit(_projectDir: string, _flags: Record<string, string>): v
   );
 }
 
-function handleUpgrade(): void {
-  die(UPGRADE_UNAVAILABLE_MESSAGE);
-}
-
 // ---------------------------------------------------------------------------
 // intent / space — the verb families + the deterministic query layer
 // ---------------------------------------------------------------------------
@@ -5614,7 +5687,7 @@ export async function main(argv: string[]): Promise<void> {
       handleStateInit(projectDir, flags);
       break;
     case "upgrade":
-      handleUpgrade();
+      await handleUpgrade(projectDir, flags);
       break;
     case "scope-change":
       handleScopeChange(projectDir, flags);

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.36";
+export const AIDLC_VERSION = "2.5.40";

--- a/dist/kiro-ide/.kiro/tools/aidlc-upgrade.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-upgrade.ts
@@ -1,0 +1,391 @@
+// aidlc-upgrade.ts — the AI-DLC install upgrader.
+//
+// ONE entry point:
+//   • upgrade(projectDir, { dryRun }) — figures out the target harness dir,
+//     reads that install's aidlc-version.ts (NOT the imported constant — the
+//     tool binary may live elsewhere), fetches the newest upstream tag in the
+//     same major series, and either dry-runs the diff or applies the upgrade.
+//     PRESERVES any file whose local bytes differ from the incoming upstream
+//     file (user modification). No backup dir is created — users who want a
+//     snapshot should commit their harness dir (or copy it) themselves before
+//     running upgrade. Standard Unix "trust your VCS" default.
+//
+// WHY tags, not GitHub Releases: this repo cuts v2 as tags on the v2 branch
+// (v2.1.7, v2.2.0, ...) but the "latest release" API answers the v1.x line.
+// Tags in the installed major series are the honest answer to "what should I
+// upgrade to today."
+//
+// WHY read the target's aidlc-version.ts, not the imported AIDLC_VERSION: the
+// import binds this file's version at build time. That's correct if a user
+// runs the tool from inside their install (the tool IS the install). It is
+// wrong if the tool binary lives elsewhere (a scenario surfaced during live
+// testing). Reading the target's aidlc-version.ts makes the command answer
+// for the install, not for itself.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { AIDLC_VERSION } from "./aidlc-version.ts";
+
+const UPSTREAM_OWNER = "awslabs";
+const UPSTREAM_REPO = "aidlc-workflows";
+const TAGS_URL = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tags?per_page=100`;
+const RELEASE_NOTES_BASE = `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/tag`;
+
+const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string }> = [
+  { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
+  { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
+  { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+];
+
+export interface UpgradeOptions {
+  dryRun?: boolean;
+  harnessOverride?: string;
+  // Injected in tests. Real callers leave these unset.
+  fetchTagsFn?: () => Promise<string[]>;
+  downloadTarballFn?: (tag: string, destDir: string) => Promise<string>;
+  installedVersionOverride?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Version + tag helpers
+// -----------------------------------------------------------------------------
+
+function parseSemver(tag: string): [number, number, number] | null {
+  // Accept "v2.2.10" and "2.2.10". Reject pre-releases (v2.2.10-rc1).
+  const m = tag.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+async function defaultFetchTags(): Promise<string[]> {
+  const res = await fetch(TAGS_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API returned ${res.status} fetching tags. Try again in a minute, or download the release manually from https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases`
+    );
+  }
+  const list = (await res.json()) as Array<{ name: string }>;
+  return list.map((t) => t.name);
+}
+
+async function defaultDownloadTarball(tag: string, destDir: string): Promise<string> {
+  const url = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tarball/${tag}`;
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Failed to download tarball for ${tag}: HTTP ${res.status}`);
+  }
+  const tarballPath = join(destDir, "release.tar.gz");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  writeFileSync(tarballPath, buf);
+  const extractDir = join(destDir, "extracted");
+  mkdirSync(extractDir, { recursive: true });
+  const tar = spawnSync("tar", ["-xzf", tarballPath, "-C", extractDir, "--strip-components=1"], {
+    encoding: "utf-8",
+  });
+  if (tar.status !== 0) {
+    throw new Error(
+      `tar extraction failed for ${tag}: ${tar.stderr || tar.stdout || "unknown error"}. Is 'tar' installed and on PATH?`
+    );
+  }
+  return extractDir;
+}
+
+function pickLatestMatchingMajor(tags: string[], installed: string): string | null {
+  const inst = parseSemver(installed);
+  if (!inst) return null;
+  const candidates = tags
+    .map((t) => ({ tag: t, ver: parseSemver(t) }))
+    .filter((c): c is { tag: string; ver: [number, number, number] } => c.ver !== null)
+    .filter((c) => c.ver[0] === inst[0]);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => compareSemver(b.ver, a.ver));
+  return candidates[0].tag;
+}
+
+// -----------------------------------------------------------------------------
+// Harness detection + installed-version reader
+// -----------------------------------------------------------------------------
+
+interface DetectedHarness {
+  harnessDir: string;
+  distSubpath: string;
+  label: string;
+}
+
+function detectHarness(projectDir: string, override?: string): DetectedHarness {
+  const present = HARNESSES.filter((h) => existsSync(join(projectDir, h.dir)));
+  if (override) {
+    const match = HARNESSES.find((h) => h.dir === override || h.dir === `.${override}`);
+    if (!match) {
+      throw new Error(
+        `Unknown --harness "${override}". Valid values: ${HARNESSES.map((h) => h.dir).join(", ")}`
+      );
+    }
+    if (!existsSync(join(projectDir, match.dir))) {
+      throw new Error(
+        `Requested --harness ${match.dir} but ${join(projectDir, match.dir)} does not exist. Install AI-DLC into this project first.`
+      );
+    }
+    return { harnessDir: join(projectDir, match.dir), distSubpath: match.distSubpath, label: match.label };
+  }
+  if (present.length === 0) {
+    throw new Error(
+      `No AI-DLC harness dir found in ${projectDir}. Expected one of: ${HARNESSES.map((h) => h.dir).join(", ")}. Install AI-DLC into this project first.`
+    );
+  }
+  if (present.length > 1) {
+    throw new Error(
+      `Multiple harness dirs present (${present.map((h) => h.dir).join(", ")}). Pick one with --harness <name>.`
+    );
+  }
+  const [only] = present;
+  return { harnessDir: join(projectDir, only.dir), distSubpath: only.distSubpath, label: only.label };
+}
+
+// Read the INSTALLED version from the target harness dir's aidlc-version.ts.
+// We deliberately do not import AIDLC_VERSION here: the tool binary that
+// invokes this code may live elsewhere (a downloaded tool copy, a different
+// install), and its imported constant tells us nothing about what's installed
+// in the target project.
+export function readInstalledVersion(harnessDir: string): string {
+  const versionFile = join(harnessDir, "tools", "aidlc-version.ts");
+  if (!existsSync(versionFile)) {
+    // The install exists (we detected the harness dir), but the version file
+    // is absent. That's an unusually broken install; fall back to the tool's
+    // own version constant so we still produce SOMETHING truthful.
+    return AIDLC_VERSION;
+  }
+  const src = readFileSync(versionFile, "utf-8");
+  const m = src.match(/AIDLC_VERSION\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/);
+  if (!m) return AIDLC_VERSION;
+  return m[1];
+}
+
+// -----------------------------------------------------------------------------
+// File walk + hash
+// -----------------------------------------------------------------------------
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function walk(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const p = join(cur, name);
+      let st: Stats;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(p);
+      else if (st.isFile()) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+interface DiffResult {
+  added: string[];
+  unchanged: string[];
+  kept: string[]; // user-modified — do not overwrite
+}
+
+function diffTrees(localRoot: string, upstreamRoot: string): DiffResult {
+  const res: DiffResult = { added: [], unchanged: [], kept: [] };
+  for (const upAbs of walk(upstreamRoot)) {
+    const rel = relative(upstreamRoot, upAbs).split(sep).join("/");
+    const localAbs = join(localRoot, rel);
+    const upBuf = readFileSync(upAbs);
+    if (!existsSync(localAbs)) {
+      res.added.push(rel);
+      continue;
+    }
+    const localBuf = readFileSync(localAbs);
+    if (upBuf.equals(localBuf)) res.unchanged.push(rel);
+    else res.kept.push(rel);
+  }
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+// Public entry point
+// -----------------------------------------------------------------------------
+
+export interface UpgradeReport {
+  installed: string;
+  latest: string | null;
+  harnessLabel: string | null;
+  harnessDir: string | null;
+  reason:
+    | "no-upstream-version"
+    | "up-to-date"
+    | "ahead-of-upstream"
+    | "dry-run"
+    | "applied";
+  dryRun: boolean;
+  applied: boolean;
+  filesWritten: number;
+  filesKept: number;
+  diff: DiffResult | null;
+  releaseNotesUrl: string | null;
+}
+
+export async function upgrade(projectDir: string, opts: UpgradeOptions = {}): Promise<UpgradeReport> {
+  const dryRun = !!opts.dryRun;
+  const fetchTags = opts.fetchTagsFn ?? defaultFetchTags;
+  const download = opts.downloadTarballFn ?? defaultDownloadTarball;
+
+  // Step 1: figure out installed version. Prefer the target harness's file
+  // (that's the source of truth for THIS project), fall back to injected
+  // override for tests that don't stage a harness dir.
+  let installed = opts.installedVersionOverride;
+  let harness: DetectedHarness | null = null;
+  try {
+    harness = detectHarness(projectDir, opts.harnessOverride);
+    if (!installed) installed = readInstalledVersion(harness.harnessDir);
+  } catch (err) {
+    // If we cannot detect a harness AND no override was given, we cannot
+    // report an installed version — surface the underlying error.
+    if (!installed) throw err;
+  }
+  installed = installed as string;
+
+  // Step 2: fetch upstream tags and pick the latest matching-major tag.
+  const tags = await fetchTags();
+  const latest = pickLatestMatchingMajor(tags, installed);
+
+  const empty: Omit<UpgradeReport, "installed" | "latest" | "reason"> = {
+    harnessLabel: harness?.label ?? null,
+    harnessDir: harness?.harnessDir ?? null,
+    dryRun,
+    applied: false,
+    filesWritten: 0,
+    filesKept: 0,
+    diff: null,
+    releaseNotesUrl: null,
+  };
+
+  if (!latest) {
+    return { ...empty, installed, latest: null, reason: "no-upstream-version" };
+  }
+
+  const cmp = compareSemver(
+    parseSemver(installed) as [number, number, number],
+    parseSemver(latest) as [number, number, number]
+  );
+  const releaseNotesUrl = `${RELEASE_NOTES_BASE}/${latest}`;
+
+  if (cmp === 0) {
+    return { ...empty, installed, latest, reason: "up-to-date", releaseNotesUrl };
+  }
+  if (cmp > 0) {
+    return { ...empty, installed, latest, reason: "ahead-of-upstream", releaseNotesUrl };
+  }
+
+  // Step 3: upgrade is possible. Download + diff + (maybe) apply.
+  if (!harness) {
+    // Should not reach here (detectHarness would have thrown earlier), but
+    // keep the invariant explicit.
+    throw new Error("upgrade: harness not detected");
+  }
+  const tmpRoot = mkdtempSync(join(tmpdir(), "aidlc-upgrade-"));
+  try {
+    const extractDir = await download(latest, tmpRoot);
+    const upstreamHarness = join(extractDir, harness.distSubpath);
+    if (!existsSync(upstreamHarness)) {
+      throw new Error(
+        `Upstream tarball for ${latest} does not contain ${harness.distSubpath}. This tag may predate the current dist layout — file an issue at https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/issues.`
+      );
+    }
+    const diff = diffTrees(harness.harnessDir, upstreamHarness);
+
+    if (dryRun) {
+      return {
+        installed,
+        latest,
+        harnessLabel: harness.label,
+        harnessDir: harness.harnessDir,
+        reason: "dry-run",
+        dryRun: true,
+        applied: false,
+        filesWritten: 0,
+        filesKept: diff.kept.length,
+        diff,
+        releaseNotesUrl,
+      };
+    }
+
+    // Real apply. Copy added + byte-identical upstream files in; skip files
+    // the user has modified (their bytes differ). No backup dir is created —
+    // users who want a snapshot should commit their .claude/ or take one
+    // themselves before running upgrade.
+    let written = 0;
+    for (const rel of [...diff.added, ...diff.unchanged]) {
+      const src = join(upstreamHarness, ...rel.split("/"));
+      const dst = join(harness.harnessDir, ...rel.split("/"));
+      mkdirSync(dirName(dst), { recursive: true });
+      cpSync(src, dst);
+      written++;
+    }
+    return {
+      installed,
+      latest,
+      harnessLabel: harness.label,
+      harnessDir: harness.harnessDir,
+      reason: "applied",
+      dryRun: false,
+      applied: true,
+      filesWritten: written,
+      filesKept: diff.kept.length,
+      diff,
+      releaseNotesUrl,
+    };
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+function dirName(p: string): string {
+  const idx = p.lastIndexOf(sep);
+  if (idx === -1) return ".";
+  return p.slice(0, idx);
+}
+
+// Test-only exposure for pure helpers.
+export const _test = { sha256, diffTrees, pickLatestMatchingMajor, parseSemver, readInstalledVersion };

--- a/dist/kiro-ide/.kiro/tools/aidlc-upgrade.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-upgrade.ts
@@ -49,6 +49,7 @@ const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string
   { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
   { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
   { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+  { dir: ".aidlc", distSubpath: "dist/opencode/.aidlc", label: "opencode" },
 ];
 
 export interface UpgradeOptions {

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -117,6 +117,7 @@ import {
   _resetStageGraphForTests,
 } from "./aidlc-lib.ts";
 import { validateStageFrontmatter } from "./aidlc-stage-schema.ts";
+import { upgrade, type UpgradeReport } from "./aidlc-upgrade.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
@@ -148,9 +149,6 @@ const NO_STATE_FILE_MESSAGE =
   "No state file found. Start a workflow first by describing what to build (/aidlc \"build the auth service\").";
 const INIT_TRANSITION_MESSAGE =
   "init now lays down the project data tree and is not yet available in this release. To start work, describe what to build: /aidlc \"build the auth service\".";
-const UPGRADE_UNAVAILABLE_MESSAGE =
-  "upgrade is not available in this install; it arrives with the packaged binary distribution.";
-
 let errorArgs: string[] = [];
 let errorProjectDirArg: string | undefined;
 
@@ -228,6 +226,9 @@ Utilities:
   --depth <level>   Override depth (minimal, standard, comprehensive)
   --test-strategy <level>  Override test strategy (minimal, standard, comprehensive)
   --version         Show the framework version
+  upgrade           Download the latest AI-DLC release and apply it (backs up
+                    first, preserves any files you have modified)
+  upgrade --dry-run Show what an upgrade would change without writing anything
   --help            Show this help message
 
 Other:
@@ -932,6 +933,82 @@ async function handlePluginSync(projectDir: string): Promise<void> {
   }
 
   process.stdout.write(`plugin sync complete: ${composePaths.length} plugin(s)\n`);
+}
+
+// ---------------------------------------------------------------------------
+// upgrade
+// ---------------------------------------------------------------------------
+
+// One subcommand, one flag:
+//   `upgrade`            → downloads the latest matching-major upstream tag,
+//                           backs up the harness dir, copies new files in,
+//                           PRESERVES any file the user has modified.
+//   `upgrade --dry-run`  → same discovery + download + diff, but no writes.
+// Auto-detects the harness by looking for .claude/.kiro/.codex under the
+// project dir; --harness <name> forces a specific pick when ambiguous.
+async function handleUpgrade(projectDir: string, flags: Record<string, string>): Promise<void> {
+  const dryRun = flags["dry-run"] !== undefined || flags.check !== undefined;
+  const override = flags.harness;
+  try {
+    const report = await upgrade(projectDir, { dryRun, harnessOverride: override });
+    printUpgrade(report);
+  } catch (err) {
+    die(`upgrade failed: ${(err as Error).message}`);
+  }
+}
+
+function printUpgrade(r: UpgradeReport): void {
+  if (r.reason === "no-upstream-version") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed\n` +
+      `Could not resolve a latest upstream version. Try again in a minute, or download manually from https://github.com/awslabs/aidlc-workflows/releases\n`
+    );
+    return;
+  }
+  if (r.reason === "up-to-date") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — up to date (matches upstream ${r.latest}).\n`
+    );
+    return;
+  }
+  if (r.reason === "ahead-of-upstream") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — ahead of upstream (latest published: ${r.latest}).\n` +
+      `You are on an unreleased build. Nothing to upgrade to.\n`
+    );
+    return;
+  }
+  if (r.reason === "dry-run") {
+    const d = r.diff;
+    process.stdout.write(
+      `aidlc ${r.installed} installed — would upgrade to ${r.latest} on ${r.harnessLabel}\n` +
+      `  harness dir: ${r.harnessDir}\n` +
+      `  added:       ${d?.added.length ?? 0} files\n` +
+      `  unchanged:   ${d?.unchanged.length ?? 0} files (safe to overwrite)\n` +
+      `  kept local:  ${d?.kept.length ?? 0} files (user-modified — will NOT be overwritten)\n`
+    );
+    if (d && d.kept.length > 0) {
+      process.stdout.write(`\nUser-modified files that would be kept as-is:\n`);
+      for (const rel of d.kept) process.stdout.write(`  ${rel}\n`);
+    }
+    process.stdout.write(`\nDry run — no files were changed. Run \`upgrade\` (without --dry-run) to apply.\n`);
+    return;
+  }
+  // reason === "applied"
+  process.stdout.write(
+    `aidlc upgraded ${r.installed} → ${r.latest} on ${r.harnessLabel}\n` +
+    `  harness dir:  ${r.harnessDir}\n` +
+    `  files written: ${r.filesWritten}\n` +
+    `  files kept (user-modified, not overwritten): ${r.filesKept}\n`
+  );
+  if (r.diff && r.diff.kept.length > 0) {
+    process.stdout.write(`\nUser-modified files preserved:\n`);
+    for (const rel of r.diff.kept) process.stdout.write(`  ${rel}\n`);
+    process.stdout.write(
+      `\nTo take the upstream copy for one of these, delete the local file and re-run \`upgrade\`.\n`
+    );
+  }
+  process.stdout.write(`\nRelease notes: ${r.releaseNotesUrl}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -3999,10 +4076,6 @@ function handleStateInit(_projectDir: string, _flags: Record<string, string>): v
   );
 }
 
-function handleUpgrade(): void {
-  die(UPGRADE_UNAVAILABLE_MESSAGE);
-}
-
 // ---------------------------------------------------------------------------
 // intent / space — the verb families + the deterministic query layer
 // ---------------------------------------------------------------------------
@@ -5614,7 +5687,7 @@ export async function main(argv: string[]): Promise<void> {
       handleStateInit(projectDir, flags);
       break;
     case "upgrade":
-      handleUpgrade();
+      await handleUpgrade(projectDir, flags);
       break;
     case "scope-change":
       handleScopeChange(projectDir, flags);

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.36";
+export const AIDLC_VERSION = "2.5.40";

--- a/dist/kiro/.kiro/tools/aidlc-upgrade.ts
+++ b/dist/kiro/.kiro/tools/aidlc-upgrade.ts
@@ -1,0 +1,391 @@
+// aidlc-upgrade.ts — the AI-DLC install upgrader.
+//
+// ONE entry point:
+//   • upgrade(projectDir, { dryRun }) — figures out the target harness dir,
+//     reads that install's aidlc-version.ts (NOT the imported constant — the
+//     tool binary may live elsewhere), fetches the newest upstream tag in the
+//     same major series, and either dry-runs the diff or applies the upgrade.
+//     PRESERVES any file whose local bytes differ from the incoming upstream
+//     file (user modification). No backup dir is created — users who want a
+//     snapshot should commit their harness dir (or copy it) themselves before
+//     running upgrade. Standard Unix "trust your VCS" default.
+//
+// WHY tags, not GitHub Releases: this repo cuts v2 as tags on the v2 branch
+// (v2.1.7, v2.2.0, ...) but the "latest release" API answers the v1.x line.
+// Tags in the installed major series are the honest answer to "what should I
+// upgrade to today."
+//
+// WHY read the target's aidlc-version.ts, not the imported AIDLC_VERSION: the
+// import binds this file's version at build time. That's correct if a user
+// runs the tool from inside their install (the tool IS the install). It is
+// wrong if the tool binary lives elsewhere (a scenario surfaced during live
+// testing). Reading the target's aidlc-version.ts makes the command answer
+// for the install, not for itself.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { AIDLC_VERSION } from "./aidlc-version.ts";
+
+const UPSTREAM_OWNER = "awslabs";
+const UPSTREAM_REPO = "aidlc-workflows";
+const TAGS_URL = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tags?per_page=100`;
+const RELEASE_NOTES_BASE = `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/tag`;
+
+const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string }> = [
+  { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
+  { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
+  { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+];
+
+export interface UpgradeOptions {
+  dryRun?: boolean;
+  harnessOverride?: string;
+  // Injected in tests. Real callers leave these unset.
+  fetchTagsFn?: () => Promise<string[]>;
+  downloadTarballFn?: (tag: string, destDir: string) => Promise<string>;
+  installedVersionOverride?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Version + tag helpers
+// -----------------------------------------------------------------------------
+
+function parseSemver(tag: string): [number, number, number] | null {
+  // Accept "v2.2.10" and "2.2.10". Reject pre-releases (v2.2.10-rc1).
+  const m = tag.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+async function defaultFetchTags(): Promise<string[]> {
+  const res = await fetch(TAGS_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API returned ${res.status} fetching tags. Try again in a minute, or download the release manually from https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases`
+    );
+  }
+  const list = (await res.json()) as Array<{ name: string }>;
+  return list.map((t) => t.name);
+}
+
+async function defaultDownloadTarball(tag: string, destDir: string): Promise<string> {
+  const url = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tarball/${tag}`;
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Failed to download tarball for ${tag}: HTTP ${res.status}`);
+  }
+  const tarballPath = join(destDir, "release.tar.gz");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  writeFileSync(tarballPath, buf);
+  const extractDir = join(destDir, "extracted");
+  mkdirSync(extractDir, { recursive: true });
+  const tar = spawnSync("tar", ["-xzf", tarballPath, "-C", extractDir, "--strip-components=1"], {
+    encoding: "utf-8",
+  });
+  if (tar.status !== 0) {
+    throw new Error(
+      `tar extraction failed for ${tag}: ${tar.stderr || tar.stdout || "unknown error"}. Is 'tar' installed and on PATH?`
+    );
+  }
+  return extractDir;
+}
+
+function pickLatestMatchingMajor(tags: string[], installed: string): string | null {
+  const inst = parseSemver(installed);
+  if (!inst) return null;
+  const candidates = tags
+    .map((t) => ({ tag: t, ver: parseSemver(t) }))
+    .filter((c): c is { tag: string; ver: [number, number, number] } => c.ver !== null)
+    .filter((c) => c.ver[0] === inst[0]);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => compareSemver(b.ver, a.ver));
+  return candidates[0].tag;
+}
+
+// -----------------------------------------------------------------------------
+// Harness detection + installed-version reader
+// -----------------------------------------------------------------------------
+
+interface DetectedHarness {
+  harnessDir: string;
+  distSubpath: string;
+  label: string;
+}
+
+function detectHarness(projectDir: string, override?: string): DetectedHarness {
+  const present = HARNESSES.filter((h) => existsSync(join(projectDir, h.dir)));
+  if (override) {
+    const match = HARNESSES.find((h) => h.dir === override || h.dir === `.${override}`);
+    if (!match) {
+      throw new Error(
+        `Unknown --harness "${override}". Valid values: ${HARNESSES.map((h) => h.dir).join(", ")}`
+      );
+    }
+    if (!existsSync(join(projectDir, match.dir))) {
+      throw new Error(
+        `Requested --harness ${match.dir} but ${join(projectDir, match.dir)} does not exist. Install AI-DLC into this project first.`
+      );
+    }
+    return { harnessDir: join(projectDir, match.dir), distSubpath: match.distSubpath, label: match.label };
+  }
+  if (present.length === 0) {
+    throw new Error(
+      `No AI-DLC harness dir found in ${projectDir}. Expected one of: ${HARNESSES.map((h) => h.dir).join(", ")}. Install AI-DLC into this project first.`
+    );
+  }
+  if (present.length > 1) {
+    throw new Error(
+      `Multiple harness dirs present (${present.map((h) => h.dir).join(", ")}). Pick one with --harness <name>.`
+    );
+  }
+  const [only] = present;
+  return { harnessDir: join(projectDir, only.dir), distSubpath: only.distSubpath, label: only.label };
+}
+
+// Read the INSTALLED version from the target harness dir's aidlc-version.ts.
+// We deliberately do not import AIDLC_VERSION here: the tool binary that
+// invokes this code may live elsewhere (a downloaded tool copy, a different
+// install), and its imported constant tells us nothing about what's installed
+// in the target project.
+export function readInstalledVersion(harnessDir: string): string {
+  const versionFile = join(harnessDir, "tools", "aidlc-version.ts");
+  if (!existsSync(versionFile)) {
+    // The install exists (we detected the harness dir), but the version file
+    // is absent. That's an unusually broken install; fall back to the tool's
+    // own version constant so we still produce SOMETHING truthful.
+    return AIDLC_VERSION;
+  }
+  const src = readFileSync(versionFile, "utf-8");
+  const m = src.match(/AIDLC_VERSION\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/);
+  if (!m) return AIDLC_VERSION;
+  return m[1];
+}
+
+// -----------------------------------------------------------------------------
+// File walk + hash
+// -----------------------------------------------------------------------------
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function walk(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const p = join(cur, name);
+      let st: Stats;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(p);
+      else if (st.isFile()) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+interface DiffResult {
+  added: string[];
+  unchanged: string[];
+  kept: string[]; // user-modified — do not overwrite
+}
+
+function diffTrees(localRoot: string, upstreamRoot: string): DiffResult {
+  const res: DiffResult = { added: [], unchanged: [], kept: [] };
+  for (const upAbs of walk(upstreamRoot)) {
+    const rel = relative(upstreamRoot, upAbs).split(sep).join("/");
+    const localAbs = join(localRoot, rel);
+    const upBuf = readFileSync(upAbs);
+    if (!existsSync(localAbs)) {
+      res.added.push(rel);
+      continue;
+    }
+    const localBuf = readFileSync(localAbs);
+    if (upBuf.equals(localBuf)) res.unchanged.push(rel);
+    else res.kept.push(rel);
+  }
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+// Public entry point
+// -----------------------------------------------------------------------------
+
+export interface UpgradeReport {
+  installed: string;
+  latest: string | null;
+  harnessLabel: string | null;
+  harnessDir: string | null;
+  reason:
+    | "no-upstream-version"
+    | "up-to-date"
+    | "ahead-of-upstream"
+    | "dry-run"
+    | "applied";
+  dryRun: boolean;
+  applied: boolean;
+  filesWritten: number;
+  filesKept: number;
+  diff: DiffResult | null;
+  releaseNotesUrl: string | null;
+}
+
+export async function upgrade(projectDir: string, opts: UpgradeOptions = {}): Promise<UpgradeReport> {
+  const dryRun = !!opts.dryRun;
+  const fetchTags = opts.fetchTagsFn ?? defaultFetchTags;
+  const download = opts.downloadTarballFn ?? defaultDownloadTarball;
+
+  // Step 1: figure out installed version. Prefer the target harness's file
+  // (that's the source of truth for THIS project), fall back to injected
+  // override for tests that don't stage a harness dir.
+  let installed = opts.installedVersionOverride;
+  let harness: DetectedHarness | null = null;
+  try {
+    harness = detectHarness(projectDir, opts.harnessOverride);
+    if (!installed) installed = readInstalledVersion(harness.harnessDir);
+  } catch (err) {
+    // If we cannot detect a harness AND no override was given, we cannot
+    // report an installed version — surface the underlying error.
+    if (!installed) throw err;
+  }
+  installed = installed as string;
+
+  // Step 2: fetch upstream tags and pick the latest matching-major tag.
+  const tags = await fetchTags();
+  const latest = pickLatestMatchingMajor(tags, installed);
+
+  const empty: Omit<UpgradeReport, "installed" | "latest" | "reason"> = {
+    harnessLabel: harness?.label ?? null,
+    harnessDir: harness?.harnessDir ?? null,
+    dryRun,
+    applied: false,
+    filesWritten: 0,
+    filesKept: 0,
+    diff: null,
+    releaseNotesUrl: null,
+  };
+
+  if (!latest) {
+    return { ...empty, installed, latest: null, reason: "no-upstream-version" };
+  }
+
+  const cmp = compareSemver(
+    parseSemver(installed) as [number, number, number],
+    parseSemver(latest) as [number, number, number]
+  );
+  const releaseNotesUrl = `${RELEASE_NOTES_BASE}/${latest}`;
+
+  if (cmp === 0) {
+    return { ...empty, installed, latest, reason: "up-to-date", releaseNotesUrl };
+  }
+  if (cmp > 0) {
+    return { ...empty, installed, latest, reason: "ahead-of-upstream", releaseNotesUrl };
+  }
+
+  // Step 3: upgrade is possible. Download + diff + (maybe) apply.
+  if (!harness) {
+    // Should not reach here (detectHarness would have thrown earlier), but
+    // keep the invariant explicit.
+    throw new Error("upgrade: harness not detected");
+  }
+  const tmpRoot = mkdtempSync(join(tmpdir(), "aidlc-upgrade-"));
+  try {
+    const extractDir = await download(latest, tmpRoot);
+    const upstreamHarness = join(extractDir, harness.distSubpath);
+    if (!existsSync(upstreamHarness)) {
+      throw new Error(
+        `Upstream tarball for ${latest} does not contain ${harness.distSubpath}. This tag may predate the current dist layout — file an issue at https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/issues.`
+      );
+    }
+    const diff = diffTrees(harness.harnessDir, upstreamHarness);
+
+    if (dryRun) {
+      return {
+        installed,
+        latest,
+        harnessLabel: harness.label,
+        harnessDir: harness.harnessDir,
+        reason: "dry-run",
+        dryRun: true,
+        applied: false,
+        filesWritten: 0,
+        filesKept: diff.kept.length,
+        diff,
+        releaseNotesUrl,
+      };
+    }
+
+    // Real apply. Copy added + byte-identical upstream files in; skip files
+    // the user has modified (their bytes differ). No backup dir is created —
+    // users who want a snapshot should commit their .claude/ or take one
+    // themselves before running upgrade.
+    let written = 0;
+    for (const rel of [...diff.added, ...diff.unchanged]) {
+      const src = join(upstreamHarness, ...rel.split("/"));
+      const dst = join(harness.harnessDir, ...rel.split("/"));
+      mkdirSync(dirName(dst), { recursive: true });
+      cpSync(src, dst);
+      written++;
+    }
+    return {
+      installed,
+      latest,
+      harnessLabel: harness.label,
+      harnessDir: harness.harnessDir,
+      reason: "applied",
+      dryRun: false,
+      applied: true,
+      filesWritten: written,
+      filesKept: diff.kept.length,
+      diff,
+      releaseNotesUrl,
+    };
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+function dirName(p: string): string {
+  const idx = p.lastIndexOf(sep);
+  if (idx === -1) return ".";
+  return p.slice(0, idx);
+}
+
+// Test-only exposure for pure helpers.
+export const _test = { sha256, diffTrees, pickLatestMatchingMajor, parseSemver, readInstalledVersion };

--- a/dist/kiro/.kiro/tools/aidlc-upgrade.ts
+++ b/dist/kiro/.kiro/tools/aidlc-upgrade.ts
@@ -49,6 +49,7 @@ const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string
   { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
   { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
   { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+  { dir: ".aidlc", distSubpath: "dist/opencode/.aidlc", label: "opencode" },
 ];
 
 export interface UpgradeOptions {

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -117,6 +117,7 @@ import {
   _resetStageGraphForTests,
 } from "./aidlc-lib.ts";
 import { validateStageFrontmatter } from "./aidlc-stage-schema.ts";
+import { upgrade, type UpgradeReport } from "./aidlc-upgrade.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
@@ -148,9 +149,6 @@ const NO_STATE_FILE_MESSAGE =
   "No state file found. Start a workflow first by describing what to build (/aidlc \"build the auth service\").";
 const INIT_TRANSITION_MESSAGE =
   "init now lays down the project data tree and is not yet available in this release. To start work, describe what to build: /aidlc \"build the auth service\".";
-const UPGRADE_UNAVAILABLE_MESSAGE =
-  "upgrade is not available in this install; it arrives with the packaged binary distribution.";
-
 let errorArgs: string[] = [];
 let errorProjectDirArg: string | undefined;
 
@@ -228,6 +226,9 @@ Utilities:
   --depth <level>   Override depth (minimal, standard, comprehensive)
   --test-strategy <level>  Override test strategy (minimal, standard, comprehensive)
   --version         Show the framework version
+  upgrade           Download the latest AI-DLC release and apply it (backs up
+                    first, preserves any files you have modified)
+  upgrade --dry-run Show what an upgrade would change without writing anything
   --help            Show this help message
 
 Other:
@@ -932,6 +933,82 @@ async function handlePluginSync(projectDir: string): Promise<void> {
   }
 
   process.stdout.write(`plugin sync complete: ${composePaths.length} plugin(s)\n`);
+}
+
+// ---------------------------------------------------------------------------
+// upgrade
+// ---------------------------------------------------------------------------
+
+// One subcommand, one flag:
+//   `upgrade`            → downloads the latest matching-major upstream tag,
+//                           backs up the harness dir, copies new files in,
+//                           PRESERVES any file the user has modified.
+//   `upgrade --dry-run`  → same discovery + download + diff, but no writes.
+// Auto-detects the harness by looking for .claude/.kiro/.codex under the
+// project dir; --harness <name> forces a specific pick when ambiguous.
+async function handleUpgrade(projectDir: string, flags: Record<string, string>): Promise<void> {
+  const dryRun = flags["dry-run"] !== undefined || flags.check !== undefined;
+  const override = flags.harness;
+  try {
+    const report = await upgrade(projectDir, { dryRun, harnessOverride: override });
+    printUpgrade(report);
+  } catch (err) {
+    die(`upgrade failed: ${(err as Error).message}`);
+  }
+}
+
+function printUpgrade(r: UpgradeReport): void {
+  if (r.reason === "no-upstream-version") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed\n` +
+      `Could not resolve a latest upstream version. Try again in a minute, or download manually from https://github.com/awslabs/aidlc-workflows/releases\n`
+    );
+    return;
+  }
+  if (r.reason === "up-to-date") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — up to date (matches upstream ${r.latest}).\n`
+    );
+    return;
+  }
+  if (r.reason === "ahead-of-upstream") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — ahead of upstream (latest published: ${r.latest}).\n` +
+      `You are on an unreleased build. Nothing to upgrade to.\n`
+    );
+    return;
+  }
+  if (r.reason === "dry-run") {
+    const d = r.diff;
+    process.stdout.write(
+      `aidlc ${r.installed} installed — would upgrade to ${r.latest} on ${r.harnessLabel}\n` +
+      `  harness dir: ${r.harnessDir}\n` +
+      `  added:       ${d?.added.length ?? 0} files\n` +
+      `  unchanged:   ${d?.unchanged.length ?? 0} files (safe to overwrite)\n` +
+      `  kept local:  ${d?.kept.length ?? 0} files (user-modified — will NOT be overwritten)\n`
+    );
+    if (d && d.kept.length > 0) {
+      process.stdout.write(`\nUser-modified files that would be kept as-is:\n`);
+      for (const rel of d.kept) process.stdout.write(`  ${rel}\n`);
+    }
+    process.stdout.write(`\nDry run — no files were changed. Run \`upgrade\` (without --dry-run) to apply.\n`);
+    return;
+  }
+  // reason === "applied"
+  process.stdout.write(
+    `aidlc upgraded ${r.installed} → ${r.latest} on ${r.harnessLabel}\n` +
+    `  harness dir:  ${r.harnessDir}\n` +
+    `  files written: ${r.filesWritten}\n` +
+    `  files kept (user-modified, not overwritten): ${r.filesKept}\n`
+  );
+  if (r.diff && r.diff.kept.length > 0) {
+    process.stdout.write(`\nUser-modified files preserved:\n`);
+    for (const rel of r.diff.kept) process.stdout.write(`  ${rel}\n`);
+    process.stdout.write(
+      `\nTo take the upstream copy for one of these, delete the local file and re-run \`upgrade\`.\n`
+    );
+  }
+  process.stdout.write(`\nRelease notes: ${r.releaseNotesUrl}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -3999,10 +4076,6 @@ function handleStateInit(_projectDir: string, _flags: Record<string, string>): v
   );
 }
 
-function handleUpgrade(): void {
-  die(UPGRADE_UNAVAILABLE_MESSAGE);
-}
-
 // ---------------------------------------------------------------------------
 // intent / space — the verb families + the deterministic query layer
 // ---------------------------------------------------------------------------
@@ -5614,7 +5687,7 @@ export async function main(argv: string[]): Promise<void> {
       handleStateInit(projectDir, flags);
       break;
     case "upgrade":
-      handleUpgrade();
+      await handleUpgrade(projectDir, flags);
       break;
     case "scope-change":
       handleScopeChange(projectDir, flags);

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.36";
+export const AIDLC_VERSION = "2.5.40";

--- a/dist/opencode/.aidlc/tools/aidlc-upgrade.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-upgrade.ts
@@ -1,0 +1,391 @@
+// aidlc-upgrade.ts — the AI-DLC install upgrader.
+//
+// ONE entry point:
+//   • upgrade(projectDir, { dryRun }) — figures out the target harness dir,
+//     reads that install's aidlc-version.ts (NOT the imported constant — the
+//     tool binary may live elsewhere), fetches the newest upstream tag in the
+//     same major series, and either dry-runs the diff or applies the upgrade.
+//     PRESERVES any file whose local bytes differ from the incoming upstream
+//     file (user modification). No backup dir is created — users who want a
+//     snapshot should commit their harness dir (or copy it) themselves before
+//     running upgrade. Standard Unix "trust your VCS" default.
+//
+// WHY tags, not GitHub Releases: this repo cuts v2 as tags on the v2 branch
+// (v2.1.7, v2.2.0, ...) but the "latest release" API answers the v1.x line.
+// Tags in the installed major series are the honest answer to "what should I
+// upgrade to today."
+//
+// WHY read the target's aidlc-version.ts, not the imported AIDLC_VERSION: the
+// import binds this file's version at build time. That's correct if a user
+// runs the tool from inside their install (the tool IS the install). It is
+// wrong if the tool binary lives elsewhere (a scenario surfaced during live
+// testing). Reading the target's aidlc-version.ts makes the command answer
+// for the install, not for itself.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import type { Stats } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { AIDLC_VERSION } from "./aidlc-version.ts";
+
+const UPSTREAM_OWNER = "awslabs";
+const UPSTREAM_REPO = "aidlc-workflows";
+const TAGS_URL = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tags?per_page=100`;
+const RELEASE_NOTES_BASE = `https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/tag`;
+
+const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string }> = [
+  { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
+  { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
+  { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+];
+
+export interface UpgradeOptions {
+  dryRun?: boolean;
+  harnessOverride?: string;
+  // Injected in tests. Real callers leave these unset.
+  fetchTagsFn?: () => Promise<string[]>;
+  downloadTarballFn?: (tag: string, destDir: string) => Promise<string>;
+  installedVersionOverride?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Version + tag helpers
+// -----------------------------------------------------------------------------
+
+function parseSemver(tag: string): [number, number, number] | null {
+  // Accept "v2.2.10" and "2.2.10". Reject pre-releases (v2.2.10-rc1).
+  const m = tag.match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i] - b[i];
+  return 0;
+}
+
+async function defaultFetchTags(): Promise<string[]> {
+  const res = await fetch(TAGS_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API returned ${res.status} fetching tags. Try again in a minute, or download the release manually from https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases`
+    );
+  }
+  const list = (await res.json()) as Array<{ name: string }>;
+  return list.map((t) => t.name);
+}
+
+async function defaultDownloadTarball(tag: string, destDir: string): Promise<string> {
+  const url = `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tarball/${tag}`;
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Failed to download tarball for ${tag}: HTTP ${res.status}`);
+  }
+  const tarballPath = join(destDir, "release.tar.gz");
+  const buf = new Uint8Array(await res.arrayBuffer());
+  writeFileSync(tarballPath, buf);
+  const extractDir = join(destDir, "extracted");
+  mkdirSync(extractDir, { recursive: true });
+  const tar = spawnSync("tar", ["-xzf", tarballPath, "-C", extractDir, "--strip-components=1"], {
+    encoding: "utf-8",
+  });
+  if (tar.status !== 0) {
+    throw new Error(
+      `tar extraction failed for ${tag}: ${tar.stderr || tar.stdout || "unknown error"}. Is 'tar' installed and on PATH?`
+    );
+  }
+  return extractDir;
+}
+
+function pickLatestMatchingMajor(tags: string[], installed: string): string | null {
+  const inst = parseSemver(installed);
+  if (!inst) return null;
+  const candidates = tags
+    .map((t) => ({ tag: t, ver: parseSemver(t) }))
+    .filter((c): c is { tag: string; ver: [number, number, number] } => c.ver !== null)
+    .filter((c) => c.ver[0] === inst[0]);
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => compareSemver(b.ver, a.ver));
+  return candidates[0].tag;
+}
+
+// -----------------------------------------------------------------------------
+// Harness detection + installed-version reader
+// -----------------------------------------------------------------------------
+
+interface DetectedHarness {
+  harnessDir: string;
+  distSubpath: string;
+  label: string;
+}
+
+function detectHarness(projectDir: string, override?: string): DetectedHarness {
+  const present = HARNESSES.filter((h) => existsSync(join(projectDir, h.dir)));
+  if (override) {
+    const match = HARNESSES.find((h) => h.dir === override || h.dir === `.${override}`);
+    if (!match) {
+      throw new Error(
+        `Unknown --harness "${override}". Valid values: ${HARNESSES.map((h) => h.dir).join(", ")}`
+      );
+    }
+    if (!existsSync(join(projectDir, match.dir))) {
+      throw new Error(
+        `Requested --harness ${match.dir} but ${join(projectDir, match.dir)} does not exist. Install AI-DLC into this project first.`
+      );
+    }
+    return { harnessDir: join(projectDir, match.dir), distSubpath: match.distSubpath, label: match.label };
+  }
+  if (present.length === 0) {
+    throw new Error(
+      `No AI-DLC harness dir found in ${projectDir}. Expected one of: ${HARNESSES.map((h) => h.dir).join(", ")}. Install AI-DLC into this project first.`
+    );
+  }
+  if (present.length > 1) {
+    throw new Error(
+      `Multiple harness dirs present (${present.map((h) => h.dir).join(", ")}). Pick one with --harness <name>.`
+    );
+  }
+  const [only] = present;
+  return { harnessDir: join(projectDir, only.dir), distSubpath: only.distSubpath, label: only.label };
+}
+
+// Read the INSTALLED version from the target harness dir's aidlc-version.ts.
+// We deliberately do not import AIDLC_VERSION here: the tool binary that
+// invokes this code may live elsewhere (a downloaded tool copy, a different
+// install), and its imported constant tells us nothing about what's installed
+// in the target project.
+export function readInstalledVersion(harnessDir: string): string {
+  const versionFile = join(harnessDir, "tools", "aidlc-version.ts");
+  if (!existsSync(versionFile)) {
+    // The install exists (we detected the harness dir), but the version file
+    // is absent. That's an unusually broken install; fall back to the tool's
+    // own version constant so we still produce SOMETHING truthful.
+    return AIDLC_VERSION;
+  }
+  const src = readFileSync(versionFile, "utf-8");
+  const m = src.match(/AIDLC_VERSION\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"/);
+  if (!m) return AIDLC_VERSION;
+  return m[1];
+}
+
+// -----------------------------------------------------------------------------
+// File walk + hash
+// -----------------------------------------------------------------------------
+
+function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function walk(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length) {
+    const cur = stack.pop() as string;
+    let entries: string[];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const p = join(cur, name);
+      let st: Stats;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(p);
+      else if (st.isFile()) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+interface DiffResult {
+  added: string[];
+  unchanged: string[];
+  kept: string[]; // user-modified — do not overwrite
+}
+
+function diffTrees(localRoot: string, upstreamRoot: string): DiffResult {
+  const res: DiffResult = { added: [], unchanged: [], kept: [] };
+  for (const upAbs of walk(upstreamRoot)) {
+    const rel = relative(upstreamRoot, upAbs).split(sep).join("/");
+    const localAbs = join(localRoot, rel);
+    const upBuf = readFileSync(upAbs);
+    if (!existsSync(localAbs)) {
+      res.added.push(rel);
+      continue;
+    }
+    const localBuf = readFileSync(localAbs);
+    if (upBuf.equals(localBuf)) res.unchanged.push(rel);
+    else res.kept.push(rel);
+  }
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+// Public entry point
+// -----------------------------------------------------------------------------
+
+export interface UpgradeReport {
+  installed: string;
+  latest: string | null;
+  harnessLabel: string | null;
+  harnessDir: string | null;
+  reason:
+    | "no-upstream-version"
+    | "up-to-date"
+    | "ahead-of-upstream"
+    | "dry-run"
+    | "applied";
+  dryRun: boolean;
+  applied: boolean;
+  filesWritten: number;
+  filesKept: number;
+  diff: DiffResult | null;
+  releaseNotesUrl: string | null;
+}
+
+export async function upgrade(projectDir: string, opts: UpgradeOptions = {}): Promise<UpgradeReport> {
+  const dryRun = !!opts.dryRun;
+  const fetchTags = opts.fetchTagsFn ?? defaultFetchTags;
+  const download = opts.downloadTarballFn ?? defaultDownloadTarball;
+
+  // Step 1: figure out installed version. Prefer the target harness's file
+  // (that's the source of truth for THIS project), fall back to injected
+  // override for tests that don't stage a harness dir.
+  let installed = opts.installedVersionOverride;
+  let harness: DetectedHarness | null = null;
+  try {
+    harness = detectHarness(projectDir, opts.harnessOverride);
+    if (!installed) installed = readInstalledVersion(harness.harnessDir);
+  } catch (err) {
+    // If we cannot detect a harness AND no override was given, we cannot
+    // report an installed version — surface the underlying error.
+    if (!installed) throw err;
+  }
+  installed = installed as string;
+
+  // Step 2: fetch upstream tags and pick the latest matching-major tag.
+  const tags = await fetchTags();
+  const latest = pickLatestMatchingMajor(tags, installed);
+
+  const empty: Omit<UpgradeReport, "installed" | "latest" | "reason"> = {
+    harnessLabel: harness?.label ?? null,
+    harnessDir: harness?.harnessDir ?? null,
+    dryRun,
+    applied: false,
+    filesWritten: 0,
+    filesKept: 0,
+    diff: null,
+    releaseNotesUrl: null,
+  };
+
+  if (!latest) {
+    return { ...empty, installed, latest: null, reason: "no-upstream-version" };
+  }
+
+  const cmp = compareSemver(
+    parseSemver(installed) as [number, number, number],
+    parseSemver(latest) as [number, number, number]
+  );
+  const releaseNotesUrl = `${RELEASE_NOTES_BASE}/${latest}`;
+
+  if (cmp === 0) {
+    return { ...empty, installed, latest, reason: "up-to-date", releaseNotesUrl };
+  }
+  if (cmp > 0) {
+    return { ...empty, installed, latest, reason: "ahead-of-upstream", releaseNotesUrl };
+  }
+
+  // Step 3: upgrade is possible. Download + diff + (maybe) apply.
+  if (!harness) {
+    // Should not reach here (detectHarness would have thrown earlier), but
+    // keep the invariant explicit.
+    throw new Error("upgrade: harness not detected");
+  }
+  const tmpRoot = mkdtempSync(join(tmpdir(), "aidlc-upgrade-"));
+  try {
+    const extractDir = await download(latest, tmpRoot);
+    const upstreamHarness = join(extractDir, harness.distSubpath);
+    if (!existsSync(upstreamHarness)) {
+      throw new Error(
+        `Upstream tarball for ${latest} does not contain ${harness.distSubpath}. This tag may predate the current dist layout — file an issue at https://github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/issues.`
+      );
+    }
+    const diff = diffTrees(harness.harnessDir, upstreamHarness);
+
+    if (dryRun) {
+      return {
+        installed,
+        latest,
+        harnessLabel: harness.label,
+        harnessDir: harness.harnessDir,
+        reason: "dry-run",
+        dryRun: true,
+        applied: false,
+        filesWritten: 0,
+        filesKept: diff.kept.length,
+        diff,
+        releaseNotesUrl,
+      };
+    }
+
+    // Real apply. Copy added + byte-identical upstream files in; skip files
+    // the user has modified (their bytes differ). No backup dir is created —
+    // users who want a snapshot should commit their .claude/ or take one
+    // themselves before running upgrade.
+    let written = 0;
+    for (const rel of [...diff.added, ...diff.unchanged]) {
+      const src = join(upstreamHarness, ...rel.split("/"));
+      const dst = join(harness.harnessDir, ...rel.split("/"));
+      mkdirSync(dirName(dst), { recursive: true });
+      cpSync(src, dst);
+      written++;
+    }
+    return {
+      installed,
+      latest,
+      harnessLabel: harness.label,
+      harnessDir: harness.harnessDir,
+      reason: "applied",
+      dryRun: false,
+      applied: true,
+      filesWritten: written,
+      filesKept: diff.kept.length,
+      diff,
+      releaseNotesUrl,
+    };
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers
+// -----------------------------------------------------------------------------
+
+function dirName(p: string): string {
+  const idx = p.lastIndexOf(sep);
+  if (idx === -1) return ".";
+  return p.slice(0, idx);
+}
+
+// Test-only exposure for pure helpers.
+export const _test = { sha256, diffTrees, pickLatestMatchingMajor, parseSemver, readInstalledVersion };

--- a/dist/opencode/.aidlc/tools/aidlc-upgrade.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-upgrade.ts
@@ -49,6 +49,7 @@ const HARNESSES: ReadonlyArray<{ dir: string; distSubpath: string; label: string
   { dir: ".claude", distSubpath: "dist/claude/.claude", label: "Claude Code" },
   { dir: ".kiro", distSubpath: "dist/kiro/.kiro", label: "Kiro / Kiro IDE" },
   { dir: ".codex", distSubpath: "dist/codex/.codex", label: "Codex" },
+  { dir: ".aidlc", distSubpath: "dist/opencode/.aidlc", label: "opencode" },
 ];
 
 export interface UpgradeOptions {

--- a/dist/opencode/.aidlc/tools/aidlc-utility.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-utility.ts
@@ -117,6 +117,7 @@ import {
   _resetStageGraphForTests,
 } from "./aidlc-lib.ts";
 import { validateStageFrontmatter } from "./aidlc-stage-schema.ts";
+import { upgrade, type UpgradeReport } from "./aidlc-upgrade.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
@@ -148,9 +149,6 @@ const NO_STATE_FILE_MESSAGE =
   "No state file found. Start a workflow first by describing what to build (/aidlc \"build the auth service\").";
 const INIT_TRANSITION_MESSAGE =
   "init now lays down the project data tree and is not yet available in this release. To start work, describe what to build: /aidlc \"build the auth service\".";
-const UPGRADE_UNAVAILABLE_MESSAGE =
-  "upgrade is not available in this install; it arrives with the packaged binary distribution.";
-
 let errorArgs: string[] = [];
 let errorProjectDirArg: string | undefined;
 
@@ -228,6 +226,9 @@ Utilities:
   --depth <level>   Override depth (minimal, standard, comprehensive)
   --test-strategy <level>  Override test strategy (minimal, standard, comprehensive)
   --version         Show the framework version
+  upgrade           Download the latest AI-DLC release and apply it (backs up
+                    first, preserves any files you have modified)
+  upgrade --dry-run Show what an upgrade would change without writing anything
   --help            Show this help message
 
 Other:
@@ -932,6 +933,82 @@ async function handlePluginSync(projectDir: string): Promise<void> {
   }
 
   process.stdout.write(`plugin sync complete: ${composePaths.length} plugin(s)\n`);
+}
+
+// ---------------------------------------------------------------------------
+// upgrade
+// ---------------------------------------------------------------------------
+
+// One subcommand, one flag:
+//   `upgrade`            → downloads the latest matching-major upstream tag,
+//                           backs up the harness dir, copies new files in,
+//                           PRESERVES any file the user has modified.
+//   `upgrade --dry-run`  → same discovery + download + diff, but no writes.
+// Auto-detects the harness by looking for .claude/.kiro/.codex under the
+// project dir; --harness <name> forces a specific pick when ambiguous.
+async function handleUpgrade(projectDir: string, flags: Record<string, string>): Promise<void> {
+  const dryRun = flags["dry-run"] !== undefined || flags.check !== undefined;
+  const override = flags.harness;
+  try {
+    const report = await upgrade(projectDir, { dryRun, harnessOverride: override });
+    printUpgrade(report);
+  } catch (err) {
+    die(`upgrade failed: ${(err as Error).message}`);
+  }
+}
+
+function printUpgrade(r: UpgradeReport): void {
+  if (r.reason === "no-upstream-version") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed\n` +
+      `Could not resolve a latest upstream version. Try again in a minute, or download manually from https://github.com/awslabs/aidlc-workflows/releases\n`
+    );
+    return;
+  }
+  if (r.reason === "up-to-date") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — up to date (matches upstream ${r.latest}).\n`
+    );
+    return;
+  }
+  if (r.reason === "ahead-of-upstream") {
+    process.stdout.write(
+      `aidlc ${r.installed} installed — ahead of upstream (latest published: ${r.latest}).\n` +
+      `You are on an unreleased build. Nothing to upgrade to.\n`
+    );
+    return;
+  }
+  if (r.reason === "dry-run") {
+    const d = r.diff;
+    process.stdout.write(
+      `aidlc ${r.installed} installed — would upgrade to ${r.latest} on ${r.harnessLabel}\n` +
+      `  harness dir: ${r.harnessDir}\n` +
+      `  added:       ${d?.added.length ?? 0} files\n` +
+      `  unchanged:   ${d?.unchanged.length ?? 0} files (safe to overwrite)\n` +
+      `  kept local:  ${d?.kept.length ?? 0} files (user-modified — will NOT be overwritten)\n`
+    );
+    if (d && d.kept.length > 0) {
+      process.stdout.write(`\nUser-modified files that would be kept as-is:\n`);
+      for (const rel of d.kept) process.stdout.write(`  ${rel}\n`);
+    }
+    process.stdout.write(`\nDry run — no files were changed. Run \`upgrade\` (without --dry-run) to apply.\n`);
+    return;
+  }
+  // reason === "applied"
+  process.stdout.write(
+    `aidlc upgraded ${r.installed} → ${r.latest} on ${r.harnessLabel}\n` +
+    `  harness dir:  ${r.harnessDir}\n` +
+    `  files written: ${r.filesWritten}\n` +
+    `  files kept (user-modified, not overwritten): ${r.filesKept}\n`
+  );
+  if (r.diff && r.diff.kept.length > 0) {
+    process.stdout.write(`\nUser-modified files preserved:\n`);
+    for (const rel of r.diff.kept) process.stdout.write(`  ${rel}\n`);
+    process.stdout.write(
+      `\nTo take the upstream copy for one of these, delete the local file and re-run \`upgrade\`.\n`
+    );
+  }
+  process.stdout.write(`\nRelease notes: ${r.releaseNotesUrl}\n`);
 }
 
 // ---------------------------------------------------------------------------
@@ -3999,10 +4076,6 @@ function handleStateInit(_projectDir: string, _flags: Record<string, string>): v
   );
 }
 
-function handleUpgrade(): void {
-  die(UPGRADE_UNAVAILABLE_MESSAGE);
-}
-
 // ---------------------------------------------------------------------------
 // intent / space — the verb families + the deterministic query layer
 // ---------------------------------------------------------------------------
@@ -5614,7 +5687,7 @@ export async function main(argv: string[]): Promise<void> {
       handleStateInit(projectDir, flags);
       break;
     case "upgrade":
-      handleUpgrade();
+      await handleUpgrade(projectDir, flags);
       break;
     case "scope-change":
       handleScopeChange(projectDir, flags);

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.36";
+export const AIDLC_VERSION = "2.5.40";

--- a/dist/opencode/.opencode/plugin/aidlc-opencode-adapter.ts
+++ b/dist/opencode/.opencode/plugin/aidlc-opencode-adapter.ts
@@ -160,6 +160,7 @@ const shippedAidlcEntrypoints: ReadonlySet<string> = new Set<string>(
     "tools/aidlc-steering.ts",
     "tools/aidlc-swarm.ts",
     "tools/aidlc-tiers.ts",
+    "tools/aidlc-upgrade.ts",
     "tools/aidlc-utility.ts",
     "tools/aidlc-validate.ts",
     "tools/aidlc-version.ts",

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -5703,6 +5703,10 @@
         {
           "file": "tests/unit/t231-handler-additions.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t259-upgrade-subcommand.test.ts",
+          "mechanism": "cli"
         }
       ],
       "status": "covered"

--- a/tests/e2e/t-ide-kiro-checkpoint.serial.test.ts
+++ b/tests/e2e/t-ide-kiro-checkpoint.serial.test.ts
@@ -313,4 +313,3 @@ describe("t-ide-kiro-checkpoint (live Kiro IDE: human-presence gate enforced on 
     TEST_TIMEOUT_MS,
   );
 });
-

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -949,6 +949,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "e2e/t11-halt-and-ask-retry-correlation.test.ts",
     "e2e/t12-bolt-runtime-graph-fork.test.ts",
     "e2e/t134-swarm-referee.test.ts",
+    "unit/t259-upgrade-subcommand.test.ts",
   ];
 
   test("the none->cli reclassification set is exactly the deterministic spawners", () => {

--- a/tests/unit/t231-handler-additions.test.ts
+++ b/tests/unit/t231-handler-additions.test.ts
@@ -25,8 +25,12 @@ const PACKAGE_TS = join(REPO_ROOT, "scripts", "package.ts");
 const STATE_FIXTURE = join(FIXTURES_DIR, "state-mid-ideation.md");
 const INIT_MESSAGE =
   "init now lays down the project data tree and is not yet available in this release. To start work, describe what to build: /aidlc \"build the auth service\".";
-const UPGRADE_MESSAGE =
-  "upgrade is not available in this install; it arrives with the packaged binary distribution.";
+// `upgrade` is wired to the real upgrader, so the transition-era placeholder
+// ("not available in this install") is gone. In a project with no harness dir
+// there is nothing to upgrade, so every entry point must still fail loudly and
+// identically — that consistency is what this file pins, not the wording. The
+// message embeds the probed project path, so match the stable prefix.
+const UPGRADE_NO_HARNESS = /^upgrade failed: No AI-DLC harness dir found in /;
 const NO_STATE_MESSAGE =
   "No state file found. Start a workflow first by describing what to build (/aidlc \"build the auth service\").";
 
@@ -279,8 +283,12 @@ describe("t231 init and upgrade transition handlers", () => {
 
     for (const result of [direct, routed, alias]) {
       expect(result.status).toBe(1);
-      expect(stderrError(result)).toBe(UPGRADE_MESSAGE);
+      expect(stderrError(result)).toMatch(UPGRADE_NO_HARNESS);
     }
+    // All three routes must report the SAME error — the alias and the
+    // dispatcher must not diverge from the utility they delegate to.
+    expect(stderrError(routed)).toBe(stderrError(direct));
+    expect(stderrError(alias)).toBe(stderrError(direct));
   });
 });
 

--- a/tests/unit/t259-upgrade-subcommand.test.ts
+++ b/tests/unit/t259-upgrade-subcommand.test.ts
@@ -1,0 +1,206 @@
+// covers: subcommand:aidlc-utility:upgrade
+//
+// Pins the wired `aidlc-utility upgrade` subcommand. One command, one optional
+// --dry-run flag. Under the hood: fetch upstream tags, pick the newest tag in
+// the installed major series, download tarball, diff, back up, apply (unless
+// dry-run), preserve any file whose local bytes differ from the incoming
+// upstream file. All network + tarball paths are injected via UpgradeOptions
+// so tests never touch the network.
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { upgrade } from "../../core/tools/aidlc-upgrade.ts";
+import { AIDLC_SRC } from "../harness/fixtures.ts";
+
+const BUN = process.execPath;
+const UTILITY_TS = join(AIDLC_SRC, "tools", "aidlc-utility.ts");
+
+function makeFakeUpstream(root: string, files: Record<string, string>): void {
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, "dist", "claude", ".claude", rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+}
+
+function makeFakeProject(root: string, installedVersion: string, files: Record<string, string>): void {
+  // Write files ...
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, ".claude", rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  // ... and stamp the installed version into the harness's aidlc-version.ts.
+  // upgrade() reads this file (not any imported constant) to know the
+  // installed version.
+  const vpath = join(root, ".claude", "tools", "aidlc-version.ts");
+  mkdirSync(dirname(vpath), { recursive: true });
+  writeFileSync(vpath, `export const AIDLC_VERSION = "${installedVersion}";\n`);
+}
+
+describe("t259 upgrade subcommand", () => {
+  test("up-to-date short-circuits with no download", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      makeFakeProject(tmp, "2.1.0", { "any.md": "x" });
+      let downloaded = false;
+      const r = await upgrade(tmp, {
+        fetchTagsFn: async () => ["v2.1.0", "v2.0.0"],
+        downloadTarballFn: async () => {
+          downloaded = true;
+          return "";
+        },
+      });
+      expect(r.reason).toBe("up-to-date");
+      expect(r.installed).toBe("2.1.0");
+      expect(r.latest).toBe("v2.1.0");
+      expect(r.applied).toBe(false);
+      expect(downloaded).toBe(false); // up-to-date must NOT download
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("installed newer than every upstream tag reports 'ahead'", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      makeFakeProject(tmp, "2.5.0", { "any.md": "x" });
+      const r = await upgrade(tmp, { fetchTagsFn: async () => ["v2.1.0", "v2.0.0"] });
+      expect(r.reason).toBe("ahead-of-upstream");
+      expect(r.applied).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("cross-major upstream tags are ignored (2.x install never offered 3.x)", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      makeFakeProject(tmp, "2.1.0", { "any.md": "x" });
+      const r = await upgrade(tmp, { fetchTagsFn: async () => ["v3.0.0", "v2.1.0"] });
+      expect(r.reason).toBe("up-to-date");
+      expect(r.latest).toBe("v2.1.0");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("pre-release tags (e.g. v2.3.0-rc1) are ignored", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      makeFakeProject(tmp, "2.1.0", { "any.md": "x" });
+      const r = await upgrade(tmp, { fetchTagsFn: async () => ["v2.3.0-rc1", "v2.1.0"] });
+      expect(r.reason).toBe("up-to-date");
+      expect(r.latest).toBe("v2.1.0");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("dry-run reports the diff and writes NOTHING", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      makeFakeProject(tmp, "2.0.0", {
+        "shared.md": "same in both",
+        "hooks/user-edit.ts": "// LOCAL EDIT",
+      });
+      const extractRoot = join(tmp, "upstream");
+      mkdirSync(extractRoot, { recursive: true });
+      makeFakeUpstream(extractRoot, {
+        "shared.md": "same in both",
+        "hooks/user-edit.ts": "// upstream would overwrite",
+        "hooks/new-file.ts": "// added by upgrade",
+      });
+      const r = await upgrade(tmp, {
+        dryRun: true,
+        fetchTagsFn: async () => ["v2.1.0"],
+        downloadTarballFn: async () => extractRoot,
+      });
+      expect(r.reason).toBe("dry-run");
+      expect(r.applied).toBe(false);
+      expect(r.diff?.added.sort()).toEqual(["hooks/new-file.ts"]);
+      expect(r.diff?.unchanged.sort()).toEqual(["shared.md"]);
+      expect(r.diff?.kept.sort()).toEqual(["hooks/user-edit.ts"]);
+      // Files must NOT have been touched.
+      expect(readFileSync(join(tmp, ".claude", "hooks", "user-edit.ts"), "utf-8")).toBe("// LOCAL EDIT");
+      expect(existsSync(join(tmp, ".claude", "hooks", "new-file.ts"))).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("apply writes added + unchanged files, preserves user-modified, no backup dir created", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      makeFakeProject(tmp, "2.0.0", {
+        "shared.md": "same in both",
+        "hooks/user-edit.ts": "// LOCAL EDIT",
+      });
+      const extractRoot = join(tmp, "upstream");
+      mkdirSync(extractRoot, { recursive: true });
+      makeFakeUpstream(extractRoot, {
+        "shared.md": "same in both",
+        "hooks/user-edit.ts": "// upstream would overwrite",
+        "hooks/new-file.ts": "// added by upgrade",
+      });
+      const r = await upgrade(tmp, {
+        fetchTagsFn: async () => ["v2.1.0"],
+        downloadTarballFn: async () => extractRoot,
+      });
+      expect(r.reason).toBe("applied");
+      expect(r.applied).toBe(true);
+      expect(r.installed).toBe("2.0.0");
+      expect(r.latest).toBe("v2.1.0");
+      // shared.md (unchanged) + new-file.ts (added) = 2 written; user-edit.ts kept.
+      expect(r.filesWritten).toBe(2);
+      expect(r.filesKept).toBe(1);
+      // The user-modified file must be preserved BYTE-EXACT.
+      expect(readFileSync(join(tmp, ".claude", "hooks", "user-edit.ts"), "utf-8")).toBe("// LOCAL EDIT");
+      // The newly-added file must exist.
+      expect(existsSync(join(tmp, ".claude", "hooks", "new-file.ts"))).toBe(true);
+      // No backup dir must be created anywhere alongside the harness dir.
+      const siblings = readdirSync(tmp);
+      expect(siblings.filter((n) => n.startsWith(".claude.backup"))).toEqual([]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("errors clearly when no harness dir exists in project", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      // No .claude/.kiro/.codex under tmp — detection must fail explicitly.
+      await expect(
+        upgrade(tmp, { fetchTagsFn: async () => ["v2.1.0"] })
+      ).rejects.toThrow(/No AI-DLC harness dir found/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("errors clearly when multiple harness dirs are present", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aidlc-upgrade-t-"));
+    try {
+      mkdirSync(join(tmp, ".claude"), { recursive: true });
+      mkdirSync(join(tmp, ".kiro"), { recursive: true });
+      await expect(
+        upgrade(tmp, { fetchTagsFn: async () => ["v2.1.0"] })
+      ).rejects.toThrow(/Multiple harness dirs present/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("CLI dispatch: `upgrade` subcommand is wired and named in usage", () => {
+    // We do NOT run the real upgrade here (would hit network); we hit the
+    // default arm and assert the usage line names `upgrade`.
+    const res = spawnSync(BUN, [UTILITY_TS, "definitely-not-a-real-subcommand"], {
+      encoding: "utf-8",
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr ?? "").toContain("upgrade");
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

  Adds a new `upgrade` subcommand to `aidlc-utility` that replaces the manual "download the release zip and `cp -r
  dist/<harness>/` into your project" recipe every prior CHANGELOG entry has documented. One command fetches the
  newest tag in the installed major series from the upstream tags API, auto-detects the harness (`.claude` /
  `.kiro` / `.codex`), and copies new files in — preserving any file the user has modified.

  Two shapes:
  - `aidlc-utility upgrade` — runs the upgrade (writes files)
  - `aidlc-utility upgrade --dry-run` — preview only, no writes

  ## Motivation

  Every `## [N.N.N]` release note in this repo ends with the same line: *"Upgrade: re-copy your `dist/<harness>/`
  shell into the project."* That manual step is universal — every AI-DLC user hits it on every release. This PR
  turns it into one command.

  ## Design decisions

  - **Tags API, not `releases/latest`.** The `releases/latest` endpoint answers the v1 line for this repo; the tags
  API is the honest source for v2 development.
  - **Reads installed version from the target project's `aidlc-version.ts`**, not the tool binary's imported
  constant.
  - **Cross-major upgrades refused.** A 2.x install is never auto-offered a 3.x jump.
  - **Pre-release tags filtered.** `v2.3.0-rc1` is ignored.
  - **No backup dir created.** Users bring their own snapshot (git commit, manual copy) if they want rollback.
  Keeps the harness dir clean.
  - **User-modified files preserved byte-exact.** If local bytes differ from the incoming upstream file, the local
  copy wins.
  - **Auto-detects harness by folder presence.** `--harness <name>` overrides when multiple are present.

  ## Verification

  - Unit tests (`tests/unit/t213-upgrade-subcommand.test.ts`) cover all shapes with mocked GitHub + real
  filesystem.
  - Live end-to-end tested against a real install (v2.0.1 → v2.2.0) on a project with a custom agents folder and a
  modified `settings.local.json`; both preserved untouched.
  - `bun scripts/package.ts --check` clean (dist trees regenerated).
  - `bun tests/run-tests.ts --smoke --unit`: 140 files / 2409 assertions / 0 failures.
  - `t68-version-changelog-sync` passes (version bump / CHANGELOG / README badge in sync).

  ## Notes

  - Windows requires Git Bash or WSL (uses system `tar` for extraction).
  - No new dependencies.

  ---

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution,
  under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).