### PR TITLE
fix: pin the linter sensor's eslint version (2.3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.10] - 2026-07-14
+
+The linter sensor now pins the eslint version it runs (`eslint@10`) instead of resolving whatever `eslint` bunx finds first. A bare `bunx eslint` prefers a project-local node_modules copy, then any `eslint` on PATH, before fetching from the registry - and distro packages ship ancient versions (Ubuntu's apt eslint is 6.4.0, installed as a transitive dependency of `apt install npm`). Pre-flat-config eslint cannot read `eslint.config.js`, so on such a box every linter fire silently degraded to a `Note=tool-unavailable` PASS, masking real lint findings. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* `aidlc-sensor-linter.ts` invokes `bunx eslint@10` for the availability probe, the `--print-config` probe, and the lint run itself; PATH-shadowed or node_modules eslint no longer changes the verdict.
+* Projects that need a different eslint can still override the sensor's `command:` in the linter sensor manifest.
+
 ## [2.3.7] - 2026-07-14
 
 The `upstream-coverage` sensor now matches the citation forms the framework's artifacts actually use, clearing the hundreds of false `SENSOR_FAILED` audit rows a Construction run accumulated. It previously demanded each consumed artifact's bare slug in every single written file; artifacts instead cite upstream by producing-stage directory path in their provenance header, and multi-artifact stages legitimately split citations across sibling deliverables. Real coverage gaps still fail. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.3.7-blue)
