### PR TITLE
fix: serialize Codex hook-trust entries with a real TOML library and validate trust arguments (2.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.3] - 2026-07-17
+
+Codex hook-trust entries are now generated with a standards-compliant TOML serializer, including paths with spaces, quotes, and backslashes on Unix and Windows. **Upgrade:** re-copy `dist/codex/`, run `bun install --frozen-lockfile` in the AI-DLC source checkout, regenerate the entries, and replace the existing entries for that `hooks.json` path in `$CODEX_HOME/config.toml`; appending a second copy creates invalid TOML.
+
+* `bun scripts/package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]` preserves both native Unix and Windows paths while emitting parseable TOML.
+* Forward-slash UNC project paths such as `//server/share/project` derive a native Windows UNC default for `.codex\hooks.json` instead of collapsing the server prefix.
+* The trust command now rejects relative paths, rootless Windows paths, incomplete UNC paths, missing values, duplicate flags, and unknown arguments instead of printing unusable trust keys.
+
 ## [2.4.2] - 2026-07-16
 
 The multi-harness packager now treats each `dist/<harness>/` directory as one generated root, closing drift gaps for project-root onboarding, configuration, and removed outputs. **Upgrade:** re-copy your `dist/<harness>/` shell into the project after regenerating it with this version.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.4.2-blue)
+![version](https://img.shields.io/badge/version-2.4.3-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)
@@ -310,7 +310,7 @@ Most first-run trouble is one of these; each harness guide covers the rest.
 | `which bun` works in your terminal, but the harness can't find bun | all | bun isn't on the non-interactive PATH. Copy the `BUN_INSTALL`/`PATH` export into `~/.zshenv` (zsh) or `~/.bashrc` (bash/Git Bash) — see the tip under [Quick Start](#quick-start). |
 | `/aidlc --doctor` reports a Codex CLI version below 0.139.0 | Codex | Upgrade to Codex CLI 0.139.0 or later. Older releases break subagent attribution and hyphenated agent TOML resolution. |
 | Bedrock calls fail with `AccessDenied` or a model-not-found error | Claude, Codex | Enable model access for the harness's configured models in your AWS account and put working credentials on your SDK chain. Confirm `AWS_REGION` is a region where you enabled them. |
-| Hooks never fire (no audit rows, no gates) | Codex | Trust the hooks: run `bun scripts/package.ts codex trust --project <dir>`, or start one TUI session and choose "Trust all." Untrusted hooks never run. |
+| Hooks never fire (no audit rows, no gates) | Codex | Trust the hooks: from the AI-DLC source checkout run `bun install --frozen-lockfile`, then `bun scripts/package.ts codex trust --project <dir>` and replace any existing entries for that hook path; or start one TUI session and choose "Trust all." Untrusted hooks never run. |
 | Skills or rules don't take effect after you copy a new `dist/` | all | Start a fresh session — harnesses load skills, agents, and rules at session start. |
 
 ## Contributing

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@xterm/headless": "^5.5.0",
         "bun-types": "^1.3.13",
         "node-pty": "1.1.0",
+        "smol-toml": "1.7.0",
         "typescript": "^6.0.3",
       },
     },
@@ -234,6 +235,8 @@
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "smol-toml": ["smol-toml@1.7.0", "", {}, "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.4.2";
+export const AIDLC_VERSION = "2.4.3";

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.4.2";
+export const AIDLC_VERSION = "2.4.3";

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.4.2";
+export const AIDLC_VERSION = "2.4.3";

--- a/dist/codex/.codex/trust-seed.toml
+++ b/dist/codex/.codex/trust-seed.toml
@@ -1,8 +1,8 @@
 # dist/codex hook-trust pre-seed (S9a) — TEMPLATE.
-# Append these entries to the USER config.toml ($CODEX_HOME/config.toml)
-# after replacing <PROJECT_DIR> with the project's absolute path, or run:
-#   bun scripts/package.ts codex trust --project <abs-dir>
-# to print them substituted and ready to paste. The hash covers the
+# Generate ready-to-paste entries with the TOML serializer:
+#   bun scripts/package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]
+# Append the command's complete stdout to the USER config.toml
+# ($CODEX_HOME/config.toml). The hash covers the
 # normalized hook identity (event + command + defaults), NOT the path —
 # only the key changes per install. Codex then runs the hooks without a
 # TUI trust pass (the --dangerously-bypass-hook-trust flag does NOT fire

--- a/dist/codex/.codex/trust-seed.toml
+++ b/dist/codex/.codex/trust-seed.toml
@@ -1,8 +1,11 @@
 # dist/codex hook-trust pre-seed (S9a) — TEMPLATE.
-# Generate ready-to-paste entries with the TOML serializer:
+# From an AI-DLC source checkout, install the pinned serializer first:
+#   bun install --frozen-lockfile
+# Then generate ready-to-paste entries:
 #   bun scripts/package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]
-# Append the command's complete stdout to the USER config.toml
-# ($CODEX_HOME/config.toml). The hash covers the
+# Paste the complete stdout into the USER config.toml ($CODEX_HOME/config.toml).
+# If entries for that hooks.json path already exist, replace the full set;
+# appending a second set creates invalid TOML. The hash covers the
 # normalized hook identity (event + command + defaults), NOT the path —
 # only the key changes per install. Codex then runs the hooks without a
 # TUI trust pass (the --dangerously-bypass-hook-trust flag does NOT fire

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.4.2";
+export const AIDLC_VERSION = "2.4.3";

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.4.2";
+export const AIDLC_VERSION = "2.4.3";

--- a/docs/guide/harnesses/codex-cli.md
+++ b/docs/guide/harnesses/codex-cli.md
@@ -51,12 +51,25 @@ never hand-edit it (the drift guard fails CI).
    continue" at the hooks dialog, or pre-seed deterministically:
 
    ```bash
-   bun scripts/package.ts codex trust --project /abs/path/to/your-project
+   bun scripts/package.ts codex trust --project "/abs/path/to/your project"
    ```
 
    appends ready-to-paste `[hooks.state]` entries for `$CODEX_HOME/config.toml`
    (the hash covers the hook identity, not the path — the printed entries are
-   exact for the shipped `hooks.json`).
+   exact for the shipped `hooks.json`). The command serializes the complete
+   output as TOML, so quoted paths, spaces, and Windows backslashes are
+   preserved. If the hook manifest is not at `<project>/.codex/hooks.json`,
+   pass its exact path explicitly:
+
+   ```bash
+   bun scripts/package.ts codex trust \
+     --project "/abs/path/to/your project" \
+     --hooks-json "/abs/custom path/hooks.json"
+   ```
+
+   Quote both arguments in the shell. `--hooks-json` is used verbatim as the
+   Codex trust identity; do not normalize or replace it after generating the
+   entries.
 
 4. Merge the shipped `.codex/config.toml` into your `~/.codex/config.toml`
    (or keep it project-level — trusted projects read it). Verify with:

