### PR TITLE
fix(kiro-ide): never read stdin in adapter entry paths (2.5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.5.7] - 2026-07-23
+
+Fixes a Kiro IDE regression that silently disabled the agent-stop hooks: the forwarding-loop reminder and `SESSION_ENDED` never ran, because the IDE delivers an empty `USER_PROMPT` on agent stop and the adapter's entry guard then waited on stdin, which Kiro IDE opens but never writes. Hooks on prompt submit and after tool use were unaffected (the IDE populates `USER_PROMPT` for those events). Verified live on Kiro IDE against both the broken and fixed adapter. **Upgrade:** re-copy `dist/kiro-ide/` into your project (only `.kiro/hooks/aidlc-kiro-adapter.ts` changed).
+
+* Kiro IDE agent-stop hooks (forwarding loop, session end) work again: the adapter no longer reads stdin on any event (context arrives only via the `USER_PROMPT` environment variable; the stdin value was never consumed).
+
 ## [2.5.6] - 2026-07-22
 
 Unblocks agent delegation on the Kiro harnesses (#601): every shipped model pin is removed from the Kiro agent surfaces, so the conductor and all 14 personas inherit the session model. Previously every `invoke_sub_agent` spawn failed with `Invalid model ID` whenever the pinned IDs (`claude-opus-4.8` on the conductor JSON, `claude-sonnet-4.5` on the tier-projected persona JSONs and `.md` frontmatter) were not enabled on the user's Kiro install - blocking the subagent stages, every `reviewer:`-bound gate, the 2.5.0 ensemble dispatches, and any manual delegation. Verified fix shape (live on Kiro IDE): with both pin layers stripped, all 14 agents spawn and respond on a session model the pins never named. **Upgrade:** re-copy the entire `.kiro/` tree from `dist/kiro/` or `dist/kiro-ide/` into your project (agents, settings, tools, and knowledge all carry changes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [2.5.7] - 2026-07-23
 
-Fixes a Kiro IDE regression that silently disabled the agent-stop hooks: the forwarding-loop reminder and `SESSION_ENDED` never ran, because the IDE delivers an empty `USER_PROMPT` on agent stop and the adapter's entry guard then waited on stdin, which Kiro IDE opens but never writes. Hooks on prompt submit and after tool use were unaffected (the IDE populates `USER_PROMPT` for those events). Verified live on Kiro IDE against both the broken and fixed adapter. **Upgrade:** re-copy `dist/kiro-ide/` into your project (only `.kiro/hooks/aidlc-kiro-adapter.ts` changed).
+Fixes a Kiro IDE regression that silently disabled the agent-stop hooks: the forwarding-loop reminder and `SESSION_ENDED` never ran, because the IDE delivers an empty `USER_PROMPT` on agent stop and the adapter's entry guard then waited on stdin, which Kiro IDE opens but never writes. Hooks on prompt submit and after tool use were unaffected (the IDE populates `USER_PROMPT` for those events). Verified live on Kiro IDE against both the broken and fixed adapter. **Upgrade:** re-copy your `dist/<harness>/` shell into the project (on Kiro IDE the fix is in `.kiro/hooks/aidlc-kiro-adapter.ts` and `.kiro/tools/aidlc.ts`).
 
 * Kiro IDE agent-stop hooks (forwarding loop, session end) work again: the adapter no longer reads stdin on any event (context arrives only via the `USER_PROMPT` environment variable; the stdin value was never consumed).
+* The dispatcher route (`aidlc adapter kiro-ide <target>`) had the same hang - it acquired stdin before invoking the adapter - and is fixed the same way: stdin is never read for the kiro-ide harness.
 
 ## [2.5.6] - 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.6-blue)
+![version](https://img.shields.io/badge/version-2.5.7-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.6";
+export const AIDLC_VERSION = "2.5.7";

--- a/core/tools/aidlc.ts
+++ b/core/tools/aidlc.ts
@@ -979,7 +979,12 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
       text(2, `aidlc adapter ${action.harness} ${action.target}: adapter does not export run(target, input, extraArgs)\n`);
       return 1;
     }
-    return await mod.run(action.target, await readStdin(), action.extraArgs);
+    // kiro-ide: NEVER read stdin - the IDE opens hook stdin without writing
+    // or closing it, so awaiting it hangs the hook process forever. The IDE
+    // adapter's run() ignores its input parameter (context arrives via the
+    // USER_PROMPT env var); mirrors the adapter's own entry guard.
+    const input = action.harness === "kiro-ide" ? "" : await readStdin();
+    return await mod.run(action.target, input, action.extraArgs);
   } finally {
     if (previousHarness === undefined) delete process.env.AIDLC_HARNESS_DIR;
     else process.env.AIDLC_HARNESS_DIR = previousHarness;

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.6";
+export const AIDLC_VERSION = "2.5.7";

--- a/dist/claude/.claude/tools/aidlc.ts
+++ b/dist/claude/.claude/tools/aidlc.ts
@@ -979,7 +979,12 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
       text(2, `aidlc adapter ${action.harness} ${action.target}: adapter does not export run(target, input, extraArgs)\n`);
       return 1;
     }
