### PR TITLE
fix: advance the `## Phase Progress` section on phase transitions (#556)

### DIFF
--- a/core/tools/aidlc-state.ts
+++ b/core/tools/aidlc-state.ts
@@ -1195,6 +1195,20 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // 3b. Phase Progress flip on a boundary crossing. The `## Phase Progress`
+  // section is seeded once at init (all EXECUTE phases Pending); nothing else
+  // advanced it, so it drifted stale against the Stage Progress checkboxes.
+  // Honour the field's own doc contract ("Pending phases flip to Active on
+  // their phase-boundary advance and to Verified at phase completion"): flip
+  // the completed phase → Verified and the entered phase → Active. Labels are
+  // Title Case single words (Ideation, Inception, …); setField is a no-op when
+  // the label is absent, so a boundary into a `done`-only tail is harmless.
+  if (crossesPhaseBoundary) {
+    const label = (p: string): string => p.charAt(0).toUpperCase() + p.slice(1);
+    content = setField(content, label(completedStage.phase), "Verified");
+    content = setField(content, label(nextStage.phase), "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1384,6 +1398,19 @@ function handleCompleteWorkflow(args: string[]): void {
   // 2. Sync Completed counter
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // 2b. Phase Progress flip on final completion. This is a phase-completing
+  // transition (it emits PHASE_COMPLETED + PHASE_VERIFIED below), so honour the
+  // `## Phase Progress` doc contract the same way handleAdvance's boundary path
+  // does: flip the completed phase → Verified. There is no entered phase (the
+  // workflow ends here), so unlike the advance path there is no Active flip.
+  // setField is a no-op when the label is absent, so this is harmless on a
+  // state file without the section.
+  content = setField(
+    content,
+    completedStage.phase.charAt(0).toUpperCase() + completedStage.phase.slice(1),
+    "Verified",
+  );
 
   // 3. Update all fields atomically for workflow completion
   const timestamp = isoTimestamp();

--- a/dist/claude/.claude/tools/aidlc-state.ts
+++ b/dist/claude/.claude/tools/aidlc-state.ts
@@ -1195,6 +1195,20 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // 3b. Phase Progress flip on a boundary crossing. The `## Phase Progress`
+  // section is seeded once at init (all EXECUTE phases Pending); nothing else
+  // advanced it, so it drifted stale against the Stage Progress checkboxes.
+  // Honour the field's own doc contract ("Pending phases flip to Active on
+  // their phase-boundary advance and to Verified at phase completion"): flip
+  // the completed phase → Verified and the entered phase → Active. Labels are
+  // Title Case single words (Ideation, Inception, …); setField is a no-op when
+  // the label is absent, so a boundary into a `done`-only tail is harmless.
+  if (crossesPhaseBoundary) {
+    const label = (p: string): string => p.charAt(0).toUpperCase() + p.slice(1);
+    content = setField(content, label(completedStage.phase), "Verified");
+    content = setField(content, label(nextStage.phase), "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1384,6 +1398,19 @@ function handleCompleteWorkflow(args: string[]): void {
   // 2. Sync Completed counter
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // 2b. Phase Progress flip on final completion. This is a phase-completing
+  // transition (it emits PHASE_COMPLETED + PHASE_VERIFIED below), so honour the
+  // `## Phase Progress` doc contract the same way handleAdvance's boundary path
+  // does: flip the completed phase → Verified. There is no entered phase (the
+  // workflow ends here), so unlike the advance path there is no Active flip.
+  // setField is a no-op when the label is absent, so this is harmless on a
+  // state file without the section.
+  content = setField(
+    content,
+    completedStage.phase.charAt(0).toUpperCase() + completedStage.phase.slice(1),
+    "Verified",
+  );
 
   // 3. Update all fields atomically for workflow completion
   const timestamp = isoTimestamp();

--- a/dist/codex/.codex/tools/aidlc-state.ts
+++ b/dist/codex/.codex/tools/aidlc-state.ts
@@ -1195,6 +1195,20 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // 3b. Phase Progress flip on a boundary crossing. The `## Phase Progress`
+  // section is seeded once at init (all EXECUTE phases Pending); nothing else
+  // advanced it, so it drifted stale against the Stage Progress checkboxes.
+  // Honour the field's own doc contract ("Pending phases flip to Active on
+  // their phase-boundary advance and to Verified at phase completion"): flip
+  // the completed phase → Verified and the entered phase → Active. Labels are
+  // Title Case single words (Ideation, Inception, …); setField is a no-op when
+  // the label is absent, so a boundary into a `done`-only tail is harmless.
+  if (crossesPhaseBoundary) {
+    const label = (p: string): string => p.charAt(0).toUpperCase() + p.slice(1);
+    content = setField(content, label(completedStage.phase), "Verified");
+    content = setField(content, label(nextStage.phase), "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1384,6 +1398,19 @@ function handleCompleteWorkflow(args: string[]): void {
   // 2. Sync Completed counter
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // 2b. Phase Progress flip on final completion. This is a phase-completing
+  // transition (it emits PHASE_COMPLETED + PHASE_VERIFIED below), so honour the
+  // `## Phase Progress` doc contract the same way handleAdvance's boundary path
+  // does: flip the completed phase → Verified. There is no entered phase (the
+  // workflow ends here), so unlike the advance path there is no Active flip.
+  // setField is a no-op when the label is absent, so this is harmless on a
+  // state file without the section.
+  content = setField(
+    content,
+    completedStage.phase.charAt(0).toUpperCase() + completedStage.phase.slice(1),
+    "Verified",
+  );
 
   // 3. Update all fields atomically for workflow completion
   const timestamp = isoTimestamp();

--- a/dist/kiro-ide/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-state.ts
@@ -1195,6 +1195,20 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // 3b. Phase Progress flip on a boundary crossing. The `## Phase Progress`
+  // section is seeded once at init (all EXECUTE phases Pending); nothing else
+  // advanced it, so it drifted stale against the Stage Progress checkboxes.
+  // Honour the field's own doc contract ("Pending phases flip to Active on
+  // their phase-boundary advance and to Verified at phase completion"): flip
+  // the completed phase → Verified and the entered phase → Active. Labels are
+  // Title Case single words (Ideation, Inception, …); setField is a no-op when
+  // the label is absent, so a boundary into a `done`-only tail is harmless.
+  if (crossesPhaseBoundary) {
+    const label = (p: string): string => p.charAt(0).toUpperCase() + p.slice(1);
+    content = setField(content, label(completedStage.phase), "Verified");
+    content = setField(content, label(nextStage.phase), "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1384,6 +1398,19 @@ function handleCompleteWorkflow(args: string[]): void {
   // 2. Sync Completed counter
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // 2b. Phase Progress flip on final completion. This is a phase-completing
+  // transition (it emits PHASE_COMPLETED + PHASE_VERIFIED below), so honour the
+  // `## Phase Progress` doc contract the same way handleAdvance's boundary path
+  // does: flip the completed phase → Verified. There is no entered phase (the
+  // workflow ends here), so unlike the advance path there is no Active flip.
+  // setField is a no-op when the label is absent, so this is harmless on a
+  // state file without the section.
+  content = setField(
+    content,
+    completedStage.phase.charAt(0).toUpperCase() + completedStage.phase.slice(1),
+    "Verified",
+  );
 
   // 3. Update all fields atomically for workflow completion
   const timestamp = isoTimestamp();

--- a/dist/kiro/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro/.kiro/tools/aidlc-state.ts
@@ -1195,6 +1195,20 @@ function handleAdvance(args: string[]): void {
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
 
+  // 3b. Phase Progress flip on a boundary crossing. The `## Phase Progress`
+  // section is seeded once at init (all EXECUTE phases Pending); nothing else
+  // advanced it, so it drifted stale against the Stage Progress checkboxes.
+  // Honour the field's own doc contract ("Pending phases flip to Active on
+  // their phase-boundary advance and to Verified at phase completion"): flip
+  // the completed phase → Verified and the entered phase → Active. Labels are
+  // Title Case single words (Ideation, Inception, …); setField is a no-op when
+  // the label is absent, so a boundary into a `done`-only tail is harmless.
+  if (crossesPhaseBoundary) {
+    const label = (p: string): string => p.charAt(0).toUpperCase() + p.slice(1);
+    content = setField(content, label(completedStage.phase), "Verified");
+    content = setField(content, label(nextStage.phase), "Active");
+  }
+
   // 4. Atomic audit emission — audit-first, then state write.
   // If audit fails, throw before touching state (writeStateFile below is skipped).
   try {
@@ -1384,6 +1398,19 @@ function handleCompleteWorkflow(args: string[]): void {
   // 2. Sync Completed counter
   const completedCount = countCheckboxes(content, "completed");
   content = setField(content, "Completed", String(completedCount));
+
+  // 2b. Phase Progress flip on final completion. This is a phase-completing
+  // transition (it emits PHASE_COMPLETED + PHASE_VERIFIED below), so honour the
+  // `## Phase Progress` doc contract the same way handleAdvance's boundary path
+  // does: flip the completed phase → Verified. There is no entered phase (the
+  // workflow ends here), so unlike the advance path there is no Active flip.
+  // setField is a no-op when the label is absent, so this is harmless on a
+  // state file without the section.
+  content = setField(
+    content,
+    completedStage.phase.charAt(0).toUpperCase() + completedStage.phase.slice(1),
+    "Verified",
+  );
 
   // 3. Update all fields atomically for workflow completion
   const timestamp = isoTimestamp();


### PR DESCRIPTION

Fixes #556.

## What

The state file's `## Phase Progress` section is seeded once at init (every EXECUTE phase `Pending`), and the `phaseStatus` comment in `aidlc-utility.ts` promises the rows flip to `Active` on a phase-boundary advance and to `Verified` at phase completion. No code performs that flip, so the section holds its init values for the whole run while the Stage Progress checkboxes advance underneath it — a reader sees `Ideation: Pending` above a fully-checked Ideation phase.

This change makes the two phase-completing transitions honour the documented contract:

- **`handleAdvance`** — on a boundary crossing (`crossesPhaseBoundary`), flip the completed phase to `Verified` and the entered phase to `Active`. It reuses the `crossesPhaseBoundary`, `completedStage`, and `nextStage` values the function already computes, right after the `Completed` counter sync.
- **`handleCompleteWorkflow`** — final completion already emits `PHASE_COMPLETED` + `PHASE_VERIFIED`, so flip the completed phase to `Verified`. There is no entered phase (the workflow ends), so unlike the advance path there is no `Active` flip.

Both use the existing `setField` helper, which is a no-op when the phase label is absent — harmless on a state file without the section.

## Scope notes

- **`handleFinalize` is intentionally left alone.** It emits no phase events (it is a complete-and-pause, not a phase completion), so flipping a row there would report a phase as verified when it was only paused.
- **`Initialization` stays `Active` after a full run.** The first EXECUTE stage is reached via the init seed, not an advance across the Init→next boundary, so no flip fires for Initialization. Correcting that would touch the init seed path and is out of scope here.
- The issue text described only the `handleAdvance` case; `handleCompleteWorkflow` is the same drift on the final-stage path and is included so a completed workflow does not leave its last phase unverified.

## Verification

- `bun scripts/package.ts --check` — clean (no drift); `dist/{claude,codex,kiro,kiro-ide}` regenerated in the same commit.
- End-to-end on a bugfix-scope fixture via real CLI transitions:
  - boundary advance (`requirements-analysis` → `code-generation`) flips `Inception → Verified`, `Construction → Active`;
  - a non-boundary advance leaves the section unchanged;
  - `complete-workflow` on the final stage flips `Construction → Verified`;
  - the `PHASE_VERIFIED` / `WORKFLOW_COMPLETED` audit rows are consistent with the flipped section.

A fix only corrects boundaries crossed after it lands; a run already mid-flow keeps the stale rows for boundaries it already passed. A fresh run is correct from its first boundary.