--- a/docs/guide/harnesses/codex-cli.md
+++ b/docs/guide/harnesses/codex-cli.md
@@ -48,13 +48,17 @@ never hand-edit it (the drift guard fails CI).
 3. Trust the project and pre-seed hook trust. Codex never runs untrusted
    hooks (the `--dangerously-bypass-hook-trust` flag does not run them
    either). Either run one interactive TUI session and choose "Trust all and
-   continue" at the hooks dialog, or pre-seed deterministically:
+   continue" at the hooks dialog, or pre-seed deterministically from the
+   AI-DLC source checkout. Install its pinned development dependencies once,
+   then generate the entries:
 
    ```bash
+   bun install --frozen-lockfile
    bun scripts/package.ts codex trust --project "/abs/path/to/your project"
    ```
 
-   appends ready-to-paste `[hooks.state]` entries for `$CODEX_HOME/config.toml`
+   The command prints ready-to-paste `[hooks.state]` entries for
+   `$CODEX_HOME/config.toml`
    (the hash covers the hook identity, not the path — the printed entries are
    exact for the shipped `hooks.json`). The command serializes the complete
    output as TOML, so quoted paths, spaces, and Windows backslashes are
@@ -69,7 +73,10 @@ never hand-edit it (the drift guard fails CI).
 
    Quote both arguments in the shell. `--hooks-json` is used verbatim as the
    Codex trust identity; do not normalize or replace it after generating the
-   entries.
+   entries. Paste the command's complete stdout into the user config. If
+   entries for the same `hooks.json` path already exist, replace that full set;
+   do not append a second copy because duplicate TOML tables invalidate the
+   entire config.
 
 4. Merge the shipped `.codex/config.toml` into your `~/.codex/config.toml`
    (or keep it project-level — trusted projects read it). Verify with:

--- a/docs/reference/11-contributing.md
+++ b/docs/reference/11-contributing.md
@@ -16,6 +16,13 @@ Contributions to this implementation are welcome. This guide covers prerequisite
 - **Bash** -- Optional for the POSIX compatibility wrapper (`tests/run-tests.sh`). The primary test runner is `bun tests/run-tests.ts`; at runtime, none of the distributable hooks require Bash.
 - **Bedrock access** -- Required for running live integration and e2e tests (L2/L3). Not needed for L1 protocol tests.
 
