### PR TITLE
docs: promote the global workflow principles out of the Operations placeholder

### DIFF
--- a/aidlc-rules/aws-aidlc-rules/core-workflow.md
+++ b/aidlc-rules/aws-aidlc-rules/core-workflow.md
@@ -74,6 +74,98 @@ All subsequent rule detail file references (e.g., `common/process-overview.md`, 
 3. This should only be done ONCE at the start of a new workflow
 4. Do NOT load this file in subsequent interactions to save context space
 
+## Key Principles
+
+- **Adaptive Execution**: Only execute stages that add value
+- **Transparent Planning**: Always show execution plan before starting
+- **User Control**: User can request stage inclusion/exclusion
+- **Progress Tracking**: Update aidlc-state.md with executed and skipped stages
+- **Complete Audit Trail**: Log ALL user inputs and AI responses in audit.md with timestamps
+  - **CRITICAL**: Capture user's COMPLETE RAW INPUT exactly as provided
+  - **CRITICAL**: Never summarize or paraphrase user input in audit log
+  - **CRITICAL**: Log every interaction, not just approvals
+- **Quality Focus**: Complex changes get full treatment, simple changes stay efficient
+- **Content Validation**: Always validate content before file creation per content-validation.md rules
+- **NO EMERGENT BEHAVIOR**: Construction phases MUST use standardized 2-option completion messages as defined in their respective rule files. DO NOT create 3-option menus or other emergent navigation patterns.
+
+## MANDATORY: Plan-Level Checkbox Enforcement
+
+### MANDATORY RULES FOR PLAN EXECUTION
+1. **NEVER complete any work without updating plan checkboxes**
+2. **IMMEDIATELY after completing ANY step described in a plan file, mark that step [x]**
+3. **This must happen in the SAME interaction where the work is completed**
+4. **NO EXCEPTIONS**: Every plan step completion MUST be tracked with checkbox updates
+
+### Two-Level Checkbox Tracking System
+- **Plan-Level**: Track detailed execution progress within each stage
+- **Stage-Level**: Track overall workflow progress in aidlc-state.md
+- **Update immediately**: All progress updates in SAME interaction where work is completed
+
+## Prompts Logging Requirements
+- **MANDATORY**: Log EVERY user input (prompts, questions, responses) with timestamp in audit.md
+- **MANDATORY**: Capture user's COMPLETE RAW INPUT exactly as provided (never summarize)
+- **MANDATORY**: Log every approval prompt with timestamp before asking the user
+- **MANDATORY**: Record every user response with timestamp after receiving it
+- **CRITICAL**: ALWAYS append changes to EDIT audit.md file, NEVER use tools and commands that completely overwrite its contents
+- **CRITICAL**: NEVER use file writing tools and commands that overwrite the entire contents of audit.md, as this causes duplication
+- Use ISO 8601 format for timestamps (YYYY-MM-DDTHH:MM:SSZ)
+- Include stage context for each entry
+
+### Audit Log Format:
+```markdown
+## [Stage Name or Interaction Type]
+**Timestamp**: [ISO timestamp]
+**User Input**: "[Complete raw user input - never summarized]"
+**AI Response**: "[AI's response or action taken]"
+**Context**: [Stage, action, or decision made]
+
+---
+```
+
+### Correct Tool Usage for audit.md
+
+✅ CORRECT:
+
+1. Read the audit.md file
+2. Append/Edit the file to make changes
+
+❌ WRONG:
+
+1. Read the audit.md file
+2. Completely overwrite the audit.md with the contents of what you read, plus the new changes you want to add to it
+
+## Directory Structure
+
+```text
+<WORKSPACE-ROOT>/                   # ⚠️ APPLICATION CODE HERE
+├── [project-specific structure]    # Varies by project (see code-generation.md)
+│
+├── aidlc-docs/                     # 📄 DOCUMENTATION ONLY
+│   ├── inception/                  # 🔵 INCEPTION PHASE
+│   │   ├── plans/
+│   │   ├── reverse-engineering/    # Brownfield only
+│   │   ├── requirements/
+│   │   ├── user-stories/
+│   │   └── application-design/
+│   ├── construction/               # 🟢 CONSTRUCTION PHASE
+│   │   ├── plans/
+│   │   ├── {unit-name}/
+│   │   │   ├── functional-design/
+│   │   │   ├── nfr-requirements/
+│   │   │   ├── nfr-design/
+│   │   │   ├── infrastructure-design/
+│   │   │   └── code/               # Markdown summaries only
+│   │   └── build-and-test/
+│   ├── operations/                 # 🟡 OPERATIONS PHASE (placeholder)
+│   ├── aidlc-state.md
+│   └── audit.md
+```
+
+**CRITICAL RULE**:
+- Application code: Workspace root (NEVER in aidlc-docs/)
+- Documentation: aidlc-docs/ only
+- Project structure: See code-generation.md for patterns by project type
+
 # Adaptive Software Development Workflow
 
 ---
@@ -445,95 +537,3 @@ The Operations stage will eventually include:
 - Production readiness checklists
 
 **Current State**: All build and test activities are handled in the CONSTRUCTION phase.
-
-## Key Principles
-
-- **Adaptive Execution**: Only execute stages that add value
-- **Transparent Planning**: Always show execution plan before starting
-- **User Control**: User can request stage inclusion/exclusion
-- **Progress Tracking**: Update aidlc-state.md with executed and skipped stages
-- **Complete Audit Trail**: Log ALL user inputs and AI responses in audit.md with timestamps
-  - **CRITICAL**: Capture user's COMPLETE RAW INPUT exactly as provided
-  - **CRITICAL**: Never summarize or paraphrase user input in audit log
-  - **CRITICAL**: Log every interaction, not just approvals
-- **Quality Focus**: Complex changes get full treatment, simple changes stay efficient
-- **Content Validation**: Always validate content before file creation per content-validation.md rules
-- **NO EMERGENT BEHAVIOR**: Construction phases MUST use standardized 2-option completion messages as defined in their respective rule files. DO NOT create 3-option menus or other emergent navigation patterns.
-
-## MANDATORY: Plan-Level Checkbox Enforcement
-
-### MANDATORY RULES FOR PLAN EXECUTION
-1. **NEVER complete any work without updating plan checkboxes**
-2. **IMMEDIATELY after completing ANY step described in a plan file, mark that step [x]**
-3. **This must happen in the SAME interaction where the work is completed**
-4. **NO EXCEPTIONS**: Every plan step completion MUST be tracked with checkbox updates
-
-### Two-Level Checkbox Tracking System
-- **Plan-Level**: Track detailed execution progress within each stage
-- **Stage-Level**: Track overall workflow progress in aidlc-state.md
-- **Update immediately**: All progress updates in SAME interaction where work is completed
-
-## Prompts Logging Requirements
-- **MANDATORY**: Log EVERY user input (prompts, questions, responses) with timestamp in audit.md
-- **MANDATORY**: Capture user's COMPLETE RAW INPUT exactly as provided (never summarize)
-- **MANDATORY**: Log every approval prompt with timestamp before asking the user
-- **MANDATORY**: Record every user response with timestamp after receiving it
-- **CRITICAL**: ALWAYS append changes to EDIT audit.md file, NEVER use tools and commands that completely overwrite its contents
-- **CRITICAL**: NEVER use file writing tools and commands that overwrite the entire contents of audit.md, as this causes duplication
-- Use ISO 8601 format for timestamps (YYYY-MM-DDTHH:MM:SSZ)
-- Include stage context for each entry
-
-### Audit Log Format:
-```markdown
-## [Stage Name or Interaction Type]
-**Timestamp**: [ISO timestamp]
-**User Input**: "[Complete raw user input - never summarized]"
-**AI Response**: "[AI's response or action taken]"
-**Context**: [Stage, action, or decision made]
-
----
-```
-
-### Correct Tool Usage for audit.md
-
-✅ CORRECT:
-
-1. Read the audit.md file
-2. Append/Edit the file to make changes
-
-❌ WRONG:
-
-1. Read the audit.md file
-2. Completely overwrite the audit.md with the contents of what you read, plus the new changes you want to add to it
-
-## Directory Structure
-
-```text
-<WORKSPACE-ROOT>/                   # ⚠️ APPLICATION CODE HERE
-├── [project-specific structure]    # Varies by project (see code-generation.md)
-│
-├── aidlc-docs/                     # 📄 DOCUMENTATION ONLY
-│   ├── inception/                  # 🔵 INCEPTION PHASE
-│   │   ├── plans/
-│   │   ├── reverse-engineering/    # Brownfield only
-│   │   ├── requirements/
-│   │   ├── user-stories/
-│   │   └── application-design/
-│   ├── construction/               # 🟢 CONSTRUCTION PHASE
-│   │   ├── plans/
-│   │   ├── {unit-name}/
-│   │   │   ├── functional-design/
-│   │   │   ├── nfr-requirements/
-│   │   │   ├── nfr-design/
-│   │   │   ├── infrastructure-design/
-│   │   │   └── code/               # Markdown summaries only
-│   │   └── build-and-test/
-│   ├── operations/                 # 🟡 OPERATIONS PHASE (placeholder)
-│   ├── aidlc-state.md
-│   └── audit.md
-```
-
-**CRITICAL RULE**:
-- Application code: Workspace root (NEVER in aidlc-docs/)
-- Documentation: aidlc-docs/ only
-- Project structure: See code-generation.md for patterns by project type


### PR DESCRIPTION
# Summary

Moves the four global-workflow sections out from under the placeholder `# 🟡 OPERATIONS PHASE` heading in `aidlc-rules/aws-aidlc-rules/core-workflow.md`, as described in #584. Closes #584.

`## Key Principles`, `## MANDATORY: Plan-Level Checkbox Enforcement`, `## Prompts Logging Requirements`, and `## Directory Structure` describe rules that apply across all three phases (adaptive execution, checkbox tracking, audit logging, the `aidlc-docs/` layout), but they sat nested under the Operations placeholder — implying they were Operations-specific, and giving the placeholder more apparent substance than it has.

## Changes

- The four sections move, **byte-for-byte unchanged**, into the document's global preamble — after `## MANDATORY: Custom Welcome Message` and before `# Adaptive Software Development Workflow` — where the other always-on `## MANDATORY:` sections already live (the issue's suggested placement: global rules presented upfront, before any phase-specific content).
- Heading levels and titles are untouched, so existing anchors keep working (grepped the repo: no links target these sections).
- `# 🟡 OPERATIONS PHASE` now ends cleanly with its own placeholder content.
- Pure move: the diff is 92 insertions / 92 deletions in one file, net zero.

## User experience

A reader (or a model loading the rules) now encounters the global principles once, upfront, alongside the other global MANDATORY sections — instead of finding them after the Operations placeholder and incorrectly associating them with a phase that is explicitly "a placeholder for future expansion". Rule content itself is unchanged.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

## Test Plan

- `npx markdownlint-cli2 "aidlc-rules/aws-aidlc-rules/core-workflow.md"` → 0 issues.
- `git diff --stat` → 92 insertions / 92 deletions, single file — reviewers can verify the moved block is identical by comparing the `-`/`+` hunks.
- Grepped the repository for anchor links to the four headings — none exist outside the file itself.
- Honest scope note: no full workflow run on a platform was performed for this PR — no rule text changes, only document position. The sections now load *earlier* in the file, which if anything increases their prominence for models that weight early context.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
