### PR TITLE
fix: advance the state file's Phase Progress rows at phase boundaries (2.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.6] - 2026-07-12
+
+The state file's `## Phase Progress` section now advances with the workflow. Previously it was seeded once at intent birth and never touched again, so a few stages in it still showed `Ideation: Pending` above a fully-checked Ideation checkbox block - a visible contradiction for anyone reading `aidlc-state.md` directly (routing was never affected; the engine reads `Lifecycle Phase` and the checkboxes, and `/aidlc --status` recomputes its own phase block). The section now tracks every transition the tools already audit. **Upgrade:** re-copy your `dist/<harness>/` shell into the project; a run already mid-flow keeps its stale rows for boundaries it already passed, and corrects from its next boundary onward.
+
+* Intent birth seeds the section truthfully: `Initialization: Verified` (birth completes every init stage before handing off) and the first post-init phase `Active`; later phases stay `Pending`/`Skipped` by scope as before.
+* `advance` and `finalize` at a phase boundary flip the completed phase to `Verified` and the entered phase to `Active`; non-boundary transitions leave the section byte-identical. `complete-workflow` (and a final-stage `finalize`) flips the last phase to `Verified`.
+* Stage/phase jumps update the rows too: a forward jump marks the source phase `Verified`, wholly jumped-over phases `Skipped`, and the target phase `Active`; a backward jump returns reset phases to `Pending`.
+* `scope-change` and `recompose` re-derive only the not-yet-reached rows (`Pending`/`Skipped`) against the new plan; `Verified`/`Active` rows record history and are never rewritten.
+* A state file without the section (older installs) still transitions cleanly - the row update is a silent no-op, never an error.
+
 ## [2.3.5] - 2026-07-12
 
 Completes the plugin mechanism with **install-time plugin selection** and the full plugin content surface, proven at scale in a customer pilot. Plugins add, the install selects: a plugin can now ship scopes, agent personas, and knowledge alongside stages, every stage-enumerating surface is generated from the compiled graph, and a new `select-plugins` command lets an install choose which plugins' content its users see (core is the implicit `aidlc` plugin and can itself be deselected; a plugin-only install shows only that plugin's commands and scopes). The ownership frontmatter field is renamed from `bundle:` to `plugin:` (the old key is rejected with an error naming the fix). **Upgrade:** re-copy your `dist/<harness>/` shell and re-run any installed plugin's compose hook; a plugin tree still authoring `bundle:` must rename the key to `plugin:`. Existing installs without a selection are otherwise unaffected (an absent `plugins` key enables everything, and the shipped trees are byte-identical on core surfaces).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.3.5-blue)
+![version](https://img.shields.io/badge/version-2.3.6-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-jump.ts
+++ b/core/tools/aidlc-jump.ts
@@ -21,6 +21,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   stageIndex,
   writeStateFile,
 } from "./aidlc-lib.js";
@@ -365,6 +366,40 @@ function handleExecute(args: string[]): void {
   // Count [x] checkboxes for Completed field
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // Phase Progress rows track the boundary crossing the audit trio below
+  // records. Forward: the source phase's remaining work was force-[S]'d and
+  // PHASE_VERIFIED is emitted, so its row reads Verified; any phase jumped
+  // over entirely reads Skipped. Backward (or a caller-mis-specified redo
+  // that crosses a boundary): every phase after the target just had its
+  // EXECUTE stages reset to pending above, so those rows return to Pending,
+  // leaving zero-EXECUTE phases at their birth Skipped. Either way the
+  // target's phase is now the active one.
+  if (crossesPhaseBoundary && currentStageForPhase) {
+    const phaseIdx = (p: string): number =>
+      (PHASES as readonly string[]).indexOf(p);
+    if (direction === "forward") {
+      content = setPhaseProgress(content, currentStageForPhase.phase, "Verified");
+      for (
+        let i = phaseIdx(currentStageForPhase.phase) + 1;
+        i < phaseIdx(targetStage.phase);
+        i++
+      ) {
+        content = setPhaseProgress(content, PHASES[i], "Skipped");
+      }
+    } else {
+      for (let i = phaseIdx(targetStage.phase) + 1; i < PHASES.length; i++) {
+        const p = PHASES[i];
+        const hasExecute = graph.some(
+          (s) =>
+            s.phase === p &&
+            effectiveAction(suffixes, scopeMapping, s.slug) === "EXECUTE"
+        );
+        if (hasExecute) content = setPhaseProgress(content, p, "Pending");
+      }
+    }
+    content = setPhaseProgress(content, targetStage.phase, "Active");
+  }
 
   // Find last completed stage before target
   const allCheckboxes = parseCheckboxes(content);

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -2240,6 +2240,22 @@ export function setFieldStrict(content: string, field: string, value: string): s
   return content.replace(regex, `$1 ${value}`);
 }
 
+// setPhaseProgress: flip one `- **<Phase>**: <status>` row in the state
+// file's `## Phase Progress` section. The row label is the capitalized phase
+// slug ("ideation" -> "Ideation"), and each label appears exactly once in the
+// state template (only inside that section), so the plain setField match
+// cannot collide with another field. A no-op when the row is absent (an older
+// or hand-edited state file): the section is display-only, so a missing row
+// must never fail a transition.
+export function setPhaseProgress(
+  content: string,
+  phase: string,
+  status: "Pending" | "Active" | "Verified" | "Skipped",
+): string {
+  const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+  return setField(content, label, status);
+}
+
 // setOrInsertField: update field if present; otherwise insert a new
 // `- **Field**: value` bullet at the end of the named `## Heading` section.
 // Intended for optional fields that don't ship in the current state-template

