### PR TITLE
fix: case-fold the swarm unit-name membership tests (2.5.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.12] - 2026-07-24
+
+Fixes an autonomous-Construction hang: when unit names are authored in uppercase (e.g. `U-16`) in `unit-of-work-dependency.md`, the swarm's converged batches were compared against the referee's kebab-lower audit slugs without case-folding, so `next` re-emitted `invoke-swarm` for the first batch forever and the stage could never settle. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* `next` now case-folds the unit-name membership tests (batch advance, the report-side settle evidence gate, the approve-time artifact-guard exemption, and the per-unit review-receipt check), while still emitting the original-cased unit names in `invoke-swarm` directives.
+* Fixes #621.
+
 ## [2.5.11] - 2026-07-24
 
 Intent Capture now keeps generated intent and stakeholder claims grounded in the user's description, confirmed answers, workflow-selected scope, or explicitly registered memory. Unsupported content is omitted, elicited, or surfaced as a human-owned assumption instead of being presented as fact. **Upgrade:** re-copy your `dist/<harness>/` shell into the project so the updated stage, Product Lead reviewer contract, and `claim-sources` sensor are installed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.11-blue)
+![version](https://img.shields.io/badge/version-2.5.12-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -3513,6 +3513,13 @@ export function latestMainWorkflowStageStarted(
 // fields (pre-2.5.0 audit logs) fail closed: the affected units re-fan on the
 // next swarm pass, which finalize's re-verify makes safe. The timestamp check
 // stays as belt-and-braces.
+//
+// The set holds LOWERCASED names: rows carry the referee's forced kebab-lower
+// unit slug (prepare/finalize reject non-kebab), while bolt_dag.batches
+// preserve unit names as authored in unit-of-work-dependency.md (often upper,
+// e.g. "U-16"). Every consumer must lowercase the DAG-side name before its
+// membership test, or an uppercase-authored batch reads as unconverged
+// forever (#621).
 export function swarmConvergedUnits(
   projectDir: string,
   slug: string,
@@ -3526,7 +3533,7 @@ export function swarmConvergedUnits(
     if ((auditBlockField(block, "Run floor") ?? "") !== floor) continue;
     if (floor && timestamp < floor) continue;
     const unit = auditBlockField(block, "Unit name");
-    if (unit) converged.add(unit);
+    if (unit) converged.add(unit.toLowerCase());
   }
   return converged;
 }

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -2012,8 +2012,10 @@ function isSettledAutonomousSwarm(
   if (r.state !== "ok") return false;
   const units = r.batches.flat();
   if (units.length === 0) return false;
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(projectDir, node.slug);
-  return units.every((unit) => converged.has(unit));
+  return units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Try to handle an eligible autonomous swarm stage, returning true (and emitting)
@@ -2070,12 +2072,15 @@ function tryEmitSwarm(
   // Select the first topological batch with an unconverged unit; emit only that
   // batch's still-owed units. Ledger signal = SWARM_UNIT_CONVERGED (see above),
   // floored at this stage's latest STAGE_STARTED so a jump-driven re-run never
-  // reads a prior run's rows as coverage.
+  // reads a prior run's rows as coverage. converged holds kebab-lower slugs
+  // (see swarmConvergedUnits), so lowercase the authored batch name for the
+  // membership test — but emit the ORIGINAL name: the conductor's `prepare`
+  // re-derives the kebab slug from it (#621).
   const converged = swarmConvergedUnits(projectDir, slug);
   let pendingUnits: string[] | null = null;
   for (const batch of batches) {
     if (!Array.isArray(batch) || batch.length === 0) continue;
-    const owed = batch.filter((u) => !converged.has(u));
+    const owed = batch.filter((u) => !converged.has(u.toLowerCase()));
     if (owed.length > 0) {
       pendingUnits = owed;
       break;

--- a/core/tools/aidlc-state.ts
+++ b/core/tools/aidlc-state.ts
@@ -984,8 +984,10 @@ function isSettledSwarmForArtifactGuard(
   // Shared attempt-scoped read (aidlc-lib.ts): a row counts only when its
   // Stage names this slug AND its Run floor equals the current attempt's
   // floor, so stale-attempt and cross-stage rows never satisfy the guard.
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(pd, stage.slug);
-  return resolution.units.every((unit) => converged.has(unit));
+  return resolution.units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Deterministic off-switch for the approve-time gate-revision backstop (mirrors
@@ -1365,6 +1367,12 @@ function verifyReviewerPrecondition(
   // declared-artifact write clears the matching receipt. For per-unit stages,
   // the path's construction/<unit>/ segment scopes invalidation to that unit;
   // an ambiguous matching path fails closed by clearing every unit receipt.
+  //
+  // The set holds LOWERCASED unit names: an autonomous swarm's reviews run in
+  // kebab-lower-slugged Bolt worktrees (so their rows carry e.g. "u-16"),
+  // while the DAG preserves the authored casing (e.g. "U-16") — the same
+  // mismatch as the convergence ledger (#621). Every membership op below
+  // case-folds so an uppercase-authored DAG is not refused over casing.
   const recordedRepos = new Set(intentRepos(pd));
   const reviewedUnits = new Set<string>();
   let sawStageReview = false;
@@ -1380,7 +1388,7 @@ function verifyReviewerPrecondition(
       } else if (targetUnit === null) {
         reviewedUnits.clear();
       } else {
-        reviewedUnits.delete(targetUnit);
+        reviewedUnits.delete(targetUnit.toLowerCase());
       }
       continue;
     }
@@ -1392,7 +1400,7 @@ function verifyReviewerPrecondition(
     if (verdict !== "READY" && verdict !== "NOT-READY") continue;
     sawStageReview = true;
     const unit = auditBlockField(e.block, "Unit");
-    if (unit) reviewedUnits.add(unit);
+    if (unit) reviewedUnits.add(unit.toLowerCase());
   }
 
   if (!perUnit) {
@@ -1427,7 +1435,7 @@ function verifyReviewerPrecondition(
   );
   if (reviewUnits.length === 0) return;
 
-  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u));
+  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u.toLowerCase()));
   if (missing.length > 0) {
     error(
       `Refusing to complete "${stage.slug}": it declares a reviewer (${reviewer}) but ` +

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.12";

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -3513,6 +3513,13 @@ export function latestMainWorkflowStageStarted(
 // fields (pre-2.5.0 audit logs) fail closed: the affected units re-fan on the
 // next swarm pass, which finalize's re-verify makes safe. The timestamp check
 // stays as belt-and-braces.
+//
+// The set holds LOWERCASED names: rows carry the referee's forced kebab-lower
+// unit slug (prepare/finalize reject non-kebab), while bolt_dag.batches
+// preserve unit names as authored in unit-of-work-dependency.md (often upper,
+// e.g. "U-16"). Every consumer must lowercase the DAG-side name before its
+// membership test, or an uppercase-authored batch reads as unconverged
+// forever (#621).
 export function swarmConvergedUnits(
   projectDir: string,
   slug: string,
@@ -3526,7 +3533,7 @@ export function swarmConvergedUnits(
     if ((auditBlockField(block, "Run floor") ?? "") !== floor) continue;
     if (floor && timestamp < floor) continue;
     const unit = auditBlockField(block, "Unit name");
-    if (unit) converged.add(unit);
+    if (unit) converged.add(unit.toLowerCase());
   }
   return converged;
 }

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -2012,8 +2012,10 @@ function isSettledAutonomousSwarm(
   if (r.state !== "ok") return false;
   const units = r.batches.flat();
   if (units.length === 0) return false;
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(projectDir, node.slug);
-  return units.every((unit) => converged.has(unit));
+  return units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Try to handle an eligible autonomous swarm stage, returning true (and emitting)
@@ -2070,12 +2072,15 @@ function tryEmitSwarm(
   // Select the first topological batch with an unconverged unit; emit only that
   // batch's still-owed units. Ledger signal = SWARM_UNIT_CONVERGED (see above),
   // floored at this stage's latest STAGE_STARTED so a jump-driven re-run never
-  // reads a prior run's rows as coverage.
+  // reads a prior run's rows as coverage. converged holds kebab-lower slugs
+  // (see swarmConvergedUnits), so lowercase the authored batch name for the
+  // membership test — but emit the ORIGINAL name: the conductor's `prepare`
+  // re-derives the kebab slug from it (#621).
   const converged = swarmConvergedUnits(projectDir, slug);
   let pendingUnits: string[] | null = null;
   for (const batch of batches) {
     if (!Array.isArray(batch) || batch.length === 0) continue;
-    const owed = batch.filter((u) => !converged.has(u));
+    const owed = batch.filter((u) => !converged.has(u.toLowerCase()));
     if (owed.length > 0) {
       pendingUnits = owed;
       break;

--- a/dist/claude/.claude/tools/aidlc-state.ts
+++ b/dist/claude/.claude/tools/aidlc-state.ts
@@ -984,8 +984,10 @@ function isSettledSwarmForArtifactGuard(
   // Shared attempt-scoped read (aidlc-lib.ts): a row counts only when its
   // Stage names this slug AND its Run floor equals the current attempt's
   // floor, so stale-attempt and cross-stage rows never satisfy the guard.
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(pd, stage.slug);
-  return resolution.units.every((unit) => converged.has(unit));
+  return resolution.units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Deterministic off-switch for the approve-time gate-revision backstop (mirrors
@@ -1365,6 +1367,12 @@ function verifyReviewerPrecondition(
   // declared-artifact write clears the matching receipt. For per-unit stages,
   // the path's construction/<unit>/ segment scopes invalidation to that unit;
   // an ambiguous matching path fails closed by clearing every unit receipt.
+  //
+  // The set holds LOWERCASED unit names: an autonomous swarm's reviews run in
+  // kebab-lower-slugged Bolt worktrees (so their rows carry e.g. "u-16"),
+  // while the DAG preserves the authored casing (e.g. "U-16") — the same
+  // mismatch as the convergence ledger (#621). Every membership op below
+  // case-folds so an uppercase-authored DAG is not refused over casing.
   const recordedRepos = new Set(intentRepos(pd));
   const reviewedUnits = new Set<string>();
   let sawStageReview = false;
@@ -1380,7 +1388,7 @@ function verifyReviewerPrecondition(
       } else if (targetUnit === null) {
         reviewedUnits.clear();
       } else {
-        reviewedUnits.delete(targetUnit);
+        reviewedUnits.delete(targetUnit.toLowerCase());
       }
       continue;
     }
@@ -1392,7 +1400,7 @@ function verifyReviewerPrecondition(
     if (verdict !== "READY" && verdict !== "NOT-READY") continue;
     sawStageReview = true;
     const unit = auditBlockField(e.block, "Unit");
-    if (unit) reviewedUnits.add(unit);
+    if (unit) reviewedUnits.add(unit.toLowerCase());
   }
 
   if (!perUnit) {
@@ -1427,7 +1435,7 @@ function verifyReviewerPrecondition(
   );
   if (reviewUnits.length === 0) return;
 
-  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u));
+  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u.toLowerCase()));
   if (missing.length > 0) {
     error(
       `Refusing to complete "${stage.slug}": it declares a reviewer (${reviewer}) but ` +

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.12";

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -3513,6 +3513,13 @@ export function latestMainWorkflowStageStarted(
 // fields (pre-2.5.0 audit logs) fail closed: the affected units re-fan on the
 // next swarm pass, which finalize's re-verify makes safe. The timestamp check
 // stays as belt-and-braces.
+//
+// The set holds LOWERCASED names: rows carry the referee's forced kebab-lower
+// unit slug (prepare/finalize reject non-kebab), while bolt_dag.batches
+// preserve unit names as authored in unit-of-work-dependency.md (often upper,
+// e.g. "U-16"). Every consumer must lowercase the DAG-side name before its
+// membership test, or an uppercase-authored batch reads as unconverged
+// forever (#621).
 export function swarmConvergedUnits(
   projectDir: string,
   slug: string,
@@ -3526,7 +3533,7 @@ export function swarmConvergedUnits(
     if ((auditBlockField(block, "Run floor") ?? "") !== floor) continue;
     if (floor && timestamp < floor) continue;
     const unit = auditBlockField(block, "Unit name");
-    if (unit) converged.add(unit);
+    if (unit) converged.add(unit.toLowerCase());
   }
   return converged;
 }

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -2012,8 +2012,10 @@ function isSettledAutonomousSwarm(
   if (r.state !== "ok") return false;
   const units = r.batches.flat();
   if (units.length === 0) return false;
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(projectDir, node.slug);
-  return units.every((unit) => converged.has(unit));
+  return units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Try to handle an eligible autonomous swarm stage, returning true (and emitting)
@@ -2070,12 +2072,15 @@ function tryEmitSwarm(
   // Select the first topological batch with an unconverged unit; emit only that
   // batch's still-owed units. Ledger signal = SWARM_UNIT_CONVERGED (see above),
   // floored at this stage's latest STAGE_STARTED so a jump-driven re-run never
-  // reads a prior run's rows as coverage.
+  // reads a prior run's rows as coverage. converged holds kebab-lower slugs
+  // (see swarmConvergedUnits), so lowercase the authored batch name for the
+  // membership test — but emit the ORIGINAL name: the conductor's `prepare`
+  // re-derives the kebab slug from it (#621).
   const converged = swarmConvergedUnits(projectDir, slug);
   let pendingUnits: string[] | null = null;
   for (const batch of batches) {
     if (!Array.isArray(batch) || batch.length === 0) continue;
-    const owed = batch.filter((u) => !converged.has(u));
+    const owed = batch.filter((u) => !converged.has(u.toLowerCase()));
     if (owed.length > 0) {
       pendingUnits = owed;
       break;

--- a/dist/codex/.codex/tools/aidlc-state.ts
+++ b/dist/codex/.codex/tools/aidlc-state.ts
@@ -984,8 +984,10 @@ function isSettledSwarmForArtifactGuard(
   // Shared attempt-scoped read (aidlc-lib.ts): a row counts only when its
   // Stage names this slug AND its Run floor equals the current attempt's
   // floor, so stale-attempt and cross-stage rows never satisfy the guard.
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(pd, stage.slug);
-  return resolution.units.every((unit) => converged.has(unit));
+  return resolution.units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Deterministic off-switch for the approve-time gate-revision backstop (mirrors
@@ -1365,6 +1367,12 @@ function verifyReviewerPrecondition(
   // declared-artifact write clears the matching receipt. For per-unit stages,
   // the path's construction/<unit>/ segment scopes invalidation to that unit;
   // an ambiguous matching path fails closed by clearing every unit receipt.
+  //
+  // The set holds LOWERCASED unit names: an autonomous swarm's reviews run in
+  // kebab-lower-slugged Bolt worktrees (so their rows carry e.g. "u-16"),
+  // while the DAG preserves the authored casing (e.g. "U-16") — the same
+  // mismatch as the convergence ledger (#621). Every membership op below
+  // case-folds so an uppercase-authored DAG is not refused over casing.
   const recordedRepos = new Set(intentRepos(pd));
   const reviewedUnits = new Set<string>();
   let sawStageReview = false;
@@ -1380,7 +1388,7 @@ function verifyReviewerPrecondition(
       } else if (targetUnit === null) {
         reviewedUnits.clear();
       } else {
-        reviewedUnits.delete(targetUnit);
+        reviewedUnits.delete(targetUnit.toLowerCase());
       }
       continue;
     }
@@ -1392,7 +1400,7 @@ function verifyReviewerPrecondition(
     if (verdict !== "READY" && verdict !== "NOT-READY") continue;
     sawStageReview = true;
     const unit = auditBlockField(e.block, "Unit");
-    if (unit) reviewedUnits.add(unit);
+    if (unit) reviewedUnits.add(unit.toLowerCase());
   }
 
   if (!perUnit) {
@@ -1427,7 +1435,7 @@ function verifyReviewerPrecondition(
   );
   if (reviewUnits.length === 0) return;
 
-  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u));
+  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u.toLowerCase()));
   if (missing.length > 0) {
     error(
       `Refusing to complete "${stage.slug}": it declares a reviewer (${reviewer}) but ` +

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.12";

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -3513,6 +3513,13 @@ export function latestMainWorkflowStageStarted(
 // fields (pre-2.5.0 audit logs) fail closed: the affected units re-fan on the
 // next swarm pass, which finalize's re-verify makes safe. The timestamp check
 // stays as belt-and-braces.
+//
+// The set holds LOWERCASED names: rows carry the referee's forced kebab-lower
+// unit slug (prepare/finalize reject non-kebab), while bolt_dag.batches
+// preserve unit names as authored in unit-of-work-dependency.md (often upper,
+// e.g. "U-16"). Every consumer must lowercase the DAG-side name before its
+// membership test, or an uppercase-authored batch reads as unconverged
+// forever (#621).
 export function swarmConvergedUnits(
   projectDir: string,
   slug: string,
@@ -3526,7 +3533,7 @@ export function swarmConvergedUnits(
     if ((auditBlockField(block, "Run floor") ?? "") !== floor) continue;
     if (floor && timestamp < floor) continue;
     const unit = auditBlockField(block, "Unit name");
-    if (unit) converged.add(unit);
+    if (unit) converged.add(unit.toLowerCase());
   }
   return converged;
 }

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -2012,8 +2012,10 @@ function isSettledAutonomousSwarm(
   if (r.state !== "ok") return false;
   const units = r.batches.flat();
   if (units.length === 0) return false;
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(projectDir, node.slug);
-  return units.every((unit) => converged.has(unit));
+  return units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Try to handle an eligible autonomous swarm stage, returning true (and emitting)
@@ -2070,12 +2072,15 @@ function tryEmitSwarm(
   // Select the first topological batch with an unconverged unit; emit only that
   // batch's still-owed units. Ledger signal = SWARM_UNIT_CONVERGED (see above),
   // floored at this stage's latest STAGE_STARTED so a jump-driven re-run never
-  // reads a prior run's rows as coverage.
+  // reads a prior run's rows as coverage. converged holds kebab-lower slugs
+  // (see swarmConvergedUnits), so lowercase the authored batch name for the
+  // membership test — but emit the ORIGINAL name: the conductor's `prepare`
+  // re-derives the kebab slug from it (#621).
   const converged = swarmConvergedUnits(projectDir, slug);
   let pendingUnits: string[] | null = null;
   for (const batch of batches) {
     if (!Array.isArray(batch) || batch.length === 0) continue;
-    const owed = batch.filter((u) => !converged.has(u));
+    const owed = batch.filter((u) => !converged.has(u.toLowerCase()));
     if (owed.length > 0) {
       pendingUnits = owed;
       break;

--- a/dist/kiro-ide/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-state.ts
@@ -984,8 +984,10 @@ function isSettledSwarmForArtifactGuard(
   // Shared attempt-scoped read (aidlc-lib.ts): a row counts only when its
   // Stage names this slug AND its Run floor equals the current attempt's
   // floor, so stale-attempt and cross-stage rows never satisfy the guard.
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(pd, stage.slug);
-  return resolution.units.every((unit) => converged.has(unit));
+  return resolution.units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Deterministic off-switch for the approve-time gate-revision backstop (mirrors
@@ -1365,6 +1367,12 @@ function verifyReviewerPrecondition(
   // declared-artifact write clears the matching receipt. For per-unit stages,
   // the path's construction/<unit>/ segment scopes invalidation to that unit;
   // an ambiguous matching path fails closed by clearing every unit receipt.
+  //
+  // The set holds LOWERCASED unit names: an autonomous swarm's reviews run in
+  // kebab-lower-slugged Bolt worktrees (so their rows carry e.g. "u-16"),
+  // while the DAG preserves the authored casing (e.g. "U-16") — the same
+  // mismatch as the convergence ledger (#621). Every membership op below
+  // case-folds so an uppercase-authored DAG is not refused over casing.
   const recordedRepos = new Set(intentRepos(pd));
   const reviewedUnits = new Set<string>();
   let sawStageReview = false;
@@ -1380,7 +1388,7 @@ function verifyReviewerPrecondition(
       } else if (targetUnit === null) {
         reviewedUnits.clear();
       } else {
-        reviewedUnits.delete(targetUnit);
+        reviewedUnits.delete(targetUnit.toLowerCase());
       }
       continue;
     }
@@ -1392,7 +1400,7 @@ function verifyReviewerPrecondition(
     if (verdict !== "READY" && verdict !== "NOT-READY") continue;
     sawStageReview = true;
     const unit = auditBlockField(e.block, "Unit");
-    if (unit) reviewedUnits.add(unit);
+    if (unit) reviewedUnits.add(unit.toLowerCase());
   }
 
   if (!perUnit) {
@@ -1427,7 +1435,7 @@ function verifyReviewerPrecondition(
   );
   if (reviewUnits.length === 0) return;
 
-  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u));
+  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u.toLowerCase()));
   if (missing.length > 0) {
     error(
       `Refusing to complete "${stage.slug}": it declares a reviewer (${reviewer}) but ` +

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.12";

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -3513,6 +3513,13 @@ export function latestMainWorkflowStageStarted(
 // fields (pre-2.5.0 audit logs) fail closed: the affected units re-fan on the
 // next swarm pass, which finalize's re-verify makes safe. The timestamp check
 // stays as belt-and-braces.
+//
+// The set holds LOWERCASED names: rows carry the referee's forced kebab-lower
+// unit slug (prepare/finalize reject non-kebab), while bolt_dag.batches
+// preserve unit names as authored in unit-of-work-dependency.md (often upper,
+// e.g. "U-16"). Every consumer must lowercase the DAG-side name before its
+// membership test, or an uppercase-authored batch reads as unconverged
+// forever (#621).
 export function swarmConvergedUnits(
   projectDir: string,
   slug: string,
@@ -3526,7 +3533,7 @@ export function swarmConvergedUnits(
     if ((auditBlockField(block, "Run floor") ?? "") !== floor) continue;
     if (floor && timestamp < floor) continue;
     const unit = auditBlockField(block, "Unit name");
-    if (unit) converged.add(unit);
+    if (unit) converged.add(unit.toLowerCase());
   }
   return converged;
 }

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -2012,8 +2012,10 @@ function isSettledAutonomousSwarm(
   if (r.state !== "ok") return false;
   const units = r.batches.flat();
   if (units.length === 0) return false;
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(projectDir, node.slug);
-  return units.every((unit) => converged.has(unit));
+  return units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Try to handle an eligible autonomous swarm stage, returning true (and emitting)
@@ -2070,12 +2072,15 @@ function tryEmitSwarm(
   // Select the first topological batch with an unconverged unit; emit only that
   // batch's still-owed units. Ledger signal = SWARM_UNIT_CONVERGED (see above),
   // floored at this stage's latest STAGE_STARTED so a jump-driven re-run never
-  // reads a prior run's rows as coverage.
+  // reads a prior run's rows as coverage. converged holds kebab-lower slugs
+  // (see swarmConvergedUnits), so lowercase the authored batch name for the
+  // membership test — but emit the ORIGINAL name: the conductor's `prepare`
+  // re-derives the kebab slug from it (#621).
   const converged = swarmConvergedUnits(projectDir, slug);
   let pendingUnits: string[] | null = null;
   for (const batch of batches) {
     if (!Array.isArray(batch) || batch.length === 0) continue;
-    const owed = batch.filter((u) => !converged.has(u));
+    const owed = batch.filter((u) => !converged.has(u.toLowerCase()));
     if (owed.length > 0) {
       pendingUnits = owed;
       break;

--- a/dist/kiro/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro/.kiro/tools/aidlc-state.ts
@@ -984,8 +984,10 @@ function isSettledSwarmForArtifactGuard(
   // Shared attempt-scoped read (aidlc-lib.ts): a row counts only when its
   // Stage names this slug AND its Run floor equals the current attempt's
   // floor, so stale-attempt and cross-stage rows never satisfy the guard.
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(pd, stage.slug);
-  return resolution.units.every((unit) => converged.has(unit));
+  return resolution.units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Deterministic off-switch for the approve-time gate-revision backstop (mirrors
@@ -1365,6 +1367,12 @@ function verifyReviewerPrecondition(
   // declared-artifact write clears the matching receipt. For per-unit stages,
   // the path's construction/<unit>/ segment scopes invalidation to that unit;
   // an ambiguous matching path fails closed by clearing every unit receipt.
+  //
+  // The set holds LOWERCASED unit names: an autonomous swarm's reviews run in
+  // kebab-lower-slugged Bolt worktrees (so their rows carry e.g. "u-16"),
+  // while the DAG preserves the authored casing (e.g. "U-16") — the same
+  // mismatch as the convergence ledger (#621). Every membership op below
+  // case-folds so an uppercase-authored DAG is not refused over casing.
   const recordedRepos = new Set(intentRepos(pd));
   const reviewedUnits = new Set<string>();
   let sawStageReview = false;
@@ -1380,7 +1388,7 @@ function verifyReviewerPrecondition(
       } else if (targetUnit === null) {
         reviewedUnits.clear();
       } else {
-        reviewedUnits.delete(targetUnit);
+        reviewedUnits.delete(targetUnit.toLowerCase());
       }
       continue;
     }
@@ -1392,7 +1400,7 @@ function verifyReviewerPrecondition(
     if (verdict !== "READY" && verdict !== "NOT-READY") continue;
     sawStageReview = true;
     const unit = auditBlockField(e.block, "Unit");
-    if (unit) reviewedUnits.add(unit);
+    if (unit) reviewedUnits.add(unit.toLowerCase());
   }
 
   if (!perUnit) {
@@ -1427,7 +1435,7 @@ function verifyReviewerPrecondition(
   );
   if (reviewUnits.length === 0) return;
 
-  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u));
+  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u.toLowerCase()));
   if (missing.length > 0) {
     error(
       `Refusing to complete "${stage.slug}": it declares a reviewer (${reviewer}) but ` +

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.12";

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -3513,6 +3513,13 @@ export function latestMainWorkflowStageStarted(
 // fields (pre-2.5.0 audit logs) fail closed: the affected units re-fan on the
 // next swarm pass, which finalize's re-verify makes safe. The timestamp check
 // stays as belt-and-braces.
+//
+// The set holds LOWERCASED names: rows carry the referee's forced kebab-lower
+// unit slug (prepare/finalize reject non-kebab), while bolt_dag.batches
+// preserve unit names as authored in unit-of-work-dependency.md (often upper,
+// e.g. "U-16"). Every consumer must lowercase the DAG-side name before its
+// membership test, or an uppercase-authored batch reads as unconverged
+// forever (#621).
 export function swarmConvergedUnits(
   projectDir: string,
   slug: string,
@@ -3526,7 +3533,7 @@ export function swarmConvergedUnits(
     if ((auditBlockField(block, "Run floor") ?? "") !== floor) continue;
     if (floor && timestamp < floor) continue;
     const unit = auditBlockField(block, "Unit name");
-    if (unit) converged.add(unit);
+    if (unit) converged.add(unit.toLowerCase());
   }
   return converged;
 }

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -2012,8 +2012,10 @@ function isSettledAutonomousSwarm(
   if (r.state !== "ok") return false;
   const units = r.batches.flat();
   if (units.length === 0) return false;
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(projectDir, node.slug);
-  return units.every((unit) => converged.has(unit));
+  return units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Try to handle an eligible autonomous swarm stage, returning true (and emitting)
@@ -2070,12 +2072,15 @@ function tryEmitSwarm(
   // Select the first topological batch with an unconverged unit; emit only that
   // batch's still-owed units. Ledger signal = SWARM_UNIT_CONVERGED (see above),
   // floored at this stage's latest STAGE_STARTED so a jump-driven re-run never
-  // reads a prior run's rows as coverage.
+  // reads a prior run's rows as coverage. converged holds kebab-lower slugs
+  // (see swarmConvergedUnits), so lowercase the authored batch name for the
+  // membership test — but emit the ORIGINAL name: the conductor's `prepare`
+  // re-derives the kebab slug from it (#621).
   const converged = swarmConvergedUnits(projectDir, slug);
   let pendingUnits: string[] | null = null;
   for (const batch of batches) {
     if (!Array.isArray(batch) || batch.length === 0) continue;
-    const owed = batch.filter((u) => !converged.has(u));
+    const owed = batch.filter((u) => !converged.has(u.toLowerCase()));
     if (owed.length > 0) {
       pendingUnits = owed;
       break;

--- a/dist/opencode/.aidlc/tools/aidlc-state.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-state.ts
@@ -984,8 +984,10 @@ function isSettledSwarmForArtifactGuard(
   // Shared attempt-scoped read (aidlc-lib.ts): a row counts only when its
   // Stage names this slug AND its Run floor equals the current attempt's
   // floor, so stale-attempt and cross-stage rows never satisfy the guard.
+  // converged holds kebab-lower slugs (see swarmConvergedUnits); lowercase the
+  // authored DAG name for the membership test (#621).
   const converged = swarmConvergedUnits(pd, stage.slug);
-  return resolution.units.every((unit) => converged.has(unit));
+  return resolution.units.every((unit) => converged.has(unit.toLowerCase()));
 }
 
 // Deterministic off-switch for the approve-time gate-revision backstop (mirrors
@@ -1365,6 +1367,12 @@ function verifyReviewerPrecondition(
   // declared-artifact write clears the matching receipt. For per-unit stages,
   // the path's construction/<unit>/ segment scopes invalidation to that unit;
   // an ambiguous matching path fails closed by clearing every unit receipt.
+  //
+  // The set holds LOWERCASED unit names: an autonomous swarm's reviews run in
+  // kebab-lower-slugged Bolt worktrees (so their rows carry e.g. "u-16"),
+  // while the DAG preserves the authored casing (e.g. "U-16") — the same
+  // mismatch as the convergence ledger (#621). Every membership op below
+  // case-folds so an uppercase-authored DAG is not refused over casing.
   const recordedRepos = new Set(intentRepos(pd));
   const reviewedUnits = new Set<string>();
   let sawStageReview = false;
@@ -1380,7 +1388,7 @@ function verifyReviewerPrecondition(
       } else if (targetUnit === null) {
         reviewedUnits.clear();
       } else {
-        reviewedUnits.delete(targetUnit);
+        reviewedUnits.delete(targetUnit.toLowerCase());
       }
       continue;
     }
@@ -1392,7 +1400,7 @@ function verifyReviewerPrecondition(
     if (verdict !== "READY" && verdict !== "NOT-READY") continue;
     sawStageReview = true;
     const unit = auditBlockField(e.block, "Unit");
-    if (unit) reviewedUnits.add(unit);
+    if (unit) reviewedUnits.add(unit.toLowerCase());
   }
 
   if (!perUnit) {
@@ -1427,7 +1435,7 @@ function verifyReviewerPrecondition(
   );
   if (reviewUnits.length === 0) return;
 
-  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u));
+  const missing = reviewUnits.filter((u) => !reviewedUnits.has(u.toLowerCase()));
   if (missing.length > 0) {
     error(
       `Refusing to complete "${stage.slug}": it declares a reviewer (${reviewer}) but ` +

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.12";

--- a/tests/integration/t185-stage-artifact-guard.test.ts
+++ b/tests/integration/t185-stage-artifact-guard.test.ts
@@ -407,7 +407,7 @@ describe("t185: stage-completion artifact guard (#366)", () => {
   describe("settled-swarm exemption (autonomous code-generation)", () => {
     const UNITS = ["user-auth", "billing"];
 
-    function seedSwarm(converged: string[]): void {
+    function seedSwarm(converged: string[], dagUnits: string[] = UNITS): void {
       guarded(proj, ["set", "Current Stage=code-generation"]);
       guarded(proj, ["checkbox", "code-generation=in-progress"]);
       // Autonomy grant: append the field beside Scope (fixture ships without it).
@@ -424,8 +424,8 @@ describe("t185: stage-completion artifact guard (#366)", () => {
         join(seededRecordDir(proj), "runtime-graph.json"),
         `${JSON.stringify({
           bolt_dag: {
-            units: UNITS.map((name) => ({ name, depends_on: [] })),
-            batches: [UNITS],
+            units: dagUnits.map((name) => ({ name, depends_on: [] })),
+            batches: [dagUnits],
           },
         })}\n`,
       );
@@ -466,6 +466,17 @@ describe("t185: stage-completion artifact guard (#366)", () => {
       const r = guarded(proj, ["approve", "code-generation", "--user-input", "ok"]);
       expect(r.rc).not.toBe(0);
       expect(r.out).toContain("Refusing to complete");
+    });
+
+    // #621: the DAG preserves unit names as authored (mixed/upper case) while
+    // the referee's convergence rows carry the forced kebab-lower slug. The
+    // exemption's membership test must case-fold, or an uppercase-authored
+    // DAG is refused the settle approval the engine just presented.
+    test("PASSES an uppercase-authored DAG whose rows carry kebab-lower slugs (#621)", () => {
+      seedSwarm(["user-auth", "billing"], ["User-Auth", "BILLING"]);
+      bypassed(proj, ["gate-start", "code-generation"]);
+      const r = guarded(proj, ["approve", "code-generation", "--user-input", "ok"]);
+      expect(r.rc).toBe(0);
     });
   });
 });

--- a/tests/unit/t201-swarm-batch-advance.test.ts
+++ b/tests/unit/t201-swarm-batch-advance.test.ts
@@ -468,3 +468,53 @@ describe("t201 converged-row attempt identity (Stage + Run floor stamp)", () => 
     expect(d.units).toEqual(["auth"]);
   }, 30000);
 });
+
+describe("t201 authored-casing vs referee slug (issue #621)", () => {
+  // bolt_dag.batches preserve unit names EXACTLY as authored in
+  // unit-of-work-dependency.md (often upper, e.g. "U-16"), but the referee
+  // forces kebab-lower slugs (prepare/finalize reject non-kebab), so the
+  // SWARM_UNIT_CONVERGED rows finalize writes carry "u-16". The membership
+  // test must case-fold or an uppercase-authored batch reads as unconverged
+  // forever and next re-emits batch 1 indefinitely (#621). The directive keeps
+  // the ORIGINAL-cased names: the conductor's `prepare` derives the slug.
+
+  // 13: the hang itself. Batch 1 fully converged under lowercase rows must
+  // advance to batch 2 - and batch 2's unit keeps its authored casing.
+  test("13: lowercase converged rows advance an uppercase-authored batch", () => {
+    const proj = seedProject();
+    seedBoltDagBatches(proj, [["U-16", "U-AUTH", "U-AZ"], ["U-BENCH"]]);
+    seedConverged(proj, ["u-16", "u-auth", "u-az"]);
+    const d = runNext(proj);
+    expect(d.kind).toBe("invoke-swarm");
+    expect(d.units).toEqual(["U-BENCH"]);
+  }, 30000);
+
+  // 14: a partial pass re-fans only the owed units, original-cased.
+  test("14: a partially-converged uppercase batch re-emits only the owed units, original-cased", () => {
+    const proj = seedProject();
+    seedBoltDagBatches(proj, [["U-16", "U-AUTH", "U-AZ"], ["U-BENCH"]]);
+    seedConverged(proj, ["u-16"]);
+    const d = runNext(proj);
+    expect(d.kind).toBe("invoke-swarm");
+    expect(d.units).toEqual(["U-AUTH", "U-AZ"]);
+  }, 30000);
+
+  // 15: every unit converged (lowercase rows) -> the settle directive, not a
+  // re-fan, and the settle's report is accepted once each unit's review is
+  // recorded (the report-side evidence gate case-folds too).
+  test("15: an uppercase DAG settles and reports approved on lowercase rows", () => {
+    const proj = seedProject();
+    seedBoltDagBatches(proj, [["U-16", "U-AUTH", "U-AZ"], ["U-BENCH"]]);
+    seedConverged(proj, ["u-16", "u-auth", "u-az", "u-bench"]);
+    const d = runNext(proj);
+    expect(d.kind).toBe("run-stage");
+    expect(d.gate).toBe(true);
+    expect(d.unit).toBe("U-BENCH"); // last unit, authored casing preserved
+
+    for (const unit of ["U-16", "U-AUTH", "U-AZ", "U-BENCH"]) {
+      logReviewReady(proj, unit);
+    }
+    const accepted = runReport(proj);
+    expect(accepted.kind).toBe("done");
+  }, 30000);
+});


### PR DESCRIPTION
Fixes #621.

## What

Case-folds the engine's swarm unit-name membership tests so an autonomous Construction run whose unit names are authored in uppercase (e.g. `U-16` in `unit-of-work-dependency.md`) can advance batches, settle the stage, and pass the approval gates. Before this fix, `next` re-emitted `invoke-swarm` for the first batch forever after that batch had genuinely converged — the silent hang in #621.

## Root cause (recap from the issue)

`bolt_dag.batches` preserves unit names **exactly as authored**, while the swarm referee (`aidlc-swarm.ts`) forces **kebab-lower** unit slugs — `prepare`/`finalize` reject non-kebab — so the `SWARM_UNIT_CONVERGED` rows carry `u-16`. `converged.has("U-16")` against a set holding `"u-16"` is always false, so every batch read as fully unconverged.

## The fix — all four comparison sites, not just the hang

Since the issue was filed (against 2.2.17-era code), the ledger reader moved to `aidlc-lib.ts` and grew more consumers (including 2.5.5's per-unit review enforcement). Fixing only `tryEmitSwarm` would have moved the failure downstream: the engine would advance the batches, but the settle report, the approve-time artifact guard, and the per-unit review-receipt check would each then refuse for the same casing reason. So:

- `aidlc-lib.ts` `swarmConvergedUnits()` — the shared reader stores **lowercased** `Unit name`s (documented in its header comment).
- `aidlc-orchestrate.ts` `tryEmitSwarm()` — folds the authored batch name at the membership test, and still emits the **original-cased** names in the `invoke-swarm` directive (the conductor's `prepare` re-derives the kebab slug from them).
- `aidlc-orchestrate.ts` `isSettledAutonomousSwarm()` — the report-side settle evidence gate folds the DAG name.
- `aidlc-state.ts` `isSettledSwarmForArtifactGuard()` — the approve-time artifact-guard exemption folds the DAG name.
- `aidlc-state.ts` per-unit review-receipt check (`reviewedUnits`) — a swarm's reviews run in kebab-lower-slugged Bolt worktrees, so their `REVIEW_COMPLETED` rows carry the lower slug too; the set and both membership ops fold (add, artifact-invalidation delete, and the missing-units filter).

Per the issue's suggested fix, this is the comparison-site case-fold — **not** canonicalizing in `computeBoltDag`/`parseBoltDag`, which would change the stored graph shape other readers depend on.

## Non-goal

`aidlc-swarm.ts prepare --units U-16` still rejects the raw uppercase name loudly (`Invalid --slug`) and the conductor adapts by deriving the kebab slug — that loud path is unchanged. #621 is specifically the silent hang in the deterministic engine.

## Changes

- `core/tools/aidlc-lib.ts`, `core/tools/aidlc-orchestrate.ts`, `core/tools/aidlc-state.ts` — the case-folds above (comment-documented at each site).
- `tests/unit/t201-swarm-batch-advance.test.ts` — new describe "authored-casing vs referee slug (issue #621)", 3 red-first cases: batch 1 converged under lowercase rows advances to batch 2 (`["U-BENCH"]` original-cased); a partial pass re-fans only the owed units original-cased; a fully-converged uppercase DAG settles and `report --approved` completes after per-unit reviews are recorded.
- `tests/integration/t185-stage-artifact-guard.test.ts` — new settled-swarm exemption case: an uppercase-authored DAG whose rows carry kebab-lower slugs passes `approve`.
- Version 2.5.12 + CHANGELOG entry + README badge; all dists regenerated. (Rebased once onto v2 after it advanced to 2.5.11 — the original 2.5.6 number this PR claimed was consumed upstream in the meantime; re-bumped past it.)

## Testing

- Red-first: all 4 new cases fail on the unfixed engine, pass with the fix.
- Full smoke + unit tiers via `tests/run-tests.sh`: **178 files, 4399 assertions, 0 failures**. Integration tier: pass.
- `bun scripts/package.ts --check`, `bun tests/gen-coverage-registry.ts --check`, `bun run typecheck`, and `bun run lint` all clean.
- `bun run check` (the exact command the repo's new v2 PR gate CI job runs) and `bun scripts/ci-changelog-guard.ts` (the new gate's changelog-deletion guard) both pass locally against this branch.

## Context

Found and mitigated during a field engagement (a 3-unit parallel batch under autonomous mode hung at `code-generation`); the fix here extends that mitigation to the consumer sites added since.

## Note on the Security Scanners signal

`Security Scanners` (`.github/workflows/security-scanners.yml`) triggers only on `push`/`pull_request` to `main`, plus a daily schedule — never on a PR against `v2`. So this PR cannot inherit that workflow's result regardless of #638's status; confirmed by reading the workflow's `on:` block rather than by absence of a run. It does fail on `main` itself today (e.g. run 29914525428): grype flags 17 pre-existing findings in `scripts/aidlc-evaluator/uv.lock` (`pillow` 12.2.0 — Dependabot #619 — plus `mcp` 1.23.3 and `pydantic-settings` 2.14.1), and gitleaks flags 7 deliberate fake credentials in test fixtures not yet in the `.gitleaks.toml` allowlist. Tracked in #638, orthogonal to this PR.

The checks that DO apply here are `v2`'s new PR gate (`ci.yml`, added since this PR opened): contract checks (`bun run check`), smoke+unit tests, and a changelog-deletion guard. All three verified green locally against this branch (see Testing above).
