### PR TITLE
feat(kiro-ide): add v1 JSON hooks for IDE 1.0+ backward compat

### DIFF
--- a/dist/kiro-ide/.kiro/hooks/aidlc-audit-logger.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-audit-logger.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-audit-logger",
+      "description": "Logs artifact create/update events on file writes to aidlc-docs/.",
+      "trigger": "PostToolUse",
+      "matcher": "^(fs_write|fs_append|str_replace|delete_file|code)$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts audit-and-sensors"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-block.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-block.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-block",
+      "description": "Hard-blocks tool calls while an approval gate is open and no human acted since (human-presence floor).",
+      "trigger": "PreToolUse",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts block"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-log-subagent.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-log-subagent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-log-subagent",
+      "description": "Logs sub-agent completion to audit trail.",
+      "trigger": "PostToolUse",
+      "matcher": "^invoke_sub_agent$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts log-subagent"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-mint.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-mint.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-mint",
+      "description": "Records a human-turn event on prompt submit (human-presence gate).",
+      "trigger": "UserPromptSubmit",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts mint"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-runtime-compile.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-runtime-compile.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-runtime-compile",
+      "description": "Dispatches runtime graph compile after transition-class tool calls.",
+      "trigger": "PostToolUse",
+      "matcher": "^execute_bash$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts runtime-compile"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-session-end.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-session-end.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-session-end",
+      "description": "Emits SESSION_ENDED when agent execution stops.",
+      "trigger": "Stop",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts session-end"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-session-start.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-session-start.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-session-start",
+      "description": "Emits SESSION_STARTED and injects workflow context on prompt submit.",
+      "trigger": "UserPromptSubmit",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts session-start"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-stop.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-stop.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-stop",
+      "description": "Enforces the forwarding loop — reminds the agent to continue when workflow has pending work.",
+      "trigger": "Stop",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts stop"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/dist/kiro-ide/.kiro/hooks/aidlc-sync-statusline.json
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-sync-statusline.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-sync-statusline",
+      "description": "Syncs aidlc-state.md Current Stage from the audit tail after shell commands.",
+      "trigger": "PostToolUse",
+      "matcher": "^execute_bash$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts state-sync"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-audit-logger.json
+++ b/harness/kiro-ide/hooks/aidlc-audit-logger.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-audit-logger",
+      "description": "Logs artifact create/update events on file writes to aidlc-docs/.",
+      "trigger": "PostToolUse",
+      "matcher": "^(fs_write|fs_append|str_replace|delete_file|code)$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts audit-and-sensors"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-block.json
+++ b/harness/kiro-ide/hooks/aidlc-block.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-block",
+      "description": "Hard-blocks tool calls while an approval gate is open and no human acted since (human-presence floor).",
+      "trigger": "PreToolUse",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts block"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-log-subagent.json
+++ b/harness/kiro-ide/hooks/aidlc-log-subagent.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-log-subagent",
+      "description": "Logs sub-agent completion to audit trail.",
+      "trigger": "PostToolUse",
+      "matcher": "^invoke_sub_agent$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts log-subagent"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-mint.json
+++ b/harness/kiro-ide/hooks/aidlc-mint.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-mint",
+      "description": "Records a human-turn event on prompt submit (human-presence gate).",
+      "trigger": "UserPromptSubmit",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts mint"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-runtime-compile.json
+++ b/harness/kiro-ide/hooks/aidlc-runtime-compile.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-runtime-compile",
+      "description": "Dispatches runtime graph compile after transition-class tool calls.",
+      "trigger": "PostToolUse",
+      "matcher": "^execute_bash$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts runtime-compile"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-session-end.json
+++ b/harness/kiro-ide/hooks/aidlc-session-end.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-session-end",
+      "description": "Emits SESSION_ENDED when agent execution stops.",
+      "trigger": "Stop",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts session-end"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-session-start.json
+++ b/harness/kiro-ide/hooks/aidlc-session-start.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-session-start",
+      "description": "Emits SESSION_STARTED and injects workflow context on prompt submit.",
+      "trigger": "UserPromptSubmit",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts session-start"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-stop.json
+++ b/harness/kiro-ide/hooks/aidlc-stop.json
@@ -1,0 +1,15 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-stop",
+      "description": "Enforces the forwarding loop — reminds the agent to continue when workflow has pending work.",
+      "trigger": "Stop",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts stop"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/hooks/aidlc-sync-statusline.json
+++ b/harness/kiro-ide/hooks/aidlc-sync-statusline.json
@@ -1,0 +1,16 @@
+{
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "aidlc-sync-statusline",
+      "description": "Syncs aidlc-state.md Current Stage from the audit tail after shell commands.",
+      "trigger": "PostToolUse",
+      "matcher": "^execute_bash$",
+      "action": {
+        "type": "command",
+        "command": "bun .kiro/hooks/aidlc-kiro-adapter.ts state-sync"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/harness/kiro-ide/manifest.ts
+++ b/harness/kiro-ide/manifest.ts
@@ -57,6 +57,16 @@ const manifest: HarnessManifest = {
     { src: "hooks/aidlc-session-start.kiro.hook", dst: "hooks/aidlc-session-start.kiro.hook" },
     { src: "hooks/aidlc-stop.kiro.hook", dst: "hooks/aidlc-stop.kiro.hook" },
     { src: "hooks/aidlc-sync-statusline.kiro.hook", dst: "hooks/aidlc-sync-statusline.kiro.hook" },
+    // v1 format (Kiro IDE 1.0+) — new JSON hook files alongside the legacy .kiro.hook files
+    { src: "hooks/aidlc-audit-logger.json", dst: "hooks/aidlc-audit-logger.json" },
+    { src: "hooks/aidlc-mint.json", dst: "hooks/aidlc-mint.json" },
+    { src: "hooks/aidlc-block.json", dst: "hooks/aidlc-block.json" },
+    { src: "hooks/aidlc-log-subagent.json", dst: "hooks/aidlc-log-subagent.json" },
+    { src: "hooks/aidlc-runtime-compile.json", dst: "hooks/aidlc-runtime-compile.json" },
+    { src: "hooks/aidlc-session-end.json", dst: "hooks/aidlc-session-end.json" },
+    { src: "hooks/aidlc-session-start.json", dst: "hooks/aidlc-session-start.json" },
+    { src: "hooks/aidlc-stop.json", dst: "hooks/aidlc-stop.json" },
+    { src: "hooks/aidlc-sync-statusline.json", dst: "hooks/aidlc-sync-statusline.json" },
     { src: "settings/cli.json", dst: "settings/cli.json" },
     // Project-root .gitignore (beside .kiro/, not inside it) — same workspace-layout
     // committed-vs-ignored split as the Kiro CLI tree: per-user cursors + machine-local


### PR DESCRIPTION
# Summary

Add v1 JSON hook format for Kiro IDE 1.0+ while preserving backward compatibility with pre-1.0 IDE installations. Ships new `.json` hook files alongside existing `.kiro.hook` files so both IDE generations work from the same distribution. We can remove the pre-v1 hooks once the majority of Kiro-IDE users upgrade to v1.0+

## Changes

- Add 9 new v1-format `.json` hook files in `harness/kiro-ide/hooks/` using the updated schema (`"version": "v1"`, PascalCase triggers, `matcher` regex, `action` object wrapper)
- Update `harness/kiro-ide/manifest.ts` `harnessFiles` to include the new `.json` entries for dist projection
- Regenerate `dist/kiro-ide/.kiro/hooks/` — both `.kiro.hook` (legacy) and `.json` (v1) files now ship side by side

**Trigger mapping (old → new):**

| Old `when.type` | New `trigger` |
|-----------------|---------------|
| `postToolUse` | `PostToolUse` |
| `preToolUse` | `PreToolUse` |
| `promptSubmit` | `UserPromptSubmit` |
| `agentStop` | `Stop` |

**Tool type mapping (old `toolTypes` → new `matcher`):**

| Old `toolTypes` | New `matcher` regex |
|-----------------|-------------------|
| `["write"]` | `^(fs_write\|fs_append\|str_replace\|delete_file\|code)$` |
| `["shell"]` | `^execute_bash$` |
| `[".*invoke_sub_agent.*"]` | `^invoke_sub_agent$` |
| (none/all) | (omitted) |

## User experience

**Before:** Only `.kiro.hook` files ship in `dist/kiro-ide/.kiro/hooks/`. Pre-1.0 IDE loads them. Kiro IDE 1.0+ (which expects the new v1 JSON format) cannot discover or register these hooks.

**After:** Both formats ship side by side. Pre-1.0 IDE continues to read `.kiro.hook` files (ignores `.json`). Kiro IDE 1.0+ reads the new `.json` files (ignores `.kiro.hook`). No double-firing — each IDE version recognizes only its own extension. Users copying `dist/kiro-ide/` get a distribution that works on both IDE generations without any action.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)

* [x] I have performed a self-review of this change

* [x] Changes have been tested

* [ ] Changes are documented

## Test Plan

1. Run `bun scripts/package.ts kiro-ide` — should regenerate without errors
2. Run `bun scripts/package.ts kiro-ide --check` — should report `OK` (no drift)
3. Verify `dist/kiro-ide/.kiro/hooks/` contains both `.kiro.hook` and `.json` files for all 9 hooks
4. Validate each `.json` file parses as valid JSON matching the v1 schema (`version: "v1"`, `hooks` array with `name`, `trigger`, `action`)
5. On a pre-1.0 Kiro IDE install: copy `dist/kiro-ide/` into a project, confirm hooks register and fire from the `.kiro.hook` files
6. On a Kiro IDE 1.0+ install: copy `dist/kiro-ide/` into a project, confirm hooks register and fire from the `.json` files

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
