### PR TITLE
fix: rename agent frontmatter modelOverride to model so agent tiers engage on Claude Code (2.2.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.15] - 2026-07-09
+
+Agent frontmatter now uses Claude Code's real `model:` key instead of the inert `modelOverride:` key, preserving the same Opus/Sonnet policy while keeping Codex and Kiro behavior stable. **Upgrade:** re-copy your dist/<harness>/ shell into the project.
+
+* Claude Code now honors the shipped `model: sonnet` pins for architecture-reviewer, product-lead, delivery, pipeline-deploy, and operations; those five delegated agents run on Sonnet instead of the session model.
+* Codex TOML emission is byte-identical; it now reads the renamed `model` key before applying the same Opus/Sonnet mapping.
+* Kiro CLI and Kiro IDE agent JSON configs are untouched and unaffected; they continue to use their hand-authored `"model"` fields.
+
+
 ## [2.2.14] - 2026-07-09
 
 Fixes a silent-data-loss failure in Construction: when the compiled runtime graph was missing its bolt_dag node (a stale or deleted runtime-graph.json, for example when the runtime-compile hook never fired), every per-unit Construction stage silently degraded to a single iteration, so a multi-unit project shipped only its first unit with no error and the workflow completed as if done. The engine now self-heals on the read side: when the cached bolt_dag is absent it recomputes the unit batch DAG directly from inception/units-generation/unit-of-work-dependency.md (the same pure parse the compiler uses), so per-unit iteration, the approve-side coverage guard, and the autonomous swarm all see the full unit list regardless of whether a hook refreshed the graph. Scopes that never run units-generation are unaffected. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.2.14-blue)
