### PR TITLE
fix: upstream-coverage matches real citation forms over the stage's deliverable set (2.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.7] - 2026-07-14
+
+The `upstream-coverage` sensor now matches the citation forms the framework's artifacts actually use, clearing the hundreds of false `SENSOR_FAILED` audit rows a Construction run accumulated. It previously demanded each consumed artifact's bare slug in every single written file; artifacts instead cite upstream by producing-stage directory path in their provenance header, and multi-artifact stages legitimately split citations across sibling deliverables. Real coverage gaps still fail. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* A citation of the producing stage's directory (e.g. `nfr-requirements/` in a basis/trace header) now covers every artifact that stage produces; the producer slug must appear as a whole path segment, so a longer sibling slug never satisfies it.
+* Coverage is evaluated over the union of the stage's declared deliverables in the output directory, not the single fired file, so a citation in a sibling artifact counts. Scaffolding (`memory.md`, `*-questions.md`, `*-timestamp.md`) is excluded from both sides: a fire on it is judged against the deliverables, and a slug appearing only there never counts.
+* A scaffolding write that fires before any deliverable exists now passes vacuously with `reason: "no deliverables on disk yet"` instead of failing every consume against an empty body.
+* False-positive fix: a consume slug no longer matches inside a longer kebab token (`requirements` inside `nfr-requirements` previously counted as a reference).
+* Sensor JSON output gains `scanned_files`; the dispatcher threads `--consumes` as `artifact:producer` pairs plus a new `--deliverables` flag. Direct invocations with the old bare-slug `--consumes` and no `--deliverables` keep the previous per-file behavior.
+
 ## [2.3.6] - 2026-07-12
 
 The state file's `## Phase Progress` section now advances with the workflow. Previously it was seeded once at intent birth and never touched again, so a few stages in it still showed `Ideation: Pending` above a fully-checked Ideation checkbox block - a visible contradiction for anyone reading `aidlc-state.md` directly (routing was never affected; the engine reads `Lifecycle Phase` and the checkboxes, and `/aidlc --status` recomputes its own phase block). The section now tracks every transition the tools already audit. **Upgrade:** re-copy your `dist/<harness>/` shell into the project; a run already mid-flow keeps its stale rows for boundaries it already passed, and corrects from its next boundary onward.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.3.6-blue)
+![version](https://img.shields.io/badge/version-2.3.7-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/sensors/aidlc-upstream-coverage.md
+++ b/core/sensors/aidlc-upstream-coverage.md
@@ -3,13 +3,14 @@ id: upstream-coverage
 kind: deterministic
 command: bun {{HARNESS_DIR}}/tools/aidlc-sensor-upstream-coverage.ts
 default_severity: advisory
-description: Checks the output prose references the upstream artifacts the stage frontmatter declares it consumes
+description: Checks the stage's deliverables reference the upstream artifacts the stage frontmatter declares it consumes
 category: document-shape
 matches: "**/{aidlc-docs,intents}/**"
 input_schema:
   output_path: string
   stage_slug: string
   consumes: string[]
+  deliverables: string[]
 output_schema:
   pass: boolean
   unreferenced_artifacts: string[]
@@ -18,12 +19,27 @@ timeout_seconds: 5
 
 # upstream-coverage sensor
 
-Reads the stage frontmatter `consumes:` list and checks the output prose
-references each upstream artifact (by name or wikilink).
+Reads the stage frontmatter `consumes:` list and checks the stage's
+deliverables reference each upstream artifact. A reference counts in any
+of the forms the framework's artifacts actually use:
 
-Pure derivation from frontmatter — no per-stage config needed.
+- the artifact slug as a standalone token (not embedded in a longer
+  kebab token: `requirements` inside `nfr-requirements` does not count)
+- a wikilink (`[[<slug>]]`) or backticked filename (`` `<slug>.md` ``)
+- the producing stage's directory as a path segment (e.g. a provenance
+  header citing `nfr-requirements/` covers every artifact that stage
+  produces)
+
+Coverage is a property of the stage's whole output, not of each file:
+the check runs over the union of the stage's declared deliverables in
+the output directory (scaffolding - `*-questions.md`, `*-timestamp.md`,
+`memory.md` - is excluded from both sides), so a citation in a sibling
+deliverable counts.
+
+Pure derivation from frontmatter - no per-stage config needed.
 
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing artifacts declared in
-`consumes:` that don't appear anywhere in the output prose.
+`consumes:` that appear in none of the stage's deliverables in any
+accepted form.

