### PR TITLE
fix(codex): count explicit structured selections as human turns (2.6.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.44] - 2026-08-21
+
+Codex structured `request_user_input` selections now mint the same `HUMAN_TURN` evidence as typed prompts, without treating empty, cancelled, timed-out, auto-resolved, error, or malformed responses as human judgment. **Upgrade:** refresh `dist/codex/`, then re-run `bun scripts/package.ts codex trust --project "/absolute/project/path"` and replace the existing hook trust tables before starting a fresh Codex session.
+
+* The new PostToolUse registration routes `request_user_input` through the existing record-human-turn target only when `tool_response` is the Codex JSON-encoded `answers: Record<questionId,{answers:string[]}>` contract and every selected value is explicit, nonblank, and passes the shared cancellation-boilerplate floor.
+* Completed-looking `{}` payloads and cancellation metadata fail closed; substantive selections remain valid, and values such as `Abort` count when they exactly match an option the question actually presented.
+* Codex duplicate delivery replays the first response and emits exactly one `HUMAN_TURN`; projects without active workflow state remain untouched.
+
 ## [2.6.43] - 2026-08-21
 
 Explicit resume now means continue immediately: `/aidlc --resume` no longer repeats the session re-entry Resume / Redo / Jump / Start Fresh menu before returning to the saved stage. Bare `/aidlc` still offers that menu when a harness session re-enters existing work. **Upgrade:** refresh your `dist/<harness>/` shell; existing workflow state needs no migration, and legacy Copilot resume markers are superseded by the next explicit resume.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.43-blue)
+![version](https://img.shields.io/badge/version-2.6.44-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/dist/codex/.codex/hooks.json
+++ b/dist/codex/.codex/hooks.json
@@ -68,6 +68,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bun .codex/hooks/aidlc-codex-adapter.ts record-human-turn"
+          }
+        ],
+        "matcher": "request_user_input"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "bun .codex/hooks/aidlc-codex-adapter.ts audit-and-sensors"
           }
         ],

--- a/dist/codex/.codex/hooks/aidlc-codex-adapter.ts
+++ b/dist/codex/.codex/hooks/aidlc-codex-adapter.ts
@@ -57,7 +57,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
-import { sessionsDir, stateFilePath } from "../tools/aidlc-lib.ts";
+import { isNonAnswer, sessionsDir, stateFilePath } from "../tools/aidlc-lib.ts";
 
 const HOOKS_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -94,6 +94,57 @@ function spawnAgentPrompt(input: CodexSpawnAgentInput): string {
     }
   }
   return parts.join("\n");
