### PR TITLE
docs: add the clone + v2 checkout step to the Quickstart and harness guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tre
 After copying, apply the `.gitignore` entries from the shipped `AGENTS.md` before your first workflow, pre-seed hook trust, then verify:
 
 ```bash
-bun .codex/tools/aidlc-utility.ts doctor
+cd your-project && bun .codex/tools/aidlc-utility.ts doctor
 ```
 
 Invoke the orchestrator with `$aidlc` (or `/skills` → aidlc) followed by a scope or description. The [Codex guide](docs/guide/harnesses/codex-cli.md) covers the trust dialog, config merge, and sandbox/git notes in full.
@@ -264,7 +264,7 @@ The engine deliberately lives in `.aidlc/`, NOT `.opencode/` — opencode auto-i
 After copying, apply the `.gitignore` entries from the shipped `AGENTS.md` before your first workflow, then verify:
 
 ```bash
-bun .aidlc/tools/aidlc-utility.ts doctor
+cd your-project && bun .aidlc/tools/aidlc-utility.ts doctor
 ```
 
 Invoke the orchestrator with `/aidlc` followed by a scope or description. The [opencode guide](docs/guide/harnesses/opencode.md) covers the split layout, the adapter plugin, and what differs on this harness in full.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ On Windows, use *either* PowerShell *or* CMD, not both — your prompt shows `PS
 
 Every harness runs on **AWS Bedrock**, so set Bedrock up before your first run — enable model access in your AWS account and make sure the harness can see working AWS credentials. Each harness section below has the specifics.
 
+### Get the code
+
+Every install below copies from this repository's `dist/<harness>/` trees, so clone it and switch to the `v2` branch first:
+
+```bash
+git clone https://github.com/awslabs/aidlc-workflows.git
+cd aidlc-workflows
+git checkout v2
+```
+
+Run the `cp` commands in the sections below from this repository's root.
+
 ### Install a harness
 
 With bun in place, pick your harness below and expand it — each section installs that CLI, sets up your project, and walks the first run end to end.

--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -290,6 +290,7 @@ In your shell:
 command -v claude >/dev/null && echo "✓ Claude Code" || echo "✗ Claude Code"
 command -v bun    >/dev/null && echo "✓ bun"          || echo "✗ bun"
 
+# From your aidlc-workflows clone (v2 branch) - see Installation above
 # Install (engine + the workspace shell sibling)
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/

--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -141,6 +141,15 @@ other distributions, see [Running on Kiro CLI](harnesses/kiro-cli.md),
 [AI-DLC on opencode](harnesses/opencode.md). The Claude Code implementation
 ships as a `.claude/` directory that you copy into your project.
 
+The `cp` commands below run from a clone of this repository on the `v2`
+branch:
+
+```bash
+git clone https://github.com/awslabs/aidlc-workflows.git
+cd aidlc-workflows
+git checkout v2
+```
+
 ### Step 1: Copy the implementation
 
 ```bash

--- a/docs/guide/harnesses/codex-cli.md
+++ b/docs/guide/harnesses/codex-cli.md
@@ -22,6 +22,16 @@ never hand-edit it (the drift guard fails CI).
 
 ## Install
 
+The copies below come from a clone of the
+[aidlc-workflows](https://github.com/awslabs/aidlc-workflows) repository on the
+`v2` branch:
+
+```bash
+git clone https://github.com/awslabs/aidlc-workflows.git
+cd aidlc-workflows
+git checkout v2
+```
+
 1. Copy the distribution into your project (which must be a **git
    repository** — Codex only discovers a project `.codex/hooks.json` inside
    one):

--- a/docs/guide/harnesses/codex-cli.md
+++ b/docs/guide/harnesses/codex-cli.md
@@ -88,10 +88,12 @@ git checkout v2
    do not append a second copy because duplicate TOML tables invalidate the
    entire config.
 
-4. Merge the shipped `.codex/config.toml` into your `~/.codex/config.toml`
-   (or keep it project-level — trusted projects read it). Verify with:
+4. Back in `your-project/` (step 3 ran from the AI-DLC source checkout), merge
+   the shipped `.codex/config.toml` into your `~/.codex/config.toml` (or keep
+   it project-level — trusted projects read it). Verify with:
 
    ```bash
+   cd your-project
    bun .codex/tools/aidlc-utility.ts doctor
    ```
 

--- a/docs/guide/harnesses/kiro-cli.md
+++ b/docs/guide/harnesses/kiro-cli.md
@@ -44,7 +44,7 @@ of `.kiro/`, so copy it separately (or copy the whole `dist/kiro/` tree at once)
 Then start a session in your project:
 
 ```bash
-kiro-cli chat
+cd your-project && kiro-cli chat
 ```
 
 The install ships `.kiro/settings/cli.json` with `chat.defaultAgent: "aidlc"`,

--- a/docs/guide/harnesses/kiro-cli.md
+++ b/docs/guide/harnesses/kiro-cli.md
@@ -20,6 +20,16 @@ configs, hook wiring, activation) differs.
 
 ## Install
 