--- a/core/tools/aidlc-sensor-upstream-coverage.ts
+++ b/core/tools/aidlc-sensor-upstream-coverage.ts
@@ -1,12 +1,19 @@
 import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { errorMessage } from "./aidlc-lib.ts";
 
 interface Result {
 	pass: boolean;
 	consumes: string[];
 	unreferenced: string[];
+	scanned_files: string[];
 	reason?: string;
 	findings_count: number;
+}
+
+interface Consume {
+	slug: string;
+	producer?: string;
 }
 
 interface Flags {
@@ -14,6 +21,7 @@ interface Flags {
 	outputPath?: string;
 	consumes?: string;
 	consumesPresent: boolean;
+	deliverables?: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -29,6 +37,8 @@ function parseFlags(argv: string[]): Flags {
 			// Handle `--consumes` as last flag (no value) and `--consumes ""`
 			// identically: treat both as empty list.
 			out.consumes = argv[++i] ?? "";
+		} else if (arg === "--deliverables") {
+			out.deliverables = argv[++i] ?? "";
 		}
 	}
 	return out;
@@ -43,6 +53,40 @@ function escapeRegex(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// A slug reference counts only when the slug is not embedded in a longer
+// kebab token: `requirements` must NOT match inside `nfr-requirements`.
+// \b treats `-` as a boundary, so the anchors here are lookarounds that
+// exclude word chars AND hyphens. Backticked filenames (`<slug>.md`) and
+// wikilinks ([[<slug>]]) still match: backtick, `[`, `.`, `]` are all
+// outside [\w-]. The explicit wikilink alternative is kept for contract
+// clarity even though the anchored form subsumes it.
+function slugPattern(slug: string): RegExp {
+	const e = escapeRegex(slug);
+	return new RegExp(`(?<![\\w-])${e}(?![\\w-])|\\[\\[${e}\\]\\]`, "i");
+}
+
+// A producing-stage directory citation counts as coverage for every
+// artifact that stage produces: artifacts cite upstream by provenance
+// path (`construction/<unit>/nfr-requirements/`), not by re-naming each
+// slug. The producer slug must appear as a whole path segment - leading
+// (`nfr-requirements/`) or trailing (`.../nfr-requirements`) - so a
+// longer sibling slug (`some-nfr-requirements/`) never satisfies it.
+function producerDirPattern(producer: string): RegExp {
+	const e = escapeRegex(producer);
+	return new RegExp(`(?<![\\w-])${e}(?=/)|(?<=/)${e}(?![\\w-])`, "i");
+}
+
+// Consume entries arrive as `artifact` or `artifact:producer-stage`. The
+// bare form stays valid (direct invocations, older dispatchers): it just
+// gets no producer-directory alternative.
+function parseConsume(entry: string): Consume {
+	const idx = entry.indexOf(":");
+	if (idx === -1) return { slug: entry };
+	const slug = entry.slice(0, idx).trim();
+	const producer = entry.slice(idx + 1).trim();
+	return producer.length > 0 ? { slug, producer } : { slug };
+}
+
 function main(): void {
 	const flags = parseFlags(process.argv.slice(2));
 
@@ -53,15 +97,6 @@ function main(): void {
 		fail(`--output-path not found: ${flags.outputPath}`);
 	}
 
-	let body: string;
-	try {
-		body = readFileSync(flags.outputPath, "utf-8");
-	} catch (err) {
-		fail(
-			`failed to read --output-path ${flags.outputPath}: ${errorMessage(err)}`,
-		);
-	}
-
 	// Split, trim, drop empties. Both `--consumes ""` and an absent flag
 	// collapse to consumes = [], which triggers the "no upstream" early
 	// return below.
@@ -69,13 +104,16 @@ function main(): void {
 	const consumes = rawConsumes
 		.split(",")
 		.map((s) => s.trim())
-		.filter((s) => s.length > 0);
+		.filter((s) => s.length > 0)
+		.map(parseConsume)
+		.filter((c) => c.slug.length > 0);
 
 	if (consumes.length === 0) {
 		const result: Result = {
 			pass: true,
 			consumes: [],
 			unreferenced: [],
+			scanned_files: [],
 			reason: "no upstream",
 			findings_count: 0,
 		};
@@ -83,24 +121,99 @@ function main(): void {
 		process.exit(0);
 	}
 
-	// Per the locked plan: case-insensitive grep with word-boundary
-	// anchors on the slug and either form: \b<slug>\b (literal) OR
-	// \[\[<slug>\]\] (wikilink). Slugs are kebab-case so word boundaries
-	// resolve cleanly without escaping anything beyond standard regex
-	// metacharacters.
+	// Coverage is a property of the STAGE's output, not of each file: a
+	// multi-artifact stage legitimately splits its upstream citations
+	// across sibling deliverables (business-rules.md cites the domain
+	// model; tech-stack-decisions.md has no reason to). So when the
+	// dispatcher threads --deliverables (the stage's produces union,
+	// already filtered of `*-questions`/`*-timestamp` scaffolding), the
+	// body under test is the union of those files in the fired file's
+	// directory, plus the fired file itself UNLESS it is scaffolding:
+	// the fire hook also fires on memory.md / `*-questions.md` writes,
+	// and a slug that appears only in the Q&A or the builder's diary is
+	// not upstream coverage. Every fire within a stage thus converges on
+	// the same stage-level verdict. Without --deliverables (direct
+	// invocation, older dispatcher) only the fired file is read, as
+	// before.
+	const firedPath = resolve(flags.outputPath);
+	const dir = dirname(firedPath);
+	const deliverables = (flags.deliverables ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	const firedBase = basename(firedPath);
+	const firedIsScaffolding =
+		firedBase === "memory.md" ||
+		firedBase.endsWith("-questions.md") ||
+		firedBase.endsWith("-timestamp.md");
+
+	const scanPaths: string[] = [];
+	if (deliverables.length === 0) {
+		scanPaths.push(firedPath);
+	} else {
+		for (const stem of deliverables) {
+			const p = resolve(join(dir, `${stem}.md`));
+			if (existsSync(p)) scanPaths.push(p);
+		}
+		if (!firedIsScaffolding && !scanPaths.includes(firedPath)) {
+			scanPaths.push(firedPath);
+		}
+	}
+
+	let body = "";
+	const scannedFiles: string[] = [];
+	for (const p of scanPaths) {
+		try {
+			body += `\n${readFileSync(p, "utf-8")}`;
+			scannedFiles.push(p);
+		} catch (err) {
+			if (p === firedPath) {
+				fail(`failed to read --output-path ${p}: ${errorMessage(err)}`);
+			}
+			// Unreadable sibling: skip - coverage falls back to what is
+			// readable rather than erroring the whole fire.
+		}
+	}
+
+	// A scaffolding write can fire before any deliverable exists (stages
+	// write their questions file first). With nothing to evaluate, the
+	// check is vacuous - pass with a reason, mirroring "no upstream" -
+	// rather than reporting every consume unreferenced against an empty
+	// set. The stage's later deliverable writes re-fire and evaluate for
+	// real.
+	if (scannedFiles.length === 0) {
+		const result: Result = {
+			pass: true,
+			consumes: consumes.map((c) => c.slug),
+			unreferenced: [],
+			scanned_files: [],
+			reason: "no deliverables on disk yet",
+			findings_count: 0,
+		};
+		process.stdout.write(`${JSON.stringify(result)}\n`);
+		process.exit(0);
+	}
+
+	// A consume is covered when the union body references it in any form
+	// the framework's artifacts actually use: the bare slug (anchored so
+	// longer kebab tokens don't false-positive), a wikilink, or the
+	// producing stage's directory as a path segment.
 	const unreferenced: string[] = [];
-	for (const slug of consumes) {
-		const escaped = escapeRegex(slug);
-		const pattern = new RegExp(`\\b${escaped}\\b|\\[\\[${escaped}\\]\\]`, "i");
-		if (!pattern.test(body)) {
-			unreferenced.push(slug);
+	for (const c of consumes) {
+		const covered =
+			slugPattern(c.slug).test(body) ||
+			(c.producer !== undefined && producerDirPattern(c.producer).test(body));
+		if (!covered) {
+			unreferenced.push(c.slug);
 		}
 	}
 
 	const result: Result = {
 		pass: unreferenced.length === 0,
-		consumes,
+		consumes: consumes.map((c) => c.slug),
 		unreferenced,
+		scanned_files: scannedFiles,
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
 		findings_count: unreferenced.length,
 	};

--- a/core/tools/aidlc-sensor.ts
+++ b/core/tools/aidlc-sensor.ts
@@ -273,6 +273,16 @@ function presentConsumes(pd: string, slugs: string[]): string[] {
 	});
 }
 
+// upstream-coverage consume entries carry the producing stage as
+// `artifact:producer-stage` so the sensor can count a citation of the
+// producer's directory (the framework's provenance-header convention)
+// as coverage of every artifact under it. An orphan consume (no
+// producer in the graph - doctor surfaces those) stays a bare slug.
+function consumeWithProducer(slug: string): string {
+	const producer = producersOf(slug)[0];
+	return producer ? `${slug}:${producer.slug}` : slug;
+}
+
 // --- Subcommand: fire ---
 //
 // Step 1 — validate + resolve all inputs + generate Fire id (no lock).
@@ -351,13 +361,15 @@ function handleFire(args: string[]): void {
 
 	// --- 2. Compute extra args for the per-sensor script ---
 	// Markdown sensors take --output-path; code sensors take --file-path.
-	// upstream-coverage additionally takes --consumes "art1,art2,..." sourced
-	// from the GraphStage.consumes[].artifact field, filtered to artifacts
-	// that exist on disk: a consume whose producing stage was skipped by the
-	// scope (or runtime-skipped, e.g. reverse-engineering on greenfield)
-	// never produced its file, and demanding the output prose reference it
-	// would be a guaranteed false SENSOR_FAILED on every run of that stage
-	// in that scope.
+	// upstream-coverage additionally takes --consumes
+	// "art1:producer1,art2:producer2,..." sourced from the
+	// GraphStage.consumes[].artifact field (producer resolved via
+	// producersOf so a producing-directory citation can count as
+	// coverage), filtered to artifacts that exist on disk: a consume
+	// whose producing stage was skipped by the scope (or runtime-skipped,
+	// e.g. reverse-engineering on greenfield) never produced its file,
+	// and demanding the output prose reference it would be a guaranteed
+	// false SENSOR_FAILED on every run of that stage in that scope.
 	const isCodeSensor = id === "linter" || id === "type-check";
 	const scriptArgs: string[] = ["--stage", stageSlug];
 	if (isCodeSensor) {
@@ -371,7 +383,22 @@ function handleFire(args: string[]): void {
 			.filter((a) => typeof a === "string" && a.length > 0);
 		scriptArgs.push(
 			"--consumes",
-			presentConsumes(projectDir, consumeSlugs).join(","),
+			presentConsumes(projectDir, consumeSlugs)
+				.map(consumeWithProducer)
+				.join(","),
+		);
+		// Coverage is evaluated over the stage's whole deliverable set (the
+		// sensor unions the sibling files named here), not the single fired
+		// file - a multi-artifact stage splits its upstream citations across
+		// siblings. Same eligibility filter as required-sections: the
+		// `*-questions`/`*-timestamp` scaffolding is excluded so a citation
+		// that appears only in the Q&A file never counts as coverage.
+		scriptArgs.push(
+			"--deliverables",
+			templateEligibleArtifacts([
+				...(stageNode.produces ?? []),
+				...(stageNode.optional_produces ?? []),
+			]).join(","),
 		);
 	}
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.6";
+export const AIDLC_VERSION = "2.3.7";

--- a/dist/claude/.claude/sensors/aidlc-upstream-coverage.md
+++ b/dist/claude/.claude/sensors/aidlc-upstream-coverage.md
@@ -3,13 +3,14 @@ id: upstream-coverage
 kind: deterministic
 command: bun .claude/tools/aidlc-sensor-upstream-coverage.ts
 default_severity: advisory
-description: Checks the output prose references the upstream artifacts the stage frontmatter declares it consumes
+description: Checks the stage's deliverables reference the upstream artifacts the stage frontmatter declares it consumes
 category: document-shape
 matches: "**/{aidlc-docs,intents}/**"
 input_schema:
   output_path: string
   stage_slug: string
   consumes: string[]
+  deliverables: string[]
 output_schema:
   pass: boolean
   unreferenced_artifacts: string[]
@@ -18,12 +19,27 @@ timeout_seconds: 5
 
 # upstream-coverage sensor
 
-Reads the stage frontmatter `consumes:` list and checks the output prose
-references each upstream artifact (by name or wikilink).
+Reads the stage frontmatter `consumes:` list and checks the stage's
+deliverables reference each upstream artifact. A reference counts in any
+of the forms the framework's artifacts actually use:
 
-Pure derivation from frontmatter — no per-stage config needed.
+- the artifact slug as a standalone token (not embedded in a longer
+  kebab token: `requirements` inside `nfr-requirements` does not count)
+- a wikilink (`[[<slug>]]`) or backticked filename (`` `<slug>.md` ``)
+- the producing stage's directory as a path segment (e.g. a provenance
+  header citing `nfr-requirements/` covers every artifact that stage
+  produces)
+
+Coverage is a property of the stage's whole output, not of each file:
+the check runs over the union of the stage's declared deliverables in
+the output directory (scaffolding - `*-questions.md`, `*-timestamp.md`,
+`memory.md` - is excluded from both sides), so a citation in a sibling
+deliverable counts.
+
+Pure derivation from frontmatter - no per-stage config needed.
 
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing artifacts declared in
-`consumes:` that don't appear anywhere in the output prose.
+`consumes:` that appear in none of the stage's deliverables in any
+accepted form.

--- a/dist/claude/.claude/tools/aidlc-sensor-upstream-coverage.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-upstream-coverage.ts
@@ -1,12 +1,19 @@
 import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { errorMessage } from "./aidlc-lib.ts";
 
 interface Result {
 	pass: boolean;
 	consumes: string[];
 	unreferenced: string[];
+	scanned_files: string[];
 	reason?: string;
 	findings_count: number;
+}
+
+interface Consume {
+	slug: string;
+	producer?: string;
 }
 
 interface Flags {
@@ -14,6 +21,7 @@ interface Flags {
 	outputPath?: string;
 	consumes?: string;
 	consumesPresent: boolean;
+	deliverables?: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -29,6 +37,8 @@ function parseFlags(argv: string[]): Flags {
 			// Handle `--consumes` as last flag (no value) and `--consumes ""`
 			// identically: treat both as empty list.
 			out.consumes = argv[++i] ?? "";
+		} else if (arg === "--deliverables") {
+			out.deliverables = argv[++i] ?? "";
 		}
 	}
 	return out;
@@ -43,6 +53,40 @@ function escapeRegex(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// A slug reference counts only when the slug is not embedded in a longer
+// kebab token: `requirements` must NOT match inside `nfr-requirements`.
+// \b treats `-` as a boundary, so the anchors here are lookarounds that
+// exclude word chars AND hyphens. Backticked filenames (`<slug>.md`) and
+// wikilinks ([[<slug>]]) still match: backtick, `[`, `.`, `]` are all
+// outside [\w-]. The explicit wikilink alternative is kept for contract
+// clarity even though the anchored form subsumes it.
+function slugPattern(slug: string): RegExp {
+	const e = escapeRegex(slug);
+	return new RegExp(`(?<![\\w-])${e}(?![\\w-])|\\[\\[${e}\\]\\]`, "i");
+}
+
+// A producing-stage directory citation counts as coverage for every
+// artifact that stage produces: artifacts cite upstream by provenance
+// path (`construction/<unit>/nfr-requirements/`), not by re-naming each
+// slug. The producer slug must appear as a whole path segment - leading
+// (`nfr-requirements/`) or trailing (`.../nfr-requirements`) - so a
+// longer sibling slug (`some-nfr-requirements/`) never satisfies it.
+function producerDirPattern(producer: string): RegExp {
+	const e = escapeRegex(producer);
+	return new RegExp(`(?<![\\w-])${e}(?=/)|(?<=/)${e}(?![\\w-])`, "i");
+}
+
+// Consume entries arrive as `artifact` or `artifact:producer-stage`. The
+// bare form stays valid (direct invocations, older dispatchers): it just
+// gets no producer-directory alternative.
+function parseConsume(entry: string): Consume {
+	const idx = entry.indexOf(":");
+	if (idx === -1) return { slug: entry };
+	const slug = entry.slice(0, idx).trim();
+	const producer = entry.slice(idx + 1).trim();
+	return producer.length > 0 ? { slug, producer } : { slug };
+}
+
 function main(): void {
 	const flags = parseFlags(process.argv.slice(2));
 
@@ -53,15 +97,6 @@ function main(): void {
 		fail(`--output-path not found: ${flags.outputPath}`);
 	}
 
-	let body: string;
-	try {
-		body = readFileSync(flags.outputPath, "utf-8");
-	} catch (err) {
-		fail(
-			`failed to read --output-path ${flags.outputPath}: ${errorMessage(err)}`,
-		);
-	}
-
 	// Split, trim, drop empties. Both `--consumes ""` and an absent flag
 	// collapse to consumes = [], which triggers the "no upstream" early
 	// return below.
@@ -69,13 +104,16 @@ function main(): void {
 	const consumes = rawConsumes
 		.split(",")
 		.map((s) => s.trim())
-		.filter((s) => s.length > 0);
+		.filter((s) => s.length > 0)
+		.map(parseConsume)
+		.filter((c) => c.slug.length > 0);
 
 	if (consumes.length === 0) {
 		const result: Result = {
 			pass: true,
 			consumes: [],
 			unreferenced: [],
+			scanned_files: [],
 			reason: "no upstream",
 			findings_count: 0,
 		};
@@ -83,24 +121,99 @@ function main(): void {
 		process.exit(0);
 	}
 
-	// Per the locked plan: case-insensitive grep with word-boundary
-	// anchors on the slug and either form: \b<slug>\b (literal) OR
-	// \[\[<slug>\]\] (wikilink). Slugs are kebab-case so word boundaries
-	// resolve cleanly without escaping anything beyond standard regex
-	// metacharacters.
+	// Coverage is a property of the STAGE's output, not of each file: a
+	// multi-artifact stage legitimately splits its upstream citations
+	// across sibling deliverables (business-rules.md cites the domain
+	// model; tech-stack-decisions.md has no reason to). So when the
+	// dispatcher threads --deliverables (the stage's produces union,
+	// already filtered of `*-questions`/`*-timestamp` scaffolding), the
+	// body under test is the union of those files in the fired file's
+	// directory, plus the fired file itself UNLESS it is scaffolding:
+	// the fire hook also fires on memory.md / `*-questions.md` writes,
+	// and a slug that appears only in the Q&A or the builder's diary is
+	// not upstream coverage. Every fire within a stage thus converges on
+	// the same stage-level verdict. Without --deliverables (direct
+	// invocation, older dispatcher) only the fired file is read, as
+	// before.
+	const firedPath = resolve(flags.outputPath);
+	const dir = dirname(firedPath);
+	const deliverables = (flags.deliverables ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	const firedBase = basename(firedPath);
+	const firedIsScaffolding =
+		firedBase === "memory.md" ||
+		firedBase.endsWith("-questions.md") ||
+		firedBase.endsWith("-timestamp.md");
+
+	const scanPaths: string[] = [];
+	if (deliverables.length === 0) {
+		scanPaths.push(firedPath);
+	} else {
+		for (const stem of deliverables) {
+			const p = resolve(join(dir, `${stem}.md`));
+			if (existsSync(p)) scanPaths.push(p);
+		}
+		if (!firedIsScaffolding && !scanPaths.includes(firedPath)) {
+			scanPaths.push(firedPath);
+		}
+	}
+
+	let body = "";
+	const scannedFiles: string[] = [];
+	for (const p of scanPaths) {
+		try {
+			body += `\n${readFileSync(p, "utf-8")}`;
+			scannedFiles.push(p);
+		} catch (err) {
+			if (p === firedPath) {
+				fail(`failed to read --output-path ${p}: ${errorMessage(err)}`);
+			}
+			// Unreadable sibling: skip - coverage falls back to what is
+			// readable rather than erroring the whole fire.
+		}
+	}
+
+	// A scaffolding write can fire before any deliverable exists (stages
+	// write their questions file first). With nothing to evaluate, the
+	// check is vacuous - pass with a reason, mirroring "no upstream" -
+	// rather than reporting every consume unreferenced against an empty
+	// set. The stage's later deliverable writes re-fire and evaluate for
+	// real.
+	if (scannedFiles.length === 0) {
+		const result: Result = {
+			pass: true,
+			consumes: consumes.map((c) => c.slug),
+			unreferenced: [],
+			scanned_files: [],
+			reason: "no deliverables on disk yet",
+			findings_count: 0,
+		};
+		process.stdout.write(`${JSON.stringify(result)}\n`);
+		process.exit(0);
+	}
+
+	// A consume is covered when the union body references it in any form
+	// the framework's artifacts actually use: the bare slug (anchored so
+	// longer kebab tokens don't false-positive), a wikilink, or the
+	// producing stage's directory as a path segment.
 	const unreferenced: string[] = [];
-	for (const slug of consumes) {
-		const escaped = escapeRegex(slug);
-		const pattern = new RegExp(`\\b${escaped}\\b|\\[\\[${escaped}\\]\\]`, "i");
-		if (!pattern.test(body)) {
-			unreferenced.push(slug);
+	for (const c of consumes) {
+		const covered =
+			slugPattern(c.slug).test(body) ||
+			(c.producer !== undefined && producerDirPattern(c.producer).test(body));
+		if (!covered) {
+			unreferenced.push(c.slug);
 		}
 	}
 
 	const result: Result = {
 		pass: unreferenced.length === 0,
-		consumes,
+		consumes: consumes.map((c) => c.slug),
 		unreferenced,
+		scanned_files: scannedFiles,
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
 		findings_count: unreferenced.length,
 	};

--- a/dist/claude/.claude/tools/aidlc-sensor.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor.ts
@@ -273,6 +273,16 @@ function presentConsumes(pd: string, slugs: string[]): string[] {
 	});
 }
 
+// upstream-coverage consume entries carry the producing stage as
+// `artifact:producer-stage` so the sensor can count a citation of the
+// producer's directory (the framework's provenance-header convention)
+// as coverage of every artifact under it. An orphan consume (no
+// producer in the graph - doctor surfaces those) stays a bare slug.
+function consumeWithProducer(slug: string): string {
+	const producer = producersOf(slug)[0];
+	return producer ? `${slug}:${producer.slug}` : slug;
+}
+
 // --- Subcommand: fire ---
 //
 // Step 1 — validate + resolve all inputs + generate Fire id (no lock).
@@ -351,13 +361,15 @@ function handleFire(args: string[]): void {
 
 	// --- 2. Compute extra args for the per-sensor script ---
 	// Markdown sensors take --output-path; code sensors take --file-path.
-	// upstream-coverage additionally takes --consumes "art1,art2,..." sourced
-	// from the GraphStage.consumes[].artifact field, filtered to artifacts
-	// that exist on disk: a consume whose producing stage was skipped by the
-	// scope (or runtime-skipped, e.g. reverse-engineering on greenfield)
-	// never produced its file, and demanding the output prose reference it
-	// would be a guaranteed false SENSOR_FAILED on every run of that stage
-	// in that scope.
+	// upstream-coverage additionally takes --consumes
+	// "art1:producer1,art2:producer2,..." sourced from the
+	// GraphStage.consumes[].artifact field (producer resolved via
+	// producersOf so a producing-directory citation can count as
+	// coverage), filtered to artifacts that exist on disk: a consume
+	// whose producing stage was skipped by the scope (or runtime-skipped,
+	// e.g. reverse-engineering on greenfield) never produced its file,
+	// and demanding the output prose reference it would be a guaranteed
+	// false SENSOR_FAILED on every run of that stage in that scope.
 	const isCodeSensor = id === "linter" || id === "type-check";
 	const scriptArgs: string[] = ["--stage", stageSlug];
 	if (isCodeSensor) {
@@ -371,7 +383,22 @@ function handleFire(args: string[]): void {
 			.filter((a) => typeof a === "string" && a.length > 0);
 		scriptArgs.push(
 			"--consumes",
-			presentConsumes(projectDir, consumeSlugs).join(","),
+			presentConsumes(projectDir, consumeSlugs)
+				.map(consumeWithProducer)
+				.join(","),
+		);
+		// Coverage is evaluated over the stage's whole deliverable set (the
+		// sensor unions the sibling files named here), not the single fired
+		// file - a multi-artifact stage splits its upstream citations across
+		// siblings. Same eligibility filter as required-sections: the
+		// `*-questions`/`*-timestamp` scaffolding is excluded so a citation
+		// that appears only in the Q&A file never counts as coverage.
+		scriptArgs.push(
+			"--deliverables",
+			templateEligibleArtifacts([
+				...(stageNode.produces ?? []),
+				...(stageNode.optional_produces ?? []),
+			]).join(","),
 		);
 	}
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.6";
+export const AIDLC_VERSION = "2.3.7";

--- a/dist/codex/.codex/sensors/aidlc-upstream-coverage.md
+++ b/dist/codex/.codex/sensors/aidlc-upstream-coverage.md
@@ -3,13 +3,14 @@ id: upstream-coverage
 kind: deterministic
 command: bun .codex/tools/aidlc-sensor-upstream-coverage.ts
 default_severity: advisory
-description: Checks the output prose references the upstream artifacts the stage frontmatter declares it consumes
+description: Checks the stage's deliverables reference the upstream artifacts the stage frontmatter declares it consumes
 category: document-shape
 matches: "**/{aidlc-docs,intents}/**"
 input_schema:
   output_path: string
   stage_slug: string
   consumes: string[]
+  deliverables: string[]
 output_schema:
   pass: boolean
   unreferenced_artifacts: string[]
@@ -18,12 +19,27 @@ timeout_seconds: 5
 
 # upstream-coverage sensor
 
-Reads the stage frontmatter `consumes:` list and checks the output prose
-references each upstream artifact (by name or wikilink).
+Reads the stage frontmatter `consumes:` list and checks the stage's
+deliverables reference each upstream artifact. A reference counts in any
+of the forms the framework's artifacts actually use:
 
-Pure derivation from frontmatter — no per-stage config needed.
+- the artifact slug as a standalone token (not embedded in a longer
+  kebab token: `requirements` inside `nfr-requirements` does not count)
+- a wikilink (`[[<slug>]]`) or backticked filename (`` `<slug>.md` ``)
+- the producing stage's directory as a path segment (e.g. a provenance
+  header citing `nfr-requirements/` covers every artifact that stage
+  produces)
+
+Coverage is a property of the stage's whole output, not of each file:
+the check runs over the union of the stage's declared deliverables in
+the output directory (scaffolding - `*-questions.md`, `*-timestamp.md`,
+`memory.md` - is excluded from both sides), so a citation in a sibling
+deliverable counts.
+
+Pure derivation from frontmatter - no per-stage config needed.
 
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing artifacts declared in
-`consumes:` that don't appear anywhere in the output prose.
+`consumes:` that appear in none of the stage's deliverables in any
+accepted form.

--- a/dist/codex/.codex/tools/aidlc-sensor-upstream-coverage.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-upstream-coverage.ts
@@ -1,12 +1,19 @@
 import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { errorMessage } from "./aidlc-lib.ts";
 
 interface Result {
 	pass: boolean;
 	consumes: string[];
 	unreferenced: string[];
+	scanned_files: string[];
 	reason?: string;
 	findings_count: number;
+}
+
+interface Consume {
+	slug: string;
+	producer?: string;
 }
 
 interface Flags {
@@ -14,6 +21,7 @@ interface Flags {
 	outputPath?: string;
 	consumes?: string;
 	consumesPresent: boolean;
+	deliverables?: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -29,6 +37,8 @@ function parseFlags(argv: string[]): Flags {
 			// Handle `--consumes` as last flag (no value) and `--consumes ""`
 			// identically: treat both as empty list.
 			out.consumes = argv[++i] ?? "";
+		} else if (arg === "--deliverables") {
+			out.deliverables = argv[++i] ?? "";
 		}
 	}
 	return out;
@@ -43,6 +53,40 @@ function escapeRegex(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// A slug reference counts only when the slug is not embedded in a longer
+// kebab token: `requirements` must NOT match inside `nfr-requirements`.
+// \b treats `-` as a boundary, so the anchors here are lookarounds that
+// exclude word chars AND hyphens. Backticked filenames (`<slug>.md`) and
+// wikilinks ([[<slug>]]) still match: backtick, `[`, `.`, `]` are all
+// outside [\w-]. The explicit wikilink alternative is kept for contract
+// clarity even though the anchored form subsumes it.
+function slugPattern(slug: string): RegExp {
+	const e = escapeRegex(slug);
+	return new RegExp(`(?<![\\w-])${e}(?![\\w-])|\\[\\[${e}\\]\\]`, "i");
+}
+
+// A producing-stage directory citation counts as coverage for every
+// artifact that stage produces: artifacts cite upstream by provenance
+// path (`construction/<unit>/nfr-requirements/`), not by re-naming each
+// slug. The producer slug must appear as a whole path segment - leading
+// (`nfr-requirements/`) or trailing (`.../nfr-requirements`) - so a
+// longer sibling slug (`some-nfr-requirements/`) never satisfies it.
+function producerDirPattern(producer: string): RegExp {
+	const e = escapeRegex(producer);
+	return new RegExp(`(?<![\\w-])${e}(?=/)|(?<=/)${e}(?![\\w-])`, "i");
+}
+
+// Consume entries arrive as `artifact` or `artifact:producer-stage`. The
+// bare form stays valid (direct invocations, older dispatchers): it just
+// gets no producer-directory alternative.
+function parseConsume(entry: string): Consume {
+	const idx = entry.indexOf(":");
+	if (idx === -1) return { slug: entry };
+	const slug = entry.slice(0, idx).trim();
+	const producer = entry.slice(idx + 1).trim();
+	return producer.length > 0 ? { slug, producer } : { slug };
+}
+
 function main(): void {
 	const flags = parseFlags(process.argv.slice(2));
 
@@ -53,15 +97,6 @@ function main(): void {
 		fail(`--output-path not found: ${flags.outputPath}`);
 	}
 
-	let body: string;
-	try {
-		body = readFileSync(flags.outputPath, "utf-8");
-	} catch (err) {
-		fail(
-			`failed to read --output-path ${flags.outputPath}: ${errorMessage(err)}`,
-		);
-	}
-
 	// Split, trim, drop empties. Both `--consumes ""` and an absent flag
 	// collapse to consumes = [], which triggers the "no upstream" early
 	// return below.
@@ -69,13 +104,16 @@ function main(): void {
 	const consumes = rawConsumes
 		.split(",")
 		.map((s) => s.trim())
-		.filter((s) => s.length > 0);
+		.filter((s) => s.length > 0)
+		.map(parseConsume)
+		.filter((c) => c.slug.length > 0);
 
 	if (consumes.length === 0) {
 		const result: Result = {
 			pass: true,
 			consumes: [],
 			unreferenced: [],
+			scanned_files: [],
 			reason: "no upstream",
 			findings_count: 0,
 		};
@@ -83,24 +121,99 @@ function main(): void {
 		process.exit(0);
 	}
 
-	// Per the locked plan: case-insensitive grep with word-boundary
-	// anchors on the slug and either form: \b<slug>\b (literal) OR
-	// \[\[<slug>\]\] (wikilink). Slugs are kebab-case so word boundaries
-	// resolve cleanly without escaping anything beyond standard regex
-	// metacharacters.
+	// Coverage is a property of the STAGE's output, not of each file: a
+	// multi-artifact stage legitimately splits its upstream citations
+	// across sibling deliverables (business-rules.md cites the domain
+	// model; tech-stack-decisions.md has no reason to). So when the
+	// dispatcher threads --deliverables (the stage's produces union,
+	// already filtered of `*-questions`/`*-timestamp` scaffolding), the
+	// body under test is the union of those files in the fired file's
+	// directory, plus the fired file itself UNLESS it is scaffolding:
+	// the fire hook also fires on memory.md / `*-questions.md` writes,
+	// and a slug that appears only in the Q&A or the builder's diary is
+	// not upstream coverage. Every fire within a stage thus converges on
+	// the same stage-level verdict. Without --deliverables (direct
+	// invocation, older dispatcher) only the fired file is read, as
+	// before.
+	const firedPath = resolve(flags.outputPath);
+	const dir = dirname(firedPath);
+	const deliverables = (flags.deliverables ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	const firedBase = basename(firedPath);
+	const firedIsScaffolding =
+		firedBase === "memory.md" ||
+		firedBase.endsWith("-questions.md") ||
+		firedBase.endsWith("-timestamp.md");
+
+	const scanPaths: string[] = [];
+	if (deliverables.length === 0) {
+		scanPaths.push(firedPath);
+	} else {
+		for (const stem of deliverables) {
+			const p = resolve(join(dir, `${stem}.md`));
+			if (existsSync(p)) scanPaths.push(p);
+		}
+		if (!firedIsScaffolding && !scanPaths.includes(firedPath)) {
+			scanPaths.push(firedPath);
+		}
+	}
+
+	let body = "";
+	const scannedFiles: string[] = [];
+	for (const p of scanPaths) {
+		try {
+			body += `\n${readFileSync(p, "utf-8")}`;
+			scannedFiles.push(p);
+		} catch (err) {
+			if (p === firedPath) {
+				fail(`failed to read --output-path ${p}: ${errorMessage(err)}`);
+			}
+			// Unreadable sibling: skip - coverage falls back to what is
+			// readable rather than erroring the whole fire.
+		}
+	}
+
+	// A scaffolding write can fire before any deliverable exists (stages
+	// write their questions file first). With nothing to evaluate, the
+	// check is vacuous - pass with a reason, mirroring "no upstream" -
+	// rather than reporting every consume unreferenced against an empty
+	// set. The stage's later deliverable writes re-fire and evaluate for
+	// real.
+	if (scannedFiles.length === 0) {
+		const result: Result = {
+			pass: true,
+			consumes: consumes.map((c) => c.slug),
+			unreferenced: [],
+			scanned_files: [],
+			reason: "no deliverables on disk yet",
+			findings_count: 0,
+		};
+		process.stdout.write(`${JSON.stringify(result)}\n`);
+		process.exit(0);
+	}
+
+	// A consume is covered when the union body references it in any form
+	// the framework's artifacts actually use: the bare slug (anchored so
+	// longer kebab tokens don't false-positive), a wikilink, or the
+	// producing stage's directory as a path segment.
 	const unreferenced: string[] = [];
-	for (const slug of consumes) {
-		const escaped = escapeRegex(slug);
-		const pattern = new RegExp(`\\b${escaped}\\b|\\[\\[${escaped}\\]\\]`, "i");
-		if (!pattern.test(body)) {
-			unreferenced.push(slug);
+	for (const c of consumes) {
+		const covered =
+			slugPattern(c.slug).test(body) ||
+			(c.producer !== undefined && producerDirPattern(c.producer).test(body));
+		if (!covered) {
+			unreferenced.push(c.slug);
 		}
 	}
 
 	const result: Result = {
 		pass: unreferenced.length === 0,
-		consumes,
+		consumes: consumes.map((c) => c.slug),
 		unreferenced,
+		scanned_files: scannedFiles,
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
 		findings_count: unreferenced.length,
 	};

--- a/dist/codex/.codex/tools/aidlc-sensor.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor.ts
@@ -273,6 +273,16 @@ function presentConsumes(pd: string, slugs: string[]): string[] {
 	});
 }
 
+// upstream-coverage consume entries carry the producing stage as
+// `artifact:producer-stage` so the sensor can count a citation of the
+// producer's directory (the framework's provenance-header convention)
+// as coverage of every artifact under it. An orphan consume (no
+// producer in the graph - doctor surfaces those) stays a bare slug.
+function consumeWithProducer(slug: string): string {
+	const producer = producersOf(slug)[0];
+	return producer ? `${slug}:${producer.slug}` : slug;
+}
+
 // --- Subcommand: fire ---
 //
 // Step 1 — validate + resolve all inputs + generate Fire id (no lock).
@@ -351,13 +361,15 @@ function handleFire(args: string[]): void {
 
 	// --- 2. Compute extra args for the per-sensor script ---
 	// Markdown sensors take --output-path; code sensors take --file-path.
-	// upstream-coverage additionally takes --consumes "art1,art2,..." sourced
-	// from the GraphStage.consumes[].artifact field, filtered to artifacts
-	// that exist on disk: a consume whose producing stage was skipped by the
-	// scope (or runtime-skipped, e.g. reverse-engineering on greenfield)
-	// never produced its file, and demanding the output prose reference it
-	// would be a guaranteed false SENSOR_FAILED on every run of that stage
-	// in that scope.
+	// upstream-coverage additionally takes --consumes
+	// "art1:producer1,art2:producer2,..." sourced from the
+	// GraphStage.consumes[].artifact field (producer resolved via
+	// producersOf so a producing-directory citation can count as
+	// coverage), filtered to artifacts that exist on disk: a consume
+	// whose producing stage was skipped by the scope (or runtime-skipped,
+	// e.g. reverse-engineering on greenfield) never produced its file,
+	// and demanding the output prose reference it would be a guaranteed
+	// false SENSOR_FAILED on every run of that stage in that scope.
 	const isCodeSensor = id === "linter" || id === "type-check";
 	const scriptArgs: string[] = ["--stage", stageSlug];
 	if (isCodeSensor) {
@@ -371,7 +383,22 @@ function handleFire(args: string[]): void {
 			.filter((a) => typeof a === "string" && a.length > 0);
 		scriptArgs.push(
 			"--consumes",
-			presentConsumes(projectDir, consumeSlugs).join(","),
+			presentConsumes(projectDir, consumeSlugs)
+				.map(consumeWithProducer)
+				.join(","),
+		);
+		// Coverage is evaluated over the stage's whole deliverable set (the
+		// sensor unions the sibling files named here), not the single fired
+		// file - a multi-artifact stage splits its upstream citations across
+		// siblings. Same eligibility filter as required-sections: the
+		// `*-questions`/`*-timestamp` scaffolding is excluded so a citation
+		// that appears only in the Q&A file never counts as coverage.
+		scriptArgs.push(
+			"--deliverables",
+			templateEligibleArtifacts([
+				...(stageNode.produces ?? []),
+				...(stageNode.optional_produces ?? []),
+			]).join(","),
 		);
 	}
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.6";
+export const AIDLC_VERSION = "2.3.7";

--- a/dist/kiro-ide/.kiro/sensors/aidlc-upstream-coverage.md
+++ b/dist/kiro-ide/.kiro/sensors/aidlc-upstream-coverage.md
@@ -3,13 +3,14 @@ id: upstream-coverage
 kind: deterministic
 command: bun .kiro/tools/aidlc-sensor-upstream-coverage.ts
 default_severity: advisory
-description: Checks the output prose references the upstream artifacts the stage frontmatter declares it consumes
+description: Checks the stage's deliverables reference the upstream artifacts the stage frontmatter declares it consumes
 category: document-shape
 matches: "**/{aidlc-docs,intents}/**"
 input_schema:
   output_path: string
   stage_slug: string
   consumes: string[]
+  deliverables: string[]
 output_schema:
   pass: boolean
   unreferenced_artifacts: string[]
@@ -18,12 +19,27 @@ timeout_seconds: 5
 
 # upstream-coverage sensor
 
-Reads the stage frontmatter `consumes:` list and checks the output prose
-references each upstream artifact (by name or wikilink).
+Reads the stage frontmatter `consumes:` list and checks the stage's
+deliverables reference each upstream artifact. A reference counts in any
+of the forms the framework's artifacts actually use:
 
-Pure derivation from frontmatter — no per-stage config needed.
+- the artifact slug as a standalone token (not embedded in a longer
+  kebab token: `requirements` inside `nfr-requirements` does not count)
+- a wikilink (`[[<slug>]]`) or backticked filename (`` `<slug>.md` ``)
+- the producing stage's directory as a path segment (e.g. a provenance
+  header citing `nfr-requirements/` covers every artifact that stage
+  produces)
+
+Coverage is a property of the stage's whole output, not of each file:
+the check runs over the union of the stage's declared deliverables in
+the output directory (scaffolding - `*-questions.md`, `*-timestamp.md`,
+`memory.md` - is excluded from both sides), so a citation in a sibling
+deliverable counts.
+
+Pure derivation from frontmatter - no per-stage config needed.
 
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing artifacts declared in
-`consumes:` that don't appear anywhere in the output prose.
+`consumes:` that appear in none of the stage's deliverables in any
+accepted form.

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-upstream-coverage.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-upstream-coverage.ts
@@ -1,12 +1,19 @@
 import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { errorMessage } from "./aidlc-lib.ts";
 
 interface Result {
 	pass: boolean;
 	consumes: string[];
 	unreferenced: string[];
+	scanned_files: string[];
 	reason?: string;
 	findings_count: number;
+}
+
+interface Consume {
+	slug: string;
+	producer?: string;
 }
 
 interface Flags {
@@ -14,6 +21,7 @@ interface Flags {
 	outputPath?: string;
 	consumes?: string;
 	consumesPresent: boolean;
+	deliverables?: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -29,6 +37,8 @@ function parseFlags(argv: string[]): Flags {
 			// Handle `--consumes` as last flag (no value) and `--consumes ""`
 			// identically: treat both as empty list.
 			out.consumes = argv[++i] ?? "";
+		} else if (arg === "--deliverables") {
+			out.deliverables = argv[++i] ?? "";
 		}
 	}
 	return out;
@@ -43,6 +53,40 @@ function escapeRegex(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// A slug reference counts only when the slug is not embedded in a longer
+// kebab token: `requirements` must NOT match inside `nfr-requirements`.
+// \b treats `-` as a boundary, so the anchors here are lookarounds that
+// exclude word chars AND hyphens. Backticked filenames (`<slug>.md`) and
+// wikilinks ([[<slug>]]) still match: backtick, `[`, `.`, `]` are all
+// outside [\w-]. The explicit wikilink alternative is kept for contract
+// clarity even though the anchored form subsumes it.
+function slugPattern(slug: string): RegExp {
+	const e = escapeRegex(slug);
+	return new RegExp(`(?<![\\w-])${e}(?![\\w-])|\\[\\[${e}\\]\\]`, "i");
+}
+
+// A producing-stage directory citation counts as coverage for every
+// artifact that stage produces: artifacts cite upstream by provenance
+// path (`construction/<unit>/nfr-requirements/`), not by re-naming each
+// slug. The producer slug must appear as a whole path segment - leading
+// (`nfr-requirements/`) or trailing (`.../nfr-requirements`) - so a
+// longer sibling slug (`some-nfr-requirements/`) never satisfies it.
+function producerDirPattern(producer: string): RegExp {
+	const e = escapeRegex(producer);
+	return new RegExp(`(?<![\\w-])${e}(?=/)|(?<=/)${e}(?![\\w-])`, "i");
+}
+
+// Consume entries arrive as `artifact` or `artifact:producer-stage`. The
+// bare form stays valid (direct invocations, older dispatchers): it just
+// gets no producer-directory alternative.
+function parseConsume(entry: string): Consume {
+	const idx = entry.indexOf(":");
+	if (idx === -1) return { slug: entry };
+	const slug = entry.slice(0, idx).trim();
+	const producer = entry.slice(idx + 1).trim();
+	return producer.length > 0 ? { slug, producer } : { slug };
+}
+
 function main(): void {
 	const flags = parseFlags(process.argv.slice(2));
 
@@ -53,15 +97,6 @@ function main(): void {
 		fail(`--output-path not found: ${flags.outputPath}`);
 	}
 
-	let body: string;
-	try {
-		body = readFileSync(flags.outputPath, "utf-8");
-	} catch (err) {
-		fail(
-			`failed to read --output-path ${flags.outputPath}: ${errorMessage(err)}`,
-		);
-	}
-
 	// Split, trim, drop empties. Both `--consumes ""` and an absent flag
 	// collapse to consumes = [], which triggers the "no upstream" early
 	// return below.
@@ -69,13 +104,16 @@ function main(): void {
 	const consumes = rawConsumes
 		.split(",")
 		.map((s) => s.trim())
-		.filter((s) => s.length > 0);
+		.filter((s) => s.length > 0)
+		.map(parseConsume)
+		.filter((c) => c.slug.length > 0);
 
 	if (consumes.length === 0) {
 		const result: Result = {
 			pass: true,
 			consumes: [],
 			unreferenced: [],
+			scanned_files: [],
 			reason: "no upstream",
 			findings_count: 0,
 		};
@@ -83,24 +121,99 @@ function main(): void {
 		process.exit(0);
 	}
 
-	// Per the locked plan: case-insensitive grep with word-boundary
-	// anchors on the slug and either form: \b<slug>\b (literal) OR
-	// \[\[<slug>\]\] (wikilink). Slugs are kebab-case so word boundaries
-	// resolve cleanly without escaping anything beyond standard regex
-	// metacharacters.
+	// Coverage is a property of the STAGE's output, not of each file: a
+	// multi-artifact stage legitimately splits its upstream citations
+	// across sibling deliverables (business-rules.md cites the domain
+	// model; tech-stack-decisions.md has no reason to). So when the
+	// dispatcher threads --deliverables (the stage's produces union,
+	// already filtered of `*-questions`/`*-timestamp` scaffolding), the
+	// body under test is the union of those files in the fired file's
+	// directory, plus the fired file itself UNLESS it is scaffolding:
+	// the fire hook also fires on memory.md / `*-questions.md` writes,
+	// and a slug that appears only in the Q&A or the builder's diary is
+	// not upstream coverage. Every fire within a stage thus converges on
+	// the same stage-level verdict. Without --deliverables (direct
+	// invocation, older dispatcher) only the fired file is read, as
+	// before.
+	const firedPath = resolve(flags.outputPath);
+	const dir = dirname(firedPath);
+	const deliverables = (flags.deliverables ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	const firedBase = basename(firedPath);
+	const firedIsScaffolding =
+		firedBase === "memory.md" ||
+		firedBase.endsWith("-questions.md") ||
+		firedBase.endsWith("-timestamp.md");
+
+	const scanPaths: string[] = [];
+	if (deliverables.length === 0) {
+		scanPaths.push(firedPath);
+	} else {
+		for (const stem of deliverables) {
+			const p = resolve(join(dir, `${stem}.md`));
+			if (existsSync(p)) scanPaths.push(p);
+		}
+		if (!firedIsScaffolding && !scanPaths.includes(firedPath)) {
+			scanPaths.push(firedPath);
+		}
+	}
+
+	let body = "";
+	const scannedFiles: string[] = [];
+	for (const p of scanPaths) {
+		try {
+			body += `\n${readFileSync(p, "utf-8")}`;
+			scannedFiles.push(p);
+		} catch (err) {
+			if (p === firedPath) {
+				fail(`failed to read --output-path ${p}: ${errorMessage(err)}`);
+			}
+			// Unreadable sibling: skip - coverage falls back to what is
+			// readable rather than erroring the whole fire.
+		}
+	}
+
+	// A scaffolding write can fire before any deliverable exists (stages
+	// write their questions file first). With nothing to evaluate, the
+	// check is vacuous - pass with a reason, mirroring "no upstream" -
+	// rather than reporting every consume unreferenced against an empty
+	// set. The stage's later deliverable writes re-fire and evaluate for
+	// real.
+	if (scannedFiles.length === 0) {
+		const result: Result = {
+			pass: true,
+			consumes: consumes.map((c) => c.slug),
+			unreferenced: [],
+			scanned_files: [],
+			reason: "no deliverables on disk yet",
+			findings_count: 0,
+		};
+		process.stdout.write(`${JSON.stringify(result)}\n`);
+		process.exit(0);
+	}
+
+	// A consume is covered when the union body references it in any form
+	// the framework's artifacts actually use: the bare slug (anchored so
+	// longer kebab tokens don't false-positive), a wikilink, or the
+	// producing stage's directory as a path segment.
 	const unreferenced: string[] = [];
-	for (const slug of consumes) {
-		const escaped = escapeRegex(slug);
-		const pattern = new RegExp(`\\b${escaped}\\b|\\[\\[${escaped}\\]\\]`, "i");
-		if (!pattern.test(body)) {
-			unreferenced.push(slug);
+	for (const c of consumes) {
+		const covered =
+			slugPattern(c.slug).test(body) ||
+			(c.producer !== undefined && producerDirPattern(c.producer).test(body));
+		if (!covered) {
+			unreferenced.push(c.slug);
 		}
 	}
 
 	const result: Result = {
 		pass: unreferenced.length === 0,
-		consumes,
+		consumes: consumes.map((c) => c.slug),
 		unreferenced,
+		scanned_files: scannedFiles,
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
 		findings_count: unreferenced.length,
 	};

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor.ts
@@ -273,6 +273,16 @@ function presentConsumes(pd: string, slugs: string[]): string[] {
 	});
 }
 
+// upstream-coverage consume entries carry the producing stage as
+// `artifact:producer-stage` so the sensor can count a citation of the
+// producer's directory (the framework's provenance-header convention)
+// as coverage of every artifact under it. An orphan consume (no
+// producer in the graph - doctor surfaces those) stays a bare slug.
+function consumeWithProducer(slug: string): string {
+	const producer = producersOf(slug)[0];
+	return producer ? `${slug}:${producer.slug}` : slug;
+}
+
 // --- Subcommand: fire ---
 //
 // Step 1 — validate + resolve all inputs + generate Fire id (no lock).
@@ -351,13 +361,15 @@ function handleFire(args: string[]): void {
 
 	// --- 2. Compute extra args for the per-sensor script ---
 	// Markdown sensors take --output-path; code sensors take --file-path.
-	// upstream-coverage additionally takes --consumes "art1,art2,..." sourced
-	// from the GraphStage.consumes[].artifact field, filtered to artifacts
-	// that exist on disk: a consume whose producing stage was skipped by the
-	// scope (or runtime-skipped, e.g. reverse-engineering on greenfield)
-	// never produced its file, and demanding the output prose reference it
-	// would be a guaranteed false SENSOR_FAILED on every run of that stage
-	// in that scope.
+	// upstream-coverage additionally takes --consumes
+	// "art1:producer1,art2:producer2,..." sourced from the
+	// GraphStage.consumes[].artifact field (producer resolved via
+	// producersOf so a producing-directory citation can count as
+	// coverage), filtered to artifacts that exist on disk: a consume
+	// whose producing stage was skipped by the scope (or runtime-skipped,
+	// e.g. reverse-engineering on greenfield) never produced its file,
+	// and demanding the output prose reference it would be a guaranteed
+	// false SENSOR_FAILED on every run of that stage in that scope.
 	const isCodeSensor = id === "linter" || id === "type-check";
 	const scriptArgs: string[] = ["--stage", stageSlug];
 	if (isCodeSensor) {
@@ -371,7 +383,22 @@ function handleFire(args: string[]): void {
 			.filter((a) => typeof a === "string" && a.length > 0);
 		scriptArgs.push(
 			"--consumes",
-			presentConsumes(projectDir, consumeSlugs).join(","),
+			presentConsumes(projectDir, consumeSlugs)
+				.map(consumeWithProducer)
+				.join(","),
+		);
+		// Coverage is evaluated over the stage's whole deliverable set (the
+		// sensor unions the sibling files named here), not the single fired
+		// file - a multi-artifact stage splits its upstream citations across
+		// siblings. Same eligibility filter as required-sections: the
+		// `*-questions`/`*-timestamp` scaffolding is excluded so a citation
+		// that appears only in the Q&A file never counts as coverage.
+		scriptArgs.push(
+			"--deliverables",
+			templateEligibleArtifacts([
+				...(stageNode.produces ?? []),
+				...(stageNode.optional_produces ?? []),
+			]).join(","),
 		);
 	}
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.6";
+export const AIDLC_VERSION = "2.3.7";

--- a/dist/kiro/.kiro/sensors/aidlc-upstream-coverage.md
+++ b/dist/kiro/.kiro/sensors/aidlc-upstream-coverage.md
@@ -3,13 +3,14 @@ id: upstream-coverage
 kind: deterministic
 command: bun .kiro/tools/aidlc-sensor-upstream-coverage.ts
 default_severity: advisory
-description: Checks the output prose references the upstream artifacts the stage frontmatter declares it consumes
+description: Checks the stage's deliverables reference the upstream artifacts the stage frontmatter declares it consumes
 category: document-shape
 matches: "**/{aidlc-docs,intents}/**"
 input_schema:
   output_path: string
   stage_slug: string
   consumes: string[]
+  deliverables: string[]
 output_schema:
   pass: boolean
   unreferenced_artifacts: string[]
@@ -18,12 +19,27 @@ timeout_seconds: 5
 
 # upstream-coverage sensor
 
-Reads the stage frontmatter `consumes:` list and checks the output prose
-references each upstream artifact (by name or wikilink).
+Reads the stage frontmatter `consumes:` list and checks the stage's
+deliverables reference each upstream artifact. A reference counts in any
+of the forms the framework's artifacts actually use:
 
-Pure derivation from frontmatter — no per-stage config needed.
+- the artifact slug as a standalone token (not embedded in a longer
+  kebab token: `requirements` inside `nfr-requirements` does not count)
+- a wikilink (`[[<slug>]]`) or backticked filename (`` `<slug>.md` ``)
+- the producing stage's directory as a path segment (e.g. a provenance
+  header citing `nfr-requirements/` covers every artifact that stage
+  produces)
+
+Coverage is a property of the stage's whole output, not of each file:
+the check runs over the union of the stage's declared deliverables in
+the output directory (scaffolding - `*-questions.md`, `*-timestamp.md`,
+`memory.md` - is excluded from both sides), so a citation in a sibling
+deliverable counts.
+
+Pure derivation from frontmatter - no per-stage config needed.
 
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing artifacts declared in
-`consumes:` that don't appear anywhere in the output prose.
+`consumes:` that appear in none of the stage's deliverables in any
+accepted form.

--- a/dist/kiro/.kiro/tools/aidlc-sensor-upstream-coverage.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-upstream-coverage.ts
@@ -1,12 +1,19 @@
 import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { errorMessage } from "./aidlc-lib.ts";
 
 interface Result {
 	pass: boolean;
 	consumes: string[];
 	unreferenced: string[];
+	scanned_files: string[];
 	reason?: string;
 	findings_count: number;
+}
+
+interface Consume {
+	slug: string;
+	producer?: string;
 }
 
 interface Flags {
@@ -14,6 +21,7 @@ interface Flags {
 	outputPath?: string;
 	consumes?: string;
 	consumesPresent: boolean;
+	deliverables?: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -29,6 +37,8 @@ function parseFlags(argv: string[]): Flags {
 			// Handle `--consumes` as last flag (no value) and `--consumes ""`
 			// identically: treat both as empty list.
 			out.consumes = argv[++i] ?? "";
+		} else if (arg === "--deliverables") {
+			out.deliverables = argv[++i] ?? "";
 		}
 	}
 	return out;
@@ -43,6 +53,40 @@ function escapeRegex(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// A slug reference counts only when the slug is not embedded in a longer
+// kebab token: `requirements` must NOT match inside `nfr-requirements`.
+// \b treats `-` as a boundary, so the anchors here are lookarounds that
+// exclude word chars AND hyphens. Backticked filenames (`<slug>.md`) and
+// wikilinks ([[<slug>]]) still match: backtick, `[`, `.`, `]` are all
+// outside [\w-]. The explicit wikilink alternative is kept for contract
+// clarity even though the anchored form subsumes it.
+function slugPattern(slug: string): RegExp {
+	const e = escapeRegex(slug);
+	return new RegExp(`(?<![\\w-])${e}(?![\\w-])|\\[\\[${e}\\]\\]`, "i");
+}
+
+// A producing-stage directory citation counts as coverage for every
+// artifact that stage produces: artifacts cite upstream by provenance
+// path (`construction/<unit>/nfr-requirements/`), not by re-naming each
+// slug. The producer slug must appear as a whole path segment - leading
+// (`nfr-requirements/`) or trailing (`.../nfr-requirements`) - so a
+// longer sibling slug (`some-nfr-requirements/`) never satisfies it.
+function producerDirPattern(producer: string): RegExp {
+	const e = escapeRegex(producer);
+	return new RegExp(`(?<![\\w-])${e}(?=/)|(?<=/)${e}(?![\\w-])`, "i");
+}
+
+// Consume entries arrive as `artifact` or `artifact:producer-stage`. The
+// bare form stays valid (direct invocations, older dispatchers): it just
+// gets no producer-directory alternative.
+function parseConsume(entry: string): Consume {
+	const idx = entry.indexOf(":");
+	if (idx === -1) return { slug: entry };
+	const slug = entry.slice(0, idx).trim();
+	const producer = entry.slice(idx + 1).trim();
+	return producer.length > 0 ? { slug, producer } : { slug };
+}
+
 function main(): void {
 	const flags = parseFlags(process.argv.slice(2));
 
@@ -53,15 +97,6 @@ function main(): void {
 		fail(`--output-path not found: ${flags.outputPath}`);
 	}
 
-	let body: string;
-	try {
-		body = readFileSync(flags.outputPath, "utf-8");
-	} catch (err) {
-		fail(
-			`failed to read --output-path ${flags.outputPath}: ${errorMessage(err)}`,
-		);
-	}
-
 	// Split, trim, drop empties. Both `--consumes ""` and an absent flag
 	// collapse to consumes = [], which triggers the "no upstream" early
 	// return below.
@@ -69,13 +104,16 @@ function main(): void {
 	const consumes = rawConsumes
 		.split(",")
 		.map((s) => s.trim())
-		.filter((s) => s.length > 0);
+		.filter((s) => s.length > 0)
+		.map(parseConsume)
+		.filter((c) => c.slug.length > 0);
 
 	if (consumes.length === 0) {
 		const result: Result = {
 			pass: true,
 			consumes: [],
 			unreferenced: [],
+			scanned_files: [],
 			reason: "no upstream",
 			findings_count: 0,
 		};
@@ -83,24 +121,99 @@ function main(): void {
 		process.exit(0);
 	}
 
-	// Per the locked plan: case-insensitive grep with word-boundary
-	// anchors on the slug and either form: \b<slug>\b (literal) OR
-	// \[\[<slug>\]\] (wikilink). Slugs are kebab-case so word boundaries
-	// resolve cleanly without escaping anything beyond standard regex
-	// metacharacters.
+	// Coverage is a property of the STAGE's output, not of each file: a
+	// multi-artifact stage legitimately splits its upstream citations
+	// across sibling deliverables (business-rules.md cites the domain
+	// model; tech-stack-decisions.md has no reason to). So when the
+	// dispatcher threads --deliverables (the stage's produces union,
+	// already filtered of `*-questions`/`*-timestamp` scaffolding), the
+	// body under test is the union of those files in the fired file's
+	// directory, plus the fired file itself UNLESS it is scaffolding:
+	// the fire hook also fires on memory.md / `*-questions.md` writes,
+	// and a slug that appears only in the Q&A or the builder's diary is
+	// not upstream coverage. Every fire within a stage thus converges on
+	// the same stage-level verdict. Without --deliverables (direct
+	// invocation, older dispatcher) only the fired file is read, as
+	// before.
+	const firedPath = resolve(flags.outputPath);
+	const dir = dirname(firedPath);
+	const deliverables = (flags.deliverables ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	const firedBase = basename(firedPath);
+	const firedIsScaffolding =
+		firedBase === "memory.md" ||
+		firedBase.endsWith("-questions.md") ||
+		firedBase.endsWith("-timestamp.md");
+
+	const scanPaths: string[] = [];
+	if (deliverables.length === 0) {
+		scanPaths.push(firedPath);
+	} else {
+		for (const stem of deliverables) {
+			const p = resolve(join(dir, `${stem}.md`));
+			if (existsSync(p)) scanPaths.push(p);
+		}
+		if (!firedIsScaffolding && !scanPaths.includes(firedPath)) {
+			scanPaths.push(firedPath);
+		}
+	}
+
+	let body = "";
+	const scannedFiles: string[] = [];
+	for (const p of scanPaths) {
+		try {
+			body += `\n${readFileSync(p, "utf-8")}`;
+			scannedFiles.push(p);
+		} catch (err) {
+			if (p === firedPath) {
+				fail(`failed to read --output-path ${p}: ${errorMessage(err)}`);
+			}
+			// Unreadable sibling: skip - coverage falls back to what is
+			// readable rather than erroring the whole fire.
+		}
+	}
+
+	// A scaffolding write can fire before any deliverable exists (stages
+	// write their questions file first). With nothing to evaluate, the
+	// check is vacuous - pass with a reason, mirroring "no upstream" -
+	// rather than reporting every consume unreferenced against an empty
+	// set. The stage's later deliverable writes re-fire and evaluate for
+	// real.
+	if (scannedFiles.length === 0) {
+		const result: Result = {
+			pass: true,
+			consumes: consumes.map((c) => c.slug),
+			unreferenced: [],
+			scanned_files: [],
+			reason: "no deliverables on disk yet",
+			findings_count: 0,
+		};
+		process.stdout.write(`${JSON.stringify(result)}\n`);
+		process.exit(0);
+	}
+
+	// A consume is covered when the union body references it in any form
+	// the framework's artifacts actually use: the bare slug (anchored so
+	// longer kebab tokens don't false-positive), a wikilink, or the
+	// producing stage's directory as a path segment.
 	const unreferenced: string[] = [];
-	for (const slug of consumes) {
-		const escaped = escapeRegex(slug);
-		const pattern = new RegExp(`\\b${escaped}\\b|\\[\\[${escaped}\\]\\]`, "i");
-		if (!pattern.test(body)) {
-			unreferenced.push(slug);
+	for (const c of consumes) {
+		const covered =
+			slugPattern(c.slug).test(body) ||
+			(c.producer !== undefined && producerDirPattern(c.producer).test(body));
+		if (!covered) {
+			unreferenced.push(c.slug);
 		}
 	}
 
 	const result: Result = {
 		pass: unreferenced.length === 0,
-		consumes,
+		consumes: consumes.map((c) => c.slug),
 		unreferenced,
+		scanned_files: scannedFiles,
 		// findings_count emitted by the script (sensor-id-agnostic dispatcher).
 		findings_count: unreferenced.length,
 	};

--- a/dist/kiro/.kiro/tools/aidlc-sensor.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor.ts
@@ -273,6 +273,16 @@ function presentConsumes(pd: string, slugs: string[]): string[] {
 	});
 }
 
+// upstream-coverage consume entries carry the producing stage as
+// `artifact:producer-stage` so the sensor can count a citation of the
+// producer's directory (the framework's provenance-header convention)
+// as coverage of every artifact under it. An orphan consume (no
+// producer in the graph - doctor surfaces those) stays a bare slug.
+function consumeWithProducer(slug: string): string {
+	const producer = producersOf(slug)[0];
+	return producer ? `${slug}:${producer.slug}` : slug;
+}
+
 // --- Subcommand: fire ---
 //
 // Step 1 — validate + resolve all inputs + generate Fire id (no lock).
@@ -351,13 +361,15 @@ function handleFire(args: string[]): void {
 
 	// --- 2. Compute extra args for the per-sensor script ---
 	// Markdown sensors take --output-path; code sensors take --file-path.
-	// upstream-coverage additionally takes --consumes "art1,art2,..." sourced
-	// from the GraphStage.consumes[].artifact field, filtered to artifacts
-	// that exist on disk: a consume whose producing stage was skipped by the
-	// scope (or runtime-skipped, e.g. reverse-engineering on greenfield)
-	// never produced its file, and demanding the output prose reference it
-	// would be a guaranteed false SENSOR_FAILED on every run of that stage
-	// in that scope.
+	// upstream-coverage additionally takes --consumes
+	// "art1:producer1,art2:producer2,..." sourced from the
+	// GraphStage.consumes[].artifact field (producer resolved via
+	// producersOf so a producing-directory citation can count as
+	// coverage), filtered to artifacts that exist on disk: a consume
+	// whose producing stage was skipped by the scope (or runtime-skipped,
+	// e.g. reverse-engineering on greenfield) never produced its file,
+	// and demanding the output prose reference it would be a guaranteed
+	// false SENSOR_FAILED on every run of that stage in that scope.
 	const isCodeSensor = id === "linter" || id === "type-check";
 	const scriptArgs: string[] = ["--stage", stageSlug];
 	if (isCodeSensor) {
@@ -371,7 +383,22 @@ function handleFire(args: string[]): void {
 			.filter((a) => typeof a === "string" && a.length > 0);
 		scriptArgs.push(
 			"--consumes",
-			presentConsumes(projectDir, consumeSlugs).join(","),
+			presentConsumes(projectDir, consumeSlugs)
+				.map(consumeWithProducer)
+				.join(","),
+		);
+		// Coverage is evaluated over the stage's whole deliverable set (the
+		// sensor unions the sibling files named here), not the single fired
+		// file - a multi-artifact stage splits its upstream citations across
+		// siblings. Same eligibility filter as required-sections: the
+		// `*-questions`/`*-timestamp` scaffolding is excluded so a citation
+		// that appears only in the Q&A file never counts as coverage.
+		scriptArgs.push(
+			"--deliverables",
+			templateEligibleArtifacts([
+				...(stageNode.produces ?? []),
+				...(stageNode.optional_produces ?? []),
+			]).join(","),
 		);
 	}
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.6";
+export const AIDLC_VERSION = "2.3.7";

--- a/docs/guide/09-rules-and-the-learning-loop.md
+++ b/docs/guide/09-rules-and-the-learning-loop.md
@@ -150,7 +150,7 @@ Four sensors ship with the framework:
 | Sensor | Fires on | Checks |
 |--------|----------|--------|
 | `required-sections` | Any record-dir markdown output | The output contains the required H2 headings (a generic content-shape check) |
-| `upstream-coverage` | Any record-dir markdown output | The output prose references each upstream artifact the stage declares it consumes |
+| `upstream-coverage` | Any record-dir markdown output | The stage's deliverables (evaluated as a set) reference each upstream artifact the stage declares it consumes, by slug, wikilink, or the producing stage's directory path |
 | `linter` | `.ts` / `.js` code outputs | Wraps your configured linter (ESLint by default) |
 | `type-check` | `.ts` / `.tsx` code outputs | Wraps your configured type-checker (`tsc` by default) |
 

--- a/docs/harness-engineering/06-sensors.md
+++ b/docs/harness-engineering/06-sensors.md
@@ -59,7 +59,7 @@ Four manifests ship under `.claude/sensors/`, each prefixed `aidlc-`:
 | Manifest | Fires on | Checks |
 |----------|----------|--------|
 | `aidlc-required-sections.md` | record-dir markdown output | The output carries the required H2 headings — a generic content-shape check |
-| `aidlc-upstream-coverage.md` | record-dir markdown output | The prose references each upstream artifact the stage declares it consumes |
+| `aidlc-upstream-coverage.md` | record-dir markdown output | The stage's deliverables (evaluated as a set) reference each upstream artifact the stage declares it consumes, by slug, wikilink, or the producing stage's directory path |
 | `aidlc-linter.md` | `.ts` / `.js` code output | Wraps your configured linter (ESLint by default) |
 | `aidlc-type-check.md` | `.ts` / `.tsx` code output | Wraps your configured type-checker (`tsc` by default) |
 

--- a/tests/integration/t92.test.ts
+++ b/tests/integration/t92.test.ts
@@ -1126,7 +1126,14 @@ describe("t92 Group M: upstream-coverage --consumes resolution", () => {
     expect(argv).toContain('"--stage"');
     expect(argv).toContain('"market-research"');
     expect(argv).toContain('"--consumes"');
-    expect(argv).toContain('"intent-statement"');
+    // Consume entries carry the producing stage (artifact:producer) so a
+    // producing-directory citation can count as coverage.
+    expect(argv).toContain('"intent-statement:intent-capture"');
+    // The stage's deliverable union (produces minus `*-questions`/
+    // `*-timestamp` scaffolding), threaded so coverage is evaluated over
+    // sibling deliverables, not the single fired file.
+    expect(argv).toContain('"--deliverables"');
+    expect(argv).toContain('"competitive-analysis,market-trends,build-vs-buy"');
     expect(argv).toContain('"--output-path"');
   });
 });

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -738,6 +738,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
   // a new spawning test still cannot land without a human edit here.
   const EXPECTED_NONE_TO_CLI = [
     "unit/t220-tier-projection-module.test.ts",
+    "unit/t233-upstream-coverage-matching.test.ts",
     "integration/t102.test.ts",
     "integration/t104.test.ts",
     "integration/t105.test.ts",

--- a/tests/unit/t233-upstream-coverage-matching.test.ts
+++ b/tests/unit/t233-upstream-coverage-matching.test.ts
@@ -1,0 +1,343 @@
+// covers: subcommand:aidlc-sensor-upstream-coverage
+//
+// t233 - upstream-coverage matching accuracy: the citation forms the
+// framework's artifacts actually use, evaluated over the stage's
+// deliverable union rather than the single fired file.
+//
+// The shipped check used to be a per-file `\b<slug>\b | [[<slug>]]` grep
+// against the one fired file. Two structural mismatches with the
+// framework's authoring conventions made its failures mostly false:
+//   1. Artifacts cite upstream by producing-stage DIRECTORY path in their
+//      provenance header (`construction/<unit>/nfr-requirements/`), never
+//      re-naming each slug - so `\bperformance-requirements\b` missed a
+//      legitimately-cited upstream.
+//   2. A multi-artifact stage splits its citations across sibling
+//      deliverables (business-rules.md cites the domain model;
+//      tech-stack-decisions.md has no reason to) - so every file that
+//      legitimately omits an upstream failed the full consumes set.
+// And one latent false POSITIVE: `\b` treats `-` as a boundary, so the
+// consume `requirements` matched INSIDE the token `nfr-requirements`.
+//
+// This file pins the corrected contract at the PROCESS boundary - it
+// spawns the real per-sensor script (aidlc-sensor-upstream-coverage.ts)
+// via spawnSync from the SHIPPED tree (AIDLC_SRC), the same boundary t155
+// uses for required-sections - passing the dispatcher-threaded flags
+// (--consumes with `artifact:producer` pairs, --deliverables with the
+// stage's scaffolding-filtered produces union) directly. Asserted
+// properties:
+//
+//   1. Producer-directory citation covers every artifact of that stage
+//      (leading `producer/` and trailing `.../producer` segment forms).
+//   2. Sibling-union evaluation: a citation in one deliverable covers the
+//      consume for a fire on a different deliverable.
+//   3. Scaffolding never counts: a slug appearing only in the fired
+//      `*-questions.md` (or memory.md) does not satisfy coverage, and the
+//      union excludes those files.
+//   4. Hyphen-substring false positive killed: `requirements` inside
+//      `nfr-requirements` (token or directory form) is NOT a reference.
+//   5. Back-compat: bare-slug --consumes without --deliverables keeps the
+//      old per-file semantics; bare slug, wikilink, and backticked
+//      `<slug>.md` forms all still match; `--consumes ""` keeps the
+//      "no upstream" early return.
+//   6. Vacuous fire: --deliverables named but none on disk yet (the
+//      questions-file-first write order) -> pass with reason, not a false
+//      SENSOR_FAILED against an empty body.
+//
+// Mechanism: cli (spawnSync of the bun script). No LLM, no tokens -
+// byte-reproducible.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AIDLC_SRC } from "../harness/fixtures.ts";
+
+const BUN = process.execPath; // the bun running this test
+const SENSOR = join(AIDLC_SRC, "tools", "aidlc-sensor-upstream-coverage.ts");
+
+const tempDirs: string[] = [];
+afterAll(() => {
+	for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+});
+
+interface SensorResult {
+	pass: boolean;
+	consumes: string[];
+	unreferenced: string[];
+	scanned_files: string[];
+	reason?: string;
+	findings_count: number;
+}
+
+/** Fresh stage dir seeded with the given files (name -> body). */
+function makeStageDir(files: Record<string, string>): string {
+	const dir = mkdtempSync(join(tmpdir(), "aidlc-t233-"));
+	tempDirs.push(dir);
+	for (const [name, body] of Object.entries(files)) {
+		writeFileSync(join(dir, name), body, "utf-8");
+	}
+	return dir;
+}
+
+/** Spawn the real sensor script; parse its stdout JSON. */
+function run(
+	dir: string,
+	outputName: string,
+	consumes: string,
+	deliverables?: string,
+): SensorResult {
+	const args = [
+		SENSOR,
+		"--stage",
+		"t233-stage",
+		"--output-path",
+		join(dir, outputName),
+		"--consumes",
+		consumes,
+	];
+	if (deliverables !== undefined) args.push("--deliverables", deliverables);
+	const res = spawnSync(BUN, args, { encoding: "utf-8" });
+	expect(res.status).toBe(0);
+	return JSON.parse(res.stdout) as SensorResult;
+}
+
+describe("t233 producer-directory citation (fix A)", () => {
+	test("1: provenance header citing `nfr-requirements/` covers all artifacts that stage produces", () => {
+		// The representative shape from a real nfr-design output: a basis/
+		// trace header naming the producing-stage directory once, no bare
+		// slug anywhere.
+		const dir = makeStageDir({
+			"performance-design.md": [
+				"# Performance Design",
+				"",
+				"basis/trace: `construction/api-service/nfr-requirements/`,",
+				"`decisions.md`",
+				"",
+				"## Design",
+				"Content.",
+				"",
+			].join("\n"),
+		});
+		const r = run(
+			dir,
+			"performance-design.md",
+			"performance-requirements:nfr-requirements,security-requirements:nfr-requirements,scalability-requirements:nfr-requirements,reliability-requirements:nfr-requirements",
+			"performance-design",
+		);
+		expect(r.pass).toBe(true);
+		expect(r.unreferenced).toEqual([]);
+		expect(r.findings_count).toBe(0);
+	});
+
+	test("2: trailing path-segment form (`see ../nfr-requirements`) also counts", () => {
+		const dir = makeStageDir({
+			"doc.md": "# Doc\n\nSee ../nfr-requirements for the baseline.\n",
+		});
+		const r = run(
+			dir,
+			"doc.md",
+			"performance-requirements:nfr-requirements",
+			"doc",
+		);
+		expect(r.pass).toBe(true);
+	});
+
+	test("3: a LONGER slug containing the producer as a suffix does not count", () => {
+		const dir = makeStageDir({
+			"doc.md": "# Doc\n\nSee some-nfr-requirements/ for something else.\n",
+		});
+		const r = run(
+			dir,
+			"doc.md",
+			"performance-requirements:nfr-requirements",
+			"doc",
+		);
+		expect(r.pass).toBe(false);
+		expect(r.unreferenced).toEqual(["performance-requirements"]);
+	});
+
+	test("4: producer named as a bare token (no path segment) does not count", () => {
+		// The producer alternative is a DIRECTORY-citation match, not a
+		// second slug match: prose merely mentioning the stage name without
+		// a path form stays uncovered.
+		const dir = makeStageDir({
+			"doc.md": "# Doc\n\nWe did this after nfr-requirements finished.\n",
+		});
+		const r = run(
+			dir,
+			"doc.md",
+			"performance-requirements:nfr-requirements",
+			"doc",
+		);
+		expect(r.pass).toBe(false);
+	});
+});
+
+describe("t233 sibling-union evaluation (fix B)", () => {
+	test("5: citation in a sibling deliverable covers a fire on a file that omits it", () => {
+		// nfr-requirements shape: business-rules.md cites the domain model,
+		// tech-stack-decisions.md legitimately does not.
+		const dir = makeStageDir({
+			"business-rules.md":
+				"# Business Rules\n\nDerived from `business-logic-model.md`.\n\n## Rules\nContent.\n",
+			"tech-stack-decisions.md":
+				"# Tech Stack\n\n## Decisions\nStack content, no domain-model mention.\n",
+		});
+		const r = run(
+			dir,
+			"tech-stack-decisions.md",
+			"business-logic-model:functional-design",
+			"business-rules,tech-stack-decisions",
+		);
+		expect(r.pass).toBe(true);
+		// Both deliverables were scanned.
+		expect(r.scanned_files.length).toBe(2);
+	});
+
+	test("6: consume referenced in NO deliverable still fails (signal survives)", () => {
+		const dir = makeStageDir({
+			"business-rules.md": "# Business Rules\n\n## Rules\nContent.\n",
+			"tech-stack-decisions.md": "# Tech Stack\n\n## Decisions\nContent.\n",
+		});
+		const r = run(
+			dir,
+			"tech-stack-decisions.md",
+			"business-logic-model:functional-design",
+			"business-rules,tech-stack-decisions",
+		);
+		expect(r.pass).toBe(false);
+		expect(r.unreferenced).toEqual(["business-logic-model"]);
+		expect(r.findings_count).toBe(1);
+	});
+
+	test("7: every fire in the stage converges on the same stage-level verdict", () => {
+		const dir = makeStageDir({
+			"business-rules.md":
+				"# Business Rules\n\nDerived from `business-logic-model.md`.\n",
+			"tech-stack-decisions.md": "# Tech Stack\n\nContent.\n",
+		});
+		const consumes = "business-logic-model:functional-design";
+		const deliverables = "business-rules,tech-stack-decisions";
+		const a = run(dir, "business-rules.md", consumes, deliverables);
+		const b = run(dir, "tech-stack-decisions.md", consumes, deliverables);
+		expect(a.pass).toBe(true);
+		expect(b.pass).toBe(true);
+		expect(a.scanned_files).toEqual(b.scanned_files);
+	});
+});
+
+describe("t233 scaffolding exclusion", () => {
+	test("8: slug appearing ONLY in the fired *-questions.md does not count", () => {
+		// The caveat from the union design: without this exclusion a slug in
+		// the Q&A file would trade the false negative for a false positive.
+		const dir = makeStageDir({
+			"t233-stage-questions.md":
+				"# Questions\n\nQ: does business-logic-model matter? A: yes.\n",
+			"tech-stack-decisions.md": "# Tech Stack\n\nContent.\n",
+		});
+		const r = run(
+			dir,
+			"t233-stage-questions.md",
+			"business-logic-model:functional-design",
+			"tech-stack-decisions",
+		);
+		expect(r.pass).toBe(false);
+		expect(r.unreferenced).toEqual(["business-logic-model"]);
+		// The fired scaffolding file itself was not part of the union.
+		expect(r.scanned_files.length).toBe(1);
+		expect(r.scanned_files[0].endsWith("tech-stack-decisions.md")).toBe(true);
+	});
+
+	test("9: fired memory.md is excluded the same way", () => {
+		const dir = makeStageDir({
+			"memory.md": "# Memory\n\nUsed business-logic-model heavily today.\n",
+			"tech-stack-decisions.md": "# Tech Stack\n\nContent.\n",
+		});
+		const r = run(
+			dir,
+			"memory.md",
+			"business-logic-model:functional-design",
+			"tech-stack-decisions",
+		);
+		expect(r.pass).toBe(false);
+		expect(r.scanned_files.length).toBe(1);
+	});
+
+	test("10: scaffolding fired before any deliverable exists -> vacuous pass with reason", () => {
+		const dir = makeStageDir({
+			"t233-stage-questions.md": "# Questions\n\nQ: anything? A: yes.\n",
+		});
+		const r = run(
+			dir,
+			"t233-stage-questions.md",
+			"business-logic-model:functional-design",
+			"tech-stack-decisions",
+		);
+		expect(r.pass).toBe(true);
+		expect(r.reason).toBe("no deliverables on disk yet");
+		expect(r.scanned_files).toEqual([]);
+		expect(r.findings_count).toBe(0);
+	});
+});
+
+describe("t233 hyphen-substring false positive killed", () => {
+	test("11: `requirements` inside the token `nfr-requirements` is NOT a reference", () => {
+		// \b treats `-` as a word boundary, so the shipped regex matched the
+		// consume `requirements` inside `nfr-requirements` - a file naming
+		// its own stage directory falsely covered the consume.
+		const dir = makeStageDir({
+			"doc.md": "# Doc\n\nMentions nfr-requirements/ and nothing else.\n",
+		});
+		const r = run(dir, "doc.md", "requirements:requirements-analysis", "doc");
+		expect(r.pass).toBe(false);
+		expect(r.unreferenced).toEqual(["requirements"]);
+	});
+
+	test("12: the standalone token still matches", () => {
+		const dir = makeStageDir({
+			"doc.md": "# Doc\n\nPer the requirements baseline.\n",
+		});
+		const r = run(dir, "doc.md", "requirements:requirements-analysis", "doc");
+		expect(r.pass).toBe(true);
+	});
+});
+
+describe("t233 back-compat forms", () => {
+	test("13: bare-slug --consumes without --deliverables keeps per-file semantics", () => {
+		const dir = makeStageDir({
+			"a.md": "# A\n\nCites intent-statement directly.\n",
+			"b.md": "# B\n\nNo citation.\n",
+		});
+		// a.md passes on its own body; b.md fails on its own body - the
+		// sibling is NOT consulted without --deliverables.
+		expect(run(dir, "a.md", "intent-statement").pass).toBe(true);
+		const rb = run(dir, "b.md", "intent-statement");
+		expect(rb.pass).toBe(false);
+		expect(rb.scanned_files.length).toBe(1);
+	});
+
+	test("14: wikilink and backticked-filename forms still match", () => {
+		const dir = makeStageDir({
+			"wiki.md": "# W\n\nBased on [[intent-statement]].\n",
+			"tick.md": "# T\n\nBased on `intent-statement.md`.\n",
+		});
+		expect(run(dir, "wiki.md", "intent-statement").pass).toBe(true);
+		expect(run(dir, "tick.md", "intent-statement").pass).toBe(true);
+	});
+
+	test("15: --consumes \"\" keeps the no-upstream early return", () => {
+		const dir = makeStageDir({ "a.md": "# A\n\nBody.\n" });
+		const r = run(dir, "a.md", "");
+		expect(r.pass).toBe(true);
+		expect(r.reason).toBe("no upstream");
+		expect(r.consumes).toEqual([]);
+	});
+
+	test("16: matching is case-insensitive as before", () => {
+		const dir = makeStageDir({
+			"a.md": "# A\n\nSee Intent-Statement for context.\n",
+		});
+		expect(run(dir, "a.md", "intent-statement").pass).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #557.

## Problem

`upstream-coverage` checked each consumed artifact with a per-file `\b<slug>\b | [[<slug>]]` grep against the single fired file. Two structural mismatches with how the framework's artifacts actually cite upstream made its failures mostly false (the reported Construction run logged 178 false `SENSOR_FAILED` out of 186, and ~97% of flagged slugs were still "unreferenced" in the finished artifacts):

1. **Citation form.** Artifacts cite upstream by producing-stage directory path in their provenance header (`construction/<unit>/nfr-requirements/`), never re-naming each slug, so `\bperformance-requirements\b` missed a legitimately-cited upstream.
2. **Per-file vs per-stage.** A multi-artifact stage splits its citations across sibling deliverables: in `nfr-requirements`, `business-rules.md` cites `business-logic-model` but `tech-stack-decisions.md` does not (and should not). Firing per file demanded the full `consumes:` set in each.

Plus one latent false positive: `\b` treats `-` as a word boundary, so the consume `requirements` matched *inside* the token `nfr-requirements`.

## Fix (both directions from the issue, composed)

- **A. Producer-directory citations count.** The dispatcher threads `--consumes` as `artifact:producer` pairs (producer resolved via the existing `producersOf`, no new graph plumbing). The sensor counts a citation of the producing stage's directory as a whole path segment (leading `nfr-requirements/` or trailing `../nfr-requirements`) as coverage of every artifact that stage produces. A longer sibling slug (`some-nfr-requirements/`) never matches; the producer as a bare prose token (no path form) does not count either.
- **B. Stage-level evaluation.** A new `--deliverables` flag carries the stage's produces union (`produces` + `optional_produces` through the same `templateEligibleArtifacts` filter required-sections uses). The sensor evaluates coverage over the union of those files in the fired file's directory, so a citation in a sibling deliverable counts. Firing granularity is unchanged, so this stays independent of #529 (debounce), which addresses volume, not accuracy.
- **Scaffolding excluded from both sides** (the caveat the issue calls out): a slug appearing only in `memory.md` / `*-questions.md` never counts as coverage, and a fire on a scaffolding file is judged against the deliverables. A scaffolding write before any deliverable exists passes vacuously with `reason: "no deliverables on disk yet"`.
- **Hyphen-substring false positive killed:** slug anchors are now lookarounds excluding `[\w-]`. Backticked filenames, wikilinks, and case-insensitivity behave as before.

Back-compat: a bare-slug `--consumes` without `--deliverables` (direct invocations, older dispatchers) keeps the previous per-file semantics. Sensor JSON gains `scanned_files`.

On the issue's design question (is a directory-path citation *intended* to satisfy coverage?): nothing in the stage protocol or memory rules ever instructs artifacts to cite consumed slugs by name, so the artifacts are following the only convention that exists and the sensor's model is what diverged. This PR matches the sensor to the convention rather than adding authoring guidance whose enforcement would depend on LLM compliance.

## Verification

- New unit test `t233-upstream-coverage-matching` (16 cases) spawns the shipped sensor at the process boundary (same pattern as t155): directory-citation forms positive and negative, sibling-union scoring, per-fire verdict convergence, scaffolding exclusion, vacuous fire, hyphen false positive, and all back-compat forms.
- `t92` Group M extended to pin the dispatcher argv (`artifact:producer` pairs + `--deliverables` with the scaffolding-filtered produces union).
- End-to-end via the real dispatcher against the shipped stage graph: the issue's exact `nfr-design` provenance-header shape now passes; on `nfr-requirements` a split citation passes while a genuinely-absent reference still fails, listing only the true gap.
- Full default tier (smoke+unit+integration): 254 files, green except three pre-existing `t92` linter/type-check environment cases that fail identically on the untouched `v2` baseline.

`SENSOR_FAILED` stays advisory; this also clears the accuracy prerequisite noted in #431 (blocking severity) and in the issue's "latent risk" section.