-    return await mod.run(action.target, await readStdin(), action.extraArgs);
+    // kiro-ide: NEVER read stdin - the IDE opens hook stdin without writing
+    // or closing it, so awaiting it hangs the hook process forever. The IDE
+    // adapter's run() ignores its input parameter (context arrives via the
+    // USER_PROMPT env var); mirrors the adapter's own entry guard.
+    const input = action.harness === "kiro-ide" ? "" : await readStdin();
+    return await mod.run(action.target, input, action.extraArgs);
   } finally {
     if (previousHarness === undefined) delete process.env.AIDLC_HARNESS_DIR;
     else process.env.AIDLC_HARNESS_DIR = previousHarness;

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.6";
+export const AIDLC_VERSION = "2.5.7";

--- a/dist/codex/.codex/tools/aidlc.ts
+++ b/dist/codex/.codex/tools/aidlc.ts
@@ -979,7 +979,12 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
       text(2, `aidlc adapter ${action.harness} ${action.target}: adapter does not export run(target, input, extraArgs)\n`);
       return 1;
     }
-    return await mod.run(action.target, await readStdin(), action.extraArgs);
+    // kiro-ide: NEVER read stdin - the IDE opens hook stdin without writing
+    // or closing it, so awaiting it hangs the hook process forever. The IDE
+    // adapter's run() ignores its input parameter (context arrives via the
+    // USER_PROMPT env var); mirrors the adapter's own entry guard.
+    const input = action.harness === "kiro-ide" ? "" : await readStdin();
+    return await mod.run(action.target, input, action.extraArgs);
   } finally {
     if (previousHarness === undefined) delete process.env.AIDLC_HARNESS_DIR;
     else process.env.AIDLC_HARNESS_DIR = previousHarness;

--- a/dist/kiro-ide/.kiro/hooks/aidlc-kiro-adapter.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-kiro-adapter.ts
@@ -384,6 +384,9 @@ return result.code;
 }
 
 if (import.meta.main) {
-  const input = (process.env.USER_PROMPT ?? "").length > 0 ? "" : await Bun.stdin.text();
-  process.exit(await run(process.argv[2] ?? "", input, process.argv.slice(3)));
+  // NEVER await stdin here, even when USER_PROMPT is absent: the IDE opens
+  // hook stdin but never writes or closes it, so any read hangs the hook
+  // process forever (see the header). Context arrives via USER_PROMPT only;
+  // run() ignores its input parameter by design.
+  process.exit(await run(process.argv[2] ?? "", "", process.argv.slice(3)));
 }

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.6";
+export const AIDLC_VERSION = "2.5.7";

--- a/dist/kiro-ide/.kiro/tools/aidlc.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc.ts
@@ -979,7 +979,12 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
       text(2, `aidlc adapter ${action.harness} ${action.target}: adapter does not export run(target, input, extraArgs)\n`);
       return 1;
     }