+![version](https://img.shields.io/badge/version-2.2.15-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/agents/aidlc-architect-agent.md
+++ b/core/agents/aidlc-architect-agent.md
@@ -8,7 +8,7 @@ description: >
   Solutions architect responsible for application design, domain modelling, NFR patterns, and component decomposition.
   Leads Feasibility, Application Design, Units Generation, Functional Design, NFR Requirements, and NFR Design stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-architecture-reviewer-agent.md
+++ b/core/agents/aidlc-architecture-reviewer-agent.md
@@ -4,7 +4,7 @@ display_name: Architecture Reviewer
 description: >
   Senior solutions architect who reviews technical design artifacts for soundness, implementability, and coherence. Finds broken cross-references, hidden dependencies, unachievable quality targets, and designs that won't survive contact with reality.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/core/agents/aidlc-aws-platform-agent.md
+++ b/core/agents/aidlc-aws-platform-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Infrastructure Design and Environment Provisioning stages.
   Supports Feasibility, Application Design, NFR Design, and Feedback & Optimization.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-compliance-agent.md
+++ b/core/agents/aidlc-compliance-agent.md
@@ -8,7 +8,7 @@ description: >
   GRC analyst and regulatory specialist responsible for compliance mapping, data classification, and risk assessment.
   Support-only agent for Feasibility & Constraint Analysis and cross-cutting compliance validation.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-composer-agent.md
+++ b/core/agents/aidlc-composer-agent.md
@@ -8,7 +8,7 @@ description: >
   or proposes pending-stage suffix flips (in-flight). Dispatched by the
   /aidlc orchestrator; never invoked directly by a stage.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-delivery-agent.md
+++ b/core/agents/aidlc-delivery-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Team Formation, Initiative Approval & Handoff, and Delivery Planning stages.
   Supports Scope Definition and Units Generation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-design-agent.md
+++ b/core/agents/aidlc-design-agent.md
@@ -8,7 +8,7 @@ description: >
   UX/UI designer responsible for wireframing, interaction design, accessibility, and design system compliance.
   Leads Rough Mockups and Refined Mockups stages. Supports User Stories and Application Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-developer-agent.md
+++ b/core/agents/aidlc-developer-agent.md
@@ -8,7 +8,7 @@ description: >
   Senior developer responsible for code generation, reverse engineering, and data modelling.
   Leads Reverse Engineering code scan and Code Generation stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-devsecops-agent.md
+++ b/core/agents/aidlc-devsecops-agent.md
@@ -8,7 +8,7 @@ description: >
   Security engineer and DevSecOps specialist responsible for threat modelling, security requirements, secure design review,
   and security pipeline integration. Supports NFR Requirements, Infrastructure Design, Build and Test, and Environment Provisioning.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-operations-agent.md
+++ b/core/agents/aidlc-operations-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Observability Setup, Incident Response, and Feedback & Optimization stages.
   Supports Performance Validation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-pipeline-deploy-agent.md
+++ b/core/agents/aidlc-pipeline-deploy-agent.md
@@ -8,7 +8,7 @@ description: >
   CI/CD engineer and release manager responsible for pipeline configuration, deployment strategy, and release execution.
   Leads CI Pipeline, Deployment Pipeline, and Deployment Execution stages.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-product-agent.md
+++ b/core/agents/aidlc-product-agent.md
@@ -8,7 +8,7 @@ description: >
   Product manager and business analyst responsible for requirements, user stories, market research, and scope.
   Leads Intent Capture, Market Research, Scope Definition, Requirements Analysis, and User Stories stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/agents/aidlc-product-lead-agent.md
+++ b/core/agents/aidlc-product-lead-agent.md
@@ -4,7 +4,7 @@ display_name: Product Lead
 description: >
   Senior product leader who reviews requirements, user stories, and UX artifacts for completeness, business alignment, and testability. Does not produce — only reviews and challenges. Represents the customer's voice at the quality gate.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/core/agents/aidlc-quality-agent.md
+++ b/core/agents/aidlc-quality-agent.md
@@ -8,7 +8,7 @@ description: >
   QA lead responsible for test strategy, test case design, quality gates, and performance validation.
   Leads Build and Test and Performance Validation stages. Supports NFR Requirements and Functional Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/core/aidlc-common/conductor.md
+++ b/core/aidlc-common/conductor.md
@@ -18,7 +18,7 @@ For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
 knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`modelOverride` — pass
+persona and enforces the agent's `disallowedTools`/`model` - pass
 context in the prompt (subagents cannot see conversation history), never inject
 the persona text yourself.
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.14";
+export const AIDLC_VERSION = "2.2.15";

--- a/dist/claude/.claude/agents/aidlc-architect-agent.md
+++ b/dist/claude/.claude/agents/aidlc-architect-agent.md
@@ -8,7 +8,7 @@ description: >
   Solutions architect responsible for application design, domain modelling, NFR patterns, and component decomposition.
   Leads Feasibility, Application Design, Units Generation, Functional Design, NFR Requirements, and NFR Design stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-architecture-reviewer-agent.md
+++ b/dist/claude/.claude/agents/aidlc-architecture-reviewer-agent.md
@@ -4,7 +4,7 @@ display_name: Architecture Reviewer
 description: >
   Senior solutions architect who reviews technical design artifacts for soundness, implementability, and coherence. Finds broken cross-references, hidden dependencies, unachievable quality targets, and designs that won't survive contact with reality.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-aws-platform-agent.md
+++ b/dist/claude/.claude/agents/aidlc-aws-platform-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Infrastructure Design and Environment Provisioning stages.
   Supports Feasibility, Application Design, NFR Design, and Feedback & Optimization.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-compliance-agent.md
+++ b/dist/claude/.claude/agents/aidlc-compliance-agent.md
@@ -8,7 +8,7 @@ description: >
   GRC analyst and regulatory specialist responsible for compliance mapping, data classification, and risk assessment.
   Support-only agent for Feasibility & Constraint Analysis and cross-cutting compliance validation.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-composer-agent.md
+++ b/dist/claude/.claude/agents/aidlc-composer-agent.md
@@ -8,7 +8,7 @@ description: >
   or proposes pending-stage suffix flips (in-flight). Dispatched by the
   /aidlc orchestrator; never invoked directly by a stage.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-delivery-agent.md
+++ b/dist/claude/.claude/agents/aidlc-delivery-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Team Formation, Initiative Approval & Handoff, and Delivery Planning stages.
   Supports Scope Definition and Units Generation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-design-agent.md
+++ b/dist/claude/.claude/agents/aidlc-design-agent.md
@@ -8,7 +8,7 @@ description: >
   UX/UI designer responsible for wireframing, interaction design, accessibility, and design system compliance.
   Leads Rough Mockups and Refined Mockups stages. Supports User Stories and Application Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-developer-agent.md
+++ b/dist/claude/.claude/agents/aidlc-developer-agent.md
@@ -8,7 +8,7 @@ description: >
   Senior developer responsible for code generation, reverse engineering, and data modelling.
   Leads Reverse Engineering code scan and Code Generation stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-devsecops-agent.md
+++ b/dist/claude/.claude/agents/aidlc-devsecops-agent.md
@@ -8,7 +8,7 @@ description: >
   Security engineer and DevSecOps specialist responsible for threat modelling, security requirements, secure design review,
   and security pipeline integration. Supports NFR Requirements, Infrastructure Design, Build and Test, and Environment Provisioning.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-operations-agent.md
+++ b/dist/claude/.claude/agents/aidlc-operations-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Observability Setup, Incident Response, and Feedback & Optimization stages.
   Supports Performance Validation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-pipeline-deploy-agent.md
+++ b/dist/claude/.claude/agents/aidlc-pipeline-deploy-agent.md
@@ -8,7 +8,7 @@ description: >
   CI/CD engineer and release manager responsible for pipeline configuration, deployment strategy, and release execution.
   Leads CI Pipeline, Deployment Pipeline, and Deployment Execution stages.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-product-agent.md
+++ b/dist/claude/.claude/agents/aidlc-product-agent.md
@@ -8,7 +8,7 @@ description: >
   Product manager and business analyst responsible for requirements, user stories, market research, and scope.
   Leads Intent Capture, Market Research, Scope Definition, Requirements Analysis, and User Stories stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-product-lead-agent.md
+++ b/dist/claude/.claude/agents/aidlc-product-lead-agent.md
@@ -4,7 +4,7 @@ display_name: Product Lead
 description: >
   Senior product leader who reviews requirements, user stories, and UX artifacts for completeness, business alignment, and testability. Does not produce — only reviews and challenges. Represents the customer's voice at the quality gate.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/dist/claude/.claude/agents/aidlc-quality-agent.md
+++ b/dist/claude/.claude/agents/aidlc-quality-agent.md
@@ -8,7 +8,7 @@ description: >
   QA lead responsible for test strategy, test case design, quality gates, and performance validation.
   Leads Build and Test and Performance Validation stages. Supports NFR Requirements and Functional Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/claude/.claude/aidlc-common/conductor.md
+++ b/dist/claude/.claude/aidlc-common/conductor.md
@@ -18,7 +18,7 @@ For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
 knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`modelOverride` — pass
+persona and enforces the agent's `disallowedTools`/`model` - pass
 context in the prompt (subagents cannot see conversation history), never inject
 the persona text yourself.
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.14";
+export const AIDLC_VERSION = "2.2.15";

--- a/dist/codex/.codex/agents/aidlc-architect-agent.md
+++ b/dist/codex/.codex/agents/aidlc-architect-agent.md
@@ -8,7 +8,7 @@ description: >
   Solutions architect responsible for application design, domain modelling, NFR patterns, and component decomposition.
   Leads Feasibility, Application Design, Units Generation, Functional Design, NFR Requirements, and NFR Design stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-architecture-reviewer-agent.md
+++ b/dist/codex/.codex/agents/aidlc-architecture-reviewer-agent.md
@@ -4,7 +4,7 @@ display_name: Architecture Reviewer
 description: >
   Senior solutions architect who reviews technical design artifacts for soundness, implementability, and coherence. Finds broken cross-references, hidden dependencies, unachievable quality targets, and designs that won't survive contact with reality.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-aws-platform-agent.md
+++ b/dist/codex/.codex/agents/aidlc-aws-platform-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Infrastructure Design and Environment Provisioning stages.
   Supports Feasibility, Application Design, NFR Design, and Feedback & Optimization.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-compliance-agent.md
+++ b/dist/codex/.codex/agents/aidlc-compliance-agent.md
@@ -8,7 +8,7 @@ description: >
   GRC analyst and regulatory specialist responsible for compliance mapping, data classification, and risk assessment.
   Support-only agent for Feasibility & Constraint Analysis and cross-cutting compliance validation.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-composer-agent.md
+++ b/dist/codex/.codex/agents/aidlc-composer-agent.md
@@ -8,7 +8,7 @@ description: >
   or proposes pending-stage suffix flips (in-flight). Dispatched by the
   /aidlc orchestrator; never invoked directly by a stage.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-delivery-agent.md
+++ b/dist/codex/.codex/agents/aidlc-delivery-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Team Formation, Initiative Approval & Handoff, and Delivery Planning stages.
   Supports Scope Definition and Units Generation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-design-agent.md
+++ b/dist/codex/.codex/agents/aidlc-design-agent.md
@@ -8,7 +8,7 @@ description: >
   UX/UI designer responsible for wireframing, interaction design, accessibility, and design system compliance.
   Leads Rough Mockups and Refined Mockups stages. Supports User Stories and Application Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-developer-agent.md
+++ b/dist/codex/.codex/agents/aidlc-developer-agent.md
@@ -8,7 +8,7 @@ description: >
   Senior developer responsible for code generation, reverse engineering, and data modelling.
   Leads Reverse Engineering code scan and Code Generation stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-devsecops-agent.md
+++ b/dist/codex/.codex/agents/aidlc-devsecops-agent.md
@@ -8,7 +8,7 @@ description: >
   Security engineer and DevSecOps specialist responsible for threat modelling, security requirements, secure design review,
   and security pipeline integration. Supports NFR Requirements, Infrastructure Design, Build and Test, and Environment Provisioning.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-operations-agent.md
+++ b/dist/codex/.codex/agents/aidlc-operations-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Observability Setup, Incident Response, and Feedback & Optimization stages.
   Supports Performance Validation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-pipeline-deploy-agent.md
+++ b/dist/codex/.codex/agents/aidlc-pipeline-deploy-agent.md
@@ -8,7 +8,7 @@ description: >
   CI/CD engineer and release manager responsible for pipeline configuration, deployment strategy, and release execution.
   Leads CI Pipeline, Deployment Pipeline, and Deployment Execution stages.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-product-agent.md
+++ b/dist/codex/.codex/agents/aidlc-product-agent.md
@@ -8,7 +8,7 @@ description: >
   Product manager and business analyst responsible for requirements, user stories, market research, and scope.
   Leads Intent Capture, Market Research, Scope Definition, Requirements Analysis, and User Stories stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-product-lead-agent.md
+++ b/dist/codex/.codex/agents/aidlc-product-lead-agent.md
@@ -4,7 +4,7 @@ display_name: Product Lead
 description: >
   Senior product leader who reviews requirements, user stories, and UX artifacts for completeness, business alignment, and testability. Does not produce — only reviews and challenges. Represents the customer's voice at the quality gate.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/dist/codex/.codex/agents/aidlc-quality-agent.md
+++ b/dist/codex/.codex/agents/aidlc-quality-agent.md
@@ -8,7 +8,7 @@ description: >
   QA lead responsible for test strategy, test case design, quality gates, and performance validation.
   Leads Build and Test and Performance Validation stages. Supports NFR Requirements and Functional Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/codex/.codex/aidlc-common/conductor.md
+++ b/dist/codex/.codex/aidlc-common/conductor.md
@@ -18,7 +18,7 @@ For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
 knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`modelOverride` — pass
+persona and enforces the agent's `disallowedTools`/`model` - pass
 context in the prompt (subagents cannot see conversation history), never inject
 the persona text yourself.
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.14";
+export const AIDLC_VERSION = "2.2.15";

--- a/dist/kiro-ide/.kiro/agents/aidlc-architect-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-architect-agent.md
@@ -8,7 +8,7 @@ description: >
   Solutions architect responsible for application design, domain modelling, NFR patterns, and component decomposition.
   Leads Feasibility, Application Design, Units Generation, Functional Design, NFR Requirements, and NFR Design stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-architecture-reviewer-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-architecture-reviewer-agent.md
@@ -4,7 +4,7 @@ display_name: Architecture Reviewer
 description: >
   Senior solutions architect who reviews technical design artifacts for soundness, implementability, and coherence. Finds broken cross-references, hidden dependencies, unachievable quality targets, and designs that won't survive contact with reality.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-aws-platform-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-aws-platform-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Infrastructure Design and Environment Provisioning stages.
   Supports Feasibility, Application Design, NFR Design, and Feedback & Optimization.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-compliance-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-compliance-agent.md
@@ -8,7 +8,7 @@ description: >
   GRC analyst and regulatory specialist responsible for compliance mapping, data classification, and risk assessment.
   Support-only agent for Feasibility & Constraint Analysis and cross-cutting compliance validation.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-composer-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-composer-agent.md
@@ -8,7 +8,7 @@ description: >
   or proposes pending-stage suffix flips (in-flight). Dispatched by the
   /aidlc orchestrator; never invoked directly by a stage.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-delivery-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-delivery-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Team Formation, Initiative Approval & Handoff, and Delivery Planning stages.
   Supports Scope Definition and Units Generation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-design-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-design-agent.md
@@ -8,7 +8,7 @@ description: >
   UX/UI designer responsible for wireframing, interaction design, accessibility, and design system compliance.
   Leads Rough Mockups and Refined Mockups stages. Supports User Stories and Application Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-developer-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-developer-agent.md
@@ -8,7 +8,7 @@ description: >
   Senior developer responsible for code generation, reverse engineering, and data modelling.
   Leads Reverse Engineering code scan and Code Generation stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-devsecops-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-devsecops-agent.md
@@ -8,7 +8,7 @@ description: >
   Security engineer and DevSecOps specialist responsible for threat modelling, security requirements, secure design review,
   and security pipeline integration. Supports NFR Requirements, Infrastructure Design, Build and Test, and Environment Provisioning.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-operations-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-operations-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Observability Setup, Incident Response, and Feedback & Optimization stages.
   Supports Performance Validation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-pipeline-deploy-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-pipeline-deploy-agent.md
@@ -8,7 +8,7 @@ description: >
   CI/CD engineer and release manager responsible for pipeline configuration, deployment strategy, and release execution.
   Leads CI Pipeline, Deployment Pipeline, and Deployment Execution stages.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-product-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-product-agent.md
@@ -8,7 +8,7 @@ description: >
   Product manager and business analyst responsible for requirements, user stories, market research, and scope.
   Leads Intent Capture, Market Research, Scope Definition, Requirements Analysis, and User Stories stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/agents/aidlc-product-lead-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-product-lead-agent.md
@@ -4,7 +4,7 @@ display_name: Product Lead
 description: >
   Senior product leader who reviews requirements, user stories, and UX artifacts for completeness, business alignment, and testability. Does not produce — only reviews and challenges. Represents the customer's voice at the quality gate.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-quality-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-quality-agent.md
@@ -8,7 +8,7 @@ description: >
   QA lead responsible for test strategy, test case design, quality gates, and performance validation.
   Leads Build and Test and Performance Validation stages. Supports NFR Requirements and Functional Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro-ide/.kiro/aidlc-common/conductor.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/conductor.md
@@ -18,7 +18,7 @@ For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
 knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`modelOverride` — pass
+persona and enforces the agent's `disallowedTools`/`model` - pass
 context in the prompt (subagents cannot see conversation history), never inject
 the persona text yourself.
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.14";
+export const AIDLC_VERSION = "2.2.15";

--- a/dist/kiro/.kiro/agents/aidlc-architect-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-architect-agent.md
@@ -8,7 +8,7 @@ description: >
   Solutions architect responsible for application design, domain modelling, NFR patterns, and component decomposition.
   Leads Feasibility, Application Design, Units Generation, Functional Design, NFR Requirements, and NFR Design stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-architecture-reviewer-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-architecture-reviewer-agent.md
@@ -4,7 +4,7 @@ display_name: Architecture Reviewer
 description: >
   Senior solutions architect who reviews technical design artifacts for soundness, implementability, and coherence. Finds broken cross-references, hidden dependencies, unachievable quality targets, and designs that won't survive contact with reality.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-aws-platform-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-aws-platform-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Infrastructure Design and Environment Provisioning stages.
   Supports Feasibility, Application Design, NFR Design, and Feedback & Optimization.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-compliance-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-compliance-agent.md
@@ -8,7 +8,7 @@ description: >
   GRC analyst and regulatory specialist responsible for compliance mapping, data classification, and risk assessment.
   Support-only agent for Feasibility & Constraint Analysis and cross-cutting compliance validation.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-composer-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-composer-agent.md
@@ -8,7 +8,7 @@ description: >
   or proposes pending-stage suffix flips (in-flight). Dispatched by the
   /aidlc orchestrator; never invoked directly by a stage.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-delivery-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-delivery-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Team Formation, Initiative Approval & Handoff, and Delivery Planning stages.
   Supports Scope Definition and Units Generation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-design-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-design-agent.md
@@ -8,7 +8,7 @@ description: >
   UX/UI designer responsible for wireframing, interaction design, accessibility, and design system compliance.
   Leads Rough Mockups and Refined Mockups stages. Supports User Stories and Application Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-developer-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-developer-agent.md
@@ -8,7 +8,7 @@ description: >
   Senior developer responsible for code generation, reverse engineering, and data modelling.
   Leads Reverse Engineering code scan and Code Generation stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-devsecops-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-devsecops-agent.md
@@ -8,7 +8,7 @@ description: >
   Security engineer and DevSecOps specialist responsible for threat modelling, security requirements, secure design review,
   and security pipeline integration. Supports NFR Requirements, Infrastructure Design, Build and Test, and Environment Provisioning.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-operations-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-operations-agent.md
@@ -9,7 +9,7 @@ description: >
   Leads Observability Setup, Incident Response, and Feedback & Optimization stages.
   Supports Performance Validation.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-pipeline-deploy-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-pipeline-deploy-agent.md
@@ -8,7 +8,7 @@ description: >
   CI/CD engineer and release manager responsible for pipeline configuration, deployment strategy, and release execution.
   Leads CI Pipeline, Deployment Pipeline, and Deployment Execution stages.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-product-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-product-agent.md
@@ -8,7 +8,7 @@ description: >
   Product manager and business analyst responsible for requirements, user stories, market research, and scope.
   Leads Intent Capture, Market Research, Scope Definition, Requirements Analysis, and User Stories stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-product-lead-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-product-lead-agent.md
@@ -4,7 +4,7 @@ display_name: Product Lead
 description: >
   Senior product leader who reviews requirements, user stories, and UX artifacts for completeness, business alignment, and testability. Does not produce — only reviews and challenges. Represents the customer's voice at the quality gate.
 disallowedTools: Task
-modelOverride: sonnet
+model: sonnet
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated reviewer and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-quality-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-quality-agent.md
@@ -8,7 +8,7 @@ description: >
   QA lead responsible for test strategy, test case design, quality gates, and performance validation.
   Leads Build and Test and Performance Validation stages. Supports NFR Requirements and Functional Design.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/aidlc-common/conductor.md
+++ b/dist/kiro/.kiro/aidlc-common/conductor.md
@@ -18,7 +18,7 @@ For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
 knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`modelOverride` — pass
+persona and enforces the agent's `disallowedTools`/`model` - pass
 context in the prompt (subagents cannot see conversation history), never inject
 the persona text yourself.
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.2.14";
+export const AIDLC_VERSION = "2.2.15";

--- a/docs/harness-engineering/03-adding-an-agent.md
+++ b/docs/harness-engineering/03-adding-an-agent.md
@@ -47,7 +47,7 @@ description: >
   Solutions architect responsible for application design, domain modelling,
   NFR patterns, and component decomposition.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 ```
 
@@ -82,15 +82,15 @@ call when the engine's `run-stage` directive carries `mode: subagent`. Allowing
 the framework is built to prevent. Every shipped agent disallows `Task`, and so
 must yours.
 
-**`modelOverride` is opus or sonnet, and the default is opus.** Reach for
+**`model` is opus or sonnet; if omitted, the delegated subagent inherits the session model.** Reach for
 `opus` for any persona whose work is high-judgment, multi-constraint reasoning
-that cascades downstream — interpreting ambiguous intent and weighing
+that cascades downstream, interpreting ambiguous intent and weighing
 architectural trade-offs under dense context. Eight of the
-11 agents run on opus for exactly this reason. Use `sonnet` only when the
+11 domain agents run on opus for exactly this reason. Use `sonnet` only when the
 output is dominantly templated or pattern-following and the methodology is
-already encoded in the agent's knowledge files — the three sonnet agents
-(delivery, pipeline-deploy, operations) produce delivery plans, CI/CD YAML, and
-runbook scaffolding. When in doubt, opus.
+already encoded in the agent's knowledge files, as with delivery plans, CI/CD
+YAML, and runbook scaffolding. When in doubt, omit `model` to inherit the
+session model or set `opus` when the persona should pin high-judgment work.
 
 Two more fields drive presentation rather than behavior. `display_name` is the
 human-readable label the statusline renders (the architect shows as "Architect
@@ -141,7 +141,7 @@ Mirroring the reference recipe, here is the workflow end to end.
 
 1. **Create the agent file** — `core/agents/<slug>-agent.md` with the
    required frontmatter: `name`, `display_name`, `examples`, `description`,
-   `disallowedTools` (including `Task`), `modelOverride`. An optional `tools:`
+   `disallowedTools` (including `Task`), `model`. An optional `tools:`
    allowlist narrows the persona; omit it to inherit the full session toolset.
    Write the body to match the shipped files' structure (Core Responsibilities,
    Stages Owned, Collaboration, Knowledge Loading, Key Principles).

--- a/docs/reference/05-agent-system.md
+++ b/docs/reference/05-agent-system.md
@@ -83,10 +83,10 @@ Every agent *can* reach Bash and WebSearch by inheritance; the table records whi
 
 | Model | Agents |
 |-------|--------|
-| opus | aidlc-architect-agent, aidlc-product-agent, aidlc-design-agent, aidlc-developer-agent, aidlc-quality-agent, aidlc-devsecops-agent, aidlc-compliance-agent, aidlc-aws-platform-agent |
-| sonnet | aidlc-delivery-agent, aidlc-pipeline-deploy-agent, aidlc-operations-agent |
+| opus | aidlc-architect-agent, aidlc-product-agent, aidlc-design-agent, aidlc-developer-agent, aidlc-quality-agent, aidlc-devsecops-agent, aidlc-compliance-agent, aidlc-aws-platform-agent, aidlc-composer-agent |
+| sonnet | aidlc-architecture-reviewer-agent, aidlc-product-lead-agent, aidlc-delivery-agent, aidlc-pipeline-deploy-agent, aidlc-operations-agent |
 
-Omitting `model:` uses Claude Code's `inherit` default, so a delegated subagent runs on the session model. The shipped agents declare explicit values; an agent uses sonnet only when its output is dominantly templated or pattern-following (delivery plans, CI/CD YAML, observability/runbook scaffolding) and the methodology is already encoded in knowledge files.
+Omitting `model:` uses Claude Code's `inherit` default, so a delegated subagent runs on the session model. The shipped agents declare explicit values; an agent uses sonnet only when its output is dominantly templated or pattern-following (delivery plans, CI/CD YAML, observability/runbook scaffolding) and the methodology is already encoded in knowledge files. The Claude Code and Codex harnesses read `model:` from the agent .md frontmatter; Kiro CLI and Kiro IDE read the per-agent `"model"` field in `harness/kiro*/agents/aidlc-*-agent.json` and ignore the .md value.
 
 Opus is used for any agent whose work involves high-judgment, multi-constraint reasoning that cascades downstream:
 
@@ -119,7 +119,7 @@ Opus is used for any agent whose work involves high-judgment, multi-constraint r
 
 **Observations:**
 - aidlc-architect-agent has the broadest stage involvement (9 stages across 3 phases).
-- Eight of 11 agents run on opus; the three sonnet agents (delivery, pipeline-deploy, operations) handle dominantly templated planning, CI/CD, and runbook work.
+- Across the full 14-agent roster, nine run on opus and five on sonnet; the sonnet agents (architecture-reviewer, product-lead, delivery, pipeline-deploy, operations) produce reviews against explicit checklists or dominantly templated planning, CI/CD, and runbook work. The matrix above covers the 11 domain-expert agents.
 - aidlc-compliance-agent operates purely in an advisory capacity (4 support stages, no lead stages).
 - Six of 11 agents have Bash access, all in roles that need CLI interaction.
 - Three agents have WebSearch access for research tasks.

--- a/docs/reference/05-agent-system.md
+++ b/docs/reference/05-agent-system.md
@@ -21,7 +21,7 @@ description: >                      # Brief role summary (shown in Claude Code a
   System architect responsible for application design,
   NFR design, and component decomposition.
 disallowedTools: Task               # Agents cannot spawn subagents
-modelOverride: opus                 # opus for high-judgment work; sonnet for templated output
+model: opus                         # opus for high-judgment work; sonnet for templated output
 ---
 ```
 
@@ -31,7 +31,7 @@ modelOverride: opus                 # opus for high-judgment work; sonnet for te
 | `description` | Yes | Brief role summary |
 | `tools` | No | Optional allowlist; omit to inherit the full session toolset. Listing it narrows the agent and drops inherited MCP tools unless `mcp__<server>__<tool>` ids are also listed |
 | `disallowedTools` | Yes | Must include `Task` -- only the conductor delegates |
-| `modelOverride` | No | `opus` (default for most agents) or `sonnet` (templated-output agents only) |
+| `model` | No | `opus` or `sonnet` for shipped agents; omitted = `inherit`, so the delegated subagent uses the session model. Claude Code also accepts other aliases, full model ids, and `inherit` |
 
 ### Markdown Body Sections
 
@@ -86,7 +86,7 @@ Every agent *can* reach Bash and WebSearch by inheritance; the table records whi
 | opus | aidlc-architect-agent, aidlc-product-agent, aidlc-design-agent, aidlc-developer-agent, aidlc-quality-agent, aidlc-devsecops-agent, aidlc-compliance-agent, aidlc-aws-platform-agent |
 | sonnet | aidlc-delivery-agent, aidlc-pipeline-deploy-agent, aidlc-operations-agent |
 
-The default is opus. An agent uses sonnet only when its output is dominantly templated or pattern-following (delivery plans, CI/CD YAML, observability/runbook scaffolding) and the methodology is already encoded in knowledge files.
+Omitting `model:` uses Claude Code's `inherit` default, so a delegated subagent runs on the session model. The shipped agents declare explicit values; an agent uses sonnet only when its output is dominantly templated or pattern-following (delivery plans, CI/CD YAML, observability/runbook scaffolding) and the methodology is already encoded in knowledge files.
 
 Opus is used for any agent whose work involves high-judgment, multi-constraint reasoning that cascades downstream:
 
@@ -150,7 +150,7 @@ L = Lead, S = Support
 
 Agent display names and example knowledge files are authoritative in each agent's `.md` frontmatter via the `display_name` and `examples` fields — no TypeScript edits required. See [Contributing: Adding an Agent](11-contributing.md#adding-an-agent) for the full recipe (required frontmatter fields, verification steps, and what validates automatically vs. manually). Quick summary of the steps:
 
-1. Create `core/agents/{name}-agent.md` with the required frontmatter: `name`, `display_name`, `examples`, `description`, `disallowedTools` (including `Task`), `modelOverride`. An optional `tools:` allowlist narrows the inherited toolset; omit it to inherit the full session toolset. `loadAgents()` in `core/tools/aidlc-lib.ts` discovers the file on next invocation.
+1. Create `core/agents/{name}-agent.md` with the required frontmatter: `name`, `display_name`, `examples`, `description`, `disallowedTools` (including `Task`), `model`. An optional `tools:` allowlist narrows the inherited toolset; omit it to inherit the full session toolset. `loadAgents()` in `core/tools/aidlc-lib.ts` discovers the file on next invocation.
 2. Add knowledge files to `core/knowledge/{name}-agent/`
 3. Add the agent to the stage files (`core/aidlc-common/stages/`) where it participates — set `lead_agent` / `support_agents` in each stage's frontmatter. The compiled `tools/data/stage-graph.json` is GENERATED from that frontmatter by `bun scripts/package.ts`; never hand-edit it (the `package.ts --check` drift guard fails CI on a hand-edited dist).
 4. Regenerate the distributions: `bun scripts/package.ts` (then `--check` to confirm no drift)
@@ -161,7 +161,7 @@ Agent display names and example knowledge files are authoritative in each agent'
 ## How to Modify an Agent
 
 - **Change tools**: Add or edit a `tools:` allowlist in frontmatter to narrow the agent; omit it to inherit the full session toolset. A `tools:` list drops inherited MCP tools unless the `mcp__<server>__<tool>` ids are also listed.
-- **Change model**: Edit `modelOverride` to `opus` or `sonnet`.
+- **Change model**: Edit `model` to `opus` or `sonnet` (or another Claude Code alias / full id / `inherit`).
 - **Change behavior**: Edit the markdown body sections (responsibilities, principles).
 - **Change stage assignments**: Edit both the agent file (Stages Owned section) and the relevant stage files (`core/aidlc-common/stages/`), then regenerate with `bun scripts/package.ts` — the compiled stage graph is derived from stage frontmatter, never hand-edited.
 

--- a/docs/reference/11-contributing.md
+++ b/docs/reference/11-contributing.md
@@ -201,7 +201,7 @@ Agent metadata (display name, example knowledge files) is read from each agent's
    description: >
      One-paragraph description of the agent's responsibilities and which stages it leads or supports.
    disallowedTools: Task
-   modelOverride: opus
+   model: opus
    ---
    ```
 

--- a/docs/reference/14-claude-features.md
+++ b/docs/reference/14-claude-features.md
@@ -115,8 +115,8 @@ Workspace detection (0.2) used to be a subagent; it now runs deterministically i
 
 | Model | Agents | Rationale |
 |-------|--------|-----------|
-| `opus` | architect, product, design, developer, quality, devsecops, compliance, aws-platform (8) | High-judgment, multi-constraint reasoning whose decisions cascade downstream — architectural boundaries, intent interpretation, UX trade-offs, code synthesis, threat prioritisation, regulatory edge-cases, cloud architecture |
-| `sonnet` | delivery, pipeline-deploy, operations (3) | Output is dominantly templated planning tables, CI/CD YAML, or observability/runbook scaffolding; methodology is encoded in the agent's knowledge files |
+| `opus` | architect, product, design, developer, quality, devsecops, compliance, aws-platform, composer (9) | High-judgment, multi-constraint reasoning whose decisions cascade downstream - architectural boundaries, intent interpretation, UX trade-offs, code synthesis, threat prioritisation, regulatory edge-cases, cloud architecture |
+| `sonnet` | architecture-reviewer, product-lead, delivery, pipeline-deploy, operations (5) | Output is dominantly templated planning tables, CI/CD YAML, or observability/runbook scaffolding, or review against an explicit checklist; methodology is encoded in the agent's knowledge files |
 
 ---
 

--- a/docs/reference/agents/README.md
+++ b/docs/reference/agents/README.md
@@ -64,14 +64,14 @@ Every agent *can* reach Bash and WebSearch by inheritance; the table records whi
 
 | Model | Agents |
 |-------|--------|
-| opus | aidlc-architect-agent, aidlc-product-agent, aidlc-design-agent, aidlc-developer-agent, aidlc-quality-agent, aidlc-devsecops-agent, aidlc-compliance-agent, aidlc-aws-platform-agent |
-| sonnet | aidlc-delivery-agent, aidlc-pipeline-deploy-agent, aidlc-operations-agent |
+| opus | aidlc-architect-agent, aidlc-product-agent, aidlc-design-agent, aidlc-developer-agent, aidlc-quality-agent, aidlc-devsecops-agent, aidlc-compliance-agent, aidlc-aws-platform-agent, aidlc-composer-agent |
+| sonnet | aidlc-architecture-reviewer-agent, aidlc-product-lead-agent, aidlc-delivery-agent, aidlc-pipeline-deploy-agent, aidlc-operations-agent |
 
-Opus is the default. An agent uses sonnet only when its output is dominantly
+Every shipped agent declares an explicit `model:`; omitting it would make the subagent inherit the session model on Claude Code. An agent uses sonnet only when its output is dominantly
 templated — delivery plans, CI/CD YAML, observability and runbook scaffolding —
 and the methodology is already encoded in the agent's knowledge files.
 
-The eight opus agents share one property: their work requires high-judgment,
+The nine opus agents share one property: their work requires high-judgment,
 multi-constraint reasoning whose decisions cascade downstream. Architectural
 boundaries, interpretation of ambiguous intent, UX trade-offs, code synthesis
 under dense context, risk-based test strategy, threat prioritisation,
@@ -116,7 +116,7 @@ category.
 
 **Observations:**
 - The aidlc-architect-agent has the broadest stage involvement (9 stages across 3 phases), reflecting its role as the central design authority.
-- Eight of 11 agents run on opus; the three sonnet agents (delivery, pipeline-deploy, operations) produce dominantly templated planning, CI/CD, and runbook output where methodology is already encoded in knowledge files.
+- Across the full 14-agent roster, nine run on opus and five on sonnet; the sonnet agents (architecture-reviewer, product-lead, delivery, pipeline-deploy, operations) produce reviews against explicit checklists or dominantly templated planning, CI/CD, and runbook work. The matrix above covers the 11 domain-expert agents.
 - The aidlc-compliance-agent operates purely in an advisory capacity (4 support stages across Ideation, Construction, and Operation; no lead stages).
 - Six of 11 agents have Bash access, all in roles that need CLI interaction (infrastructure, security, development, testing, deployment, operations).
 - Three agents have WebSearch access for research tasks (product, design, compliance).

--- a/harness/codex/emit.ts
+++ b/harness/codex/emit.ts
@@ -269,7 +269,7 @@ export default function emit(ctx: EmitContext): EmitResult {
     const { fm, body } = parseAgentMd(raw);
     const name = fm.name ?? "";
     const description = (fm.description ?? "").replace(/\s+/g, " ").trim();
-    const model = D7_MODEL_MAP[fm.modelOverride ?? ""] ?? D7_MODEL_MAP.opus;
+    const model = D7_MODEL_MAP[fm.model ?? ""] ?? D7_MODEL_MAP.opus;
     const instructions = rewriteProse(body);
     return (
       `name = "${name}"\n` +

--- a/roadmap.html
+++ b/roadmap.html
@@ -384,7 +384,7 @@
       <h4><span class="d ship"></span>Shipped</h4>
       <ul class="items">
         <li class="l-ship">Reviewer iteration loop with budget + HITL escalation: <code>reviewer_max_iterations</code> (default 2); NOT-READY re-invokes the builder to the cap, then escalates to the human at the gate with unresolved findings. <span class="src">stage-protocol.md:885 · aidlc-stage-schema.ts:42</span></li>
-        <li class="l-ship">Different model than producer: reviewer personas pin <code>modelOverride: sonnet</code> while lead/orchestrator default to Opus (xhigh); Codex maps overrides to its slugs.</li>
+        <li class="l-ship">Different model than producer: reviewer personas pin <code>model: sonnet</code> while lead/orchestrator default to Opus (xhigh); Codex maps overrides to its slugs.</li>
         <li class="l-ship">Deterministic sensors (advisory): <code>required-sections</code>, <code>upstream-coverage</code>, <code>linter</code>, <code>type-check</code>. Reviewer field validation.</li>
       </ul>
     </div>

--- a/tests/harness/custom-harness.ts
+++ b/tests/harness/custom-harness.ts
@@ -252,7 +252,7 @@ description: >
   Specialist data migration persona seeded by the Harness-Engineer fixture.
   Leads the custom schema-snapshot and migration-plan stages.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/tests/unit/t04-agent-frontmatter.test.ts
+++ b/tests/unit/t04-agent-frontmatter.test.ts
@@ -24,7 +24,7 @@
 //   - disallowedTools: must contain `Task` — subagents must not spawn subagents
 //                     (single-level constraint; the body also carries the
 //                     "Do NOT use the Task tool" banner).
-//   - modelOverride:  must equal the documented per-agent value
+//   - model:          must equal the documented per-agent value
 //                     (opus = high-judgment / high-blast-radius work;
 //                      sonnet = templated config/scaffolding;
 //                      docs/reference/05-agent-system.md, .sh L11-19).
@@ -34,7 +34,7 @@
 //
 // Test-design note (house style): assert the OBSERVABLE shipped contract the
 // .sh asserted — frontmatter field presence/absence and exact values — against
-// the real bytes on disk. The expected modelOverride table is hard-coded here
+// the real bytes on disk. The expected model table is hard-coded here
 // independently of the source (mirrors the .sh's `expected_model()` case), so
 // the test pins the policy rather than echoing whatever the file says.
 //
@@ -46,7 +46,7 @@
 //   .sh L34-38 (description: present)                  -> "description: is present and non-empty"            [11 expects]
 //   .sh L41-45 (allowedTools: absent)                  -> "allowedTools: is ABSENT (ignored field removed in v0.5.4)" [11 expects]
 //   .sh L48-52 (disallowedTools contains Task)         -> "disallowedTools: contains Task (no nested subagents)" [11 expects]
-//   .sh L54-61 (modelOverride matches expected)        -> "modelOverride: matches the documented opus/sonnet split" [11 expects]
+//   .sh L54-61 (model matches expected)                -> "model: matches the documented opus/sonnet split" [11 expects]
 //   .sh L21    plan 55                                  -> "covers EXACTLY 11 agents × 5 invariants = 55 frontmatter assertions (TAP plan parity)"
 
 import { describe, expect, test } from "bun:test";
@@ -73,7 +73,7 @@ const AGENTS = [
   "operations",
 ] as const;
 
-// Expected modelOverride per agent — hard-coded independently of the source,
+// Expected model per agent -- hard-coded independently of the source,
 // mirroring the .sh's expected_model() case (L13-19). opus = high-judgment /
 // high-blast-radius; sonnet = templated config/scaffolding.
 const EXPECTED_MODEL: Record<(typeof AGENTS)[number], "opus" | "sonnet"> = {
@@ -171,13 +171,13 @@ describe("t04 agent-persona frontmatter contract (migrated from t04-agent-frontm
     }
   });
 
-  // .sh L54-61: modelOverride matches expected_model().
-  test("modelOverride: matches the documented opus/sonnet split [.sh test 5 ×11]", () => {
+  // .sh L54-61: model matches expected_model().
+  test("model: matches the documented opus/sonnet split [.sh test 5 x11]", () => {
     for (const agent of AGENTS) {
       const fm = frontmatter(agent);
-      // The .sh used `awk -F': *' '/^modelOverride:/ {print $2; exit}'`.
-      const m = fm.match(/^modelOverride:\s*(\S+)/m);
-      expect(m, `aidlc-${agent}-agent.md: no modelOverride: line`).not.toBeNull();
+      // The .sh used `awk -F': *' '/^model:/ {print $2; exit}'`.
+      const m = fm.match(/^model:\s*(\S+)/m);
+      expect(m, `aidlc-${agent}-agent.md: no model: line`).not.toBeNull();
       expect(m?.[1]).toBe(EXPECTED_MODEL[agent]);
     }
   });

--- a/tests/unit/t216-agent-model-key.test.ts
+++ b/tests/unit/t216-agent-model-key.test.ts
@@ -1,0 +1,109 @@
+// covers: file:agents/aidlc-architect-agent.md, file:agents/aidlc-architecture-reviewer-agent.md, file:agents/aidlc-aws-platform-agent.md, file:agents/aidlc-compliance-agent.md, file:agents/aidlc-composer-agent.md, file:agents/aidlc-delivery-agent.md, file:agents/aidlc-design-agent.md, file:agents/aidlc-developer-agent.md, file:agents/aidlc-devsecops-agent.md, file:agents/aidlc-operations-agent.md, file:agents/aidlc-pipeline-deploy-agent.md, file:agents/aidlc-product-agent.md, file:agents/aidlc-product-lead-agent.md, file:agents/aidlc-quality-agent.md (t216 agent model key contract)
+//
+// t216 - shipped Claude agent model frontmatter key.
+//
+// Mechanism: none. Pure structural check over shipped bytes on disk. The test
+// resolves the same dist/claude/.claude tree used by the harness fixtures and
+// reads each agent Markdown file in-process.
+//
+// Subject under test: the YAML frontmatter in every shipped Claude agent persona
+// under dist/claude/.claude/agents/aidlc-<agent>-agent.md. Claude Code reads
+// `model:` there to pick the delegated subagent model. The old
+// `modelOverride:` spelling is inert on Claude Code, so its presence in shipped
+// frontmatter is a regression.
+//
+// Why this exists: t04 pins the model split for the 11 domain-expert agents.
+// This companion pins the complete 14-agent roster, including the composer and
+// the two review-only agents, and asserts both key-shape invariants that make
+// the value pin meaningful.
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { AIDLC_SRC } from "../harness/fixtures.ts";
+
+const AGENTS_DIR = join(AIDLC_SRC, "agents");
+
+const AGENTS = [
+  "architect",
+  "architecture-reviewer",
+  "aws-platform",
+  "compliance",
+  "composer",
+  "delivery",
+  "design",
+  "developer",
+  "devsecops",
+  "operations",
+  "pipeline-deploy",
+  "product",
+  "product-lead",
+  "quality",
+] as const;
+
+type Agent = (typeof AGENTS)[number];
+
+const EXPECTED_MODEL: Record<Agent, "opus" | "sonnet"> = {
+  architect: "opus",
+  "architecture-reviewer": "sonnet",
+  "aws-platform": "opus",
+  compliance: "opus",
+  composer: "opus",
+  delivery: "sonnet",
+  design: "opus",
+  developer: "opus",
+  devsecops: "opus",
+  operations: "sonnet",
+  "pipeline-deploy": "sonnet",
+  product: "opus",
+  "product-lead": "sonnet",
+  quality: "opus",
+};
+
+const agentFile = (agent: Agent): string =>
+  join(AGENTS_DIR, `aidlc-${agent}-agent.md`);
+
+function frontmatter(agent: Agent): string {
+  const body = readFileSync(agentFile(agent), "utf-8");
+  const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) throw new Error(`no YAML frontmatter block in aidlc-${agent}-agent.md`);
+  return m[1];
+}
+
+function modelValues(fm: string): string[] {
+  return [...fm.matchAll(/^model:\s*(\S+)\s*$/gm)].map((m) => m[1]);
+}
+
+describe("t216 complete Claude agent model key contract", () => {
+  test("shipped Claude roster is exactly the expected 14 agent files", () => {
+    const shipped = readdirSync(AGENTS_DIR)
+      .filter((name) => name.endsWith("-agent.md"))
+      .sort();
+    const expected = AGENTS.map((agent) => `aidlc-${agent}-agent.md`).sort();
+    expect(shipped).toEqual(expected);
+  });
+
+  test("model: appears exactly once in every shipped agent frontmatter", () => {
+    for (const agent of AGENTS) {
+      const values = modelValues(frontmatter(agent));
+      expect(values.length, `aidlc-${agent}-agent.md: model: line count`).toBe(1);
+    }
+  });
+
+  test("model: values match the explicit per-agent policy", () => {
+    for (const agent of AGENTS) {
+      const values = modelValues(frontmatter(agent));
+      expect(values[0], `aidlc-${agent}-agent.md: model value`).toBe(EXPECTED_MODEL[agent]);
+    }
+  });
+
+  test("modelOverride: is absent from every shipped agent frontmatter", () => {
+    for (const agent of AGENTS) {
+      const fm = frontmatter(agent);
+      expect(
+        /^modelOverride:/m.test(fm),
+        `aidlc-${agent}-agent.md: modelOverride: must not be in frontmatter`,
+      ).toBe(false);
+    }
+  });
+});

--- a/tests/unit/t61.test.ts
+++ b/tests/unit/t61.test.ts
@@ -134,7 +134,7 @@ examples:
 description: >
   Placeholder fixture agent for t61. Not a real persona.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 
 Fixture agent body.
@@ -146,7 +146,7 @@ examples:
 description: >
   Broken fixture agent — missing display_name.
 disallowedTools: Task
-modelOverride: opus
+model: opus
 ---
 `;
   writeFileSync(file, body, "utf-8");


### PR DESCRIPTION
# fix: rename agent frontmatter `modelOverride:` to `model:` so agent tiers engage on Claude Code (2.2.15)

Fixes #533

## Problem

All 14 `core/agents/*.md` declared their model tier via a `modelOverride:` frontmatter key. Claude Code's supported subagent field is `model:` (unrecognized keys are ignored; omitted = `inherit`), so on the primary harness the key was inert and every delegated agent silently inherited the session model. The five sonnet-designated agents (`architecture-reviewer`, `product-lead`, `delivery`, `pipeline-deploy`, `operations`) never actually ran on Sonnet, as the issue's transcript evidence showed (16/16 reviewer runs on the session model; a hand-rename control engaged Sonnet immediately).

The key was functional in exactly one place: `harness/codex/emit.ts` reads it into the Codex TOML model map. Kiro CLI/IDE agent configs are hand-authored JSONs and never read the `.md` frontmatter.

## Change

- **Rename the key in all 14 agent files.** Values unchanged: 9 `opus`, 5 `sonnet` - a pure key rename (the sorted diff over `core/agents/` shows exactly the two key spellings times the two values).
- **`harness/codex/emit.ts`** now reads `fm.model` for `D7_MODEL_MAP`. The emitted `.codex/agents/*.toml` files are **byte-identical** (verified: `git diff dist/codex/.codex/agents/*.toml` is empty).
- **Kiro CLI / Kiro IDE JSON agent configs untouched** (out of scope; they carry their own `"model"` field).
- **Docs corrected, not just renamed**: `docs/reference/05-agent-system.md` and `docs/harness-engineering/03-adding-an-agent.md` previously claimed the default is `opus`; the real semantics (omitted = `inherit` = session model) are now stated. `docs/reference/11-contributing.md` and `roadmap.html` samples renamed.
- **Tests**: `t04` updated to the new key (11-agent scope and expected values unchanged); new **`t216-agent-model-key.test.ts`** pins all 14 agents: `model:` present exactly once with the documented value, and `modelOverride:` absent (the regression this issue describes). Three of t216's four assertions fail on the pre-fix bytes.
- Version 2.2.15 + CHANGELOG + README badge; `dist/` regenerated, `bun scripts/package.ts --check` green.

## Behavior change

On Claude Code, the five sonnet-designated agents now actually run on Sonnet instead of the session model. Codex and Kiro behavior is unchanged.

## Evidence

- Two independent adversarial review rounds (Claude fable tier + a gpt-5.5 second opinion). Round 1: APPROVE, pre-fix/post-fix differentiation of every t216 assertion proven against `git show HEAD:` bytes. Round 2 caught stale reference-doc content (three Model Overrides tables still describing the old 8-opus/3-sonnet roster, plus a false "Opus is the default" claim); fixed in the second commit.
- Deterministic tier: smoke+unit+integration, 239 files / 3752 assertions; reds t183 (SDK internal server error) and t185 (5s timeout, known flake) both green-alone on rerun. Unit tier standalone: 128 files, 2084 assertions, PASS.
- Targeted: t04 + t216 + t61 + t68 = 25 pass / 0 fail.

## Notes for reviewers

- Two one-character scope notes, both deliberate: the t04 comment at the `EXPECTED_MODEL` header and the renamed `conductor.md` line had pre-existing em dashes replaced with ASCII (`--` / `-`) as part of the edit.
- Sibling PR for issue #534 claims 2.2.16; the usual second-to-merge re-bump convention applies.