+The copies below come from a clone of the
+[aidlc-workflows](https://github.com/awslabs/aidlc-workflows) repository on the
+`v2` branch:
+
+```bash
+git clone https://github.com/awslabs/aidlc-workflows.git
+cd aidlc-workflows
+git checkout v2
+```
+
 ```bash
 cp -r dist/kiro/.kiro your-project/.kiro
 cp -r dist/kiro/aidlc your-project/aidlc       # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it

--- a/docs/guide/harnesses/kiro-ide.md
+++ b/docs/guide/harnesses/kiro-ide.md
@@ -30,6 +30,16 @@ hook wiring, activation) differs.
 
 ## Install
 
+The copies below come from a clone of the
+[aidlc-workflows](https://github.com/awslabs/aidlc-workflows) repository on the
+`v2` branch:
+
+```bash
+git clone https://github.com/awslabs/aidlc-workflows.git
+cd aidlc-workflows
+git checkout v2
+```
+
 ```bash
 cp -r dist/kiro-ide/.kiro your-project/.kiro
 cp -r dist/kiro-ide/aidlc your-project/aidlc        # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it

--- a/docs/guide/harnesses/opencode.md
+++ b/docs/guide/harnesses/opencode.md
@@ -38,6 +38,16 @@ script (top-level dispatch, `process.exit`) crashes the session
 
 ## Install
 
+The copies below come from a clone of the
+[aidlc-workflows](https://github.com/awslabs/aidlc-workflows) repository on the
+`v2` branch:
+
+```bash
+git clone https://github.com/awslabs/aidlc-workflows.git
+cd aidlc-workflows
+git checkout v2
+```
+
 1. Copy the distribution into your project:
 
    ```bash


### PR DESCRIPTION
# Summary

Adds the missing "clone the repository and switch to the `v2` branch" step to every install path, as reported in #570. The README Quick Start, Getting Started, and all four harness guides currently open with `cp -r dist/<harness>/...`, assuming the reader is already inside a clone on `v2` without ever saying so. Closes #570.

## Changes

One consistent snippet (`git clone` → `cd` → `git checkout v2`) added where each install sequence begins:

- `README.md` — new **Get the code** step between the shared prerequisites and **Install a harness**, so every collapsed harness section inherits it.
- `docs/guide/01-getting-started.md` — clone step in **Installation**, before *Step 1: Copy the implementation* (existing step numbering untouched).
- `docs/guide/harnesses/kiro-cli.md`, `kiro-ide.md`, `codex-cli.md`, `opencode.md` — clone step at the top of each **Install** section (these guides are landed on directly, so each states it; numbered lists kept intact).

Docs-only: no version bump or CHANGELOG entry per the policy in `AGENTS.md`, and `dist/` is untouched.

## User experience

**Before:** a new user follows the Quick Start, runs `cp -r dist/claude/.claude/ ...` in whatever directory they happen to be in, and gets `No such file or directory` — nothing told them to clone the repo, let alone that the 2.0 content lives on the `v2` branch (the default branch is `main`).

**After:** every install path starts from an explicit clone-and-checkout, and the `cp` commands run from the repository root as intended.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- `bun scripts/package.ts --check` → green for all 5 harnesses (docs are not packaged; confirms `dist/` parity).
- `bun tests/run-tests.ts --unit --filter t174` (the docs legacy-ref gate that scans `docs/**/*.md`) → PASS.
- Grepped `README.md` + `docs/guide/` to confirm every `cp -r dist/...` install sequence is now preceded by the clone step, and that no other install surface was missed.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