+After cloning, install the pinned development dependencies used by the
+packager, type checker, and tests:
+
+```bash
+bun install --frozen-lockfile
+```
+
 ## Repository Structure
 
 ```
@@ -34,7 +41,7 @@ For the full architecture, see [reference/01-architecture.md](01-architecture.md
 
 ## Development Workflow
 
-1. **Fork and branch** from `main`
+1. **Fork and branch** from `main`, then run `bun install --frozen-lockfile`
 2. **Read the architecture** -- [reference/01-architecture.md](01-architecture.md) explains the execution model, agent delegation, and hook system
 3. **Understand the entry points** -- the deterministic engine `core/tools/aidlc-orchestrate.ts` (`next` / `report`) owns routing; the conductor `harness/claude/skills/aidlc/SKILL.md` is a thin forwarding loop that acts on its directives. For the normative engine / directive / conductor / swarm contract see [The Skill System](17-skill-system.md)
 4. **Make changes** -- Edit the harness-neutral source in `core/` (tools, stages, agents, hooks, rules, knowledge) or a harness surface in `harness/<name>/` (the orchestrator skill, settings). Then run `bun scripts/package.ts` to regenerate `dist/` — never hand-edit `dist/`, the drift guard (`package.ts --check`) will fail CI
@@ -43,7 +50,7 @@ For the full architecture, see [reference/01-architecture.md](01-architecture.md
 
 ## Testing
 
-The suite is entirely TypeScript (`t*.test.ts`, run via `bun`) across four levels — `smoke`, `unit`, `integration`, `e2e` — that map onto the three-layer pyramid (smoke + unit = L1 Protocol, integration = L2 Stage, e2e = L3 Acceptance). L1 runs locally with no dependencies; the live integration and e2e files require the `claude` CLI tool (and Bedrock creds) and skip cleanly when it is absent.
+The suite is entirely TypeScript (`t*.test.ts`, run via `bun`) across four levels — `smoke`, `unit`, `integration`, `e2e` — that map onto the three-layer pyramid (smoke + unit = L1 Protocol, integration = L2 Stage, e2e = L3 Acceptance). After the pinned development dependencies are installed, L1 runs locally without external services; the live integration and e2e files require the `claude` CLI tool (and Bedrock creds) and skip cleanly when it is absent.
 
 **Quick reference:**
 

--- a/harness/codex/emit.ts
+++ b/harness/codex/emit.ts
@@ -17,7 +17,8 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, posix, relative, win32 } from "node:path";
+import { stringify } from "smol-toml";
 import type { EmitContext } from "../../scripts/manifest-types.ts";
 import { renderOnboarding } from "../../scripts/onboarding.ts";
 import onboardingFills from "./onboarding.fills.ts";
@@ -184,28 +185,32 @@ export function trustEntries(
   hooksJsonPath?: string,
   harnessDir = ".codex",
 ): string {
-  const path = hooksJsonPath ?? `${projectDir}/${harnessDir}/hooks.json`;
+  // A supplied hooks path is already the Codex trust identity: preserve it
+  // exactly. For the default, choose the path implementation from the project
+  // spelling so Windows installers can generate native paths even when this
+  // packager is invoked from Unix (and vice versa).
+  const projectPath =
+    win32.isAbsolute(projectDir) && !posix.isAbsolute(projectDir) ? win32 : posix;
+  const path = hooksJsonPath ?? projectPath.join(projectDir, harnessDir, "hooks.json");
   const counters: Record<string, number> = {};
-  const lines: string[] = [];
+  const state: Record<string, { trusted_hash: string }> = {};
   for (const { event, target } of HOOK_WIRING) {
     const snake = SNAKE[event];
     const idx = counters[snake] ?? 0;
     counters[snake] = idx + 1;
     const hash = trustHash(snake, adapterCmd(harnessDir, target));
-    lines.push(`[hooks.state."${path}:${snake}:${idx}:0"]`);
-    lines.push(`trusted_hash = "${hash}"`);
-    lines.push("");
+    state[`${path}:${snake}:${idx}:0`] = { trusted_hash: hash };
   }
-  return lines.join("\n");
+  return stringify({ hooks: { state } });
 }
 
 function emitTrustSeed(harnessDir: string): string {
   return (
     `# dist/codex hook-trust pre-seed (S9a) — TEMPLATE.\n` +
-    `# Append these entries to the USER config.toml ($CODEX_HOME/config.toml)\n` +
-    `# after replacing <PROJECT_DIR> with the project's absolute path, or run:\n` +
-    `#   bun scripts/package.ts codex trust --project <abs-dir>\n` +
-    `# to print them substituted and ready to paste. The hash covers the\n` +
+    `# Generate ready-to-paste entries with the TOML serializer:\n` +
+    `#   bun scripts/package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]\n` +
+    `# Append the command's complete stdout to the USER config.toml\n` +
+    `# ($CODEX_HOME/config.toml). The hash covers the\n` +
     `# normalized hook identity (event + command + defaults), NOT the path —\n` +
     `# only the key changes per install. Codex then runs the hooks without a\n` +
     `# TUI trust pass (the --dangerously-bypass-hook-trust flag does NOT fire\n` +

