### PR TITLE
ci: bootstrap the docs deploy workflow on the default branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,74 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - v2
+  pull_request:
+    branches:
+      - v2
+  workflow_dispatch:
+
+# The build job validates every PR and push; only the deploy job needs
+# Pages/OIDC permissions, granted at job level below.
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: '0.11.28'
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        run: uv sync --locked --group docs
+
+      # The committed markdown keeps relative links into dist/, core/, etc. so
+      # local clones navigate to the real files; the published site is built
+      # from docs/ only, so rewrite those links to GitHub blob URLs here
+      # (in-place on the CI checkout, never committed). The script exits 1 if
+      # a linked file is missing, failing the build before a dead link ships.
+      - name: Rewrite out-of-tree links to GitHub URLs
+        run: bun scripts/docs-rewrite-links.ts
+
+      - name: Build documentation
+        run: uv run zensical build --strict
+
+      # The roadmap lived at /roadmap.html under the legacy Jekyll rendering;
+      # keep that URL working (the root roadmap.html stub covers the
+      # pre-activation era, this one covers the Zensical site).
+      - name: Emit legacy /roadmap.html redirect
+        run: printf '%s\n' '<!doctype html><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=roadmap/"><title>Roadmap moved</title><a href="roadmap/">The roadmap has moved.</a>' > site/roadmap.html
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        if: github.event_name != 'pull_request'
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## What

Prerequisite for #630 (the v2 Zensical documentation site): a byte-identical copy of that PR's `.github/workflows/docs.yml` added to `main`.

## Why

GitHub registers `workflow_dispatch` only for workflows that exist on the **default branch** (`main`). Without this file on main, the docs workflow cannot be manually dispatched at all (`gh workflow run docs.yml --ref v2` errors with "workflow not found"), which is needed to trigger the first deployment after the admin flips the Pages source to "GitHub Actions" - review feedback on #630.

## Behavior on main

Inert except for dispatch registration:

- `push`/`pull_request` triggers are scoped to `v2`, so nothing runs on main's own pushes or PRs
- a manual dispatch with `--ref v2` checks out and builds the v2 docs; a dispatch against main would fail fast at the build step (main has no `zensical.toml`/`pyproject.toml`), and deploys are additionally inert until the Pages source is switched

No other content on main is touched. Merge this before or together with #630; it has no effect on the currently served Jekyll site either way.

## Testing

actionlint clean; the workflow content itself is exercised end to end in #630 (strict build + deploy path verified on a fork preview).