### PR TITLE
fix: refuse scope-change under autonomous Construction (2.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.3] - 2026-07-10
+
+`scope-change` now refuses to run under autonomous Construction, closing the gap its sibling `recompose` closed in 2.2.8: both verbs re-shape the live plan's EXECUTE/SKIP stage inclusion, and an unattended autonomous run has no human at the gate to approve the new shape. Previously the "never re-shape the plan under autonomy" rule was engine-enforced for `recompose` but prose-only for `scope-change`. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* `scope-change` (and `/aidlc --scope <name>` on a running workflow) exits non-zero with a clear error when `Construction Autonomy Mode` is `autonomous`, naming the remediation (`aidlc-bolt set-autonomy --mode gated`, or let the swarm finish). Gated and unset modes proceed exactly as before; starting a fresh workflow with `--scope` is unaffected.
 ## [2.3.2] - 2026-07-10
 
 `/aidlc --doctor` now surfaces recorded hook drops. Hooks fail open by design - an audit-emission failure or a swallowed error must never break your tool call - and each such swallow is recorded to `aidlc/.../.aidlc-hooks-health/<hook>.drops`, written specifically for doctor to surface. Doctor never read those files, so the silent-failure telemetry was invisible. It now reports them as an advisory row. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.3.2-blue)
+![version](https://img.shields.io/badge/version-2.3.3-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -44,6 +44,7 @@ import {
   getField,
   holdsAuditLock,
   hooksHealthDir,
+  isAutonomousMode,
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
@@ -3275,6 +3276,24 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   if (!newScopeDef) die(`Unknown scope: ${newScope}. Valid scopes: ${Object.keys(scopeMapping).join(", ")}`);
 
   let content = readStateFile(projectDir, flags.intent, flags.space);
+  // AUTONOMY GUARD (the recompose guard's twin, same rationale): scope-change
+  // flips stage EXECUTE/SKIP suffixes exactly like recompose does, so an
+  // unattended autonomous Construction run must not have its plan re-shaped
+  // through this verb either - there is no human at the gate to approve the
+  // new shape. Guard placed before the same-scope early exit (fail-fast, the
+  // recompose posture): under autonomy even a no-op call is refused, so the
+  // conductor learns the rule on first contact rather than on the first
+  // differing scope. Uses the exported isAutonomousMode predicate per its
+  // contract (new gate sites use the helper; only pre-existing open-coded
+  // sites are grandfathered), so this site cannot drift from the others.
+  if (isAutonomousMode(content)) {
+    die(
+      "Cannot change scope: Construction Autonomy Mode is autonomous. Re-shaping the " +
+        "plan needs a human at the gate, and an unattended run has none. Switch to " +
+        "gated Construction first (aidlc-bolt set-autonomy --mode gated) or let the " +
+        "swarm finish, then change scope.",
+    );
+  }
   const oldScope = getField(content, "Scope");
   if (!oldScope) die("Cannot read current Scope from state file.");
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.2";
+export const AIDLC_VERSION = "2.3.3";

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -44,6 +44,7 @@ import {
   getField,
   holdsAuditLock,
   hooksHealthDir,
+  isAutonomousMode,
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
@@ -3275,6 +3276,24 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   if (!newScopeDef) die(`Unknown scope: ${newScope}. Valid scopes: ${Object.keys(scopeMapping).join(", ")}`);
 
   let content = readStateFile(projectDir, flags.intent, flags.space);
+  // AUTONOMY GUARD (the recompose guard's twin, same rationale): scope-change
+  // flips stage EXECUTE/SKIP suffixes exactly like recompose does, so an
+  // unattended autonomous Construction run must not have its plan re-shaped
+  // through this verb either - there is no human at the gate to approve the
+  // new shape. Guard placed before the same-scope early exit (fail-fast, the
+  // recompose posture): under autonomy even a no-op call is refused, so the
+  // conductor learns the rule on first contact rather than on the first
+  // differing scope. Uses the exported isAutonomousMode predicate per its
+  // contract (new gate sites use the helper; only pre-existing open-coded
+  // sites are grandfathered), so this site cannot drift from the others.
+  if (isAutonomousMode(content)) {
+    die(
+      "Cannot change scope: Construction Autonomy Mode is autonomous. Re-shaping the " +
+        "plan needs a human at the gate, and an unattended run has none. Switch to " +
+        "gated Construction first (aidlc-bolt set-autonomy --mode gated) or let the " +
+        "swarm finish, then change scope.",
+    );
+  }
   const oldScope = getField(content, "Scope");
   if (!oldScope) die("Cannot read current Scope from state file.");
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.2";
+export const AIDLC_VERSION = "2.3.3";

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -44,6 +44,7 @@ import {
   getField,
   holdsAuditLock,
   hooksHealthDir,
+  isAutonomousMode,
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
@@ -3275,6 +3276,24 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   if (!newScopeDef) die(`Unknown scope: ${newScope}. Valid scopes: ${Object.keys(scopeMapping).join(", ")}`);
 
   let content = readStateFile(projectDir, flags.intent, flags.space);
+  // AUTONOMY GUARD (the recompose guard's twin, same rationale): scope-change
+  // flips stage EXECUTE/SKIP suffixes exactly like recompose does, so an
+  // unattended autonomous Construction run must not have its plan re-shaped
+  // through this verb either - there is no human at the gate to approve the
+  // new shape. Guard placed before the same-scope early exit (fail-fast, the
+  // recompose posture): under autonomy even a no-op call is refused, so the
+  // conductor learns the rule on first contact rather than on the first
+  // differing scope. Uses the exported isAutonomousMode predicate per its
+  // contract (new gate sites use the helper; only pre-existing open-coded
+  // sites are grandfathered), so this site cannot drift from the others.
+  if (isAutonomousMode(content)) {
+    die(
+      "Cannot change scope: Construction Autonomy Mode is autonomous. Re-shaping the " +
+        "plan needs a human at the gate, and an unattended run has none. Switch to " +
+        "gated Construction first (aidlc-bolt set-autonomy --mode gated) or let the " +
+        "swarm finish, then change scope.",
+    );
+  }
   const oldScope = getField(content, "Scope");
   if (!oldScope) die("Cannot read current Scope from state file.");
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.2";
+export const AIDLC_VERSION = "2.3.3";

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -44,6 +44,7 @@ import {
   getField,
   holdsAuditLock,
   hooksHealthDir,
+  isAutonomousMode,
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
@@ -3275,6 +3276,24 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   if (!newScopeDef) die(`Unknown scope: ${newScope}. Valid scopes: ${Object.keys(scopeMapping).join(", ")}`);
 
   let content = readStateFile(projectDir, flags.intent, flags.space);
+  // AUTONOMY GUARD (the recompose guard's twin, same rationale): scope-change
+  // flips stage EXECUTE/SKIP suffixes exactly like recompose does, so an
+  // unattended autonomous Construction run must not have its plan re-shaped
+  // through this verb either - there is no human at the gate to approve the
+  // new shape. Guard placed before the same-scope early exit (fail-fast, the
+  // recompose posture): under autonomy even a no-op call is refused, so the
+  // conductor learns the rule on first contact rather than on the first
+  // differing scope. Uses the exported isAutonomousMode predicate per its
+  // contract (new gate sites use the helper; only pre-existing open-coded
+  // sites are grandfathered), so this site cannot drift from the others.
+  if (isAutonomousMode(content)) {
+    die(
+      "Cannot change scope: Construction Autonomy Mode is autonomous. Re-shaping the " +
+        "plan needs a human at the gate, and an unattended run has none. Switch to " +
+        "gated Construction first (aidlc-bolt set-autonomy --mode gated) or let the " +
+        "swarm finish, then change scope.",
+    );
+  }
   const oldScope = getField(content, "Scope");
   if (!oldScope) die("Cannot read current Scope from state file.");
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.2";
+export const AIDLC_VERSION = "2.3.3";

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -44,6 +44,7 @@ import {
   getField,
   holdsAuditLock,
   hooksHealthDir,
+  isAutonomousMode,
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
@@ -3275,6 +3276,24 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   if (!newScopeDef) die(`Unknown scope: ${newScope}. Valid scopes: ${Object.keys(scopeMapping).join(", ")}`);
 
   let content = readStateFile(projectDir, flags.intent, flags.space);
+  // AUTONOMY GUARD (the recompose guard's twin, same rationale): scope-change
+  // flips stage EXECUTE/SKIP suffixes exactly like recompose does, so an
+  // unattended autonomous Construction run must not have its plan re-shaped
+  // through this verb either - there is no human at the gate to approve the
+  // new shape. Guard placed before the same-scope early exit (fail-fast, the
+  // recompose posture): under autonomy even a no-op call is refused, so the
+  // conductor learns the rule on first contact rather than on the first
+  // differing scope. Uses the exported isAutonomousMode predicate per its
+  // contract (new gate sites use the helper; only pre-existing open-coded
+  // sites are grandfathered), so this site cannot drift from the others.
+  if (isAutonomousMode(content)) {
+    die(
+      "Cannot change scope: Construction Autonomy Mode is autonomous. Re-shaping the " +
+        "plan needs a human at the gate, and an unattended run has none. Switch to " +
+        "gated Construction first (aidlc-bolt set-autonomy --mode gated) or let the " +
+        "swarm finish, then change scope.",
+    );
+  }
   const oldScope = getField(content, "Scope");
   if (!oldScope) die("Cannot read current Scope from state file.");
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.2";
+export const AIDLC_VERSION = "2.3.3";

--- a/docs/guide/12-cli-commands.md
+++ b/docs/guide/12-cli-commands.md
@@ -340,6 +340,8 @@ Change the active scope of a running workflow.
 
 **Behavior:** Updates the scope configuration in `aidlc-state.md`, recalculates which stages should execute and which should be skipped, and logs a `SCOPE_CHANGED` audit event. Can be combined with `--depth` to override the new scope's default depth.
 
+Refused under autonomous Construction (`Construction Autonomy Mode: autonomous`), the same rule as `recompose`: re-shaping the plan needs a human at the gate, and an unattended run has none. Switch to gated Construction first (`aidlc-bolt set-autonomy --mode gated`) or let the swarm finish.
+
 On a fresh project with no workflow yet, `--scope <name>` starts one instead: it behaves exactly like `/aidlc <name>` — the workspace is initialized with the named scope and the workflow begins at its first stage.
 
 ---

--- a/tests/unit/t36.test.ts
+++ b/tests/unit/t36.test.ts
@@ -85,7 +85,7 @@
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import {
@@ -300,5 +300,45 @@ describe("t36 aidlc-utility scope-change — CLI contract (migrated from t36-uti
     expect(auditField(readAllAuditShards(p), "SCOPE_CHANGED", "Old Scope")).toBe("feature");
     // STRONGER addition: the .sh comment says the row records BOTH From and To.
     expect(auditField(readAllAuditShards(p), "SCOPE_CHANGED", "New Scope")).toBe("mvp");
+  });
+
+  // --- Autonomy guard (the recompose guard's twin) ---
+  test("8: autonomous Construction rejected - scope-change refuses with the remediation named", () => {
+    // scope-change flips stage EXECUTE/SKIP suffixes exactly like recompose;
+    // under an unattended autonomous run there is no human at the gate, so the
+    // verb must refuse (t194 pins the recompose side of the same rule). The
+    // fixture has no Construction Autonomy Mode field, so inject it as
+    // set-autonomy would.
+    const p = proj();
+    const sp = statePath(p);
+    const withAutonomy = readFileSync(sp, "utf-8").replace(
+      /- \*\*Status\*\*: Running/,
+      "- **Status**: Running\n- **Construction Autonomy Mode**: autonomous",
+    );
+    expect(withAutonomy).toContain("- **Construction Autonomy Mode**: autonomous");
+    writeFileSync(sp, withAutonomy, "utf-8");
+    const r = scopeChange(["--scope", "mvp"], p);
+    expect(r.status).not.toBe(0);
+    expect(r.out).toContain("Construction Autonomy Mode is autonomous");
+    expect(r.out).toContain("set-autonomy --mode gated");
+    // The refusal mutates nothing: state byte-identical, no SCOPE_CHANGED row.
+    expect(readFileSync(sp, "utf-8")).toBe(withAutonomy);
+    expect(scopeChangedCount(readAllAuditShards(p))).toBe(0);
+  });
+
+  test("8b: gated Construction proceeds - scope-change flips as today when autonomy is not autonomous", () => {
+    const p = proj();
+    const sp = statePath(p);
+    writeFileSync(
+      sp,
+      readFileSync(sp, "utf-8").replace(
+        /- \*\*Status\*\*: Running/,
+        "- **Status**: Running\n- **Construction Autonomy Mode**: gated",
+      ),
+      "utf-8",
+    );
+    const r = scopeChange(["--scope", "mvp"], p);
+    expect(r.status).toBe(0);
+    expect(stateField(sp, "Scope")).toBe("mvp");
   });
 });


### PR DESCRIPTION
Fixes #515

## Problem

#485 (fixed in PR #500, 2.2.8) added an engine-side refusal so `recompose` cannot re-shape the plan while `Construction Autonomy Mode` is autonomous - the rule was previously prose-only. The adversarial review of that fix surfaced that `scope-change` has the identical hole and was left out of scope: `handleScopeChange` flips stage EXECUTE/SKIP suffixes with no autonomy check, so an unattended autonomous run could still have its plan re-shaped through the scope-change verb, with no human at the gate.

## Fix

The recompose guard's twin in `handleScopeChange`, expressed through the exported `isAutonomousMode` predicate (per its contract in aidlc-lib.ts: new gate sites use the helper so the sites cannot drift; only the pre-existing open-coded sites are grandfathered). Refuses with exit non-zero and the same remediation text: switch to gated Construction first (`aidlc-bolt set-autonomy --mode gated`) or let the swarm finish.

Placement is fail-fast, before the same-scope early exit (matching recompose's posture): under autonomy even a no-op call is refused, so the conductor learns the rule on first contact. Verified unaffected paths:

- Starting a fresh workflow with `--scope` never reaches the guard (it dies on the missing state file first, and the engine routes fresh-workspace `--scope` to intent-birth).
- No autonomous caller exists: nothing in `aidlc-swarm.ts`, `aidlc-bolt.ts`, or the hooks invokes scope-change; the only engine emitter is the orchestrator's Branch-5 print when a human passes a differing `--scope`.
- An invalid scope name still wins over the autonomy refusal (validation order unchanged).

**Two adjacent gaps noted, deliberately out of scope** (same class, separate issues): `aidlc-state.ts skip` marks a pending stage `[S]` with no autonomy guard, and `config-change` rewrites Depth/Test Strategy mid-run unguarded. Same guard-shape applies; happy to file follow-ups.

## Tests

- `tests/unit/t36.test.ts` cases 8/8b (the t194 recompose-guard twins): refusal under autonomy with the remediation named, state byte-untouched, no `SCOPE_CHANGED` row emitted; gated mode proceeds exactly as before.

## Verification

- t36 9/9, t194 17/17 (recompose guard unaffected), t68 green; full smoke+unit tier: 151 files / 0 failed
- `bun run typecheck` and `bun scripts/package.ts --check` clean

## Docs

`docs/guide/12-cli-commands.md`: the `--scope` section documents the refusal and remediation.

## Release mechanics

2.2.20: version trio + CHANGELOG entry in the same commit. The sibling PR #541 (doctor hook drops) also claims 2.2.20; whichever merges second re-bumps per the conflict-trap policy.