--- a/harness/codex/emit.ts
+++ b/harness/codex/emit.ts
@@ -210,10 +210,13 @@ export function trustEntries(
 function emitTrustSeed(harnessDir: string): string {
   return (
     `# dist/codex hook-trust pre-seed (S9a) — TEMPLATE.\n` +
-    `# Generate ready-to-paste entries with the TOML serializer:\n` +
+    `# From an AI-DLC source checkout, install the pinned serializer first:\n` +
+    `#   bun install --frozen-lockfile\n` +
+    `# Then generate ready-to-paste entries:\n` +
     `#   bun scripts/package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]\n` +
-    `# Append the command's complete stdout to the USER config.toml\n` +
-    `# ($CODEX_HOME/config.toml). The hash covers the\n` +
+    `# Paste the complete stdout into the USER config.toml ($CODEX_HOME/config.toml).\n` +
+    `# If entries for that hooks.json path already exist, replace the full set;\n` +
+    `# appending a second set creates invalid TOML. The hash covers the\n` +
     `# normalized hook identity (event + command + defaults), NOT the path —\n` +
     `# only the key changes per install. Codex then runs the hooks without a\n` +
     `# TUI trust pass (the --dangerously-bypass-hook-trust flag does NOT fire\n` +

--- a/harness/codex/emit.ts
+++ b/harness/codex/emit.ts
@@ -190,7 +190,10 @@ export function trustEntries(
   // spelling so Windows installers can generate native paths even when this
   // packager is invoked from Unix (and vice versa).
   const projectPath =
-    win32.isAbsolute(projectDir) && !posix.isAbsolute(projectDir) ? win32 : posix;
+    win32.isAbsolute(projectDir) &&
+    (!posix.isAbsolute(projectDir) || projectDir.startsWith("//"))
+      ? win32
+      : posix;
   const path = hooksJsonPath ?? projectPath.join(projectDir, harnessDir, "hooks.json");
   const counters: Record<string, number> = {};
   const state: Record<string, { trusted_hash: string }> = {};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@xterm/headless": "^5.5.0",
     "bun-types": "^1.3.13",
     "node-pty": "1.1.0",
+    "smol-toml": "1.7.0",
     "typescript": "^6.0.3"
   }
 }

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -46,7 +46,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, posix, relative, sep, win32 } from "node:path";
+import { dirname, isAbsolute, join, posix, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import type { HarnessManifest } from "./manifest-types.ts";
@@ -758,8 +758,13 @@ if (argv[0] === "codex" && argv[1] === "trust") {
     console.error(usage);
     process.exit(1);
   };
-  const absoluteOnEitherPlatform = (path: string): boolean =>
-    posix.isAbsolute(path) || win32.isAbsolute(path);
+  const fullyQualifiedOnEitherPlatform = (path: string): boolean => {
+    const startsAsUnc = path.startsWith("\\\\") || path.startsWith("//");
+    if (startsAsUnc) {
+      return /^[\\/]{2}[^\\/]+[\\/][^\\/]+(?:[\\/]|$)/.test(path);
+    }
+    return posix.isAbsolute(path) || /^[A-Za-z]:[\\/]/.test(path);
+  };
   let project: string | null = null;
   let hooksJson: string | null = null;
   const trustArgs = argv.slice(2);
@@ -772,8 +777,8 @@ if (argv[0] === "codex" && argv[1] === "trust") {
     if (!value || value.startsWith("--")) {
       failTrustArgs(`${flag} requires an absolute path`);
     }
-    if (!absoluteOnEitherPlatform(value)) {
-      failTrustArgs(`${flag} must be an absolute path`);
+    if (!fullyQualifiedOnEitherPlatform(value)) {
+      failTrustArgs(`${flag} must be a fully qualified absolute path`);
     }
     if (flag === "--project") {
       if (project !== null) failTrustArgs("--project may be specified only once");

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -752,11 +752,11 @@ const argv = process.argv.slice(2);
 // installer to paste into $CODEX_HOME/config.toml (the trust-seed.toml recipe).
 if (argv[0] === "codex" && argv[1] === "trust") {
   const pIdx = argv.indexOf("--project");
-  if (pIdx === -1 || !argv[pIdx + 1]) {
+  const hIdx = argv.indexOf("--hooks-json");
+  if (pIdx === -1 || !argv[pIdx + 1] || (hIdx !== -1 && !argv[hIdx + 1])) {
     console.error("usage: package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]");
     process.exit(1);
   }
-  const hIdx = argv.indexOf("--hooks-json");
   const { trustEntries } = require(join(HARNESS_ROOT, "codex", "emit.ts")) as {
     trustEntries: (project: string, hooksJson?: string) => string;
   };

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -46,7 +46,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, relative, sep } from "node:path";
+import { dirname, isAbsolute, join, posix, relative, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import type { HarnessManifest } from "./manifest-types.ts";
@@ -751,16 +751,43 @@ const argv = process.argv.slice(2);
 // print the codex hook-trust entries with <PROJECT_DIR> substituted, for the
 // installer to paste into $CODEX_HOME/config.toml (the trust-seed.toml recipe).
 if (argv[0] === "codex" && argv[1] === "trust") {
-  const pIdx = argv.indexOf("--project");
-  const hIdx = argv.indexOf("--hooks-json");
-  if (pIdx === -1 || !argv[pIdx + 1] || (hIdx !== -1 && !argv[hIdx + 1])) {
-    console.error("usage: package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]");
+  const usage =
+    "usage: package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]";
+  const failTrustArgs = (reason: string): never => {
+    console.error(`codex trust: ${reason}`);
+    console.error(usage);
     process.exit(1);
+  };
+  const absoluteOnEitherPlatform = (path: string): boolean =>
+    posix.isAbsolute(path) || win32.isAbsolute(path);
+  let project: string | null = null;
+  let hooksJson: string | null = null;
+  const trustArgs = argv.slice(2);
+  for (let i = 0; i < trustArgs.length; i += 2) {
+    const flag = trustArgs[i];
+    const value = trustArgs[i + 1];
+    if (flag !== "--project" && flag !== "--hooks-json") {
+      failTrustArgs(`unknown argument "${flag}"`);
+    }
+    if (!value || value.startsWith("--")) {
+      failTrustArgs(`${flag} requires an absolute path`);
+    }
+    if (!absoluteOnEitherPlatform(value)) {
+      failTrustArgs(`${flag} must be an absolute path`);
+    }
+    if (flag === "--project") {
+      if (project !== null) failTrustArgs("--project may be specified only once");
+      project = value;
+    } else {
+      if (hooksJson !== null) failTrustArgs("--hooks-json may be specified only once");
+      hooksJson = value;
+    }
   }
+  const resolvedProject = project ?? failTrustArgs("--project is required");
   const { trustEntries } = require(join(HARNESS_ROOT, "codex", "emit.ts")) as {
     trustEntries: (project: string, hooksJson?: string) => string;
   };
-  console.log(trustEntries(argv[pIdx + 1], hIdx !== -1 ? argv[hIdx + 1] : undefined));
+  console.log(trustEntries(resolvedProject, hooksJson ?? undefined));
   process.exit(0);
 }
 

--- a/tests/unit/t150-codex-packaging.test.ts
+++ b/tests/unit/t150-codex-packaging.test.ts
@@ -218,6 +218,10 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
         project: String.raw`\\server\shared projects\AI "DLC"`,
         hooksJson: String.raw`\\server\shared projects\AI "DLC"\.codex\hooks.json`,
       },
+      {
+        project: "//server/share/project",
+        hooksJson: String.raw`\\server\share\project\.codex\hooks.json`,
+      },
     ];
 
     for (const { project, hooksJson } of cases) {

--- a/tests/unit/t150-codex-packaging.test.ts
+++ b/tests/unit/t150-codex-packaging.test.ts
@@ -23,11 +23,47 @@ import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { parse } from "smol-toml";
 import { REPO_ROOT } from "../harness/fixtures.ts";
 
 const PACKAGE_SCRIPT = join(REPO_ROOT, "scripts", "package.ts");
 const CLAUDE_SRC = join(REPO_ROOT, "dist", "claude", ".claude");
 const CODEX_DST = join(REPO_ROOT, "dist", "codex", ".codex");
+const TRUST_SUFFIXES = [
+  "session_start:0:0",
+  "user_prompt_submit:0:0",
+  "pre_tool_use:0:0",
+  "post_tool_use:0:0",
+  "post_tool_use:1:0",
+  "post_tool_use:2:0",
+  "pre_compact:0:0",
+  "post_compact:0:0",
+  "subagent_stop:0:0",
+  "stop:0:0",
+] as const;
+
+type TrustDocument = {
+  hooks: {
+    state: Record<string, { trusted_hash: string }>;
+  };
+};
+
+type TrustEntries = (project: string, hooksJson?: string) => string;
+
+function parseTrustDocument(source: string): TrustDocument {
+  return parse(source) as unknown as TrustDocument;
+}
+
+function trustEntries(): TrustEntries {
+  const emitter = require(join(REPO_ROOT, "harness", "codex", "emit.ts")) as {
+    trustEntries: TrustEntries;
+  };
+  return emitter.trustEntries;
+}
+
+function expectedTrustKeys(hooksJsonPath: string): string[] {
+  return TRUST_SUFFIXES.map((suffix) => `${hooksJsonPath}:${suffix}`);
+}
 
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir).sort()) {
@@ -126,9 +162,10 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     }
   });
 
-  test("6: the SHIPPED trust-seed.toml is exactly what emit.ts's trustEntries() produces", () => {
-    // The installer pastes the entries in dist/codex/.codex/trust-seed.toml into
-    // $CODEX_HOME/config.toml so Codex runs the hooks without a TUI trust pass.
+  test("6: the complete shipped trust-seed is valid TOML and exactly matches trustEntries()", () => {
+    // The installer generates entries through the trust command and pastes its
+    // stdout into $CODEX_HOME/config.toml, so paths always pass through the TOML
+    // serializer and Codex runs the hooks without a TUI trust pass.
     // The pre-seed is only sound while every shipped hash matches the live hook
     // identity emit.ts hashes. Guard that by calling the REAL exported
     // trustEntries() (not an inlined copy of the recipe) and asserting it
@@ -136,16 +173,23 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     // trustHash's recipe, HOOK_WIRING, or the adapter command ever drifts, the
     // shipped hashes go stale and Codex silently rejects every hook — this fails
     // then, where --check cannot (a buggy emit regenerates the same wrong bytes).
-    const { trustEntries } = require(join(REPO_ROOT, "harness", "codex", "emit.ts")) as {
-      trustEntries: (project: string, hooksJson?: string) => string;
-    };
+    const emitTrustEntries = trustEntries();
     const shipped = readFileSync(join(CODEX_DST, "trust-seed.toml"), "utf-8");
+    const parsed = parseTrustDocument(shipped);
+    expect(Object.keys(parsed.hooks.state)).toEqual(
+      expectedTrustKeys("<PROJECT_DIR>/.codex/hooks.json"),
+    );
     // The shipped file is a header comment block + the trustEntries() body. The
     // body begins at the first [hooks.state ...] line.
     const bodyStart = shipped.indexOf("[hooks.state");
     expect(bodyStart).toBeGreaterThan(-1);
+    const header = shipped.slice(0, bodyStart);
+    expect(header).toContain(
+      "bun scripts/package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]",
+    );
+    expect(header).not.toMatch(/replac\w*\s+<PROJECT_DIR>/i);
     const shippedBody = shipped.slice(bodyStart).trimEnd();
-    const produced = trustEntries("<PROJECT_DIR>").trimEnd();
+    const produced = emitTrustEntries("<PROJECT_DIR>").trimEnd();
     expect(produced).toBe(shippedBody);
     // And the real session_start hash is a sha256 over the live adapter identity
     // — a concrete anchor so a silent recipe change can't pass by emitting a
@@ -155,7 +199,69 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     );
   });
 
-  test("8: skills tree — every runner carries the S9f implicit-invocation guard; the orchestrator does not", () => {
+  test("7: default trust paths round-trip Unix and Windows path characters exactly", () => {
+    const emitTrustEntries = trustEntries();
+    const cases = [
+      {
+        project: "/tmp/example-proj",
+        hooksJson: "/tmp/example-proj/.codex/hooks.json",
+      },
+      {
+        project: '/srv/AI DLC/project "quoted"\\literal',
+        hooksJson: '/srv/AI DLC/project "quoted"\\literal/.codex/hooks.json',
+      },
+      {
+        project: String.raw`C:\Users\Jane Doe\AI "DLC"`,
+        hooksJson: String.raw`C:\Users\Jane Doe\AI "DLC"\.codex\hooks.json`,
+      },
+      {
+        project: String.raw`\\server\shared projects\AI "DLC"`,
+        hooksJson: String.raw`\\server\shared projects\AI "DLC"\.codex\hooks.json`,
+      },
+    ];
+
+    for (const { project, hooksJson } of cases) {
+      const output = emitTrustEntries(project);
+      const parsed = parseTrustDocument(output);
+      expect(Object.keys(parsed.hooks.state)).toEqual(expectedTrustKeys(hooksJson));
+      for (const entry of Object.values(parsed.hooks.state)) {
+        expect(entry.trusted_hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+      }
+    }
+
+    // The common Unix form remains byte-identical to the historical output.
+    expect(emitTrustEntries("/tmp/example-proj")).toStartWith(
+      '[hooks.state."/tmp/example-proj/.codex/hooks.json:session_start:0:0"]\n' +
+        'trusted_hash = "sha256:ec7321a5902723dfe5d1b79fe13a48724fdf69a2029f83d4168ae28da6121c96"\n\n',
+    );
+  });
+
+  test("8: explicit hooks-json paths are preserved and complete CLI stdout parses", () => {
+    const project = "/tmp/project path that must not replace the hook path";
+    const hooksJson = String.raw`D:\custom hooks\hook "set"\hooks.json`;
+    const emitTrustEntries = trustEntries();
+    const expected = emitTrustEntries(project, hooksJson);
+    const direct = parseTrustDocument(expected);
+    expect(Object.keys(direct.hooks.state)).toEqual(expectedTrustKeys(hooksJson));
+
+    const r = spawnSync(
+      "bun",
+      [PACKAGE_SCRIPT, "codex", "trust", "--project", project, "--hooks-json", hooksJson],
+      {
+        encoding: "utf-8",
+        cwd: REPO_ROOT,
+      },
+    );
+    expect(r.status).toBe(0);
+    expect(r.stderr).toBe("");
+    // console.log adds one newline to the already newline-terminated TOML.
+    expect(r.stdout).toBe(`${expected}\n`);
+    const parsedStdout = parseTrustDocument(r.stdout);
+    expect(Object.keys(parsedStdout.hooks.state)).toEqual(expectedTrustKeys(hooksJson));
+    expect(r.stdout).not.toContain(project);
+  });
+
+  test("9: skills tree — every runner carries the S9f implicit-invocation guard; the orchestrator does not", () => {
     const skillsDir = join(REPO_ROOT, "dist", "codex", ".agents", "skills");
     const dirs = readdirSync(skillsDir).filter((d) =>
       statSync(join(skillsDir, d)).isDirectory(),
@@ -187,22 +293,20 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     expect(probe).toContain("bun .codex/tools/aidlc-orchestrate.ts next --stage intent-capture --single");
   });
 
-  test("7: trust subcommand substitutes the project path into every entry", () => {
+  test("10: trust subcommand substitutes the project path into every entry", () => {
     const r = spawnSync("bun", [PACKAGE_SCRIPT, "codex", "trust", "--project", "/tmp/example-proj"], {
       encoding: "utf-8",
       cwd: REPO_ROOT,
     });
     expect(r.status).toBe(0);
-    const entries = r.stdout.match(/\[hooks\.state\."[^"]+"\]/g) ?? [];
-    // One entry per registered hook group (8 wirings + the 1 PostCompact = 9).
+    const parsed = parseTrustDocument(r.stdout);
+    const entries = Object.keys(parsed.hooks.state);
     const wiring = JSON.parse(readFileSync(join(CODEX_DST, "hooks.json"), "utf-8")) as {
       hooks: Record<string, Array<unknown>>;
     };
     const groupCount = Object.values(wiring.hooks).reduce((n, g) => n + g.length, 0);
     expect(entries.length).toBe(groupCount);
-    for (const e of entries) {
-      expect(e).toContain("/tmp/example-proj/.codex/hooks.json:");
-    }
+    expect(entries).toEqual(expectedTrustKeys("/tmp/example-proj/.codex/hooks.json"));
     expect(r.stdout).not.toContain("<PROJECT_DIR>");
   });
 });

--- a/tests/unit/t150-codex-packaging.test.ts
+++ b/tests/unit/t150-codex-packaging.test.ts
@@ -261,7 +261,52 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     expect(r.stdout).not.toContain(project);
   });
 
-  test("9: skills tree — every runner carries the S9f implicit-invocation guard; the orchestrator does not", () => {
+  test("9: trust subcommand rejects malformed, relative, unknown, and duplicate arguments", () => {
+    const cases: Array<{ args: string[]; error: string }> = [
+      {
+        args: ["codex", "trust", "--hooks-json", "--project", "/tmp/project"],
+        error: "--hooks-json requires an absolute path",
+      },
+      {
+        args: ["codex", "trust", "--project", "relative/project"],
+        error: "--project must be an absolute path",
+      },
+      {
+        args: ["codex", "trust", "--project", "/tmp/project", "--hooks-json", "hooks.json"],
+        error: "--hooks-json must be an absolute path",
+      },
+      {
+        args: ["codex", "trust", "--project", "/tmp/project", "--hooks-josn", "/tmp/hooks.json"],
+        error: 'unknown argument "--hooks-josn"',
+      },
+      {
+        args: [
+          "codex",
+          "trust",
+          "--project",
+          "/tmp/project",
+          "--project",
+          "/tmp/other",
+        ],
+        error: "--project may be specified only once",
+      },
+    ];
+
+    for (const { args, error } of cases) {
+      const r = spawnSync("bun", [PACKAGE_SCRIPT, ...args], {
+        encoding: "utf-8",
+        cwd: REPO_ROOT,
+      });
+      expect(r.status, args.join(" ")).toBe(1);
+      expect(r.stdout, args.join(" ")).toBe("");
+      expect(r.stderr, args.join(" ")).toContain(error);
+      expect(r.stderr, args.join(" ")).toContain(
+        "usage: package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]",
+      );
+    }
+  });
+
+  test("10: skills tree — every runner carries the S9f implicit-invocation guard; the orchestrator does not", () => {
     const skillsDir = join(REPO_ROOT, "dist", "codex", ".agents", "skills");
     const dirs = readdirSync(skillsDir).filter((d) =>
       statSync(join(skillsDir, d)).isDirectory(),
@@ -293,7 +338,7 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     expect(probe).toContain("bun .codex/tools/aidlc-orchestrate.ts next --stage intent-capture --single");
   });
 
-  test("10: trust subcommand substitutes the project path into every entry", () => {
+  test("11: trust subcommand substitutes the project path into every entry", () => {
     const r = spawnSync("bun", [PACKAGE_SCRIPT, "codex", "trust", "--project", "/tmp/example-proj"], {
       encoding: "utf-8",
       cwd: REPO_ROOT,

--- a/tests/unit/t150-codex-packaging.test.ts
+++ b/tests/unit/t150-codex-packaging.test.ts
@@ -187,6 +187,9 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     expect(header).toContain(
       "bun scripts/package.ts codex trust --project <abs-dir> [--hooks-json <abs-path>]",
     );
+    expect(header).toContain("bun install --frozen-lockfile");
+    expect(header).toContain("replace the full set");
+    expect(header).toContain("appending a second set creates invalid TOML");
     expect(header).not.toMatch(/replac\w*\s+<PROJECT_DIR>/i);
     const shippedBody = shipped.slice(bodyStart).trimEnd();
     const produced = emitTrustEntries("<PROJECT_DIR>").trimEnd();
@@ -265,7 +268,36 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     expect(r.stdout).not.toContain(project);
   });
 
-  test("9: trust subcommand rejects malformed, relative, unknown, and duplicate arguments", () => {
+  test("9: trust subcommand accepts fully qualified Windows project roots", () => {
+    const cases = [
+      {
+        project: String.raw`C:\workspace\AI DLC`,
+        hooksJson: String.raw`C:\workspace\AI DLC\.codex\hooks.json`,
+      },
+      {
+        project: String.raw`\\server\share\AI DLC`,
+        hooksJson: String.raw`\\server\share\AI DLC\.codex\hooks.json`,
+      },
+      {
+        project: "//server/share/AI DLC",
+        hooksJson: String.raw`\\server\share\AI DLC\.codex\hooks.json`,
+      },
+    ];
+
+    for (const { project, hooksJson } of cases) {
+      const r = spawnSync("bun", [PACKAGE_SCRIPT, "codex", "trust", "--project", project], {
+        encoding: "utf-8",
+        cwd: REPO_ROOT,
+      });
+      expect(r.status, project).toBe(0);
+      expect(r.stderr, project).toBe("");
+      expect(Object.keys(parseTrustDocument(r.stdout).hooks.state)).toEqual(
+        expectedTrustKeys(hooksJson),
+      );
+    }
+  });
+
+  test("10: trust subcommand rejects malformed, non-qualified, unknown, and duplicate arguments", () => {
     const cases: Array<{ args: string[]; error: string }> = [
       {
         args: ["codex", "trust", "--hooks-json", "--project", "/tmp/project"],
@@ -273,11 +305,34 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
       },
       {
         args: ["codex", "trust", "--project", "relative/project"],
-        error: "--project must be an absolute path",
+        error: "--project must be a fully qualified absolute path",
       },
       {
         args: ["codex", "trust", "--project", "/tmp/project", "--hooks-json", "hooks.json"],
-        error: "--hooks-json must be an absolute path",
+        error: "--hooks-json must be a fully qualified absolute path",
+      },
+      {
+        args: ["codex", "trust", "--project", String.raw`\workspace`],
+        error: "--project must be a fully qualified absolute path",
+      },
+      {
+        args: ["codex", "trust", "--project", String.raw`\\server`],
+        error: "--project must be a fully qualified absolute path",
+      },
+      {
+        args: ["codex", "trust", "--project", "//server"],
+        error: "--project must be a fully qualified absolute path",
+      },
+      {
+        args: [
+          "codex",
+          "trust",
+          "--project",
+          "/tmp/project",
+          "--hooks-json",
+          String.raw`\custom\hooks.json`,
+        ],
+        error: "--hooks-json must be a fully qualified absolute path",
       },
       {
         args: ["codex", "trust", "--project", "/tmp/project", "--hooks-josn", "/tmp/hooks.json"],
@@ -310,7 +365,7 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     }
   });
 
-  test("10: skills tree — every runner carries the S9f implicit-invocation guard; the orchestrator does not", () => {
+  test("11: skills tree — every runner carries the S9f implicit-invocation guard; the orchestrator does not", () => {
     const skillsDir = join(REPO_ROOT, "dist", "codex", ".agents", "skills");
     const dirs = readdirSync(skillsDir).filter((d) =>
       statSync(join(skillsDir, d)).isDirectory(),
@@ -342,7 +397,7 @@ describe("t150 dist/codex packaging parity + drift guard", () => {
     expect(probe).toContain("bun .codex/tools/aidlc-orchestrate.ts next --stage intent-capture --single");
   });
 
-  test("11: trust subcommand substitutes the project path into every entry", () => {
+  test("12: trust subcommand substitutes the project path into every entry", () => {
     const r = spawnSync("bun", [PACKAGE_SCRIPT, "codex", "trust", "--project", "/tmp/example-proj"], {
       encoding: "utf-8",
       cwd: REPO_ROOT,


### PR DESCRIPTION
## Summary

`bun scripts/package.ts codex trust` previously built its `[hooks.state]` entries with ad hoc string concatenation, producing invalid or wrong TOML for any path containing spaces, quotes, or backslashes - essentially every Windows path.

- Trust entries are now serialized with smol-toml (pinned 1.7.0); tests parse the complete generated output back with the same standards-compliant parser.
- Unix paths, Windows drive-letter paths, UNC paths (both `\\server\share` and the forward-slash `//server/share` spelling, which is simultaneously posix-absolute and win32-absolute), spaces, quotes, and backslashes all round-trip exactly. The default `.codex/hooks.json` key is joined with the path implementation matching the project argument's spelling, so a Unix-invoked packager generates native Windows keys and vice versa.
- An explicit `--hooks-json` path is preserved verbatim as the trust identity - never joined or normalized.
- The trust command now rejects relative paths, missing values, duplicate flags, and unknown arguments with the reason plus usage on stderr, instead of printing trust keys that would never match.
- Normal Unix output stays byte-identical to the historical form (pinned in test); the shipped `dist/codex/.codex/trust-seed.toml` regenerates identically through the packager.

Codex harness docs updated for quoted paths and `--hooks-json`.

## Version

2.3.14. Slot ladder: 2.3.11 held by #573, 2.3.12 is #577 (packager contract), 2.3.13 held by #576. Merge after #577.

## Testing

- t150 extended: TOML round-trip cases per path family, full-CLI-stdout parse, explicit hooks-json preservation (project path must not leak), five malformed-invocation rejection cases, byte-parity pin for the Unix default
- `bun scripts/package.ts --check` green (proves the dist trust-seed regenerates byte-identically)
- `bun run typecheck` green
- Full deterministic tier green at the integration tip unioning this with its sibling PRs (single red: t92, pre-existing on v2)