### PR TITLE
test: derive harness test coverage from a manifest-discovered matrix

### DIFF
--- a/tests/harness/fixtures.ts
+++ b/tests/harness/fixtures.ts
@@ -583,9 +583,9 @@ export function setupIntegrationProject(
 // its own git-init'd sibling repos makes toplevel == dirname(common-dir) hold
 // for each repo, so the guard passes (the same posture setupCodexProject takes).
 //
-// Harness-parameterized so every shipped distribution can reuse ONE fixture.
-// The three live logic drivers (Claude SDK, Kiro ACP, Codex exec) select their
-// respective CLI rows; the deterministic fixture test also covers Kiro IDE.
+// Harness-parameterized so every shipped distribution can reuse ONE fixture:
+// the matrix resolves any discovered harness's dist root, so live drivers and
+// deterministic fixture tests alike pick their row without touching this file.
 // ============================================================================
 
 export type JourneyHarness = ShippedHarnessName;

--- a/tests/harness/fixtures.ts
+++ b/tests/harness/fixtures.ts
@@ -40,10 +40,7 @@ import { hostname, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { seedCustomHarness } from "./custom-harness.ts";
-import {
-  harnessByName,
-  type ShippedHarnessName,
-} from "./harness-matrix.ts";
+import type { ShippedHarnessName } from "./harness-matrix.ts";
 
 const HARNESS_DIR = dirname(fileURLToPath(import.meta.url));
 const requireHere = createRequire(import.meta.url);
@@ -643,6 +640,13 @@ export function setupWorkspaceJourney(harness: JourneyHarness = "claude"): Works
   // 1. Copy the complete shipped distribution root. The matrix resolves the
   //    manifest-backed dist row; copying its entries keeps this fixture agnostic
   //    to engine-dir, root-file, and emitted-skill layout differences.
+  //    Loaded lazily, NOT at module scope: harness-matrix.ts walks harness/ and
+  //    dist/ at import time, and fixtures.ts is imported by sandbox tests (t52's
+  //    t48 sandbox) whose trees ship neither - a top-level import throws ENOENT
+  //    there. Same posture as resetSelectionSensitiveCaches above.
+  const { harnessByName } = requireHere(
+    "./harness-matrix.ts",
+  ) as typeof import("./harness-matrix.ts");
   const distRoot = harnessByName(harness).distRoot;
   for (const entry of readdirSync(distRoot)) {
     cpSync(join(distRoot, entry), join(root, entry), { recursive: true });

--- a/tests/harness/fixtures.ts
+++ b/tests/harness/fixtures.ts
@@ -30,6 +30,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -39,6 +40,10 @@ import { hostname, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { seedCustomHarness } from "./custom-harness.ts";
+import {
+  harnessByName,
+  type ShippedHarnessName,
+} from "./harness-matrix.ts";
 
 const HARNESS_DIR = dirname(fileURLToPath(import.meta.url));
 const requireHere = createRequire(import.meta.url);
@@ -578,19 +583,12 @@ export function setupIntegrationProject(
 // its own git-init'd sibling repos makes toplevel == dirname(common-dir) hold
 // for each repo, so the guard passes (the same posture setupCodexProject takes).
 //
-// Harness-parameterized so all three logic drivers (Claude SDK · Kiro ACP ·
-// Codex exec) reuse ONE fixture: each copies the shipped dist/<harness>/ shell
-// (engine dir + the sibling aidlc/ memory shell) into the root, exactly as
-// setupIntegrationProject / setupTuiProject / setupCodexProject do.
+// Harness-parameterized so every shipped distribution can reuse ONE fixture.
+// The three live logic drivers (Claude SDK, Kiro ACP, Codex exec) select their
+// respective CLI rows; the deterministic fixture test also covers Kiro IDE.
 // ============================================================================
 
-/** Per-harness dist source paths for the journey shell. Reuses the same dist
- *  trees the other fixtures copy (AIDLC_SRC / KIRO_SRC / the codex shell). */
-const CLAUDE_DIST = join(REPO_ROOT, "dist", "claude");
-const KIRO_DIST = join(REPO_ROOT, "dist", "kiro");
-const CODEX_DIST = join(REPO_ROOT, "dist", "codex");
-
-export type JourneyHarness = "claude" | "kiro" | "codex";
+export type JourneyHarness = ShippedHarnessName;
 
 export interface WorkspaceJourney {
   /** The tmp workspace root (canonical realpath) — the project dir every driver
@@ -642,20 +640,12 @@ export function setupWorkspaceJourney(harness: JourneyHarness = "claude"): Works
   const home = join(root, ".home");
   mkdirSync(home, { recursive: true });
 
-  // 1. Copy the shipped harness shell: the engine dir + the sibling aidlc/ memory
-  //    shell (all three dist trees ship dist/<h>/aidlc/{active-space,spaces/default}).
-  if (harness === "kiro") {
-    cpSync(join(KIRO_DIST, ".kiro"), join(root, ".kiro"), { recursive: true });
-    cpSync(join(KIRO_DIST, "AGENTS.md"), join(root, "AGENTS.md"));
-    cpSync(join(KIRO_DIST, "aidlc"), join(root, "aidlc"), { recursive: true });
-  } else if (harness === "codex") {
-    cpSync(join(CODEX_DIST, ".codex"), join(root, ".codex"), { recursive: true });
-    cpSync(join(CODEX_DIST, ".agents"), join(root, ".agents"), { recursive: true });
-    cpSync(join(CODEX_DIST, "AGENTS.md"), join(root, "AGENTS.md"));
-    cpSync(join(CODEX_DIST, "aidlc"), join(root, "aidlc"), { recursive: true });
-  } else {
-    cpSync(join(CLAUDE_DIST, ".claude"), join(root, ".claude"), { recursive: true });
-    cpSync(join(CLAUDE_DIST, "aidlc"), join(root, "aidlc"), { recursive: true });
+  // 1. Copy the complete shipped distribution root. The matrix resolves the
+  //    manifest-backed dist row; copying its entries keeps this fixture agnostic
+  //    to engine-dir, root-file, and emitted-skill layout differences.
+  const distRoot = harnessByName(harness).distRoot;
+  for (const entry of readdirSync(distRoot)) {
+    cpSync(join(distRoot, entry), join(root, entry), { recursive: true });
   }
 
   // Pin the per-clone audit-shard token (gitignored on a real project) so any

--- a/tests/harness/harness-matrix.ts
+++ b/tests/harness/harness-matrix.ts
@@ -138,6 +138,18 @@ function fail(name: string, message: string): never {
   throw new Error(`harness matrix [${name}]: ${message}`);
 }
 
+export function manifestGrantsIdeAgentTools(
+  manifest: Pick<HarnessManifest, "frontmatterAdditions">,
+): boolean {
+  return (
+    manifest.frontmatterAdditions?.some(
+      ({ file, lines }) =>
+        /^agents\/[^/]+\.md$/.test(file) &&
+        lines.some((line) => line.split(":", 1)[0]?.trim() === "tools"),
+    ) ?? false
+  );
+}
+
 function validateManifest(
   name: ShippedHarnessName,
   manifest: HarnessManifest,
@@ -193,9 +205,8 @@ function validateManifest(
   ) {
     fail(name, "memoryInclude does not agree with manifest-owned include surfaces");
   }
-  const hasFrontmatterAdditions = (manifest.frontmatterAdditions?.length ?? 0) > 0;
-  if (hasFrontmatterAdditions !== capabilities.ideAgentTools) {
-    fail(name, "ideAgentTools does not agree with manifest frontmatterAdditions");
+  if (manifestGrantsIdeAgentTools(manifest) !== capabilities.ideAgentTools) {
+    fail(name, "ideAgentTools does not agree with manifest agent tools grants");
   }
   if (
     manifest.plugin &&

--- a/tests/harness/harness-matrix.ts
+++ b/tests/harness/harness-matrix.ts
@@ -1,0 +1,260 @@
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { HarnessManifest } from "../../scripts/manifest-types.ts";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const HARNESS_ROOT = join(REPO_ROOT, "harness");
+
+type ReviewerScopeRegistration =
+  | "claude-settings"
+  | "codex-hooks"
+  | "kiro-agent-json"
+  | "unsupported";
+
+type HarnessCapabilities = {
+  harnessDir: string;
+  onboarding: {
+    mode: "manifest" | "emit";
+    fills: string;
+    dist: string;
+  };
+  rootFiles: readonly string[];
+  skillsRoot: string;
+  plugin: {
+    kind: "store" | "kiro";
+    manifestDir: string;
+    wiringFile: string;
+  };
+  memoryInclude: "claude-import" | "codex-env" | "kiro-resources";
+  kiroAgentJson: boolean;
+  ideAgentTools: boolean;
+  reviewerScopeRegistration: ReviewerScopeRegistration;
+};
+
+// These are test capabilities, not packager instructions. Keeping every field
+// explicit makes harness-specific test selection reviewable and prevents a new
+// manifest from inheriting an accidental default.
+const HARNESS_CAPABILITIES = {
+  claude: {
+    harnessDir: ".claude",
+    onboarding: {
+      mode: "manifest",
+      fills: "onboarding.fills.ts",
+      dist: ".claude/CLAUDE.md",
+    },
+    rootFiles: [".gitignore", ".mcp.json"],
+    skillsRoot: ".claude/skills",
+    plugin: {
+      kind: "store",
+      manifestDir: ".claude-plugin",
+      wiringFile: "hooks/hooks.json",
+    },
+    memoryInclude: "claude-import",
+    kiroAgentJson: false,
+    ideAgentTools: false,
+    reviewerScopeRegistration: "claude-settings",
+  },
+  codex: {
+    harnessDir: ".codex",
+    onboarding: {
+      mode: "emit",
+      fills: "onboarding.fills.ts",
+      dist: "AGENTS.md",
+    },
+    rootFiles: [".gitignore", "AGENTS.md"],
+    skillsRoot: ".agents/skills",
+    plugin: {
+      kind: "store",
+      manifestDir: ".codex-plugin",
+      wiringFile: "hooks/hooks.json",
+    },
+    memoryInclude: "codex-env",
+    kiroAgentJson: false,
+    ideAgentTools: false,
+    reviewerScopeRegistration: "codex-hooks",
+  },
+  "kiro-ide": {
+    harnessDir: ".kiro",
+    onboarding: {
+      mode: "manifest",
+      fills: "onboarding.fills.ts",
+      dist: "AGENTS.md",
+    },
+    rootFiles: [".gitignore", "AGENTS.md"],
+    skillsRoot: ".kiro/skills",
+    plugin: {
+      kind: "kiro",
+      manifestDir: ".kiro-plugin",
+      wiringFile: "hooks/aidlc-plugin-compose.kiro.hook",
+    },
+    memoryInclude: "kiro-resources",
+    kiroAgentJson: true,
+    ideAgentTools: true,
+    reviewerScopeRegistration: "unsupported",
+  },
+  kiro: {
+    harnessDir: ".kiro",
+    onboarding: {
+      mode: "manifest",
+      fills: "onboarding.fills.ts",
+      dist: "AGENTS.md",
+    },
+    rootFiles: [".gitignore", "AGENTS.md"],
+    skillsRoot: ".kiro/skills",
+    plugin: {
+      kind: "kiro",
+      manifestDir: ".kiro-plugin",
+      wiringFile: "hooks/aidlc-plugin-compose.kiro.hook",
+    },
+    memoryInclude: "kiro-resources",
+    kiroAgentJson: true,
+    ideAgentTools: false,
+    reviewerScopeRegistration: "kiro-agent-json",
+  },
+} as const satisfies Record<string, HarnessCapabilities>;
+
+export type ShippedHarnessName = keyof typeof HARNESS_CAPABILITIES;
+
+export type ShippedHarness = {
+  name: ShippedHarnessName;
+  manifest: HarnessManifest;
+  capabilities: HarnessCapabilities;
+  authoredRoot: string;
+  distRoot: string;
+  engineRoot: string;
+  skillsRoot: string;
+  onboardingFills: string;
+  onboardingDist: string;
+};
+
+function discoverManifestNames(): string[] {
+  return readdirSync(HARNESS_ROOT)
+    .filter((name) => existsSync(join(HARNESS_ROOT, name, "manifest.ts")))
+    .sort();
+}
+
+function fail(name: string, message: string): never {
+  throw new Error(`harness matrix [${name}]: ${message}`);
+}
+
+function validateManifest(
+  name: ShippedHarnessName,
+  manifest: HarnessManifest,
+  capabilities: HarnessCapabilities,
+): void {
+  if (manifest.name !== name) fail(name, `manifest.name is "${manifest.name}"`);
+  if (manifest.harnessDir !== capabilities.harnessDir) {
+    fail(
+      name,
+      `metadata harnessDir "${capabilities.harnessDir}" != manifest "${manifest.harnessDir}"`,
+    );
+  }
+
+  const usesEmittedSkills = manifest.skipRunnerGen === true;
+  if (usesEmittedSkills !== (capabilities.skillsRoot !== `${manifest.harnessDir}/skills`)) {
+    fail(name, "skillsRoot does not agree with manifest.skipRunnerGen");
+  }
+
+  const onboarding = manifest.onboarding ?? null;
+  if (capabilities.onboarding.mode === "manifest") {
+    if (!onboarding) fail(name, "metadata expects manifest onboarding");
+    const dist = onboarding.projectRoot
+      ? onboarding.dst
+      : `${manifest.harnessDir}/${onboarding.dst}`;
+    if (dist !== capabilities.onboarding.dist) {
+      fail(name, `onboarding dist "${capabilities.onboarding.dist}" != manifest "${dist}"`);
+    }
+  } else if (onboarding || !manifest.emit) {
+    fail(name, "emitted onboarding requires onboarding:null and an emit function");
+  }
+
+  for (const file of manifest.harnessFiles.filter((file) => file.projectRoot)) {
+    if (!capabilities.rootFiles.includes(file.dst)) {
+      fail(name, `project-root manifest file "${file.dst}" is absent from rootFiles metadata`);
+    }
+  }
+  if (onboarding?.projectRoot && !capabilities.rootFiles.includes(onboarding.dst)) {
+    fail(name, `project-root onboarding "${onboarding.dst}" is absent from rootFiles metadata`);
+  }
+
+  const hasKiroAgentJson = manifest.harnessFiles.some(
+    (file) => file.dst === "agents/aidlc.json",
+  );
+  if (hasKiroAgentJson !== capabilities.kiroAgentJson) {
+    fail(name, "kiroAgentJson does not agree with manifest harnessFiles");
+  }
+  if (
+    (capabilities.memoryInclude === "kiro-resources") !== hasKiroAgentJson ||
+    (capabilities.memoryInclude === "claude-import") !==
+      manifest.harnessFiles.some((file) => file.dst === "rules/aidlc.md") ||
+    (capabilities.memoryInclude === "codex-env") !==
+      (capabilities.onboarding.mode === "emit")
+  ) {
+    fail(name, "memoryInclude does not agree with manifest-owned include surfaces");
+  }
+  const hasFrontmatterAdditions = (manifest.frontmatterAdditions?.length ?? 0) > 0;
+  if (hasFrontmatterAdditions !== capabilities.ideAgentTools) {
+    fail(name, "ideAgentTools does not agree with manifest frontmatterAdditions");
+  }
+  if (
+    manifest.plugin &&
+    (manifest.plugin.kind !== capabilities.plugin.kind ||
+      manifest.plugin.manifestDir !== capabilities.plugin.manifestDir)
+  ) {
+    fail(name, "plugin metadata does not agree with the manifest plugin block");
+  }
+}
+
+const discoveredNames = discoverManifestNames();
+const metadataNames = Object.keys(HARNESS_CAPABILITIES).sort();
+if (discoveredNames.join("\n") !== metadataNames.join("\n")) {
+  throw new Error(
+    "harness matrix metadata must exactly cover discovered manifests\n" +
+      `discovered: ${discoveredNames.join(", ")}\n` +
+      `metadata: ${metadataNames.join(", ")}`,
+  );
+}
+
+export const HARNESS_MATRIX: readonly ShippedHarness[] = discoveredNames.map((rawName) => {
+  const name = rawName as ShippedHarnessName;
+  const authoredRoot = join(HARNESS_ROOT, name);
+  const manifest = (
+    require(join(authoredRoot, "manifest.ts")) as { default: HarnessManifest }
+  ).default;
+  const capabilities: HarnessCapabilities = HARNESS_CAPABILITIES[name];
+  validateManifest(name, manifest, capabilities);
+
+  const distRoot = join(REPO_ROOT, "dist", name);
+  const engineRoot = join(distRoot, manifest.harnessDir);
+  const onboardingFills = join(authoredRoot, capabilities.onboarding.fills);
+  const onboardingDist = join(distRoot, capabilities.onboarding.dist);
+  const skillsRoot = join(distRoot, capabilities.skillsRoot);
+  for (const [label, path] of [
+    ["dist root", distRoot],
+    ["engine root", engineRoot],
+    ["onboarding fills", onboardingFills],
+    ["onboarding dist", onboardingDist],
+    ["skills root", skillsRoot],
+  ]) {
+    if (!existsSync(path)) fail(name, `${label} is missing: ${path}`);
+  }
+
+  return {
+    name,
+    manifest,
+    capabilities,
+    authoredRoot,
+    distRoot,
+    engineRoot,
+    skillsRoot,
+    onboardingFills,
+    onboardingDist,
+  };
+});
+
+export function harnessByName(name: ShippedHarnessName): ShippedHarness {
+  const harness = HARNESS_MATRIX.find((candidate) => candidate.name === name);
+  if (!harness) fail(name, "not discovered");
+  return harness;
+}

--- a/tests/harness/harness-matrix.ts
+++ b/tests/harness/harness-matrix.ts
@@ -212,7 +212,10 @@ if (discoveredNames.join("\n") !== metadataNames.join("\n")) {
   throw new Error(
     "harness matrix metadata must exactly cover discovered manifests\n" +
       `discovered: ${discoveredNames.join(", ")}\n` +
-      `metadata: ${metadataNames.join(", ")}`,
+      `metadata: ${metadataNames.join(", ")}\n` +
+      "fix: add a HARNESS_CAPABILITIES entry for the new harness in " +
+      "tests/harness/harness-matrix.ts (validateManifest cross-checks it " +
+      "against the manifest, so every field must reflect the real distribution)",
   );
 }
 

--- a/tests/integration/t188-plugin-compose.test.ts
+++ b/tests/integration/t188-plugin-compose.test.ts
@@ -17,10 +17,14 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  HARNESS_MATRIX,
+  type ShippedHarnessName,
+} from "../harness/harness-matrix.ts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const PACKAGE_TS = join(REPO_ROOT, "scripts", "package.ts");
@@ -32,10 +36,16 @@ const CLAUDE_DIST = join(REPO_ROOT, "dist", "claude", ".claude");
 const STAGE_TABLE_BEGIN =
   "<!-- BEGIN: compiled stage graph via `bun aidlc-utility.ts stage-table` - do NOT hand-edit -->";
 const STAGE_TABLE_END = "<!-- END: compiled stage graph -->";
-// The COMMITTED projection — only existsSync-probed (never mutated) by the
-// "packager emits" assertions. The compose run below uses a FRESHLY BUILT copy
-// under tmp (see beforeAll) so this test never regenerates the committed dist.
-const PLUGIN_CLAUDE_COMMITTED = join(REPO_ROOT, "dist", "plugins", PLUGIN, "claude");
+
+function fileInventory(root: string, relative = ""): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(join(root, relative)).sort()) {
+    const rel = join(relative, entry);
+    if (statSync(join(root, rel)).isDirectory()) files.push(...fileInventory(root, rel));
+    else files.push(rel);
+  }
+  return files;
+}
 
 // Absolute path to a stage's compiled node in a composed project.
 function graph(projectDir: string): Array<Record<string, any>> {
@@ -80,21 +90,30 @@ describe("t188 plugin compose — emit + compose the contribution seam", () => {
   let project: string;
   let pluginBuilt: string;
   let coreRunnerBefore: string;
+  const pluginBuilds = new Map<ShippedHarnessName, string>();
 
   beforeAll(() => {
     tmp = mkdtempSync(join(tmpdir(), "aidlc-t188-"));
 
-    // 1. Build the plugin projection into tmp via the target-dir seam — NEVER
-    //    regenerate the committed dist/ (write-mode package.ts rmSync's the
-    //    committed trees, which masks drift and races sibling tests under the
-    //    parallel integration tier). This exercises the real emitter in isolation.
-    pluginBuilt = join(tmp, "plugin", "claude");
-    const build = spawnSync(BUN, [PACKAGE_TS, "plugin", "build", PLUGIN, "claude", pluginBuilt], {
-      cwd: REPO_ROOT,
-      encoding: "utf-8",
-      timeout: TIMEOUT_MS - 5_000,
-    });
-    if (build.status !== 0) throw new Error(`plugin build failed: ${build.stderr}`);
+    // 1. Build every manifest-discovered projection into tmp via the target-dir
+    //    seam. This exercises the real emitter without mutating committed dist.
+    for (const harness of HARNESS_MATRIX) {
+      const built = join(tmp, "plugin", harness.name);
+      const build = spawnSync(
+        BUN,
+        [PACKAGE_TS, "plugin", "build", PLUGIN, harness.name, built],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf-8",
+          timeout: TIMEOUT_MS - 5_000,
+        },
+      );
+      if (build.status !== 0) {
+        throw new Error(`plugin build failed for ${harness.name}: ${build.stderr}`);
+      }
+      pluginBuilds.set(harness.name, built);
+    }
+    pluginBuilt = pluginBuilds.get("claude")!;
 
     // 2. Fresh base project = a copy of dist/claude/.claude (read-only source).
     project = join(tmp, "proj");
@@ -117,28 +136,53 @@ describe("t188 plugin compose — emit + compose the contribution seam", () => {
       },
     });
     if (compose.status !== 0) throw new Error(`compose.ts failed: ${compose.stderr}`);
-  });
+  }, TIMEOUT_MS);
 
   afterAll(() => {
     if (tmp && existsSync(tmp)) rmSync(tmp, { recursive: true, force: true });
   });
 
-  // --- Packager emits the projection ---
-  test("packager emits a Claude host-plugin projection", () => {
-    expect(existsSync(join(PLUGIN_CLAUDE_COMMITTED, ".claude-plugin", "plugin.json"))).toBe(true);
-    expect(existsSync(join(PLUGIN_CLAUDE_COMMITTED, "hooks", "compose.ts"))).toBe(true);
-    expect(existsSync(join(PLUGIN_CLAUDE_COMMITTED, "hooks", "hooks.json"))).toBe(true);
-  });
+  // --- Packager emits every projection; Claude remains the compose E2E below ---
+  test("every harness projection carries its declared host manifest, wiring, and content", () => {
+    for (const harness of HARNESS_MATRIX) {
+      const built = pluginBuilds.get(harness.name)!;
+      const committed = join(REPO_ROOT, "dist", "plugins", PLUGIN, harness.name);
+      expect(existsSync(committed), `${harness.name}: committed projection`).toBe(true);
+      expect(fileInventory(committed), `${harness.name}: committed inventory`).toEqual(
+        fileInventory(built),
+      );
 
-  test("packager emits scopes, agents, and knowledge in the Claude projection", () => {
-    expect(existsSync(join(PLUGIN_CLAUDE_COMMITTED, "scopes", "test-pro-validation.md"))).toBe(true);
-    expect(existsSync(join(PLUGIN_CLAUDE_COMMITTED, "agents", "test-pro-metrics-agent.md"))).toBe(true);
-    expect(existsSync(join(PLUGIN_CLAUDE_COMMITTED, "knowledge", "test-pro-metrics-agent", "methodology.md"))).toBe(true);
-  });
-
-  test("all four harness projections emit", () => {
-    for (const h of ["claude", "codex", "kiro", "kiro-ide"]) {
-      expect(existsSync(join(REPO_ROOT, "dist", "plugins", PLUGIN, h))).toBe(true);
+      const manifestFile = join(
+        built,
+        harness.capabilities.plugin.manifestDir,
+        "plugin.json",
+      );
+      const hostManifest = JSON.parse(readFileSync(manifestFile, "utf-8")) as {
+        name?: string;
+      };
+      expect(hostManifest.name, harness.name).toBe(`aidlc-${PLUGIN}`);
+      expect(existsSync(join(built, "hooks", "compose.ts"))).toBe(true);
+      const wiring = readFileSync(
+        join(built, harness.capabilities.plugin.wiringFile),
+        "utf-8",
+      );
+      expect(wiring, `${harness.name}: harness dir wiring`).toContain(
+        `AIDLC_HARNESS_DIR=${harness.manifest.harnessDir}`,
+      );
+      expect(existsSync(join(built, "stages", "construction", "test-pro-integration.md"))).toBe(
+        true,
+      );
+      expect(existsSync(join(built, "contributions", "construction", "build-and-test.md"))).toBe(
+        true,
+      );
+      // #550 plugin content buckets: scopes, agents, and knowledge must project
+      // into EVERY harness (stronger than the pre-matrix Claude-only guard).
+      expect(existsSync(join(built, "scopes", "test-pro-validation.md")), `${harness.name}: scope`).toBe(true);
+      expect(existsSync(join(built, "agents", "test-pro-metrics-agent.md")), `${harness.name}: agent`).toBe(true);
+      expect(
+        existsSync(join(built, "knowledge", "test-pro-metrics-agent", "methodology.md")),
+        `${harness.name}: knowledge`,
+      ).toBe(true);
     }
   });
 

--- a/tests/smoke/t123-skills-spec-conformance.test.ts
+++ b/tests/smoke/t123-skills-spec-conformance.test.ts
@@ -1,25 +1,24 @@
 // covers: file:skills, contract:agent-skills-spec-conformance
 //
 // t123 (smoke) — Agent-Skills-spec structural conformance over EVERY shipped
-// skill dir under dist/claude/.claude/skills/. Migrated from
+// harness's declared skill root. Migrated from
 // tests/smoke/t123-skills-spec-conformance.sh (TAP plan: 1 dir-count guard +
 // 5 structural assertions per skill = 1 + 5×38 = 191 assertions).
 //
 // Mechanism: none. There is no tool / process / argv seam under test — the
-// subject IS the on-disk shape of the shipped skill set and the bytes of each
+// subject IS the on-disk shape of each shipped skill set and the bytes of each
 // SKILL.md. The .sh sourced lib/tap.sh and shelled to `bun -e` only to PARSE
 // (read the graph, extract the frontmatter `name`); it never invoked an aidlc
 // tool as a process-boundary contract. So the twin reads the same static files
-// in-process (resolved from the harness's AIDLC_SRC, the same
-// dist/claude/.claude root the .sh reached via $CLAUDE_DIR) and asserts. Zero
+// in-process, with skill roots resolved by the shared harness matrix. Zero
 // LLM, zero tokens, zero subprocess. The ONE in-repo import - defaultScopeBatch
 // from aidlc-runner-gen.ts - is a pure function import, not a spawn (the .sh
 // hardcoded the same four scope-runner names in SCOPE_RUNNER_SKILLS; calling
 // the function is STRONGER: it tracks the generator's source of truth so a
 // default-batch edit flows into this guard automatically).
 //
-// Subject under test (the shipped skill set + each SKILL.md):
-//   dist/claude/.claude/skills/<skill>/SKILL.md — for the DERIVED expected set:
+// Subject under test (each shipped skill set + each SKILL.md):
+//   dist/<harness>/<skill-root>/<skill>/SKILL.md, for the DERIVED expected set:
 //     - 4 base skills (orchestrator + 3 read-only session skills)
 //     - the generator's default-batch scope-runners (imported here, not
 //       hardcoded)
@@ -59,17 +58,16 @@
 //   .sh per-skill test E (wc -l <= 500, ok/not_ok)
 //         -> per-skill "SKILL.md body <= 500 lines"
 //
-// 1 + 5×38 = 191 .sh assertions -> 1 set-equality test() + 5 expect()s ×
-// 38 skills (190) = 191 expect()-bearing assertions, same observables, the
-// dir-count + name-derivation STRONGER.
+// The original assertion set is preserved independently for every discovered
+// distribution, including Codex's emitted .agents/skills layout.
 
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { AIDLC_SRC } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 import { defaultScopeBatch } from "../../dist/claude/.claude/tools/aidlc-runner-gen.ts";
 
-const SKILLS_DIR = join(AIDLC_SRC, "skills");
 const STAGE_GRAPH = join(AIDLC_SRC, "tools", "data", "stage-graph.json");
 
 // --- The four base skills (orchestrator + the three read-only session skills).
@@ -117,10 +115,10 @@ const EXPECTED_SKILLS = [
  * contains a SKILL.md (mirrors the .sh for-loop over the skills dir that keeps
  * directories carrying a SKILL.md file).
  */
-function discoveredSkills(): string[] {
-  return readdirSync(SKILLS_DIR)
+function discoveredSkills(skillsDir: string): string[] {
+  return readdirSync(skillsDir)
     .filter((name) => {
-      const dir = join(SKILLS_DIR, name);
+      const dir = join(skillsDir, name);
       return (
         statSync(dir).isDirectory() && existsSync(join(dir, "SKILL.md"))
       );
@@ -137,14 +135,24 @@ function frontmatterName(text: string): string {
   return nm ? nm[1].trim().replace(/^["']|["']$/g, "") : "";
 }
 
-describe("t123 (smoke) skills-spec conformance — shipped skill set (migrated from t123-skills-spec-conformance.sh, plan 191)", () => {
-  // --- Test 1: the shipped skill set is exactly the DERIVED expected set ---
-  test("shipped skill set == derived expected set (sorted, exact) [.sh test 1]", () => {
-    // STRONGER than the .sh's joined-string assert_eq: element-by-element.
-    // Asserts both that the count matches (191's dir-count guard) and that the
-    // membership is exact — every base + scope-runner + stage-runner + init.
-    expect(discoveredSkills()).toEqual(EXPECTED_SKILLS);
-  });
+describe("t123 (smoke) skills-spec conformance — every shipped skill set", () => {
+  for (const harness of HARNESS_MATRIX) {
+    test(`${harness.name}: shipped skill set == derived expected set (sorted, exact)`, () => {
+      expect(discoveredSkills(harness.skillsRoot)).toEqual(EXPECTED_SKILLS);
+    });
+
+    test(`${harness.name}: generated runners invoke the manifest harness dir`, () => {
+      const runner = readFileSync(
+        join(harness.skillsRoot, "aidlc-code-generation", "SKILL.md"),
+        "utf-8",
+      );
+      expect(runner).toContain(`bun ${harness.manifest.harnessDir}/tools/`);
+      expect(runner).not.toContain("{{HARNESS_DIR}}");
+      if (harness.manifest.skipRunnerGen) {
+        expect(existsSync(join(harness.engineRoot, "skills"))).toBe(false);
+      }
+    });
+  }
 });
 
 // --- Per-skill structural conformance (5 expect()s each). One describe block
@@ -152,39 +160,34 @@ describe("t123 (smoke) skills-spec conformance — shipped skill set (migrated f
 // per-skill TAP lines. The set iterated is the DERIVED expected set (sorted),
 // exactly the .sh's `for skill in $(echo "$EXPECTED_SKILLS" | ... | sort)`.
 describe("t123 (smoke) skills-spec conformance — per-skill SKILL.md invariants", () => {
-  for (const skill of EXPECTED_SKILLS) {
-    const file = join(SKILLS_DIR, skill, "SKILL.md");
+  for (const harness of HARNESS_MATRIX) {
+    for (const skill of EXPECTED_SKILLS) {
+      const file = join(harness.skillsRoot, skill, "SKILL.md");
 
-    test(`${skill}: SKILL.md exists [.sh per-skill A]`, () => {
-      expect(existsSync(file)).toBe(true);
-    });
+      test(`${harness.name}/${skill}: SKILL.md exists`, () => {
+        expect(existsSync(file)).toBe(true);
+      });
 
-    test(`${skill}: frontmatter name == dir [.sh per-skill B]`, () => {
-      const text = readFileSync(file, "utf-8");
-      expect(frontmatterName(text)).toBe(skill);
-    });
+      test(`${harness.name}/${skill}: frontmatter name == dir`, () => {
+        const text = readFileSync(file, "utf-8");
+        expect(frontmatterName(text)).toBe(skill);
+      });
 
-    test(`${skill}: has a description: line [.sh per-skill C]`, () => {
-      const text = readFileSync(file, "utf-8");
-      // Same anchor as assert_grep "^description:": a line that starts the
-      // `description:` key (multiline mode).
-      expect(/^description:/m.test(text)).toBe(true);
-    });
+      test(`${harness.name}/${skill}: has a description: line`, () => {
+        const text = readFileSync(file, "utf-8");
+        expect(/^description:/m.test(text)).toBe(true);
+      });
 
-    test(`${skill}: carries no hooks: block [.sh per-skill D]`, () => {
-      const text = readFileSync(file, "utf-8");
-      // Same anchor as assert_not_grep "^hooks:" — Fork 2→B moved the spine to
-      // settings.json. The failure row IS reachable: any SKILL.md that grows a
-      // `hooks:` key at line-start fails here.
-      expect(/^hooks:/m.test(text)).toBe(false);
-    });
+      test(`${harness.name}/${skill}: carries no hooks: block`, () => {
+        const text = readFileSync(file, "utf-8");
+        expect(/^hooks:/m.test(text)).toBe(false);
+      });
 
-    test(`${skill}: SKILL.md body <= 500 lines [.sh per-skill E]`, () => {
-      const text = readFileSync(file, "utf-8");
-      // The .sh used `wc -l < file`, which counts newline characters. Mirror
-      // that exactly (number of "\n"), not the split-array length.
-      const lines = (text.match(/\n/g) ?? []).length;
-      expect(lines).toBeLessThanOrEqual(500);
-    });
+      test(`${harness.name}/${skill}: SKILL.md body <= 500 lines`, () => {
+        const text = readFileSync(file, "utf-8");
+        const lines = (text.match(/\n/g) ?? []).length;
+        expect(lines).toBeLessThanOrEqual(500);
+      });
+    }
   }
 });

--- a/tests/smoke/t148-kiro-file-structure.test.ts
+++ b/tests/smoke/t148-kiro-file-structure.test.ts
@@ -13,7 +13,10 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
+import {
+  HARNESS_MATRIX,
+  manifestGrantsIdeAgentTools,
+} from "../harness/harness-matrix.ts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const KIRO = join(REPO_ROOT, "dist", "kiro");
@@ -87,6 +90,24 @@ describe("t148 dist/kiro file structure", () => {
       const a = readJson(join(K, "agents", f));
       expect((a.tools as string[]) ?? []).not.toContain("subagent");
     }
+  });
+
+  test("IDE-agent capability ignores unrelated frontmatter additions", () => {
+    expect(
+      manifestGrantsIdeAgentTools({
+        frontmatterAdditions: [
+          { file: "agents/aidlc-example-agent.md", lines: ["badge: example"] },
+          { file: "skills/aidlc/SKILL.md", lines: [`tools: ["read"]`] },
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      manifestGrantsIdeAgentTools({
+        frontmatterAdditions: [
+          { file: "agents/aidlc-example-agent.md", lines: [`tools: ["read"]`] },
+        ],
+      }),
+    ).toBe(true);
   });
 
   test("IDE-native tools: frontmatter grant on delegation targets - kiro-ide ONLY", () => {

--- a/tests/smoke/t148-kiro-file-structure.test.ts
+++ b/tests/smoke/t148-kiro-file-structure.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const KIRO = join(REPO_ROOT, "dist", "kiro");
@@ -121,11 +122,10 @@ describe("t148 dist/kiro file structure", () => {
       }
     }
     // Leak guard: the grant is IDE-native and must not ship anywhere else.
-    for (const tree of [
-      join(REPO_ROOT, "dist", "claude", ".claude", "agents"),
-      join(K, "agents"), // dist/kiro (CLI)
-      join(REPO_ROOT, "dist", "codex", ".codex", "agents"),
-    ]) {
+    const nonIdeAgentTrees = HARNESS_MATRIX.filter(
+      (harness) => !harness.capabilities.ideAgentTools,
+    ).map((harness) => join(harness.engineRoot, "agents"));
+    for (const tree of nonIdeAgentTrees) {
       for (const f of readdirSync(tree).filter((n) => n.endsWith(".md"))) {
         expect(fmToolsOf(join(tree, f))).toBeUndefined();
       }

--- a/tests/smoke/t148-kiro-file-structure.test.ts
+++ b/tests/smoke/t148-kiro-file-structure.test.ts
@@ -125,6 +125,7 @@ describe("t148 dist/kiro file structure", () => {
     const nonIdeAgentTrees = HARNESS_MATRIX.filter(
       (harness) => !harness.capabilities.ideAgentTools,
     ).map((harness) => join(harness.engineRoot, "agents"));
+    expect(nonIdeAgentTrees.length).toBeGreaterThan(0);
     for (const tree of nonIdeAgentTrees) {
       for (const f of readdirSync(tree).filter((n) => n.endsWith(".md"))) {
         expect(fmToolsOf(join(tree, f))).toBeUndefined();

--- a/tests/unit/t123-skills-spec-conformance.test.ts
+++ b/tests/unit/t123-skills-spec-conformance.test.ts
@@ -1,19 +1,18 @@
 // covers: file:skills, contract:agent-skills-spec-conformance
 //
-// t123 (unit) — Agent-Skills-spec conformance over the FULL shipped skill set
-// under dist/claude/.claude/skills/, asserted with the complete frontmatter
+// t123 (unit) — Agent-Skills-spec conformance over every shipped harness's
+// declared skill root, asserted with the complete frontmatter
 // parser (the unit-tier sibling of the smoke-tier structural sweep). Migrated
 // from tests/unit/t123-skills-spec-conformance.sh (TAP plan: 1 dir-count guard
 // + 3 conformance assertions per skill = 1 + 3×38 = 115 assertions).
 //
 // Mechanism: none. There is no tool / process / argv / exit-code seam under
-// test — the subject IS the on-disk shape of the shipped skill set and the
+// test — the subject IS the on-disk shape of each shipped skill set and the
 // YAML frontmatter bytes of each SKILL.md. The .sh sourced lib/tap.sh and
 // shelled to `bun -e` ONLY to PARSE (read the stage graph; run the frontmatter
 // extractor); it never invoked an aidlc tool as a process-boundary contract.
-// So the twin reads the same static files in-process (resolved from the
-// harness's AIDLC_SRC, the same dist/claude/.claude root the .sh reached via
-// $AIDLC_SRC) and asserts. Zero LLM, zero tokens, zero subprocess. The ONE
+// So the twin reads the same static files in-process, with skill roots resolved
+// by the shared harness matrix. Zero LLM, zero tokens, zero subprocess. The ONE
 // in-repo import - defaultScopeBatch from aidlc-runner-gen.ts - is a pure
 // function import, not a spawn (the .sh hardcoded the same four scope-runner
 // names in SCOPE_RUNNER_SKILLS; calling the function is STRONGER: it tracks the
@@ -30,8 +29,8 @@
 // block-scalar-aware non-empty contract is what this twin preserves verbatim
 // from the .sh's inline `bun -e` parser (t123-skills-spec-conformance.sh:94-124).
 //
-// Subject under test (the shipped skill set + each SKILL.md's frontmatter):
-//   dist/claude/.claude/skills/<skill>/SKILL.md — for the DERIVED expected set:
+// Subject under test (each shipped skill set + each SKILL.md's frontmatter):
+//   dist/<harness>/<skill-root>/<skill>/SKILL.md, for the DERIVED expected set:
 //     - 4 base skills (orchestrator + 3 read-only session skills)
 //     - the generator's default-batch scope-runners (imported here, not
 //       hardcoded)
@@ -72,17 +71,16 @@
 //         -> per-skill "SKILL.md body <= 500 lines" (wc -l counts newlines —
 //            mirrored as the count of "\n", not the split-array length).
 //
-// 1 + 3×38 = 115 .sh assertions -> 1 set-equality test() + 3 expect()s × 38
-// skills (114) = 115 expect()-bearing assertions, same observables, the
-// dir-count + name-derivation STRONGER.
+// The original assertion set is preserved independently for every discovered
+// distribution, including Codex's emitted .agents/skills layout.
 
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { AIDLC_SRC } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 import { defaultScopeBatch } from "../../dist/claude/.claude/tools/aidlc-runner-gen.ts";
 
-const SKILLS_DIR = join(AIDLC_SRC, "skills");
 const STAGE_GRAPH = join(AIDLC_SRC, "tools", "data", "stage-graph.json");
 
 // --- The four base skills (orchestrator + the three read-only session skills).
@@ -130,10 +128,10 @@ const EXPECTED_SKILLS = [
  * contains a SKILL.md (mirrors the .sh's for-loop over the skills dir that
  * keeps directories carrying a SKILL.md file).
  */
-function discoveredSkills(): string[] {
-  return readdirSync(SKILLS_DIR)
+function discoveredSkills(skillsDir: string): string[] {
+  return readdirSync(skillsDir)
     .filter((name) => {
-      const dir = join(SKILLS_DIR, name);
+      const dir = join(skillsDir, name);
       return statSync(dir).isDirectory() && existsSync(join(dir, "SKILL.md"));
     })
     .sort();
@@ -193,15 +191,12 @@ function parseFrontmatter(text: string): FrontmatterParse {
   return { name, descPresent, descNonEmpty };
 }
 
-describe("t123 (unit) skills-spec conformance — shipped skill set (migrated from t123-skills-spec-conformance.sh, plan 115)", () => {
-  // --- Test 1: the shipped skill set is exactly the DERIVED expected set ---
-  test("shipped skill set == derived expected set (sorted, exact) [.sh test 1]", () => {
-    // STRONGER than the .sh's joined-string assert_eq: element-by-element.
-    // Asserts both that the count matches (115's dir-count guard: base 4 +
-    // 4 scope-runners + 29 stage-runners + aidlc-init = 38) and that the
-    // membership is exact.
-    expect(discoveredSkills()).toEqual(EXPECTED_SKILLS);
-  });
+describe("t123 (unit) skills-spec conformance — every shipped skill set", () => {
+  for (const harness of HARNESS_MATRIX) {
+    test(`${harness.name}: shipped skill set == derived expected set (sorted, exact)`, () => {
+      expect(discoveredSkills(harness.skillsRoot)).toEqual(EXPECTED_SKILLS);
+    });
+  }
 });
 
 // --- Per-skill spec conformance (3 expect()s each). One describe block per
@@ -209,35 +204,27 @@ describe("t123 (unit) skills-spec conformance — shipped skill set (migrated fr
 // TAP lines. The set iterated is the DERIVED expected set (sorted), exactly the
 // .sh's `for skill in $(echo "$EXPECTED_SKILLS" | tr ' ' '\n' | sort)`.
 describe("t123 (unit) skills-spec conformance — per-skill SKILL.md invariants", () => {
-  for (const skill of EXPECTED_SKILLS) {
-    const file = join(SKILLS_DIR, skill, "SKILL.md");
+  for (const harness of HARNESS_MATRIX) {
+    for (const skill of EXPECTED_SKILLS) {
+      const file = join(harness.skillsRoot, skill, "SKILL.md");
 
-    test(`${skill}: frontmatter name == dir [.sh per-skill 1]`, () => {
-      // STRONGER than `grep ^name: <skill>`: the value is read from inside the
-      // frontmatter fence and matched exactly. A missing SKILL.md (the .sh's
-      // not_ok branch) parses to an empty name here, so this row fails loudly.
-      const text = existsSync(file) ? readFileSync(file, "utf-8") : "";
-      expect(parseFrontmatter(text).name).toBe(skill);
-    });
+      test(`${harness.name}/${skill}: frontmatter name == dir`, () => {
+        const text = existsSync(file) ? readFileSync(file, "utf-8") : "";
+        expect(parseFrontmatter(text).name).toBe(skill);
+      });
 
-    test(`${skill}: description present AND non-empty (block-scalar aware) [.sh per-skill 2]`, () => {
-      // The load-bearing unit-tier contract: the .sh required descPresent==1
-      // AND descNonEmpty==1. Every shipped SKILL.md uses `description: >`, so
-      // the parser must follow the block scalar to the first non-empty
-      // continuation line. An empty/dangling `description: >` fails this row —
-      // the failure event is reachable, mirroring the .sh's not_ok.
-      const text = existsSync(file) ? readFileSync(file, "utf-8") : "";
-      const fm = parseFrontmatter(text);
-      expect(fm.descPresent).toBe(true);
-      expect(fm.descNonEmpty).toBe(true);
-    });
+      test(`${harness.name}/${skill}: description present and non-empty`, () => {
+        const text = existsSync(file) ? readFileSync(file, "utf-8") : "";
+        const fm = parseFrontmatter(text);
+        expect(fm.descPresent).toBe(true);
+        expect(fm.descNonEmpty).toBe(true);
+      });
 
-    test(`${skill}: SKILL.md body <= 500 lines [.sh per-skill 3]`, () => {
-      // The .sh used `wc -l < file`, which counts newline characters. Mirror
-      // that exactly (number of "\n"), not the split-array length.
-      const text = existsSync(file) ? readFileSync(file, "utf-8") : "";
-      const lines = (text.match(/\n/g) ?? []).length;
-      expect(lines).toBeLessThanOrEqual(500);
-    });
+      test(`${harness.name}/${skill}: SKILL.md body <= 500 lines`, () => {
+        const text = existsSync(file) ? readFileSync(file, "utf-8") : "";
+        const lines = (text.match(/\n/g) ?? []).length;
+        expect(lines).toBeLessThanOrEqual(500);
+      });
+    }
   }
 });

--- a/tests/unit/t151-onboarding-skeleton.test.ts
+++ b/tests/unit/t151-onboarding-skeleton.test.ts
@@ -12,8 +12,8 @@
 //   (2) An incomplete fill set (a declared slot left unprovided that the renderer
 //       fails to blank) cannot pass — the renderer THROWS. We assert the
 //       completeness guard fires on a deliberately-broken skeleton.
-//   (3) Each shipped harness (claude, kiro, codex) renders with zero leftover
-//       markers via its real fills — the same guarantee, on the live harnesses.
+//   (3) Each manifest-discovered shipped harness renders with zero leftover
+//       markers via its real fills, and its projected onboarding file exists.
 //
 // Mechanism: none. Pure in-process render over the skeleton + fills modules.
 // Zero spawn, zero LLM, zero tokens.
@@ -27,6 +27,7 @@ import {
   renderOnboarding,
   type OnboardingFills,
 } from "../../scripts/onboarding.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 
 const SKELETON = readFileSync(
   join(REPO_ROOT, "core", "templates", "onboarding.md"),
@@ -100,26 +101,24 @@ describe("t151 onboarding skeleton — a new harness gets a complete doc for fre
   });
 
   test("3: every shipped harness renders with zero leftover markers via its real fills", () => {
-    const harnesses: Array<[string, string]> = [
-      ["claude", ".claude"],
-      ["kiro", ".kiro"],
-      ["codex", ".codex"],
-    ];
-    for (const [name, dir] of harnesses) {
+    for (const harness of HARNESS_MATRIX) {
       const fills = (
-        require(join(REPO_ROOT, "harness", name, "onboarding.fills.ts")) as {
+        require(harness.onboardingFills) as {
           default: OnboardingFills;
         }
       ).default;
       let rendered = renderOnboarding(SKELETON, fills);
-      rendered = rendered.split("{{HARNESS_DIR}}").join(dir);
-      expect({ harness: name, leftover: noLeftoverMarkers(rendered) }).toEqual({
-        harness: name,
+      rendered = rendered.split("{{HARNESS_DIR}}").join(harness.manifest.harnessDir);
+      expect({ harness: harness.name, leftover: noLeftoverMarkers(rendered) }).toEqual({
+        harness: harness.name,
         leftover: null,
       });
-      // Shared sections present for the real harness too.
+
+      const shipped = readFileSync(harness.onboardingDist, "utf-8");
+      expect(noLeftoverMarkers(shipped), `${harness.name}: shipped onboarding markers`).toBeNull();
       for (const section of REQUIRED_SECTIONS) {
         expect(rendered).toContain(section);
+        expect(shipped, `${harness.name}: shipped ${section}`).toContain(section);
       }
     }
   });

--- a/tests/unit/t156-memory-relocation.test.ts
+++ b/tests/unit/t156-memory-relocation.test.ts
@@ -46,6 +46,7 @@ import {
   loadRules,
 } from "../../dist/claude/.claude/tools/aidlc-graph.ts";
 import { REPO_ROOT } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 
 const tempDirs: string[] = [];
 function mkTemp(tag: string): string {
@@ -144,21 +145,19 @@ describe("t156 method relocation to aidlc/spaces/default/memory/ + per-harness i
     join(REPO_ROOT, "dist", harness, "aidlc", "spaces", "default", "memory");
 
   test("5: every harness ships the relocated method tree at the workspace root", () => {
-    // All four shipped harnesses, kiro-ide included — it ships the workspace shell
-    // like the others, so it must carry the relocated method tree too.
-    for (const h of ["claude", "kiro", "codex", "kiro-ide"]) {
-      const top = readdirSync(MEM(h)).sort();
+    for (const harness of HARNESS_MATRIX) {
+      const top = readdirSync(MEM(harness.name)).sort();
       // org/team/project + phases/ are P5's relocated method; templates/ is the
       // SEED-shipped TPL override floor (empty-but-present via a .gitkeep) — it
       // is part of the shipped shell, so the method top-level now includes it.
-      expect(top, `${h} method top-level`).toEqual([
+      expect(top, `${harness.name} method top-level`).toEqual([
         "org.md",
         "phases",
         "project.md",
         "team.md",
         "templates",
       ]);
-      expect(readdirSync(join(MEM(h), "phases")).sort()).toEqual([
+      expect(readdirSync(join(MEM(harness.name), "phases")).sort()).toEqual([
         "construction.md",
         "ideation.md",
         "inception.md",
@@ -202,34 +201,36 @@ describe("t156 method relocation to aidlc/spaces/default/memory/ + per-harness i
   });
 
   test("7: EVERY Kiro-family agent resources glob points at the active space's memory tree (not the now-empty steering dir)", () => {
-    // Derive BOTH the harness list and the agent list from disk — do NOT hardcode.
+    // Select Kiro agent-JSON distributions from explicit matrix capabilities,
+    // then derive the agent list from each shipped tree.
     // A closed list let the kiro-ide harness + the two reviewer personas ship
     // pointing at the empty `.kiro/steering/*.md` glob (loading zero method files)
     // because they were absent from the enumerated set. Every dist tree that ships
     // `.kiro/agents/*.json` (kiro CLI + kiro IDE) and every agent in it that
     // declares a `resources` array must resolve the method via the relocated
     // memory glob, and none may still point at the retired steering glob.
-    const distRoot = join(REPO_ROOT, "dist");
-    const kiroTrees = readdirSync(distRoot).filter((h) =>
-      existsSync(join(distRoot, h, ".kiro", "agents")),
+    const kiroTrees = HARNESS_MATRIX.filter(
+      (harness) => harness.capabilities.kiroAgentJson,
     );
-    // Both Kiro distributions must be present (guards against the dir-detection
-    // silently matching zero trees and vacuously passing).
-    expect(kiroTrees.sort()).toEqual(["kiro", "kiro-ide"]);
+    expect(kiroTrees.length).toBeGreaterThan(0);
 
     let checkedAgents = 0;
-    for (const h of kiroTrees) {
-      const agentsDir = join(distRoot, h, ".kiro", "agents");
+    let expectedAgents = 0;
+    for (const harness of kiroTrees) {
+      const agentsDir = join(harness.engineRoot, "agents");
       const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith(".json"));
-      expect(agentFiles.length, `${h} ships agent JSONs`).toBeGreaterThan(0);
+      expect(agentFiles.length, `${harness.name} ships agent JSONs`).toBeGreaterThan(0);
+      expectedAgents += agentFiles.length;
+      let harnessChecked = 0;
       for (const f of agentFiles) {
         const json = JSON.parse(readFileSync(join(agentsDir, f), "utf-8")) as {
           resources?: string[];
         };
-        // Only agents that declare a method-loading resources array are in scope.
+        expect(Array.isArray(json.resources), `${harness.name}/${f}: resources`).toBe(true);
         if (!json.resources) continue;
         checkedAgents++;
-        expect(json.resources, `${h}/${f} resources → relocated memory`).toContain(
+        harnessChecked++;
+        expect(json.resources, `${harness.name}/${f} resources → relocated memory`).toContain(
           "file://aidlc/spaces/default/memory/**/*.md",
         );
         // The old steering glob is gone from `resources` (note: `.kiro/steering/**`
@@ -237,13 +238,12 @@ describe("t156 method relocation to aidlc/spaces/default/memory/ + per-harness i
         // permission, NOT a method-load glob, so we only inspect `resources`).
         expect(
           json.resources.some((r) => r.includes(".kiro/steering")),
-          `${h}/${f} resources must not point at the empty steering dir`,
+          `${harness.name}/${f} resources must not point at the empty steering dir`,
         ).toBe(false);
       }
+      expect(harnessChecked, `${harness.name}: agents with resources`).toBeGreaterThan(0);
     }
-    // All 5 agents × 2 trees declare resources today; guard the floor so a
-    // regression that drops the arrays cannot make this test vacuous.
-    expect(checkedAgents).toBeGreaterThanOrEqual(10);
+    expect(checkedAgents).toBe(expectedAgents);
   });
 
   test("8: Codex include is wired (AIDLC_RULES_DIR seam + AGENTS.md)", () => {

--- a/tests/unit/t157-workspace-shell-seed.test.ts
+++ b/tests/unit/t157-workspace-shell-seed.test.ts
@@ -55,8 +55,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { __resetGraphCache, loadRules } from "../../dist/claude/.claude/tools/aidlc-graph.ts";
 import { REPO_ROOT } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 
-const HARNESSES = ["claude", "kiro", "codex"] as const;
+const HARNESSES = HARNESS_MATRIX.map((harness) => harness.name);
 
 // The shipped method tree for a harness: dist/<h>/aidlc/spaces/default/memory/.
 const mem = (h: string, ...parts: string[]): string =>
@@ -120,24 +121,23 @@ describe("t157 seeded workspace shell + re-rooted .gitignore (SEED)", () => {
 
   // === (a) dist-shell — the per-harness NATIVE INCLUDE ships ================
   test("4: every harness ships its native include pointing at the method tree", () => {
-    // Claude: the @-stub at .claude/rules/aidlc.md with explicit @-lines.
-    const stub = readFileSync(
-      join(REPO_ROOT, "dist", "claude", ".claude", "rules", "aidlc.md"),
-      "utf-8",
-    );
-    expect(stub).toContain("@../../aidlc/spaces/default/memory/org.md");
-    // Kiro: the agent JSON resources glob.
-    const kiroAgent = JSON.parse(
-      readFileSync(join(REPO_ROOT, "dist", "kiro", ".kiro", "agents", "aidlc.json"), "utf-8"),
-    ) as { resources: string[] };
-    expect(kiroAgent.resources).toContain("file://aidlc/spaces/default/memory/**/*.md");
-    // Codex: the AIDLC_RULES_DIR seam in the shipped config.toml + root AGENTS.md.
-    const codexConfig = readFileSync(
-      join(REPO_ROOT, "dist", "codex", ".codex", "config.toml"),
-      "utf-8",
-    );
-    expect(codexConfig).toContain('AIDLC_RULES_DIR = "aidlc/spaces/default/memory"');
-    expect(existsSync(join(REPO_ROOT, "dist", "codex", "AGENTS.md"))).toBe(true);
+    for (const harness of HARNESS_MATRIX) {
+      if (harness.capabilities.memoryInclude === "claude-import") {
+        const stub = readFileSync(join(harness.engineRoot, "rules", "aidlc.md"), "utf-8");
+        expect(stub).toContain("@../../aidlc/spaces/default/memory/org.md");
+      } else if (harness.capabilities.memoryInclude === "kiro-resources") {
+        const agent = JSON.parse(
+          readFileSync(join(harness.engineRoot, "agents", "aidlc.json"), "utf-8"),
+        ) as { resources: string[] };
+        expect(agent.resources, harness.name).toContain(
+          "file://aidlc/spaces/default/memory/**/*.md",
+        );
+      } else {
+        const config = readFileSync(join(harness.engineRoot, "config.toml"), "utf-8");
+        expect(config).toContain('AIDLC_RULES_DIR = "aidlc/spaces/default/memory"');
+        expect(existsSync(harness.onboardingDist)).toBe(true);
+      }
+    }
   });
 
   // === (a) dist-shell — SEED ships ONLY the shell, not P1/P4 territory ======
@@ -191,9 +191,15 @@ describe("t157 seeded workspace shell + re-rooted .gitignore (SEED)", () => {
   });
 
   // === (c) the re-rooted .gitignore — every harness ships one ===============
-  test("7: every harness ships a .gitignore (net-new for Kiro/Codex)", () => {
-    for (const h of HARNESSES) {
-      expect(existsSync(gitignore(h)), `${h}: ships a .gitignore`).toBe(true);
+  test("7: every harness ships exactly its declared project-root regular files", () => {
+    for (const harness of HARNESS_MATRIX) {
+      const actualRootFiles = readdirSync(harness.distRoot, { withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => entry.name)
+        .sort();
+      expect(actualRootFiles, `${harness.name}: project-root regular files`).toEqual(
+        [...harness.capabilities.rootFiles].sort(),
+      );
     }
   });
 

--- a/tests/unit/t177-workspace-journey-fixture.test.ts
+++ b/tests/unit/t177-workspace-journey-fixture.test.ts
@@ -35,29 +35,28 @@ import { join } from "node:path";
 const CASE_TIMEOUT_MS = 60_000;
 import {
   cleanupWorkspaceJourney,
-  type JourneyHarness,
   setupWorkspaceJourney,
 } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 import { discoverSiblingRepos, listIntents } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 
-const HARNESS_ENGINE_DIR: Record<JourneyHarness, string> = {
-  claude: ".claude",
-  kiro: ".kiro",
-  codex: ".codex",
-};
-
 describe("t177 workspace-journey fixture (deterministic, no LLM)", () => {
-  for (const harness of ["claude", "kiro", "codex"] as JourneyHarness[]) {
-    test(`${harness}: seeds the shell + two sibling repos, no pre-born intent`, () => {
-      const journey = setupWorkspaceJourney(harness);
+  for (const harness of HARNESS_MATRIX) {
+    test(`${harness.name}: seeds the shell + two sibling repos, no pre-born intent`, () => {
+      const journey = setupWorkspaceJourney(harness.name);
       try {
         // The root is a fresh tmpdir, NOT nested under .claude/worktrees/ (the
         // construction-worktree guard's requirement — see the fixture comment).
         expect(journey.root.includes(`${join(".claude", "worktrees")}`)).toBe(false);
 
         // The shipped harness engine dir landed.
-        const engineDir = join(journey.root, HARNESS_ENGINE_DIR[harness]);
+        const engineDir = join(journey.root, harness.manifest.harnessDir);
         expect(existsSync(engineDir)).toBe(true);
+        for (const rootFile of harness.capabilities.rootFiles) {
+          expect(existsSync(join(journey.root, rootFile)), `${harness.name}: ${rootFile}`).toBe(
+            true,
+          );
+        }
 
         // The sibling aidlc/ memory shell landed (the default space's memory),
         // so the rule-layer resolver finds the method.

--- a/tests/unit/t181-conductor-skill-parity.test.ts
+++ b/tests/unit/t181-conductor-skill-parity.test.ts
@@ -2,9 +2,8 @@
 //
 // t181 — PER-HARNESS CONDUCTOR-SKILL FRESHNESS GATE. Mechanism: none
 // (readFileSync over harness/*/skills/aidlc/SKILL.md, zero spawn, zero LLM, zero
-// tokens). Technique: deterministic closed predicate, harness list derived FROM
-// DISK (mirrors t156 §7's readdirSync+filter+floor idiom — never a hardcoded
-// [claude,kiro,codex] triple, so a NEW harness tree is auto-covered).
+// tokens). Technique: deterministic closed predicate over the shared,
+// manifest-discovered harness matrix, so a new harness cannot escape the gate.
 //
 // WHY THIS EXISTS (the P11 "RESOLVE (2)" obligation): the workspace refactor
 // (per-intent layout, --init retirement, intent/space verbs, multi-repo --repo,
@@ -30,20 +29,15 @@
 // package.ts --check), so gating the authored source covers every tree.
 
 import { describe, expect, test } from "bun:test";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { REPO_ROOT } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 
-const HARNESS_DIR = join(REPO_ROOT, "harness");
-
-/** Authored conductor SKILLs, repo-root-relative (posix), derived FROM DISK:
- *  every harness/<h>/ that ships skills/aidlc/SKILL.md. Disk-derivation (not a
- *  hardcoded list) means a newly-added harness tree is covered automatically and
- *  cannot escape the gate by being absent from a static triple. */
+/** Authored conductor SKILLs for every manifest-discovered distribution. */
 function harnessSkills(): string[] {
-  return readdirSync(HARNESS_DIR)
-    .filter((h) => existsSync(join(HARNESS_DIR, h, "skills", "aidlc", "SKILL.md")))
-    .map((h) => `harness/${h}/skills/aidlc/SKILL.md`)
+  return HARNESS_MATRIX
+    .map((harness) => `harness/${harness.name}/skills/aidlc/SKILL.md`)
     .sort();
 }
 
@@ -63,16 +57,9 @@ const REQUIRED_TOKENS = [
 describe("t181 per-harness conductor-SKILL freshness gate (P11 RESOLVE-2)", () => {
   const skills = harnessSkills();
 
-  test("the disk-derived harness-SKILL set covers all four shipped trees (no vacuous pass)", () => {
-    // Floor guard (mirrors t156 §7): if the dir-detection silently matched zero
-    // trees the positive/negative scans below would vacuously pass. Pin the
-    // known four so a regression that hides a tree (or empties harness/) trips.
-    expect(skills).toEqual([
-      "harness/claude/skills/aidlc/SKILL.md",
-      "harness/codex/skills/aidlc/SKILL.md",
-      "harness/kiro-ide/skills/aidlc/SKILL.md",
-      "harness/kiro/skills/aidlc/SKILL.md",
-    ]);
+  test("the matrix-derived harness-SKILL set covers every shipped tree", () => {
+    expect(skills.length).toBe(HARNESS_MATRIX.length);
+    for (const rel of skills) expect(existsSync(join(REPO_ROOT, rel)), rel).toBe(true);
   });
 
   test("no shipped conductor SKILL carries the retired `--init` command", () => {

--- a/tests/unit/t217-reviewer-read-scope.test.ts
+++ b/tests/unit/t217-reviewer-read-scope.test.ts
@@ -14,19 +14,13 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { AIDLC_SRC, REPO_ROOT } from "../harness/fixtures.ts";
+import { AIDLC_SRC } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 
 const PROTOCOL = "aidlc-common/protocols/stage-protocol.md";
 const PERSONA = "agents/aidlc-architecture-reviewer-agent.md";
 const KNOWLEDGE = "knowledge/aidlc-architecture-reviewer-agent/reviewing.md";
 const SKILL = "skills/aidlc/SKILL.md";
-
-const HARNESS_SKILL_SOURCES = [
-  { name: "claude", path: join(REPO_ROOT, "harness", "claude", SKILL) },
-  { name: "kiro", path: join(REPO_ROOT, "harness", "kiro", SKILL) },
-  { name: "kiro-ide", path: join(REPO_ROOT, "harness", "kiro-ide", SKILL) },
-  { name: "codex", path: join(REPO_ROOT, "harness", "codex", SKILL) },
-];
 
 describe("t217 reviewer read-scope bound is stated on every surface", () => {
   test("stage-protocol §12a step 1 names directive.consumes as a per-unit pass-list entry", () => {
@@ -67,9 +61,10 @@ describe("t217 reviewer read-scope bound is stated on every surface", () => {
   });
 
   test("orchestrator SKILL.md reviewer bullet names directive.consumes and the read-scope bound", () => {
-    for (const harnessSkill of HARNESS_SKILL_SOURCES) {
-      const body = readFileSync(harnessSkill.path, "utf-8");
-      const labelledBody = `harness ${harnessSkill.name}: ${harnessSkill.path}\n${body}`;
+    for (const harness of HARNESS_MATRIX) {
+      const path = join(harness.authoredRoot, SKILL);
+      const body = readFileSync(path, "utf-8");
+      const labelledBody = `harness ${harness.name}: ${path}\n${body}`;
       // Reviewer step bullet exists and now carries both parts of the bound.
       expect(labelledBody).toMatch(/Reviewer step \(§12a\)/);
       expect(labelledBody).toMatch(/directive\.consumes/);

--- a/tests/unit/t220-tier-projection-module.test.ts
+++ b/tests/unit/t220-tier-projection-module.test.ts
@@ -293,6 +293,9 @@ describe("t220 shipped projection bytes (codex TOML, kiro JSON + md)", () => {
   const kiroHarnesses = HARNESS_MATRIX.filter(
     (harness) => harness.capabilities.kiroAgentJson,
   );
+  test("matrix exposes at least one kiroAgentJson harness (floor guard)", () => {
+    expect(kiroHarnesses.length).toBeGreaterThan(0);
+  });
   for (const harness of kiroHarnesses) {
     test(`${harness.name} agent JSONs: judgment omits "model", balanced pins sonnet-4.5, NO effort-like keys anywhere`, () => {
       for (const { file, model } of KIRO_JSON) {

--- a/tests/unit/t220-tier-projection-module.test.ts
+++ b/tests/unit/t220-tier-projection-module.test.ts
@@ -1,7 +1,7 @@
 // covers: file:tools/aidlc-tiers.ts (tier projection + cap module)
 //
 // t220 - the tier projection module (core/tools/aidlc-tiers.ts): table-driven
-// projectTier coverage for every tier x every harness, cap collapse behavior,
+// projectTier coverage for every tier x every projection flavor, cap collapse behavior,
 // the unknown-tier error path, the tier_cap precedence chain (env var beats
 // space memory; project.md beats team.md beats org.md), and the Kiro collapse
 // rule (tiers sharing a model -> the higher tier's effort wins the cli.json
@@ -18,6 +18,7 @@ import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { REPO_ROOT } from "../harness/fixtures.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 import {
   capTier,
   isTier,
@@ -33,7 +34,7 @@ import {
 } from "../../core/tools/aidlc-tiers.ts";
 
 // ---------------------------------------------------------------------------
-// The policy pin: every tier x every harness, expected values hard-coded.
+// The policy pin: every tier x every projection flavor, expected values hard-coded.
 // null = the harness-native key is OMITTED (the inherit-by-omission contract).
 // ---------------------------------------------------------------------------
 const EXPECTED: Record<
@@ -95,11 +96,11 @@ describe("t220 tier projection module", () => {
     }
   });
 
-  // --- projectTier: every tier x every harness -------------------------------
+  // --- projectTier: every tier x every projection flavor ---------------------
   for (const tier of TIERS) {
-    for (const harness of ["claude", "codex", "kiro"] as const) {
-      test(`projectTier(${tier}, ${harness}) matches the pinned policy`, () => {
-        expect(projectTier(tier, harness)).toEqual(EXPECTED[tier][harness]);
+    for (const flavor of ["claude", "codex", "kiro"] as const) {
+      test(`projectTier(${tier}, ${flavor}) matches the pinned policy`, () => {
+        expect(projectTier(tier, flavor)).toEqual(EXPECTED[tier][flavor]);
       });
     }
   }
@@ -289,41 +290,52 @@ describe("t220 shipped projection bytes (codex TOML, kiro JSON + md)", () => {
     { file: "aidlc-architecture-reviewer-agent.json", model: "claude-sonnet-4.5" }, // balanced
   ];
 
-  for (const harness of ["kiro", "kiro-ide"] as const) {
-    test(`${harness} agent JSONs: judgment omits "model", balanced pins sonnet-4.5, NO effort-like keys anywhere`, () => {
+  const kiroHarnesses = HARNESS_MATRIX.filter(
+    (harness) => harness.capabilities.kiroAgentJson,
+  );
+  for (const harness of kiroHarnesses) {
+    test(`${harness.name} agent JSONs: judgment omits "model", balanced pins sonnet-4.5, NO effort-like keys anywhere`, () => {
       for (const { file, model } of KIRO_JSON) {
         const parsed = JSON.parse(
-          readFileSync(dist(harness, ".kiro", "agents", file), "utf-8"),
+          readFileSync(join(harness.engineRoot, "agents", file), "utf-8"),
         ) as Record<string, unknown>;
         if (model === null) {
-          expect("model" in parsed, `${harness}/${file}: judgment must omit "model"`).toBe(false);
+          expect("model" in parsed, `${harness.name}/${file}: judgment must omit "model"`).toBe(
+            false,
+          );
         } else {
-          expect(parsed.model, `${harness}/${file}: model`).toBe(model);
+          expect(parsed.model, `${harness.name}/${file}: model`).toBe(model);
         }
         // kiro-cli fail-closes on unknown agent-JSON fields: any effort-like
         // key would break agent validation at install.
         for (const key of Object.keys(parsed)) {
           expect(
             /effort|reasoning|thinking/i.test(key),
-            `${harness}/${file}: forbidden inference key "${key}"`,
+            `${harness.name}/${file}: forbidden inference key "${key}"`,
           ).toBe(false);
         }
       }
     });
   }
 
-  test("kiro agent .md frontmatter: judgment omits model, templated pins sonnet-4.5, never any effort key", () => {
+  test("Kiro-family agent .md frontmatter projects model and never effort", () => {
     const fmOf = (raw: string): string => {
       const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
       if (!m) throw new Error("no frontmatter");
       return m[1];
     };
-    const arch = fmOf(readFileSync(dist("kiro", ".kiro", "agents", "aidlc-architect-agent.md"), "utf-8"));
-    expect(/^model:/m.test(arch), "judgment kiro .md must omit model:").toBe(false);
-    const delivery = fmOf(readFileSync(dist("kiro", ".kiro", "agents", "aidlc-delivery-agent.md"), "utf-8"));
-    expect(delivery).toMatch(/^model: claude-sonnet-4\.5$/m);
-    for (const fm of [arch, delivery]) {
-      expect(/^effort:/m.test(fm), "kiro .md must never carry effort:").toBe(false);
+    for (const harness of kiroHarnesses) {
+      const arch = fmOf(
+        readFileSync(join(harness.engineRoot, "agents", "aidlc-architect-agent.md"), "utf-8"),
+      );
+      expect(/^model:/m.test(arch), `${harness.name}: judgment must omit model:`).toBe(false);
+      const delivery = fmOf(
+        readFileSync(join(harness.engineRoot, "agents", "aidlc-delivery-agent.md"), "utf-8"),
+      );
+      expect(delivery).toMatch(/^model: claude-sonnet-4\.5$/m);
+      for (const fm of [arch, delivery]) {
+        expect(/^effort:/m.test(fm), `${harness.name}: .md must never carry effort:`).toBe(false);
+      }
     }
   });
 
@@ -341,20 +353,17 @@ describe("t220 shipped projection bytes (codex TOML, kiro JSON + md)", () => {
   // tier-line-removal bug in the judgment path (where no replacement keys are
   // written) would surface on the kiro/codex .md copies first - e.g. a future
   // agent authored with tier: mid-frontmatter instead of last.
-  const MD_TREES: Array<[string, string[]]> = [
-    ["claude", ["claude", ".claude", "agents"]],
-    ["codex", ["codex", ".codex", "agents"]],
-    ["kiro", ["kiro", ".kiro", "agents"]],
-    ["kiro-ide", ["kiro-ide", ".kiro", "agents"]],
-  ];
-  for (const [name, segs] of MD_TREES) {
-    test(`${name}: no shipped agent .md carries a raw tier: line (all 14)`, () => {
-      const dir = dist(...segs);
+  for (const harness of HARNESS_MATRIX) {
+    test(`${harness.name}: no shipped agent .md carries a raw tier: line (all 14)`, () => {
+      const dir = join(harness.engineRoot, "agents");
       const mds = readdirSync(dir).filter((f) => f.endsWith("-agent.md"));
       expect(mds.length).toBe(14);
       for (const f of mds) {
         const raw = readFileSync(join(dir, f), "utf-8");
-        expect(/^tier:/m.test(raw), `${name}/${f}: raw tier: leaked into dist`).toBe(false);
+        expect(
+          /^tier:/m.test(raw),
+          `${harness.name}/${f}: raw tier: leaked into dist`,
+        ).toBe(false);
       }
     });
   }

--- a/tests/unit/t221-reviewer-scope-hook.test.ts
+++ b/tests/unit/t221-reviewer-scope-hook.test.ts
@@ -31,6 +31,7 @@ import {
   type ScopeContext,
   type ReviewerDispatch,
 } from "../../dist/claude/.claude/hooks/aidlc-reviewer-scope.ts";
+import { HARNESS_MATRIX } from "../harness/harness-matrix.ts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const AIDLC_SRC = join(REPO_ROOT, "dist", "claude", ".claude");
@@ -532,31 +533,44 @@ describe("t221 (b) dispatch-record lifecycle (shipped hook, subprocess)", () => 
 
 describe("t221 (c) harness registration and protocol prose", () => {
   test("Claude settings.json wires the hook on PreToolUse with the file/search/shell matcher", () => {
-    const s = JSON.parse(readFileSync(join(AIDLC_SRC, "settings.json"), "utf-8")) as {
-      hooks?: Record<string, Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>>;
-    };
-    const groups = s.hooks?.PreToolUse ?? [];
-    const group = groups.find((g) =>
-      (g.hooks ?? []).some((h) => (h.command ?? "").includes("aidlc-reviewer-scope.ts")),
+    const harnesses = HARNESS_MATRIX.filter(
+      (harness) => harness.capabilities.reviewerScopeRegistration === "claude-settings",
     );
-    expect(group).toBeDefined();
-    expect(group?.matcher).toBe("Read|NotebookRead|Edit|MultiEdit|Write|NotebookEdit|LS|Glob|Grep|Bash");
+    expect(harnesses.length).toBeGreaterThan(0);
+    for (const harness of harnesses) {
+      const s = JSON.parse(readFileSync(join(harness.engineRoot, "settings.json"), "utf-8")) as {
+        hooks?: Record<string, Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>>;
+      };
+      const groups = s.hooks?.PreToolUse ?? [];
+      const group = groups.find((g) =>
+        (g.hooks ?? []).some((h) => (h.command ?? "").includes("aidlc-reviewer-scope.ts")),
+      );
+      expect(group, harness.name).toBeDefined();
+      expect(group?.matcher).toBe(
+        "Read|NotebookRead|Edit|MultiEdit|Write|NotebookEdit|LS|Glob|Grep|Bash",
+      );
+    }
   });
 
   test("Kiro CLI wires the adapter's reviewer-scope target inside BOTH reviewer agent JSONs", () => {
-    for (const agent of ["aidlc-architecture-reviewer-agent", "aidlc-product-lead-agent"]) {
-      const a = JSON.parse(
-        readFileSync(join(REPO_ROOT, "dist", "kiro", ".kiro", "agents", `${agent}.json`), "utf-8"),
-      ) as { hooks?: { preToolUse?: Array<{ matcher?: string; command?: string }> } };
-      const entries = a.hooks?.preToolUse ?? [];
-      expect(entries.length).toBeGreaterThanOrEqual(3);
-      const matchers = entries.map((e) => e.matcher).sort();
-      expect(matchers).toEqual(["execute_bash", "fs_read", "fs_write"]);
-      for (const e of entries) {
-        // The registration passes its own agent name as argv[3] so the
-        // adapter forwards a real identity (compared against the dispatch
-        // record's reviewer field) instead of a bare scoped_registration.
-        expect(e.command).toContain(`aidlc-kiro-adapter.ts reviewer-scope ${agent}`);
+    const harnesses = HARNESS_MATRIX.filter(
+      (harness) => harness.capabilities.reviewerScopeRegistration === "kiro-agent-json",
+    );
+    expect(harnesses.length).toBeGreaterThan(0);
+    for (const harness of harnesses) {
+      for (const agent of ["aidlc-architecture-reviewer-agent", "aidlc-product-lead-agent"]) {
+        const a = JSON.parse(
+          readFileSync(join(harness.engineRoot, "agents", `${agent}.json`), "utf-8"),
+        ) as { hooks?: { preToolUse?: Array<{ matcher?: string; command?: string }> } };
+        const entries = a.hooks?.preToolUse ?? [];
+        expect(entries.length, `${harness.name}/${agent}`).toBeGreaterThanOrEqual(3);
+        const matchers = entries.map((e) => e.matcher).sort();
+        expect(matchers).toEqual(["execute_bash", "fs_read", "fs_write"]);
+        for (const e of entries) {
+          // The registration passes its own agent name so the adapter forwards
+          // a real identity instead of a bare scoped_registration.
+          expect(e.command).toContain(`aidlc-kiro-adapter.ts reviewer-scope ${agent}`);
+        }
       }
     }
   });
@@ -569,18 +583,37 @@ describe("t221 (c) harness registration and protocol prose", () => {
     // rather than a dead hook - the 12a prose bound governs on that harness.
     // This pins the deliberate absence so a future blanket-registration sweep
     // does not wire an inert (or worse, blindly blocking) entry.
-    const ideHooks = join(REPO_ROOT, "dist", "kiro-ide", ".kiro", "hooks");
-    expect(existsSync(join(ideHooks, "aidlc-reviewer-scope.kiro.hook"))).toBe(false);
+    const harnesses = HARNESS_MATRIX.filter(
+      (harness) => harness.capabilities.reviewerScopeRegistration === "unsupported",
+    );
+    expect(harnesses.length).toBeGreaterThan(0);
+    for (const harness of harnesses) {
+      expect(existsSync(join(harness.engineRoot, "hooks", "aidlc-reviewer-scope.kiro.hook"))).toBe(
+        false,
+      );
+    }
   });
 
   test("Codex hooks.json wires the adapter's reviewer-scope target on PreToolUse", () => {
-    const wiring = JSON.parse(
-      readFileSync(join(REPO_ROOT, "dist", "codex", ".codex", "hooks.json"), "utf-8"),
-    ) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
-    const pre = wiring.hooks.PreToolUse ?? [];
-    expect(
-      pre.some((g) => g.hooks.some((h) => h.command === "bun .codex/hooks/aidlc-codex-adapter.ts reviewer-scope")),
-    ).toBe(true);
+    const harnesses = HARNESS_MATRIX.filter(
+      (harness) => harness.capabilities.reviewerScopeRegistration === "codex-hooks",
+    );
+    expect(harnesses.length).toBeGreaterThan(0);
+    for (const harness of harnesses) {
+      const wiring = JSON.parse(
+        readFileSync(join(harness.engineRoot, "hooks.json"), "utf-8"),
+      ) as { hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>> };
+      const pre = wiring.hooks.PreToolUse ?? [];
+      expect(
+        pre.some((g) =>
+          g.hooks.some(
+            (h) =>
+              h.command ===
+              `bun ${harness.manifest.harnessDir}/hooks/aidlc-codex-adapter.ts reviewer-scope`,
+          ),
+        ),
+      ).toBe(true);
+    }
   });
 
   test("stage-protocol 12a carries the dispatch-record write (step 1) and delete (step 3)", () => {
@@ -596,10 +629,10 @@ describe("t221 (c) harness registration and protocol prose", () => {
     expect(body).toMatch(/Read verdict.*delete `<record>\/\.aidlc-reviewer-dispatch\.json`/s);
   });
 
-  test("all four harness SKILL.md reviewer bullets carry the dispatch-record instruction", () => {
-    for (const h of ["claude", "kiro", "kiro-ide", "codex"]) {
-      const body = readFileSync(join(REPO_ROOT, "harness", h, "skills", "aidlc", "SKILL.md"), "utf-8");
-      const labelled = `harness ${h}: ${body}`;
+  test("every harness SKILL.md reviewer bullet carries the dispatch-record instruction", () => {
+    for (const harness of HARNESS_MATRIX) {
+      const body = readFileSync(join(harness.authoredRoot, "skills", "aidlc", "SKILL.md"), "utf-8");
+      const labelled = `harness ${harness.name}: ${body}`;
       expect(labelled).toContain(".aidlc-reviewer-dispatch.json");
       expect(labelled).toContain("Delete the dispatch record");
     }


### PR DESCRIPTION
## Summary

Tests that claimed to cover "every harness" hardcoded ~13 separate Claude/Kiro/Codex arrays, so a harness could be silently skipped and Kiro CLI vs Kiro IDE coverage was inconsistent.

- New `tests/harness/harness-matrix.ts` discovers shipped harnesses from `harness/*/manifest.ts` on disk and pairs each with an explicit `HARNESS_CAPABILITIES` record (reviewer-scope registration flavor, IDE agent tools, memory-include surface, root files, onboarding mode, plugin projection - judgments a manifest alone cannot express).
- `validateManifest` cross-checks every capability field against the real manifest at load, so the metadata cannot drift from the packager's truth; a discovered manifest without a capabilities entry fails loud at import with a fix-pointing error (deliberate: a new harness must declare its capabilities once, rather than being silently part-covered). The `ideAgentTools` check requires a `tools:` grant on an `agents/*.md` frontmatter addition specifically, not just any frontmatter addition.
- The ~13 hardcoded arrays are replaced with matrix iteration across onboarding, workspace shell, root files, skills/runners, reviewer-scope registration, tier projection, and plugin projection tests; Kiro CLI and Kiro IDE are distinct rows throughout. Floor guards prevent vacuous passes if a filtered set comes back empty.
- `setupWorkspaceJourney` resolves any discovered harness's dist root through the matrix. The matrix is loaded lazily there (it walks `harness/` and `dist/` at import time; fixtures.ts is imported by sandbox suites whose trees ship neither - a top-level import throws ENOENT inside the t52 sandbox).

Test-only; no version bump.

Note for #571 (opencode): once this merges, adding `harness/opencode/manifest.ts` will make matrix-importing tests throw until an opencode `HARNESS_CAPABILITIES` entry is added - one reviewed block, after which all matrix-driven tests cover it automatically.

## Testing

- `bun run typecheck` green
- 13 matrix-consuming test files green (1459+ assertions), including t52's sandboxed suite and the t188 plugin-compose guard
- Full deterministic tier green at the integration tip unioning this with its sibling PRs (single red: t92, pre-existing on v2)