-    return await mod.run(action.target, await readStdin(), action.extraArgs);
+    // kiro-ide: NEVER read stdin - the IDE opens hook stdin without writing
+    // or closing it, so awaiting it hangs the hook process forever. The IDE
+    // adapter's run() ignores its input parameter (context arrives via the
+    // USER_PROMPT env var); mirrors the adapter's own entry guard.
+    const input = action.harness === "kiro-ide" ? "" : await readStdin();
+    return await mod.run(action.target, input, action.extraArgs);
   } finally {
     if (previousHarness === undefined) delete process.env.AIDLC_HARNESS_DIR;
     else process.env.AIDLC_HARNESS_DIR = previousHarness;

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.6";
+export const AIDLC_VERSION = "2.5.7";

--- a/dist/kiro/.kiro/tools/aidlc.ts
+++ b/dist/kiro/.kiro/tools/aidlc.ts
@@ -979,7 +979,12 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
       text(2, `aidlc adapter ${action.harness} ${action.target}: adapter does not export run(target, input, extraArgs)\n`);
       return 1;
     }
-    return await mod.run(action.target, await readStdin(), action.extraArgs);
+    // kiro-ide: NEVER read stdin - the IDE opens hook stdin without writing
+    // or closing it, so awaiting it hangs the hook process forever. The IDE
+    // adapter's run() ignores its input parameter (context arrives via the
+    // USER_PROMPT env var); mirrors the adapter's own entry guard.
+    const input = action.harness === "kiro-ide" ? "" : await readStdin();
+    return await mod.run(action.target, input, action.extraArgs);
   } finally {
     if (previousHarness === undefined) delete process.env.AIDLC_HARNESS_DIR;
     else process.env.AIDLC_HARNESS_DIR = previousHarness;

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.6";
+export const AIDLC_VERSION = "2.5.7";

--- a/dist/opencode/.aidlc/tools/aidlc.ts
+++ b/dist/opencode/.aidlc/tools/aidlc.ts
@@ -979,7 +979,12 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
       text(2, `aidlc adapter ${action.harness} ${action.target}: adapter does not export run(target, input, extraArgs)\n`);
       return 1;
     }
-    return await mod.run(action.target, await readStdin(), action.extraArgs);
+    // kiro-ide: NEVER read stdin - the IDE opens hook stdin without writing
+    // or closing it, so awaiting it hangs the hook process forever. The IDE
+    // adapter's run() ignores its input parameter (context arrives via the
+    // USER_PROMPT env var); mirrors the adapter's own entry guard.
+    const input = action.harness === "kiro-ide" ? "" : await readStdin();
+    return await mod.run(action.target, input, action.extraArgs);
   } finally {
     if (previousHarness === undefined) delete process.env.AIDLC_HARNESS_DIR;
     else process.env.AIDLC_HARNESS_DIR = previousHarness;

--- a/harness/kiro-ide/hooks/aidlc-kiro-adapter.ts
+++ b/harness/kiro-ide/hooks/aidlc-kiro-adapter.ts
@@ -384,6 +384,9 @@ return result.code;
 }
 
 if (import.meta.main) {
-  const input = (process.env.USER_PROMPT ?? "").length > 0 ? "" : await Bun.stdin.text();
-  process.exit(await run(process.argv[2] ?? "", input, process.argv.slice(3)));
+  // NEVER await stdin here, even when USER_PROMPT is absent: the IDE opens
+  // hook stdin but never writes or closes it, so any read hangs the hook
+  // process forever (see the header). Context arrives via USER_PROMPT only;
+  // run() ignores its input parameter by design.
+  process.exit(await run(process.argv[2] ?? "", "", process.argv.slice(3)));
 }

--- a/tests/unit/t218-kiro-ide-hook-adapter.test.ts
+++ b/tests/unit/t218-kiro-ide-hook-adapter.test.ts
@@ -132,6 +132,40 @@ function ctx(toolName: string, toolResult: string): string {
   return JSON.stringify({ toolName, toolArgs: {}, toolResult, toolSuccess: true });
 }
 
