### PR TITLE
fix: add .gitattributes pinning LF so Windows checkouts pass the drift guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Pin LF for all text files, on every platform. The dist/ drift guard
+# (`bun scripts/package.ts --check`) does a byte-parity diff of the committed
+# trees against freshly generated ones, so a checkout must never rewrite line
+# endings (with Git for Windows' default core.autocrlf=true it otherwise
+# rewrites every text file to CRLF and the guard reports the whole dist/ as
+# drifted — see issue #640).
+* text=auto eol=lf
+
+# Binary assets — never normalize.
+*.pdf binary
+*.png binary
+*.jpg binary
+*.zip binary


### PR DESCRIPTION
# Summary

Adds a root `.gitattributes` pinning LF for all text files, so a fresh clone passes `bun scripts/package.ts --check` on every platform. Closes #640.

Without it, Git for Windows' default `core.autocrlf=true` checks out every text file with CRLF, and the byte-parity drift guard reports all 384 generated files in `dist/` as drifted on a completely clean clone — locking Windows contributors out of the documented contribution loop.

## Changes

- New `.gitattributes`: `* text=auto eol=lf` plus `binary` exceptions for `*.pdf` / `*.png` / `*.jpg` / `*.zip`.
- No tracked content changes: the committed blobs are already 100% LF (`git grep -I --files-with-matches $'\r' HEAD` returns nothing), so `git add --renormalize .` is a no-op. The diff is exactly one new file.

## User experience

**Before** (Windows, default `core.autocrlf=true`):

```text
git clone … && bun install && bun scripts/package.ts --check
package --check FAILED (384 problem(s)):
  DIFFERS: claude/.claude\CLAUDE.md
  … (every generated text file in every harness)
```

**After** (same machine, same global config — `.gitattributes` takes precedence over `autocrlf`):

```text
[claude] --check: OK
[codex] --check: OK
[kiro] --check: OK
[kiro-ide] --check: OK
[opencode] --check: OK
package --check: all harness trees in sync with core/ + harness/.
```

macOS/Linux contributors are unaffected (checkouts were already LF there).

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

## Test Plan

Verified end-to-end on Windows 11 (Git for Windows, bun 1.3.14):

1. `git add --renormalize .` on this branch → no tracked file changes (repo is already all-LF).
2. `bun scripts/package.ts --check` on this branch → green for all 5 harnesses.
3. Simulated the failing configuration: `git -c core.autocrlf=true clone -b fix/640-gitattributes-lf …` → the checkout contains **zero** CRLF files (`grep -rIl $'\r' core dist scripts harness` is empty), and `bun install && bun scripts/package.ts --check` in that clone is green.

Reviewers on macOS/Linux can confirm the no-op property with step 1; step 3 is the Windows repro from #640.

No version bump / CHANGELOG entry per the policy in `AGENTS.md` (repo-infrastructure change, not user-visible in the shipped `dist/` trees).

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PHArpbeJV6UDfrmA59Vvv