+}
+
+function offeredOptionLabels(toolInput: unknown): Map<string, Set<string>> {
+  const offered = new Map<string, Set<string>>();
+  if (toolInput === null || typeof toolInput !== "object") return offered;
+  const questions = (toolInput as Record<string, unknown>).questions;
+  if (!Array.isArray(questions)) return offered;
+  for (const question of questions) {
+    if (question === null || typeof question !== "object") continue;
+    const record = question as Record<string, unknown>;
+    if (typeof record.id !== "string" || !Array.isArray(record.options)) continue;
+    const labels = new Set<string>();
+    for (const option of record.options) {
+      if (typeof option === "string") labels.add(option.trim());
+      else if (option !== null && typeof option === "object") {
+        const candidate = option as Record<string, unknown>;
+        for (const key of ["label", "value", "text"] as const) {
+          if (typeof candidate[key] === "string") labels.add(candidate[key].trim());
+        }
+      }
+    }
+    offered.set(record.id, labels);
+  }
+  return offered;
+}
+
+export function hasExplicitHumanSelection(toolResponse: unknown, toolInput?: unknown): boolean {
+  if (typeof toolResponse !== "string") return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(toolResponse);
+  } catch {
+    return false;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const response = parsed as Record<string, unknown>;
+  if (Object.keys(response).length !== 1 || !("answers" in response)) return false;
+  const answers = response.answers;
+  if (answers === null || typeof answers !== "object" || Array.isArray(answers)) return false;
+  const selections = Object.entries(answers as Record<string, unknown>);
+  if (selections.length === 0) return false;
+  const offered = offeredOptionLabels(toolInput);
+  return selections.every(([questionId, selection]) => {
+    if (selection === null || typeof selection !== "object" || Array.isArray(selection)) return false;
+    const record = selection as Record<string, unknown>;
+    if (Object.keys(record).length !== 1 || !Array.isArray(record.answers)) return false;
+    return record.answers.length > 0 && record.answers.every((answer) => {
+      if (typeof answer !== "string" || answer.trim().length === 0) return false;
+      return !isNonAnswer(answer) || offered.get(questionId)?.has(answer.trim()) === true;
+    });
+  });
 }
 
 export async function run(
@@ -587,6 +638,13 @@ switch (target) {
   }
 
   case "record-human-turn": {
+    if (
+      codex.tool_name === "request_user_input" &&
+      !hasExplicitHumanSelection(codex.tool_response, codex.tool_input)
+    ) {
+      persistResponse("", 0);
+      return 0;
+    }
     // UserPromptSubmit: a real human acted this turn — record a HUMAN_TURN event
     // in the active intent's audit shard (human-presence gate). Gated on workflow
     // state existing (same self-gate as the core record-human-turn hook) so a prompt in a

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/dist/codex/.codex/trust-seed.toml
+++ b/dist/codex/.codex/trust-seed.toml
@@ -33,12 +33,15 @@ trusted_hash = "sha256:d13218ffc38c72b1fa91ea723d27e2037f30d350ffb018dd2bc31ed84
 trusted_hash = "sha256:e8e8844666c05ec69c7c8caea02ca0b071cecbf7fe53b127372c95e2c107245a"
 
 [hooks.state."<PROJECT_DIR>/.codex/hooks.json:post_tool_use:0:0"]
-trusted_hash = "sha256:3fbffd723a990f1569dd1cf9746bf05167c78d4e1681f48c552afb20a9213cdf"
+trusted_hash = "sha256:7d73fd0b92d376b5624f4c902d65c565e34944904f96ea5799ce2b546df883c1"
 
 [hooks.state."<PROJECT_DIR>/.codex/hooks.json:post_tool_use:1:0"]
-trusted_hash = "sha256:0f4f003fcf25c782c5e5759f3d383efe85337b6bd946735eeead020a2db8d2fe"
+trusted_hash = "sha256:3fbffd723a990f1569dd1cf9746bf05167c78d4e1681f48c552afb20a9213cdf"
 
 [hooks.state."<PROJECT_DIR>/.codex/hooks.json:post_tool_use:2:0"]
+trusted_hash = "sha256:0f4f003fcf25c782c5e5759f3d383efe85337b6bd946735eeead020a2db8d2fe"
+
+[hooks.state."<PROJECT_DIR>/.codex/hooks.json:post_tool_use:3:0"]
 trusted_hash = "sha256:a9c69375b8c0b1dab5db89087062be0ea85af428b2187e9d07b1095cac44ecd9"
 
 [hooks.state."<PROJECT_DIR>/.codex/hooks.json:pre_compact:0:0"]

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.43";
+export const AIDLC_VERSION = "2.6.44";

--- a/docs/guide/harnesses/codex-cli.md
+++ b/docs/guide/harnesses/codex-cli.md
@@ -90,6 +90,10 @@ git checkout v2
    do not append a second copy because duplicate TOML tables invalidate the
    entire config.
 
+   Re-run this trust command whenever an AI-DLC upgrade changes `.codex/hooks.json`,
+   including upgrades that add a new matcher. Replace the old tables before
+   opening a fresh Codex session; otherwise Codex silently skips the new hook.
+
 4. Back in `your-project/` (step 3 ran from the AI-DLC source checkout), merge
    the shipped `.codex/config.toml` into your `~/.codex/config.toml` (or keep
    it project-level — trusted projects read it). Verify with:

--- a/harness/codex/emit.ts
+++ b/harness/codex/emit.ts
@@ -45,6 +45,7 @@ const HOOK_WIRING: Array<{ event: string; matcher?: string; target: string }> = 
   // No matcher: the plan-approval-guard target self-filters (spawn_agent
   // naming the developer agent; everything else exits 0 instantly).
   { event: "PreToolUse", target: "plan-approval-guard" },
+  { event: "PostToolUse", matcher: "request_user_input", target: "record-human-turn" },
   { event: "PostToolUse", matcher: "apply_patch", target: "audit-and-sensors" },
   { event: "PostToolUse", matcher: "update_plan", target: "sync-workflow-state" },
   { event: "PostToolUse", matcher: "Bash", target: "rebuild-stage-graph" },

--- a/harness/codex/hooks/aidlc-codex-adapter.ts
+++ b/harness/codex/hooks/aidlc-codex-adapter.ts
@@ -57,7 +57,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
-import { sessionsDir, stateFilePath } from "../tools/aidlc-lib.ts";
+import { isNonAnswer, sessionsDir, stateFilePath } from "../tools/aidlc-lib.ts";
 
 const HOOKS_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -94,6 +94,57 @@ function spawnAgentPrompt(input: CodexSpawnAgentInput): string {
     }
   }
   return parts.join("\n");
+}
+
+function offeredOptionLabels(toolInput: unknown): Map<string, Set<string>> {
+  const offered = new Map<string, Set<string>>();
+  if (toolInput === null || typeof toolInput !== "object") return offered;
+  const questions = (toolInput as Record<string, unknown>).questions;
+  if (!Array.isArray(questions)) return offered;
+  for (const question of questions) {
+    if (question === null || typeof question !== "object") continue;
+    const record = question as Record<string, unknown>;
+    if (typeof record.id !== "string" || !Array.isArray(record.options)) continue;
+    const labels = new Set<string>();
+    for (const option of record.options) {
+      if (typeof option === "string") labels.add(option.trim());
+      else if (option !== null && typeof option === "object") {
+        const candidate = option as Record<string, unknown>;
+        for (const key of ["label", "value", "text"] as const) {
+          if (typeof candidate[key] === "string") labels.add(candidate[key].trim());
+        }
+      }
+    }
+    offered.set(record.id, labels);
+  }
+  return offered;
+}
+
+export function hasExplicitHumanSelection(toolResponse: unknown, toolInput?: unknown): boolean {
+  if (typeof toolResponse !== "string") return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(toolResponse);
+  } catch {
+    return false;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const response = parsed as Record<string, unknown>;
+  if (Object.keys(response).length !== 1 || !("answers" in response)) return false;
+  const answers = response.answers;
+  if (answers === null || typeof answers !== "object" || Array.isArray(answers)) return false;
+  const selections = Object.entries(answers as Record<string, unknown>);
+  if (selections.length === 0) return false;
+  const offered = offeredOptionLabels(toolInput);
+  return selections.every(([questionId, selection]) => {
+    if (selection === null || typeof selection !== "object" || Array.isArray(selection)) return false;
+    const record = selection as Record<string, unknown>;
+    if (Object.keys(record).length !== 1 || !Array.isArray(record.answers)) return false;
+    return record.answers.length > 0 && record.answers.every((answer) => {
+      if (typeof answer !== "string" || answer.trim().length === 0) return false;
+      return !isNonAnswer(answer) || offered.get(questionId)?.has(answer.trim()) === true;
+    });
+  });
 }
 
 export async function run(
@@ -587,6 +638,13 @@ switch (target) {
   }
 
   case "record-human-turn": {
+    if (
+      codex.tool_name === "request_user_input" &&
+      !hasExplicitHumanSelection(codex.tool_response, codex.tool_input)
+    ) {
+      persistResponse("", 0);
+      return 0;
+    }
     // UserPromptSubmit: a real human acted this turn — record a HUMAN_TURN event
     // in the active intent's audit shard (human-presence gate). Gated on workflow
     // state existing (same self-gate as the core record-human-turn hook) so a prompt in a

--- a/tests/unit/t149-codex-hook-adapter.test.ts
+++ b/tests/unit/t149-codex-hook-adapter.test.ts
@@ -1,7 +1,7 @@
 // t149-codex-hook-adapter: the Codex stdin shim normalizes live-captured
 // payloads into the core hooks' contract.
 //
-// covers: file:hooks/aidlc-continue-workflow.ts, file:hooks/aidlc-session-start.ts, file:hooks/aidlc-sync-workflow-state.ts, file:hooks/aidlc-log-subagent.ts, file:hooks/aidlc-write-audit-log.ts, hook:aidlc-plan-approval-guard
+// covers: file:hooks/aidlc-continue-workflow.ts, file:hooks/aidlc-session-start.ts, file:hooks/aidlc-sync-workflow-state.ts, file:hooks/aidlc-log-subagent.ts, file:hooks/aidlc-write-audit-log.ts, hook:aidlc-plan-approval-guard, function:hasExplicitHumanSelection
 //
 // WHAT. Each case pipes a fixture from tests/fixtures/codex-hook-payloads/
 // (field-verbatim captures off Codex CLI 0.137.0 — the spike corpus at
@@ -47,6 +47,7 @@ import { delimiter, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createIntent,
+  humanActedSinceGate,
   sessionsDir,
   setActiveIntentCursor,
   setActiveSpaceCursor,
@@ -252,6 +253,126 @@ function runAdapter(
     code: r.status ?? -1,
   };
 }
+
+function structuredSelectionPayload(
+  dir: string,
+  toolResponse: unknown,
+  turn = "structured-turn",
+): Record<string, unknown> {
+  return {
+    hook_event_name: "PostToolUse",
+    session_id: "codex-structured-session",
+    turn_id: turn,
+    cwd: dir,
+    tool_name: "request_user_input",
+    tool_input: {
+      questions: [{ id: "decision", question: "Approve?", options: ["Approve", "Reject"] }],
+    },
+    tool_response: toolResponse,
+    tool_use_id: `request-${turn}`,
+  };
+}
+
+function humanTurnCount(dir: string): number {
+  return readAudit(dir).split("**Event**: HUMAN_TURN").length - 1;
+}
+
+describe("t149 Codex structured request_user_input presence", () => {
+  test("an explicit nested selection mints exactly one HUMAN_TURN across duplicate delivery", () => {
+    const dir = scratchProject(true);
+    try {
+      const payload = structuredSelectionPayload(dir, JSON.stringify({
+        answers: { decision: { answers: ["Approve"] } },
+      }));
+      expect(runAdapter(dir, "record-human-turn", payload).code).toBe(0);
+      expect(runAdapter(dir, "record-human-turn", payload).code).toBe(0);
+      expect(humanTurnCount(dir)).toBe(1);
+      expect(humanActedSinceGate(dir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("substantive Codex answer arrays mint, including opaque question IDs and cancellation words in prose", () => {
+    for (const [index, answer] of ["Approve", "cancel the standing order via cron"].entries()) {
+      const dir = scratchProject(true);
+      try {
+        const payload = structuredSelectionPayload(
+          dir,
+          JSON.stringify({
+            answers: { [index === 0 ? "error" : "decision"]: { answers: [answer] } },
+          }),
+          `direct-${index}`,
+        );
+        expect(runAdapter(dir, "record-human-turn", payload).code).toBe(0);
+        expect(humanTurnCount(dir)).toBe(1);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("an explicit Abort option is human judgment, not cancellation boilerplate", () => {
+    const dir = scratchProject(true);
+    try {
+      const payload = structuredSelectionPayload(
+        dir,
+        JSON.stringify({ answers: { decision: { answers: ["Abort"] } } }),
+        "explicit-abort",
+      );
+      const question = ((payload.tool_input as { questions: Array<{ options: string[] }> }).questions[0]);
+      question.options.push("Abort");
+      expect(runAdapter(dir, "record-human-turn", payload).code).toBe(0);
+      expect(humanTurnCount(dir)).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("empty, cancelled, timed-out, auto-resolved, error, and malformed responses do not mint", () => {
+    const responses: unknown[] = [
+      "{}",
+      JSON.stringify({ status: "completed", answer: "Cancelled" }),
+      JSON.stringify({ status: "cancelled", answer: "Approve" }),
+      JSON.stringify({ answers: { decision: { answers: ["Approve"] } }, timedOut: true }),
+      JSON.stringify({ answers: { decision: { answers: ["Approve"] } }, auto_resolved: true }),
+      JSON.stringify({ answers: { decision: { answers: ["Approve"] } }, error: "transport failed" }),
+      JSON.stringify({ answers: {} }),
+      JSON.stringify({ answers: { decision: { answers: [] } } }),
+      JSON.stringify({ answers: { decision: { answers: ["   "] } } }),
+      JSON.stringify({ answers: { decision: { answers: ["Approve", "Dismissed"] } } }),
+      JSON.stringify({ answers: { decision: { answers: ["Abort"] } } }),
+      JSON.stringify({ answer: "Approve" }),
+      JSON.stringify({ selection: "Approve" }),
+      "{malformed-json",
+      { answers: { decision: { answers: ["Approve"] } } },
+      null,
+    ];
+    const dir = scratchProject(true);
+    try {
+      for (const [index, response] of responses.entries()) {
+        const payload = structuredSelectionPayload(dir, response, `rejected-${index}`);
+        expect(runAdapter(dir, "record-human-turn", payload).code).toBe(0);
+      }
+      expect(humanTurnCount(dir)).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a valid selection outside an active workflow is a no-op", () => {
+    const dir = scratchProject(false);
+    try {
+      const payload = structuredSelectionPayload(dir, JSON.stringify({
+        answers: { decision: { answers: ["Approve"] } },
+      }));
+      expect(runAdapter(dir, "record-human-turn", payload).code).toBe(0);
+      expect(humanTurnCount(dir)).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("t149 Codex hook adapter (live-captured payload fixtures)", () => {
   test("1: stop blocks with a reason while the workflow has pending work (verbatim contract)", () => {

--- a/tests/unit/t150-codex-packaging.test.ts
+++ b/tests/unit/t150-codex-packaging.test.ts
@@ -51,6 +51,7 @@ const TRUST_SUFFIXES = [
   "post_tool_use:0:0",
   "post_tool_use:1:0",
   "post_tool_use:2:0",
+  "post_tool_use:3:0",
   "pre_compact:0:0",
   "subagent_stop:0:0",
   "stop:0:0",
@@ -207,7 +208,11 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     );
     // Matchers per the verified tool-name map.
     const postMatchers = wiring.hooks.PostToolUse.map((g) => g.matcher).sort();
-    expect(postMatchers).toEqual(["Bash", "apply_patch", "update_plan"]);
+    expect(postMatchers).toEqual(["Bash", "apply_patch", "request_user_input", "update_plan"]);
+    expect(
+      wiring.hooks.PostToolUse.find((group) => group.matcher === "request_user_input")
+        ?.hooks[0]?.command,
+    ).toBe("bun .codex/hooks/aidlc-codex-adapter.ts record-human-turn");
     // Every registration routes through the single authored adapter.
     for (const groups of Object.values(wiring.hooks)) {
       for (const g of groups) {


### PR DESCRIPTION
## Summary

- mint the existing HUMAN_TURN audit event after answered Codex request_user_input calls
- keep typed UserPromptSubmit handling unchanged
- pin the generated PostToolUse matcher and regenerate all distributions

This fixes approval and interview gates rejecting a structured selection until the user types a second acknowledgment.

## Testing

- bun test tests/unit/t150-codex-packaging.test.ts tests/unit/t132-hooks-doc-count-sync.test.ts tests/unit/t68-version-changelog-sync.test.ts
- bun scripts/package.ts --check
- full unit runner: 138/140 files passed; t140 and t142 could not load the optional @anthropic-ai/claude-agent-sdk dependency in this checkout