+/** Spawn the adapter with stdin held OPEN (piped, never written, never
+ *  closed) - the live Kiro IDE condition. runIde/spawnSync's input:"" closes
+ *  stdin at EOF, so it can never reproduce the hang this reproduces: the
+ *  child must exit on its own with stdin still open, or the timeout kill
+ *  marks the red. */
+async function runIdeOpenStdin(
+  projectDir: string,
+  target: string,
+  userPrompt: string | null,
+): Promise<{ code: number; timedOut: boolean }> {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    CLAUDE_PROJECT_DIR: projectDir,
+  };
+  if (userPrompt === null) delete env.USER_PROMPT;
+  else env.USER_PROMPT = userPrompt;
+  const proc = Bun.spawn({
+    cmd: ["bun", join(projectDir, ".kiro", "hooks", "aidlc-kiro-adapter.ts"), target],
+    cwd: projectDir,
+    stdin: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
+    env,
+  });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, 15_000);
+  const code = await proc.exited;
+  clearTimeout(timer);
+  return { code, timedOut };
+}
+
 describe("t218 Kiro IDE hook adapter (USER_PROMPT env context)", () => {
   test("1: audit-and-sensors resolves a RELATIVE toolResult path (real IDE shape) and logs CREATE", () => {
     const dir = scratchProject(true);
@@ -314,6 +348,50 @@ describe("t218 Kiro IDE hook adapter (USER_PROMPT env context)", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test("12b: EMPTY USER_PROMPT + stdin held open still exits promptly (live IDE agentStop shape)", async () => {
+    // Regression guard for the entry-guard stdin read reintroduced by the
+    // run()-export refactor: `await Bun.stdin.text()` when USER_PROMPT is
+    // empty. Live-captured on Kiro IDE: agentStop fires with USER_PROMPT set
+    // but ZERO-LENGTH and stdin open-but-never-written, so that await hung
+    // the stop and session-end hooks forever. Test 12 cannot catch this
+    // (input:"" is instant EOF); this one holds the pipe open and requires
+    // the adapter to finish anyway. Both empty-string (the captured agentStop
+    // shape) and absent USER_PROMPT must survive.
+    const dir = scratchProject(true);
+    try {
+      for (const userPrompt of ["", null]) {
+        for (const target of ["session-end", "block"]) {
+          const r = await runIdeOpenStdin(dir, target, userPrompt);
+          const label = `${target}/${userPrompt === null ? "absent" : "empty"}`;
+          expect(`${label}:timedOut=${r.timedOut}`).toBe(`${label}:timedOut=false`);
+          expect(`${label}:${r.code}`).toBe(`${label}:0`);
+        }
+      }
+      expect(readAudit(dir)).toContain("SESSION_ENDED");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 90_000);
+
+  test("12c: USER_PROMPT + stdin held open still does the postToolUse work", async () => {
+    const dir = scratchProject(true);
+    try {
+      const file = join(seededRecordDir(dir), "ideation", "intent-capture", "intent.md");
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, "# intent\n");
+      const r = await runIdeOpenStdin(
+        dir,
+        "audit-and-sensors",
+        ctx("fs_write", `Created the ${file} file.`),
+      );
+      expect(r.timedOut).toBe(false);
+      expect(r.code).toBe(0);
+      expect(readAudit(dir)).toContain("ARTIFACT_CREATED");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 45_000);
 
   test("13: hook-debug.log is OPT-IN — absent without AIDLC_HOOK_DEBUG, present with it", () => {
     const debugLogPath = (dir: string) =>

--- a/tests/unit/t218-kiro-ide-hook-adapter.test.ts
+++ b/tests/unit/t218-kiro-ide-hook-adapter.test.ts
@@ -141,7 +141,8 @@ async function runIdeOpenStdin(
   projectDir: string,
   target: string,
   userPrompt: string | null,
-): Promise<{ code: number; timedOut: boolean }> {
+  entry: string[] = [join(projectDir, ".kiro", "hooks", "aidlc-kiro-adapter.ts"), target],
+): Promise<{ code: number; timedOut: boolean; stdout: string }> {
   const env: Record<string, string | undefined> = {
     ...process.env,
     CLAUDE_PROJECT_DIR: projectDir,
@@ -149,10 +150,10 @@ async function runIdeOpenStdin(
   if (userPrompt === null) delete env.USER_PROMPT;
   else env.USER_PROMPT = userPrompt;
   const proc = Bun.spawn({
-    cmd: ["bun", join(projectDir, ".kiro", "hooks", "aidlc-kiro-adapter.ts"), target],
+    cmd: ["bun", ...entry],
     cwd: projectDir,
     stdin: "pipe",
-    stdout: "ignore",
+    stdout: "pipe",
     stderr: "ignore",
     env,
   });
@@ -163,7 +164,7 @@ async function runIdeOpenStdin(
   }, 15_000);
   const code = await proc.exited;
   clearTimeout(timer);
-  return { code, timedOut };
+  return { code, timedOut, stdout: await new Response(proc.stdout).text() };
 }
 
 describe("t218 Kiro IDE hook adapter (USER_PROMPT env context)", () => {
@@ -349,26 +350,60 @@ describe("t218 Kiro IDE hook adapter (USER_PROMPT env context)", () => {
     }
   });
 
-  test("12b: EMPTY USER_PROMPT + stdin held open still exits promptly (live IDE agentStop shape)", async () => {
+  test("12b: EMPTY USER_PROMPT + stdin held open still runs the agentStop hooks (live IDE shape)", async () => {
     // Regression guard for the entry-guard stdin read reintroduced by the
     // run()-export refactor: `await Bun.stdin.text()` when USER_PROMPT is
     // empty. Live-captured on Kiro IDE: agentStop fires with USER_PROMPT set
     // but ZERO-LENGTH and stdin open-but-never-written, so that await hung
-    // the stop and session-end hooks forever. Test 12 cannot catch this
-    // (input:"" is instant EOF); this one holds the pipe open and requires
-    // the adapter to finish anyway. Both empty-string (the captured agentStop
-    // shape) and absent USER_PROMPT must survive.
+    // the agentStop hooks (stop + session-end) forever. Test 12 cannot catch
+    // this (input:"" is instant EOF); this one holds the pipe open and
+    // requires each hook to finish AND do its real work. Both empty-string
+    // (the captured agentStop shape) and absent USER_PROMPT must survive,
+    // and each invocation is asserted on its own effect - a shared final
+    // assertion would let one variant silently no-op behind the other.
     const dir = scratchProject(true);
     try {
-      for (const userPrompt of ["", null]) {
-        for (const target of ["session-end", "block"]) {
-          const r = await runIdeOpenStdin(dir, target, userPrompt);
-          const label = `${target}/${userPrompt === null ? "absent" : "empty"}`;
-          expect(`${label}:timedOut=${r.timedOut}`).toBe(`${label}:timedOut=false`);
-          expect(`${label}:${r.code}`).toBe(`${label}:0`);
-        }
+      for (const userPrompt of ["", null] as const) {
+        const label = userPrompt === null ? "absent" : "empty";
+        // stop: the forwarding loop must emit its block decision.
+        const stop = await runIdeOpenStdin(dir, "stop", userPrompt);
+        expect(`stop/${label}:timedOut=${stop.timedOut}`).toBe(`stop/${label}:timedOut=false`);
+        expect(`stop/${label}:${stop.code}`).toBe(`stop/${label}:0`);
+        const decision = JSON.parse(stop.stdout) as { decision?: string };
+        expect(`stop/${label}:decision=${decision.decision}`).toBe(`stop/${label}:decision=block`);
+        // session-end: each invocation must append its own SESSION_ENDED row.
+        const before = readAudit(dir).split("SESSION_ENDED").length - 1;
+        const end = await runIdeOpenStdin(dir, "session-end", userPrompt);
+        expect(`session-end/${label}:timedOut=${end.timedOut}`).toBe(`session-end/${label}:timedOut=false`);
+        expect(`session-end/${label}:${end.code}`).toBe(`session-end/${label}:0`);
+        const after = readAudit(dir).split("SESSION_ENDED").length - 1;
+        expect(`session-end/${label}:delta=${after - before}`).toBe(`session-end/${label}:delta=1`);
       }
-      expect(readAudit(dir)).toContain("SESSION_ENDED");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 90_000);
+
+  test("12d: the DISPATCHER adapter route also never reads stdin for kiro-ide", async () => {
+    // Same hang, second door: `aidlc adapter kiro-ide <target>` acquired
+    // stdin in runAdapter() before invoking the adapter's run(), so the
+    // dispatcher path hung even after the adapter's own entry guard was
+    // fixed. Pin both agentStop targets through the dispatcher with stdin
+    // held open and the captured empty-USER_PROMPT shape.
+    const dir = scratchProject(true);
+    try {
+      const dispatcher = join(dir, ".kiro", "tools", "aidlc.ts");
+      const stop = await runIdeOpenStdin(dir, "stop", "", [dispatcher, "adapter", "kiro-ide", "stop"]);
+      expect(`stop:timedOut=${stop.timedOut}`).toBe("stop:timedOut=false");
+      expect(`stop:${stop.code}`).toBe("stop:0");
+      const decision = JSON.parse(stop.stdout) as { decision?: string };
+      expect(decision.decision).toBe("block");
+      const before = readAudit(dir).split("SESSION_ENDED").length - 1;
+      const end = await runIdeOpenStdin(dir, "session-end", "", [dispatcher, "adapter", "kiro-ide", "session-end"]);
+      expect(`session-end:timedOut=${end.timedOut}`).toBe("session-end:timedOut=false");
+      expect(`session-end:${end.code}`).toBe("session-end:0");
+      const after = readAudit(dir).split("SESSION_ENDED").length - 1;
+      expect(after - before).toBe(1);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

The `run()` export refactor in #560 introduced unconditional stdin acquisition
in both Kiro IDE adapter entry paths. Kiro IDE opens hook stdin but does not
write or close it, so agent-stop hooks hung whenever `USER_PROMPT` was empty.
The forwarding loop (`stop`) and `SESSION_ENDED` (`session-end`) silently never
ran.

Prompt-submit and post-tool-use hooks were unaffected because Kiro IDE
populates `USER_PROMPT` for those events.

## Fix

- The direct Kiro IDE adapter entry guard never reads stdin.
- The shared CLI dispatcher skips stdin acquisition only for the `kiro-ide`
  route; Codex and Kiro CLI retain their existing stdin behavior.
- Both paths pass an empty input to the adapter, which obtains its current
  event context from `USER_PROMPT`.

## Regression Coverage

- t218 test 12 holds stdin open and verifies the direct adapter exits.
- t218 test 12b exercises the actual agent-stop targets, `stop` and
  `session-end`, with empty and absent `USER_PROMPT`. Each invocation asserts
  its own effect: the forwarding-loop decision or a `SESSION_ENDED` audit
  delta.
- t218 test 12d exercises both agent-stop targets through the CLI dispatcher
  while stdin remains open.
- t218 test 12c verifies post-tool-use work still completes with open stdin.

## Validation

- `bun scripts/package.ts --check`
- `bun test tests/unit/t218-kiro-ide-hook-adapter.test.ts tests/unit/t68-version-changelog-sync.test.ts`
  (37 passing)
- Live Kiro IDE before/after verification of `HUMAN_TURN`,
  `SESSION_STARTED`, and `SESSION_ENDED`

## Release

Version `2.5.7`; `CHANGELOG.md`, the README badge, authored version source, and
all generated harness distributions are synchronized.

Related stdin-channel work in #614 and #615 remains open. Those changes compose
with this fix; if #615 lands first, this branch will need its context-channel
comments refreshed during rebase.