--- a/core/tools/aidlc-state.ts
+++ b/core/tools/aidlc-state.ts
@@ -46,6 +46,7 @@ import {
   setField,
   setFieldStrict,
   setOrInsertField,
+  setPhaseProgress,
   stagesInScope,
   updateIntentStatus,
   validScopes,
@@ -1195,6 +1196,16 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // Phase Progress rows mirror the boundary events emitted below: the
+  // completed phase's row flips to Verified and the entered phase's to Active,
+  // in the same state write. Display-only (routing reads Lifecycle Phase and
+  // the checkboxes), but without the flip the section holds its birth values
+  // forever and contradicts the checkboxes underneath it.
+  if (crossesPhaseBoundary) {
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
+    content = setPhaseProgress(content, nextStage.phase, "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1307,11 +1318,20 @@ function handleFinalize(args: string[]): void {
     content = setField(content, "Next Stage", nextAfterNext ? nextAfterNext.slug : "none");
     content = setField(content, "Lifecycle Phase", nextStage.phase.toUpperCase());
     content = setField(content, "Active Agent", nextStage.lead_agent);
+    // Phase Progress boundary flip - mirrors handleAdvance's. finalize moves
+    // the cursor without emitting phase events, but the display rows must
+    // still track the phase the cursor now sits in.
+    if (completedStage.phase !== nextStage.phase) {
+      content = setPhaseProgress(content, completedStage.phase, "Verified");
+      content = setPhaseProgress(content, nextStage.phase, "Active");
+    }
   } else {
     content = setField(content, "Current Stage", "none");
     content = setField(content, "Next Stage", "none");
     content = setField(content, "Status", "Completed");
     content = setField(content, "In Progress", "none");
+    // No next stage: the workflow is done - the final phase is Verified.
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
   }
   content = setField(content, "Last Completed Stage", completedSlug);
   content = setField(content, "Last Updated", timestamp);
@@ -1393,6 +1413,11 @@ function handleCompleteWorkflow(args: string[]): void {
   content = setField(content, "In Progress", "none");
   content = setField(content, "Next Stage", "none");
   content = setField(content, "Next Action", "Workflow complete");
+  // Phase Progress: workflow completion is the final phase's boundary - its
+  // row flips to Verified alongside the PHASE_COMPLETED/PHASE_VERIFIED pair
+  // emitted below (the advance-side flip only fires on stage->stage
+  // boundaries, so the last phase would otherwise stay Active forever).
+  content = setPhaseProgress(content, completedStage.phase, "Verified");
 
   // 4. Atomic audit emissions. Refuse silent fallback — matches handleAdvance.
   const scope = getField(content, "Scope");

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -84,6 +84,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   setStageSuffix,
   scopeGridPath,
   scopesDir,
@@ -3473,12 +3474,17 @@ function handleIntentBirthStateBuild(
 
   const projectDesc = flags.arguments || "[Project description]";
 
-  // Phase Progress — per-phase status. Initialization is always Active at init
-  // time. Other phases are Skipped if the adjusted scope mapping has zero
-  // EXECUTE stages for that phase, otherwise Pending. Pending phases flip to
-  // Active on their phase-boundary advance and to Verified at phase completion.
+  // Phase Progress - per-phase status. Birth completes every initialization
+  // stage ([x]) and hands off to the first post-init stage ([-]), emitting the
+  // PHASE_COMPLETED/VERIFIED/STARTED trio for that boundary below - so the
+  // seed mirrors it: Initialization is Verified and the first post-init
+  // stage's phase is Active. Later phases are Skipped if the adjusted scope
+  // mapping has zero EXECUTE stages for them, otherwise Pending; advance /
+  // finalize / complete-workflow / jump flip the rows at each subsequent
+  // boundary (aidlc-state.ts, aidlc-jump.ts).
   const phaseStatus = (phase: string): string => {
-    if (phase === "initialization") return "Active";
+    if (phase === "initialization") return "Verified";
+    if (firstPostInitEntry && phase === firstPostInitEntry.phase) return "Active";
     const stagesInPhase = graph.filter((s) => s.phase === phase);
     const hasExecute = stagesInPhase.some(
       (s) => (adjustedMapping[s.slug] || scopeDef.stages[s.slug] || "SKIP") === "EXECUTE"
@@ -4097,6 +4103,21 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   ).length;
   content = setField(content, "Completed", String(completedCount));
 
+  // Re-derive the not-yet-reached Phase Progress rows against the new plan:
+  // a phase the new scope leaves without EXECUTE stages reads Skipped, one it
+  // (re-)includes reads Pending. Verified/Active rows record history the
+  // scope change does not rewrite (checkbox states are preserved above for
+  // the same reason), so they are left untouched.
+  for (const phase of PHASES) {
+    const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+    const row = getField(content, label);
+    if (row !== "Pending" && row !== "Skipped") continue;
+    const hasExecute = graph.some(
+      (s) => s.phase === phase && (adjustedMapping[s.slug] || "SKIP") === "EXECUTE"
+    );
+    content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+  }
+
   // Update Last Updated timestamp
   content = setField(content, "Last Updated", isoTimestamp());
 
@@ -4348,6 +4369,19 @@ function handleRecompose(projectDir: string, flags: Record<string, string>): voi
       (c) => c.state === "completed" && eff(c.slug) === "EXECUTE",
     ).length;
     content = setField(content, "Completed", String(completedCount));
+    // Re-derive not-yet-reached Phase Progress rows against the effective
+    // plan (scope-change's twin): a flip can empty a phase of EXECUTE stages
+    // (-> Skipped) or give a Skipped phase its first (-> Pending).
+    // Verified/Active rows are history and stay untouched.
+    for (const phase of PHASES) {
+      const phaseLabel = phase.charAt(0).toUpperCase() + phase.slice(1);
+      const row = getField(content, phaseLabel);
+      if (row !== "Pending" && row !== "Skipped") continue;
+      const hasExecute = graph.some(
+        (s) => s.phase === phase && eff(s.slug) === "EXECUTE",
+      );
+      content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+    }
     // The Next Stage projection over the recomposed plan (override-aware).
     if (currentSlug) {
       const next = nextInScopeStage(currentSlug, scope, content);

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.5";
+export const AIDLC_VERSION = "2.3.6";

--- a/dist/claude/.claude/tools/aidlc-jump.ts
+++ b/dist/claude/.claude/tools/aidlc-jump.ts
@@ -21,6 +21,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   stageIndex,
   writeStateFile,
 } from "./aidlc-lib.js";
@@ -365,6 +366,40 @@ function handleExecute(args: string[]): void {
   // Count [x] checkboxes for Completed field
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // Phase Progress rows track the boundary crossing the audit trio below
+  // records. Forward: the source phase's remaining work was force-[S]'d and
+  // PHASE_VERIFIED is emitted, so its row reads Verified; any phase jumped
+  // over entirely reads Skipped. Backward (or a caller-mis-specified redo
+  // that crosses a boundary): every phase after the target just had its
+  // EXECUTE stages reset to pending above, so those rows return to Pending,
+  // leaving zero-EXECUTE phases at their birth Skipped. Either way the
+  // target's phase is now the active one.
+  if (crossesPhaseBoundary && currentStageForPhase) {
+    const phaseIdx = (p: string): number =>
+      (PHASES as readonly string[]).indexOf(p);
+    if (direction === "forward") {
+      content = setPhaseProgress(content, currentStageForPhase.phase, "Verified");
+      for (
+        let i = phaseIdx(currentStageForPhase.phase) + 1;
+        i < phaseIdx(targetStage.phase);
+        i++
+      ) {
+        content = setPhaseProgress(content, PHASES[i], "Skipped");
+      }
+    } else {
+      for (let i = phaseIdx(targetStage.phase) + 1; i < PHASES.length; i++) {
+        const p = PHASES[i];
+        const hasExecute = graph.some(
+          (s) =>
+            s.phase === p &&
+            effectiveAction(suffixes, scopeMapping, s.slug) === "EXECUTE"
+        );
+        if (hasExecute) content = setPhaseProgress(content, p, "Pending");
+      }
+    }
+    content = setPhaseProgress(content, targetStage.phase, "Active");
+  }
 
   // Find last completed stage before target
   const allCheckboxes = parseCheckboxes(content);

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -2240,6 +2240,22 @@ export function setFieldStrict(content: string, field: string, value: string): s
   return content.replace(regex, `$1 ${value}`);
 }
 
+// setPhaseProgress: flip one `- **<Phase>**: <status>` row in the state
+// file's `## Phase Progress` section. The row label is the capitalized phase
+// slug ("ideation" -> "Ideation"), and each label appears exactly once in the
+// state template (only inside that section), so the plain setField match
+// cannot collide with another field. A no-op when the row is absent (an older
+// or hand-edited state file): the section is display-only, so a missing row
+// must never fail a transition.
+export function setPhaseProgress(
+  content: string,
+  phase: string,
+  status: "Pending" | "Active" | "Verified" | "Skipped",
+): string {
+  const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+  return setField(content, label, status);
+}
+
 // setOrInsertField: update field if present; otherwise insert a new
 // `- **Field**: value` bullet at the end of the named `## Heading` section.
 // Intended for optional fields that don't ship in the current state-template

--- a/dist/claude/.claude/tools/aidlc-state.ts
+++ b/dist/claude/.claude/tools/aidlc-state.ts
@@ -46,6 +46,7 @@ import {
   setField,
   setFieldStrict,
   setOrInsertField,
+  setPhaseProgress,
   stagesInScope,
   updateIntentStatus,
   validScopes,
@@ -1195,6 +1196,16 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // Phase Progress rows mirror the boundary events emitted below: the
+  // completed phase's row flips to Verified and the entered phase's to Active,
+  // in the same state write. Display-only (routing reads Lifecycle Phase and
+  // the checkboxes), but without the flip the section holds its birth values
+  // forever and contradicts the checkboxes underneath it.
+  if (crossesPhaseBoundary) {
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
+    content = setPhaseProgress(content, nextStage.phase, "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1307,11 +1318,20 @@ function handleFinalize(args: string[]): void {
     content = setField(content, "Next Stage", nextAfterNext ? nextAfterNext.slug : "none");
     content = setField(content, "Lifecycle Phase", nextStage.phase.toUpperCase());
     content = setField(content, "Active Agent", nextStage.lead_agent);
+    // Phase Progress boundary flip - mirrors handleAdvance's. finalize moves
+    // the cursor without emitting phase events, but the display rows must
+    // still track the phase the cursor now sits in.
+    if (completedStage.phase !== nextStage.phase) {
+      content = setPhaseProgress(content, completedStage.phase, "Verified");
+      content = setPhaseProgress(content, nextStage.phase, "Active");
+    }
   } else {
     content = setField(content, "Current Stage", "none");
     content = setField(content, "Next Stage", "none");
     content = setField(content, "Status", "Completed");
     content = setField(content, "In Progress", "none");
+    // No next stage: the workflow is done - the final phase is Verified.
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
   }
   content = setField(content, "Last Completed Stage", completedSlug);
   content = setField(content, "Last Updated", timestamp);
@@ -1393,6 +1413,11 @@ function handleCompleteWorkflow(args: string[]): void {
   content = setField(content, "In Progress", "none");
   content = setField(content, "Next Stage", "none");
   content = setField(content, "Next Action", "Workflow complete");
+  // Phase Progress: workflow completion is the final phase's boundary - its
+  // row flips to Verified alongside the PHASE_COMPLETED/PHASE_VERIFIED pair
+  // emitted below (the advance-side flip only fires on stage->stage
+  // boundaries, so the last phase would otherwise stay Active forever).
+  content = setPhaseProgress(content, completedStage.phase, "Verified");
 
   // 4. Atomic audit emissions. Refuse silent fallback — matches handleAdvance.
   const scope = getField(content, "Scope");

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -84,6 +84,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   setStageSuffix,
   scopeGridPath,
   scopesDir,
@@ -3473,12 +3474,17 @@ function handleIntentBirthStateBuild(
 
   const projectDesc = flags.arguments || "[Project description]";
 
-  // Phase Progress — per-phase status. Initialization is always Active at init
-  // time. Other phases are Skipped if the adjusted scope mapping has zero
-  // EXECUTE stages for that phase, otherwise Pending. Pending phases flip to
-  // Active on their phase-boundary advance and to Verified at phase completion.
+  // Phase Progress - per-phase status. Birth completes every initialization
+  // stage ([x]) and hands off to the first post-init stage ([-]), emitting the
+  // PHASE_COMPLETED/VERIFIED/STARTED trio for that boundary below - so the
+  // seed mirrors it: Initialization is Verified and the first post-init
+  // stage's phase is Active. Later phases are Skipped if the adjusted scope
+  // mapping has zero EXECUTE stages for them, otherwise Pending; advance /
+  // finalize / complete-workflow / jump flip the rows at each subsequent
+  // boundary (aidlc-state.ts, aidlc-jump.ts).
   const phaseStatus = (phase: string): string => {
-    if (phase === "initialization") return "Active";
+    if (phase === "initialization") return "Verified";
+    if (firstPostInitEntry && phase === firstPostInitEntry.phase) return "Active";
     const stagesInPhase = graph.filter((s) => s.phase === phase);
     const hasExecute = stagesInPhase.some(
       (s) => (adjustedMapping[s.slug] || scopeDef.stages[s.slug] || "SKIP") === "EXECUTE"
@@ -4097,6 +4103,21 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   ).length;
   content = setField(content, "Completed", String(completedCount));
 
+  // Re-derive the not-yet-reached Phase Progress rows against the new plan:
+  // a phase the new scope leaves without EXECUTE stages reads Skipped, one it
+  // (re-)includes reads Pending. Verified/Active rows record history the
+  // scope change does not rewrite (checkbox states are preserved above for
+  // the same reason), so they are left untouched.
+  for (const phase of PHASES) {
+    const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+    const row = getField(content, label);
+    if (row !== "Pending" && row !== "Skipped") continue;
+    const hasExecute = graph.some(
+      (s) => s.phase === phase && (adjustedMapping[s.slug] || "SKIP") === "EXECUTE"
+    );
+    content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+  }
+
   // Update Last Updated timestamp
   content = setField(content, "Last Updated", isoTimestamp());
 
@@ -4348,6 +4369,19 @@ function handleRecompose(projectDir: string, flags: Record<string, string>): voi
       (c) => c.state === "completed" && eff(c.slug) === "EXECUTE",
     ).length;
     content = setField(content, "Completed", String(completedCount));
+    // Re-derive not-yet-reached Phase Progress rows against the effective
+    // plan (scope-change's twin): a flip can empty a phase of EXECUTE stages
+    // (-> Skipped) or give a Skipped phase its first (-> Pending).
+    // Verified/Active rows are history and stay untouched.
+    for (const phase of PHASES) {
+      const phaseLabel = phase.charAt(0).toUpperCase() + phase.slice(1);
+      const row = getField(content, phaseLabel);
+      if (row !== "Pending" && row !== "Skipped") continue;
+      const hasExecute = graph.some(
+        (s) => s.phase === phase && eff(s.slug) === "EXECUTE",
+      );
+      content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+    }
     // The Next Stage projection over the recomposed plan (override-aware).
     if (currentSlug) {
       const next = nextInScopeStage(currentSlug, scope, content);

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.5";
+export const AIDLC_VERSION = "2.3.6";

--- a/dist/codex/.codex/tools/aidlc-jump.ts
+++ b/dist/codex/.codex/tools/aidlc-jump.ts
@@ -21,6 +21,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   stageIndex,
   writeStateFile,
 } from "./aidlc-lib.js";
@@ -365,6 +366,40 @@ function handleExecute(args: string[]): void {
   // Count [x] checkboxes for Completed field
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // Phase Progress rows track the boundary crossing the audit trio below
+  // records. Forward: the source phase's remaining work was force-[S]'d and
+  // PHASE_VERIFIED is emitted, so its row reads Verified; any phase jumped
+  // over entirely reads Skipped. Backward (or a caller-mis-specified redo
+  // that crosses a boundary): every phase after the target just had its
+  // EXECUTE stages reset to pending above, so those rows return to Pending,
+  // leaving zero-EXECUTE phases at their birth Skipped. Either way the
+  // target's phase is now the active one.
+  if (crossesPhaseBoundary && currentStageForPhase) {
+    const phaseIdx = (p: string): number =>
+      (PHASES as readonly string[]).indexOf(p);
+    if (direction === "forward") {
+      content = setPhaseProgress(content, currentStageForPhase.phase, "Verified");
+      for (
+        let i = phaseIdx(currentStageForPhase.phase) + 1;
+        i < phaseIdx(targetStage.phase);
+        i++
+      ) {
+        content = setPhaseProgress(content, PHASES[i], "Skipped");
+      }
+    } else {
+      for (let i = phaseIdx(targetStage.phase) + 1; i < PHASES.length; i++) {
+        const p = PHASES[i];
+        const hasExecute = graph.some(
+          (s) =>
+            s.phase === p &&
+            effectiveAction(suffixes, scopeMapping, s.slug) === "EXECUTE"
+        );
+        if (hasExecute) content = setPhaseProgress(content, p, "Pending");
+      }
+    }
+    content = setPhaseProgress(content, targetStage.phase, "Active");
+  }
 
   // Find last completed stage before target
   const allCheckboxes = parseCheckboxes(content);

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -2240,6 +2240,22 @@ export function setFieldStrict(content: string, field: string, value: string): s
   return content.replace(regex, `$1 ${value}`);
 }
 
+// setPhaseProgress: flip one `- **<Phase>**: <status>` row in the state
+// file's `## Phase Progress` section. The row label is the capitalized phase
+// slug ("ideation" -> "Ideation"), and each label appears exactly once in the
+// state template (only inside that section), so the plain setField match
+// cannot collide with another field. A no-op when the row is absent (an older
+// or hand-edited state file): the section is display-only, so a missing row
+// must never fail a transition.
+export function setPhaseProgress(
+  content: string,
+  phase: string,
+  status: "Pending" | "Active" | "Verified" | "Skipped",
+): string {
+  const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+  return setField(content, label, status);
+}
+
 // setOrInsertField: update field if present; otherwise insert a new
 // `- **Field**: value` bullet at the end of the named `## Heading` section.
 // Intended for optional fields that don't ship in the current state-template

--- a/dist/codex/.codex/tools/aidlc-state.ts
+++ b/dist/codex/.codex/tools/aidlc-state.ts
@@ -46,6 +46,7 @@ import {
   setField,
   setFieldStrict,
   setOrInsertField,
+  setPhaseProgress,
   stagesInScope,
   updateIntentStatus,
   validScopes,
@@ -1195,6 +1196,16 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // Phase Progress rows mirror the boundary events emitted below: the
+  // completed phase's row flips to Verified and the entered phase's to Active,
+  // in the same state write. Display-only (routing reads Lifecycle Phase and
+  // the checkboxes), but without the flip the section holds its birth values
+  // forever and contradicts the checkboxes underneath it.
+  if (crossesPhaseBoundary) {
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
+    content = setPhaseProgress(content, nextStage.phase, "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1307,11 +1318,20 @@ function handleFinalize(args: string[]): void {
     content = setField(content, "Next Stage", nextAfterNext ? nextAfterNext.slug : "none");
     content = setField(content, "Lifecycle Phase", nextStage.phase.toUpperCase());
     content = setField(content, "Active Agent", nextStage.lead_agent);
+    // Phase Progress boundary flip - mirrors handleAdvance's. finalize moves
+    // the cursor without emitting phase events, but the display rows must
+    // still track the phase the cursor now sits in.
+    if (completedStage.phase !== nextStage.phase) {
+      content = setPhaseProgress(content, completedStage.phase, "Verified");
+      content = setPhaseProgress(content, nextStage.phase, "Active");
+    }
   } else {
     content = setField(content, "Current Stage", "none");
     content = setField(content, "Next Stage", "none");
     content = setField(content, "Status", "Completed");
     content = setField(content, "In Progress", "none");
+    // No next stage: the workflow is done - the final phase is Verified.
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
   }
   content = setField(content, "Last Completed Stage", completedSlug);
   content = setField(content, "Last Updated", timestamp);
@@ -1393,6 +1413,11 @@ function handleCompleteWorkflow(args: string[]): void {
   content = setField(content, "In Progress", "none");
   content = setField(content, "Next Stage", "none");
   content = setField(content, "Next Action", "Workflow complete");
+  // Phase Progress: workflow completion is the final phase's boundary - its
+  // row flips to Verified alongside the PHASE_COMPLETED/PHASE_VERIFIED pair
+  // emitted below (the advance-side flip only fires on stage->stage
+  // boundaries, so the last phase would otherwise stay Active forever).
+  content = setPhaseProgress(content, completedStage.phase, "Verified");
 
   // 4. Atomic audit emissions. Refuse silent fallback — matches handleAdvance.
   const scope = getField(content, "Scope");

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -84,6 +84,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   setStageSuffix,
   scopeGridPath,
   scopesDir,
@@ -3473,12 +3474,17 @@ function handleIntentBirthStateBuild(
 
   const projectDesc = flags.arguments || "[Project description]";
 
-  // Phase Progress — per-phase status. Initialization is always Active at init
-  // time. Other phases are Skipped if the adjusted scope mapping has zero
-  // EXECUTE stages for that phase, otherwise Pending. Pending phases flip to
-  // Active on their phase-boundary advance and to Verified at phase completion.
+  // Phase Progress - per-phase status. Birth completes every initialization
+  // stage ([x]) and hands off to the first post-init stage ([-]), emitting the
+  // PHASE_COMPLETED/VERIFIED/STARTED trio for that boundary below - so the
+  // seed mirrors it: Initialization is Verified and the first post-init
+  // stage's phase is Active. Later phases are Skipped if the adjusted scope
+  // mapping has zero EXECUTE stages for them, otherwise Pending; advance /
+  // finalize / complete-workflow / jump flip the rows at each subsequent
+  // boundary (aidlc-state.ts, aidlc-jump.ts).
   const phaseStatus = (phase: string): string => {
-    if (phase === "initialization") return "Active";
+    if (phase === "initialization") return "Verified";
+    if (firstPostInitEntry && phase === firstPostInitEntry.phase) return "Active";
     const stagesInPhase = graph.filter((s) => s.phase === phase);
     const hasExecute = stagesInPhase.some(
       (s) => (adjustedMapping[s.slug] || scopeDef.stages[s.slug] || "SKIP") === "EXECUTE"
@@ -4097,6 +4103,21 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   ).length;
   content = setField(content, "Completed", String(completedCount));
 
+  // Re-derive the not-yet-reached Phase Progress rows against the new plan:
+  // a phase the new scope leaves without EXECUTE stages reads Skipped, one it
+  // (re-)includes reads Pending. Verified/Active rows record history the
+  // scope change does not rewrite (checkbox states are preserved above for
+  // the same reason), so they are left untouched.
+  for (const phase of PHASES) {
+    const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+    const row = getField(content, label);
+    if (row !== "Pending" && row !== "Skipped") continue;
+    const hasExecute = graph.some(
+      (s) => s.phase === phase && (adjustedMapping[s.slug] || "SKIP") === "EXECUTE"
+    );
+    content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+  }
+
   // Update Last Updated timestamp
   content = setField(content, "Last Updated", isoTimestamp());
 
@@ -4348,6 +4369,19 @@ function handleRecompose(projectDir: string, flags: Record<string, string>): voi
       (c) => c.state === "completed" && eff(c.slug) === "EXECUTE",
     ).length;
     content = setField(content, "Completed", String(completedCount));
+    // Re-derive not-yet-reached Phase Progress rows against the effective
+    // plan (scope-change's twin): a flip can empty a phase of EXECUTE stages
+    // (-> Skipped) or give a Skipped phase its first (-> Pending).
+    // Verified/Active rows are history and stay untouched.
+    for (const phase of PHASES) {
+      const phaseLabel = phase.charAt(0).toUpperCase() + phase.slice(1);
+      const row = getField(content, phaseLabel);
+      if (row !== "Pending" && row !== "Skipped") continue;
+      const hasExecute = graph.some(
+        (s) => s.phase === phase && eff(s.slug) === "EXECUTE",
+      );
+      content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+    }
     // The Next Stage projection over the recomposed plan (override-aware).
     if (currentSlug) {
       const next = nextInScopeStage(currentSlug, scope, content);

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.5";
+export const AIDLC_VERSION = "2.3.6";

--- a/dist/kiro-ide/.kiro/tools/aidlc-jump.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-jump.ts
@@ -21,6 +21,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   stageIndex,
   writeStateFile,
 } from "./aidlc-lib.js";
@@ -365,6 +366,40 @@ function handleExecute(args: string[]): void {
   // Count [x] checkboxes for Completed field
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // Phase Progress rows track the boundary crossing the audit trio below
+  // records. Forward: the source phase's remaining work was force-[S]'d and
+  // PHASE_VERIFIED is emitted, so its row reads Verified; any phase jumped
+  // over entirely reads Skipped. Backward (or a caller-mis-specified redo
+  // that crosses a boundary): every phase after the target just had its
+  // EXECUTE stages reset to pending above, so those rows return to Pending,
+  // leaving zero-EXECUTE phases at their birth Skipped. Either way the
+  // target's phase is now the active one.
+  if (crossesPhaseBoundary && currentStageForPhase) {
+    const phaseIdx = (p: string): number =>
+      (PHASES as readonly string[]).indexOf(p);
+    if (direction === "forward") {
+      content = setPhaseProgress(content, currentStageForPhase.phase, "Verified");
+      for (
+        let i = phaseIdx(currentStageForPhase.phase) + 1;
+        i < phaseIdx(targetStage.phase);
+        i++
+      ) {
+        content = setPhaseProgress(content, PHASES[i], "Skipped");
+      }
+    } else {
+      for (let i = phaseIdx(targetStage.phase) + 1; i < PHASES.length; i++) {
+        const p = PHASES[i];
+        const hasExecute = graph.some(
+          (s) =>
+            s.phase === p &&
+            effectiveAction(suffixes, scopeMapping, s.slug) === "EXECUTE"
+        );
+        if (hasExecute) content = setPhaseProgress(content, p, "Pending");
+      }
+    }
+    content = setPhaseProgress(content, targetStage.phase, "Active");
+  }
 
   // Find last completed stage before target
   const allCheckboxes = parseCheckboxes(content);

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -2240,6 +2240,22 @@ export function setFieldStrict(content: string, field: string, value: string): s
   return content.replace(regex, `$1 ${value}`);
 }
 
+// setPhaseProgress: flip one `- **<Phase>**: <status>` row in the state
+// file's `## Phase Progress` section. The row label is the capitalized phase
+// slug ("ideation" -> "Ideation"), and each label appears exactly once in the
+// state template (only inside that section), so the plain setField match
+// cannot collide with another field. A no-op when the row is absent (an older
+// or hand-edited state file): the section is display-only, so a missing row
+// must never fail a transition.
+export function setPhaseProgress(
+  content: string,
+  phase: string,
+  status: "Pending" | "Active" | "Verified" | "Skipped",
+): string {
+  const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+  return setField(content, label, status);
+}
+
 // setOrInsertField: update field if present; otherwise insert a new
 // `- **Field**: value` bullet at the end of the named `## Heading` section.
 // Intended for optional fields that don't ship in the current state-template

--- a/dist/kiro-ide/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-state.ts
@@ -46,6 +46,7 @@ import {
   setField,
   setFieldStrict,
   setOrInsertField,
+  setPhaseProgress,
   stagesInScope,
   updateIntentStatus,
   validScopes,
@@ -1195,6 +1196,16 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // Phase Progress rows mirror the boundary events emitted below: the
+  // completed phase's row flips to Verified and the entered phase's to Active,
+  // in the same state write. Display-only (routing reads Lifecycle Phase and
+  // the checkboxes), but without the flip the section holds its birth values
+  // forever and contradicts the checkboxes underneath it.
+  if (crossesPhaseBoundary) {
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
+    content = setPhaseProgress(content, nextStage.phase, "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1307,11 +1318,20 @@ function handleFinalize(args: string[]): void {
     content = setField(content, "Next Stage", nextAfterNext ? nextAfterNext.slug : "none");
     content = setField(content, "Lifecycle Phase", nextStage.phase.toUpperCase());
     content = setField(content, "Active Agent", nextStage.lead_agent);
+    // Phase Progress boundary flip - mirrors handleAdvance's. finalize moves
+    // the cursor without emitting phase events, but the display rows must
+    // still track the phase the cursor now sits in.
+    if (completedStage.phase !== nextStage.phase) {
+      content = setPhaseProgress(content, completedStage.phase, "Verified");
+      content = setPhaseProgress(content, nextStage.phase, "Active");
+    }
   } else {
     content = setField(content, "Current Stage", "none");
     content = setField(content, "Next Stage", "none");
     content = setField(content, "Status", "Completed");
     content = setField(content, "In Progress", "none");
+    // No next stage: the workflow is done - the final phase is Verified.
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
   }
   content = setField(content, "Last Completed Stage", completedSlug);
   content = setField(content, "Last Updated", timestamp);
@@ -1393,6 +1413,11 @@ function handleCompleteWorkflow(args: string[]): void {
   content = setField(content, "In Progress", "none");
   content = setField(content, "Next Stage", "none");
   content = setField(content, "Next Action", "Workflow complete");
+  // Phase Progress: workflow completion is the final phase's boundary - its
+  // row flips to Verified alongside the PHASE_COMPLETED/PHASE_VERIFIED pair
+  // emitted below (the advance-side flip only fires on stage->stage
+  // boundaries, so the last phase would otherwise stay Active forever).
+  content = setPhaseProgress(content, completedStage.phase, "Verified");
 
   // 4. Atomic audit emissions. Refuse silent fallback — matches handleAdvance.
   const scope = getField(content, "Scope");

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -84,6 +84,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   setStageSuffix,
   scopeGridPath,
   scopesDir,
@@ -3473,12 +3474,17 @@ function handleIntentBirthStateBuild(
 
   const projectDesc = flags.arguments || "[Project description]";
 
-  // Phase Progress — per-phase status. Initialization is always Active at init
-  // time. Other phases are Skipped if the adjusted scope mapping has zero
-  // EXECUTE stages for that phase, otherwise Pending. Pending phases flip to
-  // Active on their phase-boundary advance and to Verified at phase completion.
+  // Phase Progress - per-phase status. Birth completes every initialization
+  // stage ([x]) and hands off to the first post-init stage ([-]), emitting the
+  // PHASE_COMPLETED/VERIFIED/STARTED trio for that boundary below - so the
+  // seed mirrors it: Initialization is Verified and the first post-init
+  // stage's phase is Active. Later phases are Skipped if the adjusted scope
+  // mapping has zero EXECUTE stages for them, otherwise Pending; advance /
+  // finalize / complete-workflow / jump flip the rows at each subsequent
+  // boundary (aidlc-state.ts, aidlc-jump.ts).
   const phaseStatus = (phase: string): string => {
-    if (phase === "initialization") return "Active";
+    if (phase === "initialization") return "Verified";
+    if (firstPostInitEntry && phase === firstPostInitEntry.phase) return "Active";
     const stagesInPhase = graph.filter((s) => s.phase === phase);
     const hasExecute = stagesInPhase.some(
       (s) => (adjustedMapping[s.slug] || scopeDef.stages[s.slug] || "SKIP") === "EXECUTE"
@@ -4097,6 +4103,21 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   ).length;
   content = setField(content, "Completed", String(completedCount));
 
+  // Re-derive the not-yet-reached Phase Progress rows against the new plan:
+  // a phase the new scope leaves without EXECUTE stages reads Skipped, one it
+  // (re-)includes reads Pending. Verified/Active rows record history the
+  // scope change does not rewrite (checkbox states are preserved above for
+  // the same reason), so they are left untouched.
+  for (const phase of PHASES) {
+    const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+    const row = getField(content, label);
+    if (row !== "Pending" && row !== "Skipped") continue;
+    const hasExecute = graph.some(
+      (s) => s.phase === phase && (adjustedMapping[s.slug] || "SKIP") === "EXECUTE"
+    );
+    content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+  }
+
   // Update Last Updated timestamp
   content = setField(content, "Last Updated", isoTimestamp());
 
@@ -4348,6 +4369,19 @@ function handleRecompose(projectDir: string, flags: Record<string, string>): voi
       (c) => c.state === "completed" && eff(c.slug) === "EXECUTE",
     ).length;
     content = setField(content, "Completed", String(completedCount));
+    // Re-derive not-yet-reached Phase Progress rows against the effective
+    // plan (scope-change's twin): a flip can empty a phase of EXECUTE stages
+    // (-> Skipped) or give a Skipped phase its first (-> Pending).
+    // Verified/Active rows are history and stay untouched.
+    for (const phase of PHASES) {
+      const phaseLabel = phase.charAt(0).toUpperCase() + phase.slice(1);
+      const row = getField(content, phaseLabel);
+      if (row !== "Pending" && row !== "Skipped") continue;
+      const hasExecute = graph.some(
+        (s) => s.phase === phase && eff(s.slug) === "EXECUTE",
+      );
+      content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+    }
     // The Next Stage projection over the recomposed plan (override-aware).
     if (currentSlug) {
       const next = nextInScopeStage(currentSlug, scope, content);

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.5";
+export const AIDLC_VERSION = "2.3.6";

--- a/dist/kiro/.kiro/tools/aidlc-jump.ts
+++ b/dist/kiro/.kiro/tools/aidlc-jump.ts
@@ -21,6 +21,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   stageIndex,
   writeStateFile,
 } from "./aidlc-lib.js";
@@ -365,6 +366,40 @@ function handleExecute(args: string[]): void {
   // Count [x] checkboxes for Completed field
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // Phase Progress rows track the boundary crossing the audit trio below
+  // records. Forward: the source phase's remaining work was force-[S]'d and
+  // PHASE_VERIFIED is emitted, so its row reads Verified; any phase jumped
+  // over entirely reads Skipped. Backward (or a caller-mis-specified redo
+  // that crosses a boundary): every phase after the target just had its
+  // EXECUTE stages reset to pending above, so those rows return to Pending,
+  // leaving zero-EXECUTE phases at their birth Skipped. Either way the
+  // target's phase is now the active one.
+  if (crossesPhaseBoundary && currentStageForPhase) {
+    const phaseIdx = (p: string): number =>
+      (PHASES as readonly string[]).indexOf(p);
+    if (direction === "forward") {
+      content = setPhaseProgress(content, currentStageForPhase.phase, "Verified");
+      for (
+        let i = phaseIdx(currentStageForPhase.phase) + 1;
+        i < phaseIdx(targetStage.phase);
+        i++
+      ) {
+        content = setPhaseProgress(content, PHASES[i], "Skipped");
+      }
+    } else {
+      for (let i = phaseIdx(targetStage.phase) + 1; i < PHASES.length; i++) {
+        const p = PHASES[i];
+        const hasExecute = graph.some(
+          (s) =>
+            s.phase === p &&
+            effectiveAction(suffixes, scopeMapping, s.slug) === "EXECUTE"
+        );
+        if (hasExecute) content = setPhaseProgress(content, p, "Pending");
+      }
+    }
+    content = setPhaseProgress(content, targetStage.phase, "Active");
+  }
 
   // Find last completed stage before target
   const allCheckboxes = parseCheckboxes(content);

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -2240,6 +2240,22 @@ export function setFieldStrict(content: string, field: string, value: string): s
   return content.replace(regex, `$1 ${value}`);
 }
 
+// setPhaseProgress: flip one `- **<Phase>**: <status>` row in the state
+// file's `## Phase Progress` section. The row label is the capitalized phase
+// slug ("ideation" -> "Ideation"), and each label appears exactly once in the
+// state template (only inside that section), so the plain setField match
+// cannot collide with another field. A no-op when the row is absent (an older
+// or hand-edited state file): the section is display-only, so a missing row
+// must never fail a transition.
+export function setPhaseProgress(
+  content: string,
+  phase: string,
+  status: "Pending" | "Active" | "Verified" | "Skipped",
+): string {
+  const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+  return setField(content, label, status);
+}
+
 // setOrInsertField: update field if present; otherwise insert a new
 // `- **Field**: value` bullet at the end of the named `## Heading` section.
 // Intended for optional fields that don't ship in the current state-template

--- a/dist/kiro/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro/.kiro/tools/aidlc-state.ts
@@ -46,6 +46,7 @@ import {
   setField,
   setFieldStrict,
   setOrInsertField,
+  setPhaseProgress,
   stagesInScope,
   updateIntentStatus,
   validScopes,
@@ -1195,6 +1196,16 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // Phase Progress rows mirror the boundary events emitted below: the
+  // completed phase's row flips to Verified and the entered phase's to Active,
+  // in the same state write. Display-only (routing reads Lifecycle Phase and
+  // the checkboxes), but without the flip the section holds its birth values
+  // forever and contradicts the checkboxes underneath it.
+  if (crossesPhaseBoundary) {
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
+    content = setPhaseProgress(content, nextStage.phase, "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1307,11 +1318,20 @@ function handleFinalize(args: string[]): void {
     content = setField(content, "Next Stage", nextAfterNext ? nextAfterNext.slug : "none");
     content = setField(content, "Lifecycle Phase", nextStage.phase.toUpperCase());
     content = setField(content, "Active Agent", nextStage.lead_agent);
+    // Phase Progress boundary flip - mirrors handleAdvance's. finalize moves
+    // the cursor without emitting phase events, but the display rows must
+    // still track the phase the cursor now sits in.
+    if (completedStage.phase !== nextStage.phase) {
+      content = setPhaseProgress(content, completedStage.phase, "Verified");
+      content = setPhaseProgress(content, nextStage.phase, "Active");
+    }
   } else {
     content = setField(content, "Current Stage", "none");
     content = setField(content, "Next Stage", "none");
     content = setField(content, "Status", "Completed");
     content = setField(content, "In Progress", "none");
+    // No next stage: the workflow is done - the final phase is Verified.
+    content = setPhaseProgress(content, completedStage.phase, "Verified");
   }
   content = setField(content, "Last Completed Stage", completedSlug);
   content = setField(content, "Last Updated", timestamp);
@@ -1393,6 +1413,11 @@ function handleCompleteWorkflow(args: string[]): void {
   content = setField(content, "In Progress", "none");
   content = setField(content, "Next Stage", "none");
   content = setField(content, "Next Action", "Workflow complete");
+  // Phase Progress: workflow completion is the final phase's boundary - its
+  // row flips to Verified alongside the PHASE_COMPLETED/PHASE_VERIFIED pair
+  // emitted below (the advance-side flip only fires on stage->stage
+  // boundaries, so the last phase would otherwise stay Active forever).
+  content = setPhaseProgress(content, completedStage.phase, "Verified");
 
   // 4. Atomic audit emissions. Refuse silent fallback — matches handleAdvance.
   const scope = getField(content, "Scope");

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -84,6 +84,7 @@ import {
   type StageEntry,
   setCheckbox,
   setField,
+  setPhaseProgress,
   setStageSuffix,
   scopeGridPath,
   scopesDir,
@@ -3473,12 +3474,17 @@ function handleIntentBirthStateBuild(
 
   const projectDesc = flags.arguments || "[Project description]";
 
-  // Phase Progress — per-phase status. Initialization is always Active at init
-  // time. Other phases are Skipped if the adjusted scope mapping has zero
-  // EXECUTE stages for that phase, otherwise Pending. Pending phases flip to
-  // Active on their phase-boundary advance and to Verified at phase completion.
+  // Phase Progress - per-phase status. Birth completes every initialization
+  // stage ([x]) and hands off to the first post-init stage ([-]), emitting the
+  // PHASE_COMPLETED/VERIFIED/STARTED trio for that boundary below - so the
+  // seed mirrors it: Initialization is Verified and the first post-init
+  // stage's phase is Active. Later phases are Skipped if the adjusted scope
+  // mapping has zero EXECUTE stages for them, otherwise Pending; advance /
+  // finalize / complete-workflow / jump flip the rows at each subsequent
+  // boundary (aidlc-state.ts, aidlc-jump.ts).
   const phaseStatus = (phase: string): string => {
-    if (phase === "initialization") return "Active";
+    if (phase === "initialization") return "Verified";
+    if (firstPostInitEntry && phase === firstPostInitEntry.phase) return "Active";
     const stagesInPhase = graph.filter((s) => s.phase === phase);
     const hasExecute = stagesInPhase.some(
       (s) => (adjustedMapping[s.slug] || scopeDef.stages[s.slug] || "SKIP") === "EXECUTE"
@@ -4097,6 +4103,21 @@ function handleScopeChange(projectDir: string, flags: Record<string, string>): v
   ).length;
   content = setField(content, "Completed", String(completedCount));
 
+  // Re-derive the not-yet-reached Phase Progress rows against the new plan:
+  // a phase the new scope leaves without EXECUTE stages reads Skipped, one it
+  // (re-)includes reads Pending. Verified/Active rows record history the
+  // scope change does not rewrite (checkbox states are preserved above for
+  // the same reason), so they are left untouched.
+  for (const phase of PHASES) {
+    const label = phase.charAt(0).toUpperCase() + phase.slice(1);
+    const row = getField(content, label);
+    if (row !== "Pending" && row !== "Skipped") continue;
+    const hasExecute = graph.some(
+      (s) => s.phase === phase && (adjustedMapping[s.slug] || "SKIP") === "EXECUTE"
+    );
+    content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+  }
+
   // Update Last Updated timestamp
   content = setField(content, "Last Updated", isoTimestamp());
 
@@ -4348,6 +4369,19 @@ function handleRecompose(projectDir: string, flags: Record<string, string>): voi
       (c) => c.state === "completed" && eff(c.slug) === "EXECUTE",
     ).length;
     content = setField(content, "Completed", String(completedCount));
+    // Re-derive not-yet-reached Phase Progress rows against the effective
+    // plan (scope-change's twin): a flip can empty a phase of EXECUTE stages
+    // (-> Skipped) or give a Skipped phase its first (-> Pending).
+    // Verified/Active rows are history and stay untouched.
+    for (const phase of PHASES) {
+      const phaseLabel = phase.charAt(0).toUpperCase() + phase.slice(1);
+      const row = getField(content, phaseLabel);
+      if (row !== "Pending" && row !== "Skipped") continue;
+      const hasExecute = graph.some(
+        (s) => s.phase === phase && eff(s.slug) === "EXECUTE",
+      );
+      content = setPhaseProgress(content, phase, hasExecute ? "Pending" : "Skipped");
+    }
     // The Next Stage projection over the recomposed plan (override-aware).
     if (currentSlug) {
       const next = nextInScopeStage(currentSlug, scope, content);

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.5";
+export const AIDLC_VERSION = "2.3.6";

--- a/docs/reference/12-state-machine.md
+++ b/docs/reference/12-state-machine.md
@@ -68,14 +68,16 @@ stateDiagram-v2
 
 **Status values:** `Pending`, `Active`, `Verified`, `Skipped`.
 
-Phase state is tracked in the `## Phase Progress` section of `aidlc-state.md`. Intent birth stamps `Pending` for every phase, emits `PHASE_SKIPPED` per phase the scope excludes (before any stage starts), then promotes the current phase to `Active`. Phase completion fires both `PHASE_COMPLETED` and `PHASE_VERIFIED` at the phase boundary, then `PHASE_STARTED` for the next one.
+Phase state is tracked in the `## Phase Progress` section of `aidlc-state.md`. Intent birth seeds the section: `Initialization` lands `Verified` (birth completes every init stage before handing off), the first post-init stage's phase lands `Active`, and each later phase lands `Skipped` when the scope leaves it without EXECUTE stages (one `PHASE_SKIPPED` audit row each) or `Pending` otherwise. Phase completion fires both `PHASE_COMPLETED` and `PHASE_VERIFIED` at the phase boundary, then `PHASE_STARTED` for the next one, and the rows flip in the same state write. The section is display-only: routing reads `Lifecycle Phase` and the Stage Progress checkboxes, and `/aidlc --status` recomputes its phase block live.
 
 | Transition | Trigger | Emitter |
 |---|---|---|
-| `Pending → Active` (first phase) | `aidlc-utility intent-birth` | `tools/aidlc-utility.ts` |
-| `Pending → Skipped` | `aidlc-utility intent-birth` (per scope exclusion) | `tools/aidlc-utility.ts` |
-| `Active → Verified` | `aidlc-state advance` or `complete-workflow` at phase boundary | `tools/aidlc-state.ts` |
-| `Pending → Active` (boundary) | `aidlc-state advance` at phase boundary, or `aidlc-jump execute` | `tools/aidlc-state.ts`, `tools/aidlc-jump.ts` |
+| seed (`Verified`/`Active`/`Pending`/`Skipped`) | `aidlc-utility intent-birth` | `tools/aidlc-utility.ts` |
+| `Active -> Verified` | `aidlc-state advance`, `finalize`, or `complete-workflow` at phase boundary; forward `aidlc-jump execute` | `tools/aidlc-state.ts`, `tools/aidlc-jump.ts` |
+| `Pending -> Active` (boundary) | `aidlc-state advance` or `finalize` at phase boundary, or `aidlc-jump execute` | `tools/aidlc-state.ts`, `tools/aidlc-jump.ts` |
+| `Pending -> Skipped` (jumped over) | forward `aidlc-jump execute` past a whole phase | `tools/aidlc-jump.ts` |
+| `Verified/Active -> Pending` reset | backward `aidlc-jump execute` (reset phases with EXECUTE stages) | `tools/aidlc-jump.ts` |
+| `Pending <-> Skipped` re-derivation | `aidlc-utility scope-change` / `recompose` (not-yet-reached rows only) | `tools/aidlc-utility.ts` |
 
 At the init→post-init hand-off, `aidlc-utility intent-birth` itself emits `PHASE_COMPLETED + PHASE_VERIFIED + PHASE_STARTED + STAGE_STARTED` after the final init stage so the audit trail captures the transition instead of going silent between birth and the first `advance`.
 

--- a/tests/.coverage-ratchet.json
+++ b/tests/.coverage-ratchet.json
@@ -1,7 +1,7 @@
 {
   "note": "Committed baseline: covered-unit count per class. The --check ratchet fails CI if any class's covered count DROPS below these numbers without a reviewed deferred entry. Monotonic anti-regression: you can cover more, never silently less. Regenerate with: bun tests/gen-coverage-registry.ts",
   "coveredByClass": {
-    "function": 94,
+    "function": 95,
     "audit": 31,
     "scope": 9,
     "stage": 8,

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -20,9 +20,9 @@
     "render-surface": "tui"
   },
   "counts": {
-    "total": 451,
+    "total": 452,
     "enumeratedByClass": {
-      "function": 230,
+      "function": 231,
       "audit": 72,
       "scope": 9,
       "stage": 32,
@@ -31,7 +31,7 @@
       "render-surface": 7
     },
     "coveredByClass": {
-      "function": 94,
+      "function": 95,
       "audit": 31,
       "scope": 9,
       "stage": 8,
@@ -2668,6 +2668,18 @@
     },
     {
       "unitClass": "function",
+      "unitId": "function:setPhaseProgress",
+      "minMechanism": "none",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
+          "mechanism": "cli"
+        }
+      ],
+      "status": "covered"
+    },
+    {
+      "unitClass": "function",
       "unitId": "function:setStageSuffix",
       "minMechanism": "none",
       "coveredBy": [
@@ -4178,6 +4190,10 @@
         {
           "file": "tests/unit/t19.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
+          "mechanism": "cli"
         }
       ],
       "status": "covered"
@@ -4436,6 +4452,10 @@
         {
           "file": "tests/unit/t17.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
+          "mechanism": "cli"
         }
       ],
       "status": "covered"
@@ -4496,6 +4516,10 @@
         {
           "file": "tests/unit/t17.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
+          "mechanism": "cli"
         }
       ],
       "status": "covered"
@@ -4519,6 +4543,10 @@
       "coveredBy": [
         {
           "file": "tests/unit/t17.test.ts",
+          "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -5008,6 +5036,10 @@
         {
           "file": "tests/unit/t211-detect-submodules.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
+          "mechanism": "cli"
         }
       ],
       "status": "covered"
@@ -5027,6 +5059,10 @@
         },
         {
           "file": "tests/unit/t194-recompose.test.ts",
+          "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -5051,6 +5087,10 @@
       "coveredBy": [
         {
           "file": "tests/unit/t214-routing-cost-strings.test.ts",
+          "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t232-phase-progress-flip.test.ts",
           "mechanism": "cli"
         },
         {

--- a/tests/integration/t39.test.ts
+++ b/tests/integration/t39.test.ts
@@ -37,9 +37,9 @@
 //   - .sh assertion 3  every excluded phase recorded `- **<Phase>**: Skipped`
 //       in `## Phase Progress` -> here: phaseProgressStatus(state, phase) ===
 //       "Skipped" for each excluded phase (same observable, exact line match).
-//       STRONGER: we also assert Initialization === "Active" and every
-//       NON-excluded post-init phase is NOT "Skipped" (the .sh only checked
-//       the excluded set; this pins the complement too).
+//       STRONGER: we also assert Initialization === "Verified" (birth
+//       completes every init stage before handing off; the .sh only checked
+//       the excluded set).
 //
 // 9 scopes × 3 .sh asserts = 27 -> 27 expect()-bearing test() cases here
 // (one describe per scope, 3 test()s each).
@@ -271,8 +271,12 @@ describe("t39 aidlc-utility init — per-scope phase sequence (migrated from t39
         for (const phase of excluded) {
           expect(phaseProgressStatus(s, cap(phase))).toBe("Skipped");
         }
-        // STRONGER (the .sh never checked the Init row): Initialization is
-        // always Active at init time (aidlc-utility.ts:2029). We deliberately
+        // STRONGER (the .sh never checked the Init row): birth completes every
+        // initialization stage and hands off to the first post-init stage, so
+        // the seed reads Initialization=Verified with the first post-init
+        // stage's phase Active (phaseStatus in aidlc-utility.ts - before the
+        // issue-556 flip landed this seeded Active/Pending, which then never
+        // advanced). We deliberately
         // do NOT assert the non-excluded post-init phases are non-Skipped: the
         // PHASE_SKIPPED audit count (driven by stagesInScope) and the Phase
         // Progress status (driven by the depth-adjustedMapping, line 2032)
@@ -282,7 +286,7 @@ describe("t39 aidlc-utility init — per-scope phase sequence (migrated from t39
         // stage. That divergence is outside this .sh's contract (it only
         // asserts the excluded set appears as Skipped), so asserting the
         // complement would over-reach past the original observable.
-        expect(phaseProgressStatus(s, "Initialization")).toBe("Active");
+        expect(phaseProgressStatus(s, "Initialization")).toBe("Verified");
       });
     });
   }

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -854,6 +854,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t218-kiro-ide-hook-adapter.test.ts",
     "unit/t222-plugin-runner-naming.test.ts",
     "unit/t223-naming-enforcement.test.ts",
+    "unit/t232-phase-progress-flip.test.ts",
     "unit/t205-gate-revision-backstop.test.ts",
     "unit/t214-routing-cost-strings.test.ts",
     "unit/t209-unit-major-iteration.test.ts",

--- a/tests/unit/t232-phase-progress-flip.test.ts
+++ b/tests/unit/t232-phase-progress-flip.test.ts
@@ -1,0 +1,304 @@
+// covers: subcommand:aidlc-state:advance, subcommand:aidlc-state:finalize, subcommand:aidlc-state:complete-workflow, subcommand:aidlc-jump:execute, subcommand:aidlc-utility:scope-change, subcommand:aidlc-utility:recompose, subcommand:aidlc-utility:intent-birth, function:setPhaseProgress
+//
+// t232 - the state file's `## Phase Progress` rows advance with the workflow.
+//
+// Regression pin for the write-once drift: intent-birth seeded the section and
+// no code ever flipped a row afterwards, so a reader saw `- **Ideation**:
+// Pending` above a fully-checked Ideation checkbox block. The section is
+// display-only (routing reads Lifecycle Phase + the checkboxes; --status
+// recomputes its own block), so every assertion here is about the rendered
+// state file, not routing.
+//
+// The contract under test (setPhaseProgress in aidlc-lib.ts + its call sites):
+//   - intent-birth seeds Initialization=Verified (birth completes every init
+//     stage), the first post-init stage's phase Active, later phases
+//     Pending/Skipped by EXECUTE presence.
+//   - advance: non-boundary leaves the section byte-identical; a boundary
+//     flips completed->Verified and entered->Active in the same write.
+//   - finalize: same boundary flip; on the final stage the phase -> Verified.
+//   - complete-workflow: final phase -> Verified.
+//   - jump forward: source phase -> Verified, jumped-over phases -> Skipped,
+//     target -> Active. jump backward: reset phases with EXECUTE stages ->
+//     Pending, target -> Active.
+//   - scope-change / recompose: re-derive only Pending/Skipped rows against
+//     the new plan; Verified/Active rows are history and stay untouched.
+//   - a state file WITHOUT the section still transitions cleanly (the flip is
+//     a silent no-op - display must never fail a state machine move).
+//
+// Mechanism: cli - every case spawns the REAL shipped tools (dist/claude) via
+// spawnSync, asserting exit code + the on-disk aidlc-state.md, the same
+// process boundary t17/t39 pin. Deterministic: no LLM, no live driver.
+//
+// FIXTURE DISCIPLINE: live-birth cases use a fresh createTestProject() temp
+// dir per describe (birth populates state itself, as in t39); the seeded
+// cases copy fixtures via seedStateFile + sedReplaceInFile. Cleanup in
+// afterAll. Nothing is written under tests/fixtures/**.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  cleanupTestProject,
+  createTestProject,
+  seedAuditFile,
+  seededStateFile,
+  seedStateFile,
+  sedReplaceInFile,
+} from "../harness/fixtures.ts";
+
+const BUN = process.execPath;
+const TOOLS_DIR = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "dist", "claude",
+  ".claude",
+  "tools",
+);
+const STATE_TOOL = join(TOOLS_DIR, "aidlc-state.ts");
+const JUMP_TOOL = join(TOOLS_DIR, "aidlc-jump.ts");
+const UTILITY_TOOL = join(TOOLS_DIR, "aidlc-utility.ts");
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  for (const d of tempDirs) cleanupTestProject(d);
+});
+
+interface RunResult {
+  rc: number;
+  combined: string;
+}
+
+function run(tool: string, proj: string, args: string[]): RunResult {
+  const res = spawnSync(BUN, [tool, ...args, "--project-dir", proj], {
+    encoding: "utf-8",
+    cwd: proj,
+  });
+  return {
+    rc: res.status ?? -1,
+    combined: `${res.stdout ?? ""}${res.stderr ?? ""}`,
+  };
+}
+
+// Resolve the live state file: the born intent's record when a birth ran,
+// else the seeded default record (both under aidlc/spaces/...). Mirrors
+// t17's recordDirOf, trimmed to the two shapes this file produces.
+function statePath(proj: string): string {
+  const intentsDir = join(proj, "aidlc", "spaces", "default", "intents");
+  try {
+    const rec = readFileSync(join(intentsDir, "active-intent"), "utf-8").trim();
+    if (rec) return join(intentsDir, rec, "aidlc-state.md");
+  } catch {
+    // no birth ran - fall through to the seeded record
+  }
+  return seededStateFile(proj);
+}
+
+/** One row's status, or "(not found)" - the t39 helper's regex verbatim. */
+function rowStatus(proj: string, phaseCap: string): string {
+  const re = new RegExp(`^- \\*\\*${phaseCap}\\*\\*: (\\w+)$`);
+  for (const line of readFileSync(statePath(proj), "utf-8").split("\n")) {
+    const m = line.match(re);
+    if (m) return m[1];
+  }
+  return "(not found)";
+}
+
+/** The whole `## Phase Progress` section, for byte-identity assertions. */
+function phaseProgressSection(proj: string): string {
+  const m = readFileSync(statePath(proj), "utf-8").match(
+    /## Phase Progress\n[\s\S]*?(?=\n## )/,
+  );
+  return m ? m[0] : "(no section)";
+}
+
+function birth(proj: string, scope: string): RunResult {
+  return run(UTILITY_TOOL, proj, ["intent-birth", "--scope", scope]);
+}
+
+// Feature scope, greenfield: birth lands on intent-capture; the whole
+// Ideation ladder then approval-handoff -> practices-discovery crosses the
+// ideation->inception boundary (greenfield SKIPs reverse-engineering).
+const IDEATION_LADDER = [
+  "intent-capture",
+  "market-research",
+  "feasibility",
+  "scope-definition",
+  "team-formation",
+  "rough-mockups",
+] as const;
+
+describe("t232 Phase Progress - birth seed", () => {
+  test("feature scope: Verified init, Active first post-init phase, Pending rest", () => {
+    const proj = createTestProject();
+    tempDirs.push(proj);
+    expect(birth(proj, "feature").rc).toBe(0);
+    expect(rowStatus(proj, "Initialization")).toBe("Verified");
+    expect(rowStatus(proj, "Ideation")).toBe("Active");
+    expect(rowStatus(proj, "Inception")).toBe("Pending");
+    expect(rowStatus(proj, "Construction")).toBe("Pending");
+    expect(rowStatus(proj, "Operation")).toBe("Pending");
+  });
+
+  test("bugfix scope: excluded phases Skipped, first post-init phase Active", () => {
+    const proj = createTestProject();
+    tempDirs.push(proj);
+    expect(birth(proj, "bugfix").rc).toBe(0);
+    expect(rowStatus(proj, "Initialization")).toBe("Verified");
+    expect(rowStatus(proj, "Ideation")).toBe("Skipped");
+    expect(rowStatus(proj, "Inception")).toBe("Active");
+    expect(rowStatus(proj, "Operation")).toBe("Skipped");
+  });
+});
+
+describe("t232 Phase Progress - advance", () => {
+  const proj = createTestProject();
+  tempDirs.push(proj);
+  const born = birth(proj, "feature");
+
+  test("non-boundary advance leaves the section byte-identical", () => {
+    expect(born.rc).toBe(0);
+    const before = phaseProgressSection(proj);
+    expect(run(STATE_TOOL, proj, ["advance", "intent-capture"]).rc).toBe(0);
+    expect(phaseProgressSection(proj)).toBe(before);
+  });
+
+  test("boundary advance flips completed->Verified, entered->Active", () => {
+    for (const slug of IDEATION_LADDER.slice(1)) {
+      expect(run(STATE_TOOL, proj, ["advance", slug]).rc).toBe(0);
+    }
+    const res = run(STATE_TOOL, proj, ["advance", "approval-handoff"]);
+    expect(res.rc).toBe(0);
+    expect(res.combined).toContain('"phase_boundary":true');
+    expect(rowStatus(proj, "Ideation")).toBe("Verified");
+    expect(rowStatus(proj, "Inception")).toBe("Active");
+    // Untouched rows keep their seed.
+    expect(rowStatus(proj, "Construction")).toBe("Pending");
+  });
+});
+
+describe("t232 Phase Progress - finalize", () => {
+  test("boundary finalize flips completed->Verified, entered->Active", () => {
+    const proj = createTestProject();
+    tempDirs.push(proj);
+    expect(birth(proj, "feature").rc).toBe(0);
+    for (const slug of IDEATION_LADDER) {
+      expect(run(STATE_TOOL, proj, ["advance", slug]).rc).toBe(0);
+    }
+    expect(run(STATE_TOOL, proj, ["finalize", "approval-handoff"]).rc).toBe(0);
+    expect(rowStatus(proj, "Ideation")).toBe("Verified");
+    expect(rowStatus(proj, "Inception")).toBe("Active");
+  });
+
+  test("final-stage finalize flips the last phase to Verified", () => {
+    const proj = createTestProject();
+    tempDirs.push(proj);
+    seedStateFile(proj, "state-final-stage.md");
+    // The fixture pre-dates the flip in spirit: force the Operation row back
+    // to Active so the transition under test is observable.
+    sedReplaceInFile(
+      statePath(proj),
+      "- **Operation**: Verified",
+      "- **Operation**: Active",
+    );
+    expect(run(STATE_TOOL, proj, ["finalize", "feedback-optimization"]).rc).toBe(0);
+    expect(rowStatus(proj, "Operation")).toBe("Verified");
+  });
+});
+
+describe("t232 Phase Progress - jump + complete-workflow", () => {
+  const proj = createTestProject();
+  tempDirs.push(proj);
+  const born = birth(proj, "feature");
+
+  test("forward jump: source Verified, jumped-over Skipped, target Active", () => {
+    expect(born.rc).toBe(0);
+    const res = run(JUMP_TOOL, proj, [
+      "execute", "--target", "deployment-pipeline", "--direction", "forward",
+    ]);
+    expect(res.rc).toBe(0);
+    expect(rowStatus(proj, "Ideation")).toBe("Verified");
+    expect(rowStatus(proj, "Inception")).toBe("Skipped");
+    expect(rowStatus(proj, "Construction")).toBe("Skipped");
+    expect(rowStatus(proj, "Operation")).toBe("Active");
+  });
+
+  test("backward jump: reset phases with EXECUTE stages return to Pending", () => {
+    const res = run(JUMP_TOOL, proj, [
+      "execute", "--target", "practices-discovery", "--direction", "backward",
+    ]);
+    expect(res.rc).toBe(0);
+    expect(rowStatus(proj, "Inception")).toBe("Active");
+    expect(rowStatus(proj, "Construction")).toBe("Pending");
+    expect(rowStatus(proj, "Operation")).toBe("Pending");
+    // History before the target is not rewritten.
+    expect(rowStatus(proj, "Ideation")).toBe("Verified");
+  });
+
+  test("complete-workflow flips the final phase to Verified", () => {
+    expect(
+      run(JUMP_TOOL, proj, [
+        "execute", "--target", "feedback-optimization", "--direction", "forward",
+      ]).rc,
+    ).toBe(0);
+    expect(
+      run(STATE_TOOL, proj, ["complete-workflow", "feedback-optimization"]).rc,
+    ).toBe(0);
+    expect(rowStatus(proj, "Operation")).toBe("Verified");
+  });
+});
+
+describe("t232 Phase Progress - plan re-shaping re-derives unreached rows", () => {
+  test("scope-change: newly excluded phase Skipped, history untouched", () => {
+    const proj = createTestProject();
+    tempDirs.push(proj);
+    expect(birth(proj, "feature").rc).toBe(0);
+    expect(run(UTILITY_TOOL, proj, ["scope-change", "--scope", "bugfix"]).rc).toBe(0);
+    expect(rowStatus(proj, "Operation")).toBe("Skipped");
+    // The Active/Verified rows record history the plan change cannot rewrite.
+    expect(rowStatus(proj, "Initialization")).toBe("Verified");
+    expect(rowStatus(proj, "Ideation")).toBe("Active");
+  });
+
+  test("recompose: skip-all empties a phase -> Skipped; add-back -> Pending", () => {
+    const proj = createTestProject();
+    tempDirs.push(proj);
+    expect(birth(proj, "feature").rc).toBe(0);
+    const allOperation =
+      "deployment-pipeline,environment-provisioning,deployment-execution," +
+      "observability-setup,incident-response,performance-validation," +
+      "feedback-optimization";
+    expect(run(UTILITY_TOOL, proj, ["recompose", "--skip", allOperation]).rc).toBe(0);
+    expect(rowStatus(proj, "Operation")).toBe("Skipped");
+    // Add the whole set back - a lone add is refused by the strict validator
+    // (its upstream producers would stay skipped, starving its consumes).
+    expect(
+      run(UTILITY_TOOL, proj, ["recompose", "--add", allOperation]).rc,
+    ).toBe(0);
+    expect(rowStatus(proj, "Operation")).toBe("Pending");
+  });
+});
+
+describe("t232 Phase Progress - missing section tolerated", () => {
+  test("boundary advance on a state file without the section still exits 0", () => {
+    const proj = createTestProject();
+    tempDirs.push(proj);
+    seedStateFile(proj, "state-mid-ideation.md");
+    seedAuditFile(proj);
+    // Strip the whole section (an older or hand-edited state file), then
+    // drive a boundary transition: the flip must silently no-op, never fail.
+    sedReplaceInFile(
+      statePath(proj),
+      /## Phase Progress\n[\s\S]*?(?=## )/,
+      "",
+    );
+    expect(rowStatus(proj, "Ideation")).toBe("(not found)");
+    expect(run(STATE_TOOL, proj, ["set", "Current Stage=approval-handoff"]).rc).toBe(0);
+    const res = run(STATE_TOOL, proj, ["advance", "approval-handoff"]);
+    expect(res.rc).toBe(0);
+    expect(res.combined).toContain('"phase_boundary":true');
+    expect(rowStatus(proj, "Ideation")).toBe("(not found)");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #556: the state file's `## Phase Progress` section was seeded once at intent birth and never advanced, so a few stages in it still showed `Ideation: Pending` above a fully-checked Ideation checkbox block. The `phaseStatus` comment promised an Active/Verified flip that no code performed. The section is display-only (routing reads `Lifecycle Phase` + the Stage Progress checkboxes; `/aidlc --status` recomputes its phase block live), so this is a correctness fix for the human-facing state file, not a routing change.

This takes the issue's option 1 (implement the documented flip) and closes two additional drift surfaces the issue did not cover: jumps and plan re-shaping.

## Changes

- **New `setPhaseProgress` helper** (`core/tools/aidlc-lib.ts`): flips one `- **<Phase>**:` row via the existing `setField` matcher. Silent no-op when the row is absent - an older or hand-edited state file must never fail a transition over a display row.
- **`advance` / `finalize`** (`core/tools/aidlc-state.ts`): at a phase boundary, completed phase -> `Verified`, entered phase -> `Active`, in the same atomic state write as the `PHASE_COMPLETED`/`PHASE_VERIFIED`/`PHASE_STARTED` trio. Non-boundary transitions leave the section byte-identical.
- **`complete-workflow`** (and a final-stage `finalize`): last phase -> `Verified`.
- **`jump execute`** (`core/tools/aidlc-jump.ts`): forward marks the source phase `Verified`, wholly jumped-over phases `Skipped`, target `Active`; backward returns reset phases (those with EXECUTE stages) to `Pending`. Jump already emits the phase-boundary audit trio, so the rows now track it.
- **`scope-change` / `recompose`** (`core/tools/aidlc-utility.ts`): re-derive only not-yet-reached rows (`Pending`/`Skipped`) against the new plan; `Verified`/`Active` rows record history and are never rewritten.
- **Birth seed made truthful**: birth completes every init stage and emits the init boundary trio itself, so the seed now reads `Initialization: Verified` + first post-init phase `Active` (previously `Active`/`Pending`, contradicting the audit events birth emits).
- `docs/reference/12-state-machine.md`: phase-machine prose + transition table updated to describe what the code now does (the table previously described this exact behaviour aspirationally).
- Version 2.3.7 + CHANGELOG + README badge; all four `dist/<harness>/` trees regenerated (`package.ts --check` clean).

Note for a run already mid-flow: rows stay stale for boundaries already passed and correct from the next boundary onward (as the issue predicted); a fresh run is correct from birth.

## Tests

- **New `tests/unit/t232-phase-progress-flip.test.ts`** (12 cases, spawns the real shipped CLIs): birth seeds for feature/bugfix scopes, byte-identical non-boundary advance, boundary flips for advance/finalize/complete-workflow, both jump directions, scope-change/recompose re-derivation, and missing-section tolerance.
- `t39` pin updated: `Initialization` at birth is now asserted `Verified` (was `Active`).
- t232 added to the coverage registry's manual `EXPECTED_NONE_TO_CLI` ratchet; registry regenerated.

## Verification

- Full deterministic tier (smoke+unit+integration, 254 files): the only failures were the coverage-registry honesty ratchet demanding the manual t232 entry (added; green on rerun) and 3 pre-existing `t92` linter/type-check sensor assertions that fail identically on the untouched v2 tip (verified via a detached baseline worktree).
- Rebased onto v2 @ 2.3.4 (#545); `t68` version/changelog sync, `t39`, `t232`, `package.ts --check`, coverage `--check`, and `bun run typecheck` all green at the new base.
- Every flip also exercised live against the `dist/claude` tools in a scratch project (birth -> 7 advances -> forward jump -> backward jump -> complete-workflow -> scope-change -> recompose).