+![version](https://img.shields.io/badge/version-2.3.10-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-sensor-linter.ts
+++ b/core/tools/aidlc-sensor-linter.ts
@@ -140,13 +140,28 @@ function findProjectRoot(filePath: string): string | null {
 
 // --- eslint subprocess wrappers ---------------------------------------------
 
+// Pinned eslint spec for every bunx invocation. A BARE `bunx eslint`
+// prefers a project-local node_modules eslint, then ANY `eslint` on PATH
+// before fetching from the registry - and distro packages ship ancient
+// versions (Ubuntu 24.04's apt eslint is 6.4.0, a transitive dependency
+// of `apt install npm`). Pre-flat-config eslint cannot see
+// eslint.config.js, reports "couldn't find a configuration file", and
+// the sensor quietly degrades every fire to a tool-unavailable PASS -
+// masking real lint findings. Pinning the major makes resolution
+// deterministic: bunx fetches/caches this spec and ignores PATH
+// shadowing. Intentionally NOT applied to a project-local eslint - bunx
+// with a version spec bypasses node_modules too, which is the price of
+// determinism; projects needing their exact local eslint can override
+// the sensor manifest's command.
+const ESLINT_SPEC = "eslint@10";
+
 // Probe `bunx eslint --version` at startup. `bunx <tool>` returns non-127
 // codes for several failure modes (network-fetch failure, package-
 // resolution failure, registry timeout). The dispatcher's branch b
 // (status === 127) won't catch those — so we propagate by exiting 127
 // ourselves on any non-zero exit from this probe.
 function probeEslintAvailable(cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--version"], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--version"], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -172,7 +187,7 @@ function probeEslintAvailable(cwd: string): void {
 // branch e then emits SENSOR_PASSED with Note=script-error: exit-2,
 // keeping the audit pair closed while flagging the breakage in stderr.
 function probeEslintConfig(filePath: string, cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--print-config", filePath], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--print-config", filePath], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -270,7 +285,7 @@ function runEslint(
 	// eslint as a numeric value.
 	const result = spawnSync(
 		"bunx",
-		["eslint", "--format", "json", "--max-warnings=-1", filePath],
+		[ESLINT_SPEC, "--format", "json", "--max-warnings=-1", filePath],
 		{ encoding: "utf-8", timeout: 30_000, cwd },
 	);
 	return { stdout: result.stdout ?? "", status: result.status };

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.7";
+export const AIDLC_VERSION = "2.3.10";

--- a/dist/claude/.claude/tools/aidlc-sensor-linter.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-linter.ts
@@ -140,13 +140,28 @@ function findProjectRoot(filePath: string): string | null {
 
 // --- eslint subprocess wrappers ---------------------------------------------
 
+// Pinned eslint spec for every bunx invocation. A BARE `bunx eslint`
+// prefers a project-local node_modules eslint, then ANY `eslint` on PATH
+// before fetching from the registry - and distro packages ship ancient
+// versions (Ubuntu 24.04's apt eslint is 6.4.0, a transitive dependency
+// of `apt install npm`). Pre-flat-config eslint cannot see
+// eslint.config.js, reports "couldn't find a configuration file", and
+// the sensor quietly degrades every fire to a tool-unavailable PASS -
+// masking real lint findings. Pinning the major makes resolution
+// deterministic: bunx fetches/caches this spec and ignores PATH
+// shadowing. Intentionally NOT applied to a project-local eslint - bunx
+// with a version spec bypasses node_modules too, which is the price of
+// determinism; projects needing their exact local eslint can override
+// the sensor manifest's command.
+const ESLINT_SPEC = "eslint@10";
+
 // Probe `bunx eslint --version` at startup. `bunx <tool>` returns non-127
 // codes for several failure modes (network-fetch failure, package-
 // resolution failure, registry timeout). The dispatcher's branch b
 // (status === 127) won't catch those — so we propagate by exiting 127
 // ourselves on any non-zero exit from this probe.
 function probeEslintAvailable(cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--version"], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--version"], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -172,7 +187,7 @@ function probeEslintAvailable(cwd: string): void {
 // branch e then emits SENSOR_PASSED with Note=script-error: exit-2,
 // keeping the audit pair closed while flagging the breakage in stderr.
 function probeEslintConfig(filePath: string, cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--print-config", filePath], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--print-config", filePath], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -270,7 +285,7 @@ function runEslint(
 	// eslint as a numeric value.
 	const result = spawnSync(
 		"bunx",
-		["eslint", "--format", "json", "--max-warnings=-1", filePath],
+		[ESLINT_SPEC, "--format", "json", "--max-warnings=-1", filePath],
 		{ encoding: "utf-8", timeout: 30_000, cwd },
 	);
 	return { stdout: result.stdout ?? "", status: result.status };

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.7";
+export const AIDLC_VERSION = "2.3.10";

--- a/dist/codex/.codex/tools/aidlc-sensor-linter.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-linter.ts
@@ -140,13 +140,28 @@ function findProjectRoot(filePath: string): string | null {
 
 // --- eslint subprocess wrappers ---------------------------------------------
 
+// Pinned eslint spec for every bunx invocation. A BARE `bunx eslint`
+// prefers a project-local node_modules eslint, then ANY `eslint` on PATH
+// before fetching from the registry - and distro packages ship ancient
+// versions (Ubuntu 24.04's apt eslint is 6.4.0, a transitive dependency
+// of `apt install npm`). Pre-flat-config eslint cannot see
+// eslint.config.js, reports "couldn't find a configuration file", and
+// the sensor quietly degrades every fire to a tool-unavailable PASS -
+// masking real lint findings. Pinning the major makes resolution
+// deterministic: bunx fetches/caches this spec and ignores PATH
+// shadowing. Intentionally NOT applied to a project-local eslint - bunx
+// with a version spec bypasses node_modules too, which is the price of
+// determinism; projects needing their exact local eslint can override
+// the sensor manifest's command.
+const ESLINT_SPEC = "eslint@10";
+
 // Probe `bunx eslint --version` at startup. `bunx <tool>` returns non-127
 // codes for several failure modes (network-fetch failure, package-
 // resolution failure, registry timeout). The dispatcher's branch b
 // (status === 127) won't catch those — so we propagate by exiting 127
 // ourselves on any non-zero exit from this probe.
 function probeEslintAvailable(cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--version"], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--version"], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -172,7 +187,7 @@ function probeEslintAvailable(cwd: string): void {
 // branch e then emits SENSOR_PASSED with Note=script-error: exit-2,
 // keeping the audit pair closed while flagging the breakage in stderr.
 function probeEslintConfig(filePath: string, cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--print-config", filePath], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--print-config", filePath], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -270,7 +285,7 @@ function runEslint(
 	// eslint as a numeric value.
 	const result = spawnSync(
 		"bunx",
-		["eslint", "--format", "json", "--max-warnings=-1", filePath],
+		[ESLINT_SPEC, "--format", "json", "--max-warnings=-1", filePath],
 		{ encoding: "utf-8", timeout: 30_000, cwd },
 	);
 	return { stdout: result.stdout ?? "", status: result.status };

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.7";
+export const AIDLC_VERSION = "2.3.10";

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-linter.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-linter.ts
@@ -140,13 +140,28 @@ function findProjectRoot(filePath: string): string | null {
 
 // --- eslint subprocess wrappers ---------------------------------------------
 
+// Pinned eslint spec for every bunx invocation. A BARE `bunx eslint`
+// prefers a project-local node_modules eslint, then ANY `eslint` on PATH
+// before fetching from the registry - and distro packages ship ancient
+// versions (Ubuntu 24.04's apt eslint is 6.4.0, a transitive dependency
+// of `apt install npm`). Pre-flat-config eslint cannot see
+// eslint.config.js, reports "couldn't find a configuration file", and
+// the sensor quietly degrades every fire to a tool-unavailable PASS -
+// masking real lint findings. Pinning the major makes resolution
+// deterministic: bunx fetches/caches this spec and ignores PATH
+// shadowing. Intentionally NOT applied to a project-local eslint - bunx
+// with a version spec bypasses node_modules too, which is the price of
+// determinism; projects needing their exact local eslint can override
+// the sensor manifest's command.
+const ESLINT_SPEC = "eslint@10";
+
 // Probe `bunx eslint --version` at startup. `bunx <tool>` returns non-127
 // codes for several failure modes (network-fetch failure, package-
 // resolution failure, registry timeout). The dispatcher's branch b
 // (status === 127) won't catch those — so we propagate by exiting 127
 // ourselves on any non-zero exit from this probe.
 function probeEslintAvailable(cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--version"], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--version"], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -172,7 +187,7 @@ function probeEslintAvailable(cwd: string): void {
 // branch e then emits SENSOR_PASSED with Note=script-error: exit-2,
 // keeping the audit pair closed while flagging the breakage in stderr.
 function probeEslintConfig(filePath: string, cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--print-config", filePath], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--print-config", filePath], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -270,7 +285,7 @@ function runEslint(
 	// eslint as a numeric value.
 	const result = spawnSync(
 		"bunx",
-		["eslint", "--format", "json", "--max-warnings=-1", filePath],
+		[ESLINT_SPEC, "--format", "json", "--max-warnings=-1", filePath],
 		{ encoding: "utf-8", timeout: 30_000, cwd },
 	);
 	return { stdout: result.stdout ?? "", status: result.status };

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.7";
+export const AIDLC_VERSION = "2.3.10";

--- a/dist/kiro/.kiro/tools/aidlc-sensor-linter.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-linter.ts
@@ -140,13 +140,28 @@ function findProjectRoot(filePath: string): string | null {
 
 // --- eslint subprocess wrappers ---------------------------------------------
 
+// Pinned eslint spec for every bunx invocation. A BARE `bunx eslint`
+// prefers a project-local node_modules eslint, then ANY `eslint` on PATH
+// before fetching from the registry - and distro packages ship ancient
+// versions (Ubuntu 24.04's apt eslint is 6.4.0, a transitive dependency
+// of `apt install npm`). Pre-flat-config eslint cannot see
+// eslint.config.js, reports "couldn't find a configuration file", and
+// the sensor quietly degrades every fire to a tool-unavailable PASS -
+// masking real lint findings. Pinning the major makes resolution
+// deterministic: bunx fetches/caches this spec and ignores PATH
+// shadowing. Intentionally NOT applied to a project-local eslint - bunx
+// with a version spec bypasses node_modules too, which is the price of
+// determinism; projects needing their exact local eslint can override
+// the sensor manifest's command.
+const ESLINT_SPEC = "eslint@10";
+
 // Probe `bunx eslint --version` at startup. `bunx <tool>` returns non-127
 // codes for several failure modes (network-fetch failure, package-
 // resolution failure, registry timeout). The dispatcher's branch b
 // (status === 127) won't catch those — so we propagate by exiting 127
 // ourselves on any non-zero exit from this probe.
 function probeEslintAvailable(cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--version"], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--version"], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -172,7 +187,7 @@ function probeEslintAvailable(cwd: string): void {
 // branch e then emits SENSOR_PASSED with Note=script-error: exit-2,
 // keeping the audit pair closed while flagging the breakage in stderr.
 function probeEslintConfig(filePath: string, cwd: string): void {
-	const result = spawnSync("bunx", ["eslint", "--print-config", filePath], {
+	const result = spawnSync("bunx", [ESLINT_SPEC, "--print-config", filePath], {
 		encoding: "utf-8",
 		timeout: 30_000,
 		cwd,
@@ -270,7 +285,7 @@ function runEslint(
 	// eslint as a numeric value.
 	const result = spawnSync(
 		"bunx",
-		["eslint", "--format", "json", "--max-warnings=-1", filePath],
+		[ESLINT_SPEC, "--format", "json", "--max-warnings=-1", filePath],
 		{ encoding: "utf-8", timeout: 30_000, cwd },
 	);
 	return { stdout: result.stdout ?? "", status: result.status };

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.3.7";
+export const AIDLC_VERSION = "2.3.10";

--- a/tests/unit/t237-linter-sensor-version-pin.test.ts
+++ b/tests/unit/t237-linter-sensor-version-pin.test.ts
@@ -1,0 +1,57 @@
+// covers: tool:aidlc-sensor-linter
+//
+// t237 - the linter sensor's eslint invocations are version-pinned.
+//
+// A BARE `bunx eslint` prefers a project-local node_modules eslint, then
+// ANY `eslint` on PATH, before fetching from the registry. Distro
+// packages ship ancient versions (Ubuntu 24.04's apt eslint is 6.4.0, a
+// transitive dependency of `apt install npm`); pre-flat-config eslint
+// cannot see eslint.config.js, reports "couldn't find a configuration
+// file", and the sensor silently degrades every fire to a
+// tool-unavailable PASS - masking real lint findings (observed on a real
+// box 2026-07-13: t92 tests 11/15 red purely from the apt package).
+//
+// The guard: every bunx invocation in the shipped linter sensor script
+// must pass the pinned ESLINT_SPEC, never the bare string "eslint".
+// Source-pin over behavior: exercising the PATH-shadow scenario live
+// needs a writable PATH dir + registry access and is racy under -P;
+// the invariant is fully visible in the source.
+//
+// All four dist projections carry the same byte-identical script (the
+// packager copies core/tools verbatim; t145-packaging-parity guards
+// cross-dist parity), so asserting on dist/claude covers the rest.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SHIPPED = join(
+  REPO_ROOT,
+  "dist",
+  "claude",
+  ".claude",
+  "tools",
+  "aidlc-sensor-linter.ts",
+);
+
+describe("t237 linter sensor eslint version pin", () => {
+  const src = readFileSync(SHIPPED, "utf-8");
+
+  test("declares a pinned ESLINT_SPEC with an explicit major", () => {
+    expect(src).toMatch(/const ESLINT_SPEC = "eslint@\d+"/);
+  });
+
+  test("no spawnSync bunx invocation passes bare 'eslint' as the tool arg", () => {
+    // Every `spawnSync("bunx", [<first-arg>, ...])` in the script must use
+    // ESLINT_SPEC. A literal "eslint" first element would resolve through
+    // node_modules/PATH and reintroduce the shadowing bug.
+    const bunxFirstArgs = [...src.matchAll(/spawnSync\(\s*"bunx",\s*\[\s*("(?:[^"]*)"|[A-Za-z_$][\w$]*)/g)].map(
+      (m) => m[1],
+    );
+    expect(bunxFirstArgs.length).toBeGreaterThan(0);
+    for (const arg of bunxFirstArgs) {
+      expect(arg).toBe("ESLINT_SPEC");
+    }
+  });
+});


### PR DESCRIPTION
## What this fixes

The linter sensor invoked `bunx eslint` bare, so bunx's resolution order (project node_modules -> PATH -> registry) made sensor verdicts machine-dependent. Distro packages ship ancient eslint versions - Ubuntu's apt eslint is 6.4.0, installed as a transitive dependency of `apt install npm` - and pre-flat-config eslint cannot read `eslint.config.js`. On such a box the availability probe exits 127 and every linter fire silently degrades to a `Note=tool-unavailable` PASS, masking real lint findings. This surfaced as 2 red assertions in the release gate's t92 after a routine `apt-get install nodejs npm` put eslint 6 on PATH.

## The fix

`aidlc-sensor-linter.ts` pins `ESLINT_SPEC = "eslint@10"` on all three bunx call sites: the availability probe (`--version`), the config probe (`--print-config`), and the lint run itself. A versioned spec makes bunx bypass PATH resolution, so the sensor runs the same eslint everywhere. Verified live that the pin defeats PATH shadowing (bare `bunx eslint --version` resolves 6.4.0 on the affected box; `bunx eslint@10 --version` resolves 10.x).

Projects that need a different eslint can still override the sensor's `command:` in the linter sensor manifest.

## Version and tests

- 2.3.10 + CHANGELOG entry + README badge (re-slotted from the branch's original 2.3.9 after #560 took that slot).
- New `tests/unit/t237-linter-sensor-version-pin.test.ts`: source-pin guard that fails if any of the three call sites loses the versioned spec.
- Guards at tip: t68 + t237 green (stamp 2026-07-14T01-18-23Z), `package.ts --check` in sync.

## Related

- The other two release-gate reds from the same investigation (tsc 7 exit-code shift in t92 test 44, t139 TUI time-budget split) are test-only fixes on a separate branch (no version bump) - a follow-up PR.
