### PR TITLE
docs: fix Mermaid parse errors from semicolons in sequence diagrams

### DIFF
--- a/docs/guide/02-your-first-workflow.md
+++ b/docs/guide/02-your-first-workflow.md
@@ -225,7 +225,7 @@ sequenceDiagram
     T-->>O: Return structured summary
     O->>U: Present completion summary
     U->>O: Approval gate response
-    O->>O: Report outcome; engine updates state + advances
+    O->>O: Report outcome — engine updates state + advances
 ```
 
 <!-- Text fallback: The conductor reads the stage file, prepares context, and delegates via the Task tool. The subagent executes autonomously without user interaction and returns a structured summary. The conductor presents the summary to you, you respond at the approval gate, and the conductor reports the outcome so the engine advances state. -->

--- a/docs/reference/01-architecture.md
+++ b/docs/reference/01-architecture.md
@@ -224,7 +224,7 @@ sequenceDiagram
     O->>O: Log to audit.md
     O->>U: Present completion + approval gate
     U-->>O: Approve / Request Changes
-    O->>ST: Report approved; engine marks [x] and routes
+    O->>ST: Report approved — engine marks [x] and routes
     O->>O: Advance to next stage
 ```
 
@@ -246,7 +246,7 @@ sequenceDiagram
     O->>O: Validate summary, check Issues/Concerns
     O->>U: Present completion + approval gate
     U-->>O: Approve / Request Changes
-    O->>O: Report outcome; engine completes and advances
+    O->>O: Report outcome — engine completes and advances
 ```
 
 ## Source vs distribution (one core, many harnesses)

--- a/docs/reference/03-orchestrator.md
+++ b/docs/reference/03-orchestrator.md
@@ -320,7 +320,7 @@ sequenceDiagram
     participant AU as audit/ shard
 
     O->>A: 1. Read every inline_context_paths entry
-    Note over A: Inline lead/support; mob lead-only persona + knowledge paths
+    Note over A: Inline lead/support — mob lead-only persona + knowledge paths
 
     O->>SF: 2. Read stage file
     Note over SF: directive.stage_file
@@ -460,7 +460,7 @@ sequenceDiagram
     U->>O: Approve walking-skeleton gate
     O->>U: Ladder prompt (fires once)
     U->>O: "Continue autonomously"
-    O->>O: Write Construction Autonomy Mode: autonomous; emit AUTONOMY_MODE_SET
+    O->>O: Write Construction Autonomy Mode: autonomous — emit AUTONOMY_MODE_SET
 
     Note over O,T: Bolts B + C eligible in parallel batch
     O->>T: Task(B code-gen) + Task(C code-gen) in ONE message


### PR DESCRIPTION
# Summary

Five sequence diagrams in the docs fail to render on GitHub. Mermaid treats `;`
as a statement separator even inside message and Note text, so a line like
`O->>ST: Report approved; engine marks [x] and routes` is cut at the semicolon
and the remainder fails to parse (`Expecting 'SOLID_OPEN_ARROW' ... got 'NEWLINE'`).

## Changes

Replaced the semicolon with an em dash in the five affected lines — the same
style these diagrams already use (e.g. `Run Bolt A (walking skeleton) — questions,
design, code-gen`). Nothing else changed.

- `docs/reference/01-architecture.md` — Conductor Inline Stage Execution / Conductor Subagent Delegation
- `docs/guide/02-your-first-workflow.md` — Subagent Delegation
- `docs/reference/03-orchestrator.md` — agent activation (Note line) / Construction autonomy ladder

## User experience

Before: the five diagrams show GitHub's "Unable to render rich display" parse
error instead of a diagram. After: all five render.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

## Test Plan

- Rendered all five fixed diagrams with Mermaid 11.16.0 (the version GitHub
  reports in the error) — all parse and draw.
- Reviewers can verify without cloning: open the three files on this branch
  and check the diagrams render.
- `bun test tests/smoke/` and the docs-related unit tests (t132, t174, t239,
  t246) pass. Docs-only change, so no `dist/` regeneration is involved.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
