### PR TITLE
fix: inject resolved rule contents into the run-stage directive (#495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.14] - 2026-07-25
+
+Per-stage steering now reaches the workflow deterministically. The `run-stage` directive already listed the resolved rule paths in `rules_in_context`, but reading them was prose-only instruction, so an org or phase rule could be silently skipped and the stage's artifacts written without it. The engine now reads each resolved rule file at directive-build time and ships its contents in a new `rules_content` field, the same way `conductor_persona` is already injected. **Upgrade:** re-copy your `dist/<harness>/` shell into the project. No workflow, command, or file-layout change — rules you have already authored start arriving as content on the next stage.
+
+* The `run-stage` directive carries a new optional `rules_content` array of `{path, text}` entries — the on-disk contents of the rule files named in `rules_in_context`. `rules_in_context` is unchanged and remains the authoritative roster.
+* Rule files that hold only scaffolding (a heading, `>` guidance, or HTML-comment examples — the shape the shipped `team.md` and `project.md` seeds have before you affirm anything) are omitted, so an untouched install gains no directive noise. They appear as soon as they carry a real rule.
+* A missing or unreadable rule file is still not an error: the entry is dropped and the directive stays well-formed, with `rules_in_context` unaffected.
+
 ## [2.5.11] - 2026-07-24
 
 Intent Capture now keeps generated intent and stakeholder claims grounded in the user's description, confirmed answers, workflow-selected scope, or explicitly registered memory. Unsupported content is omitted, elicited, or surfaced as a human-owned assumption instead of being presented as fact. **Upgrade:** re-copy your `dist/<harness>/` shell into the project so the updated stage, Product Lead reviewer contract, and `claim-sources` sensor are installed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.11-blue)
+![version](https://img.shields.io/badge/version-2.5.14-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-directive.ts
+++ b/core/tools/aidlc-directive.ts
@@ -55,6 +55,14 @@ export type DirectiveKind =
 // are read straight off the compiled stage-graph.json node; consumes/produces
 // carry RESOLVED aidlc-docs/... paths (the engine resolves vocabulary names →
 // paths at emit time; the conductor never re-derives them).
+
+// One rules_in_context file, with its on-disk content baked in. `path` is the
+// same projectDir-relative path that appears in rules_in_context; `text` is the
+// file's full contents at emit time. See RunStageDirective.rules_content.
+export interface RuleContent {
+  path: string;
+  text: string;
+}
 export interface RunStageDirective {
   kind: "run-stage";
   stage: string;
@@ -100,6 +108,18 @@ export interface RunStageDirective {
   // in-context, with no skill referencing that file by path. Absent on every
   // later directive (the persona persists in the session once delivered).
   conductor_persona?: string;
+  // rules_content — the CONTENT of each rules_in_context file that exists on
+  // disk with substantive (non-placeholder) text, read by the engine at
+  // directive-build time and injected here so the conductor receives its
+  // per-stage steering in-context WITHOUT having to read each path itself
+  // (the read was prose-only and skipped non-deterministically in live runs).
+  // Mirrors conductor_persona's deterministic-injection pattern. rules_in_context
+  // (the paths) is unchanged and authoritative; rules_content is an additive
+  // superset covering the files that carried real content. Absent on the
+  // ctx-less emit path (no projectDir to resolve/read against) and whenever no
+  // resolved rule file has substantive content — the directive stays
+  // well-formed without it.
+  rules_content?: RuleContent[];
   // next_stage: the display name of the in-scope stage that FOLLOWS this one,
   // resolved by the engine so the approval gate's Approve option can read
   // "Continue to <next_stage>" verbatim. null = this is the final in-scope
@@ -294,6 +314,7 @@ const RUN_STAGE_FIELDS = [
   "reviewer",
   "reviewer_max_iterations",
   "conductor_persona",
+  "rules_content",
   "next_stage",
   "unit",
   "consumes_absent",
@@ -456,6 +477,9 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // rules_content: optional (present only on the live emit path when at least one
+  // rules_in_context file had substantive content). Each entry {path, text}.
+  checkOptionalRulesContent(o, "rules_content", kind, errors);
   // next_stage: optional-nullable on a run-stage directive. Present as a string
   // names the following in-scope stage; null means this is the final in-scope
   // stage; absent carries no name. So string OR null validates; any other
@@ -615,6 +639,42 @@ function checkOptionalConsumesAbsent(
     if (typeof item.expected !== "boolean") {
       errors.push(
         `${kind}: ${field}[${i}].expected must be boolean, got ${describe(item.expected)}`,
+      );
+    }
+  });
+}
+
+// rules_content — optional (present only on the live emit path with at least
+// one substantive rule file). Each entry must be {path: string, text: string}.
+// Mirrors checkOptionalConsumesAbsent's shape discipline.
+function checkOptionalRulesContent(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o)) return;
+  const v: unknown = o[field];
+  if (!Array.isArray(v)) {
+    errors.push(`${kind}: ${field} must be array, got ${describe(v)}`);
+    return;
+  }
+  const arr: unknown[] = v;
+  arr.forEach((item: unknown, i: number) => {
+    if (!isPlainObject(item)) {
+      errors.push(
+        `${kind}: ${field}[${i}] must be object, got ${describe(item)}`,
+      );
+      return;
+    }
+    if (typeof item.path !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].path must be string, got ${describe(item.path)}`,
+      );
+    }
+    if (typeof item.text !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].text must be string, got ${describe(item.text)}`,
       );
     }
   });

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -78,6 +78,7 @@ import {
   type GateValue,
   type ParkedDirective,
   type PrintDirective,
+  type RuleContent,
   type RunStageDirective,
   validateDirective,
 } from "./aidlc-directive.ts";
@@ -1290,6 +1291,42 @@ function inlineContextPaths(node: GraphStage, codekbCtx?: CodekbCtx): string[] {
   return [...new Set(paths)];
 }
 
+// A rule file is "substantive" when it carries at least one content line —
+// something other than a blank line, a Markdown heading, an HTML comment, or a
+// blockquote. The shipped team.md / project.md seeds are pure scaffolding
+// (heading + `>` guidance + `<!-- ... -->` examples, no affirmed rules), so this
+// drops them; org.md / phases/<phase>.md, which carry real rules, pass. Keeping
+// placeholders out of rules_content avoids injecting empty noise into every
+// directive.
+function ruleTextIsSubstantive(text: string): boolean {
+  return text.split("\n").some((line) => {
+    const t = line.trim();
+    if (t === "") return false;
+    if (t.startsWith("#")) return false; // heading
+    if (t.startsWith(">")) return false; // blockquote (seed guidance)
+    if (t.startsWith("<!--") || t.startsWith("-->")) return false; // HTML comment fence
+    return true;
+  });
+}
+
+// Read one rules_in_context file (a projectDir-relative path) and return its
+// content, or null when the file is absent, unreadable, or placeholder-only.
+// Path resolution mirrors splitConsumesByPresence: join(projectDir, ...split("/"))
+// so it is OS-correct and cwd-independent. Best-effort by design — a missing or
+// placeholder rule is not a routing error; the directive stays well-formed
+// without its entry. See RunStageDirective.rules_content.
+function readRuleContent(projectDir: string, relPath: string): RuleContent | null {
+  const abs = join(projectDir, ...relPath.split("/"));
+  if (!existsSync(abs)) return null;
+  try {
+    const text = readFileSync(abs, "utf-8");
+    if (!ruleTextIsSubstantive(text)) return null;
+    return { path: relPath, text };
+  } catch {
+    return null;
+  }
+}
+
 // Build a run-stage directive by reading the routing fields straight off the
 // compiled graph node. consumes/produces carry resolved active-record paths:
 // the engine resolves the node's vocabulary names → paths at emit time (so the
@@ -1335,6 +1372,19 @@ function buildRunStageDirective(
     stage_file: stageFileFor(node.phase, node.slug),
   };
   if (absent.length > 0) directive.consumes_absent = absent;
+  // rules_content — deterministically inject the CONTENT of each rules_in_context
+  // file so per-stage steering reaches the conductor without depending on it
+  // reading each path (the read is prose-only and was observed skipped across
+  // whole stages). Only on the live path (codekbCtx present gives the projectDir
+  // base); the ctx-less test/default path stays byte-identical, mirroring
+  // splitConsumesByPresence's own no-ctx skip. Placeholder-only files (team.md /
+  // project.md seeds) are dropped by readRuleContent.
+  if (codekbCtx) {
+    const rulesContent = (node.rules_in_context ?? [])
+      .map((r) => readRuleContent(codekbCtx.projectDir, r.path))
+      .filter((r): r is RuleContent => r !== null);
+    if (rulesContent.length > 0) directive.rules_content = rulesContent;
+  }
   // next_stage: the display name of the in-scope stage that follows this one, so
   // the approval gate's Approve option reads "Continue to <next_stage>" verbatim
   // instead of a guessed constant. Computed here at emit time: the gate is

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.14";

--- a/dist/claude/.claude/tools/aidlc-directive.ts
+++ b/dist/claude/.claude/tools/aidlc-directive.ts
@@ -55,6 +55,14 @@ export type DirectiveKind =
 // are read straight off the compiled stage-graph.json node; consumes/produces
 // carry RESOLVED aidlc-docs/... paths (the engine resolves vocabulary names →
 // paths at emit time; the conductor never re-derives them).
+
+// One rules_in_context file, with its on-disk content baked in. `path` is the
+// same projectDir-relative path that appears in rules_in_context; `text` is the
+// file's full contents at emit time. See RunStageDirective.rules_content.
+export interface RuleContent {
+  path: string;
+  text: string;
+}
 export interface RunStageDirective {
   kind: "run-stage";
   stage: string;
@@ -100,6 +108,18 @@ export interface RunStageDirective {
   // in-context, with no skill referencing that file by path. Absent on every
   // later directive (the persona persists in the session once delivered).
   conductor_persona?: string;
+  // rules_content — the CONTENT of each rules_in_context file that exists on
+  // disk with substantive (non-placeholder) text, read by the engine at
+  // directive-build time and injected here so the conductor receives its
+  // per-stage steering in-context WITHOUT having to read each path itself
+  // (the read was prose-only and skipped non-deterministically in live runs).
+  // Mirrors conductor_persona's deterministic-injection pattern. rules_in_context
+  // (the paths) is unchanged and authoritative; rules_content is an additive
+  // superset covering the files that carried real content. Absent on the
+  // ctx-less emit path (no projectDir to resolve/read against) and whenever no
+  // resolved rule file has substantive content — the directive stays
+  // well-formed without it.
+  rules_content?: RuleContent[];
   // next_stage: the display name of the in-scope stage that FOLLOWS this one,
   // resolved by the engine so the approval gate's Approve option can read
   // "Continue to <next_stage>" verbatim. null = this is the final in-scope
@@ -294,6 +314,7 @@ const RUN_STAGE_FIELDS = [
   "reviewer",
   "reviewer_max_iterations",
   "conductor_persona",
+  "rules_content",
   "next_stage",
   "unit",
   "consumes_absent",
@@ -456,6 +477,9 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // rules_content: optional (present only on the live emit path when at least one
+  // rules_in_context file had substantive content). Each entry {path, text}.
+  checkOptionalRulesContent(o, "rules_content", kind, errors);
   // next_stage: optional-nullable on a run-stage directive. Present as a string
   // names the following in-scope stage; null means this is the final in-scope
   // stage; absent carries no name. So string OR null validates; any other
@@ -615,6 +639,42 @@ function checkOptionalConsumesAbsent(
     if (typeof item.expected !== "boolean") {
       errors.push(
         `${kind}: ${field}[${i}].expected must be boolean, got ${describe(item.expected)}`,
+      );
+    }
+  });
+}
+
+// rules_content — optional (present only on the live emit path with at least
+// one substantive rule file). Each entry must be {path: string, text: string}.
+// Mirrors checkOptionalConsumesAbsent's shape discipline.
+function checkOptionalRulesContent(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o)) return;
+  const v: unknown = o[field];
+  if (!Array.isArray(v)) {
+    errors.push(`${kind}: ${field} must be array, got ${describe(v)}`);
+    return;
+  }
+  const arr: unknown[] = v;
+  arr.forEach((item: unknown, i: number) => {
+    if (!isPlainObject(item)) {
+      errors.push(
+        `${kind}: ${field}[${i}] must be object, got ${describe(item)}`,
+      );
+      return;
+    }
+    if (typeof item.path !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].path must be string, got ${describe(item.path)}`,
+      );
+    }
+    if (typeof item.text !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].text must be string, got ${describe(item.text)}`,
       );
     }
   });

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -78,6 +78,7 @@ import {
   type GateValue,
   type ParkedDirective,
   type PrintDirective,
+  type RuleContent,
   type RunStageDirective,
   validateDirective,
 } from "./aidlc-directive.ts";
@@ -1290,6 +1291,42 @@ function inlineContextPaths(node: GraphStage, codekbCtx?: CodekbCtx): string[] {
   return [...new Set(paths)];
 }
 
+// A rule file is "substantive" when it carries at least one content line —
+// something other than a blank line, a Markdown heading, an HTML comment, or a
+// blockquote. The shipped team.md / project.md seeds are pure scaffolding
+// (heading + `>` guidance + `<!-- ... -->` examples, no affirmed rules), so this
+// drops them; org.md / phases/<phase>.md, which carry real rules, pass. Keeping
+// placeholders out of rules_content avoids injecting empty noise into every
+// directive.
+function ruleTextIsSubstantive(text: string): boolean {
+  return text.split("\n").some((line) => {
+    const t = line.trim();
+    if (t === "") return false;
+    if (t.startsWith("#")) return false; // heading
+    if (t.startsWith(">")) return false; // blockquote (seed guidance)
+    if (t.startsWith("<!--") || t.startsWith("-->")) return false; // HTML comment fence
+    return true;
+  });
+}
+
+// Read one rules_in_context file (a projectDir-relative path) and return its
+// content, or null when the file is absent, unreadable, or placeholder-only.
+// Path resolution mirrors splitConsumesByPresence: join(projectDir, ...split("/"))
+// so it is OS-correct and cwd-independent. Best-effort by design — a missing or
+// placeholder rule is not a routing error; the directive stays well-formed
+// without its entry. See RunStageDirective.rules_content.
+function readRuleContent(projectDir: string, relPath: string): RuleContent | null {
+  const abs = join(projectDir, ...relPath.split("/"));
+  if (!existsSync(abs)) return null;
+  try {
+    const text = readFileSync(abs, "utf-8");
+    if (!ruleTextIsSubstantive(text)) return null;
+    return { path: relPath, text };
+  } catch {
+    return null;
+  }
+}
+
 // Build a run-stage directive by reading the routing fields straight off the
 // compiled graph node. consumes/produces carry resolved active-record paths:
 // the engine resolves the node's vocabulary names → paths at emit time (so the
@@ -1335,6 +1372,19 @@ function buildRunStageDirective(
     stage_file: stageFileFor(node.phase, node.slug),
   };
   if (absent.length > 0) directive.consumes_absent = absent;
+  // rules_content — deterministically inject the CONTENT of each rules_in_context
+  // file so per-stage steering reaches the conductor without depending on it
+  // reading each path (the read is prose-only and was observed skipped across
+  // whole stages). Only on the live path (codekbCtx present gives the projectDir
+  // base); the ctx-less test/default path stays byte-identical, mirroring
+  // splitConsumesByPresence's own no-ctx skip. Placeholder-only files (team.md /
+  // project.md seeds) are dropped by readRuleContent.
+  if (codekbCtx) {
+    const rulesContent = (node.rules_in_context ?? [])
+      .map((r) => readRuleContent(codekbCtx.projectDir, r.path))
+      .filter((r): r is RuleContent => r !== null);
+    if (rulesContent.length > 0) directive.rules_content = rulesContent;
+  }
   // next_stage: the display name of the in-scope stage that follows this one, so
   // the approval gate's Approve option reads "Continue to <next_stage>" verbatim
   // instead of a guessed constant. Computed here at emit time: the gate is

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.14";

--- a/dist/codex/.codex/tools/aidlc-directive.ts
+++ b/dist/codex/.codex/tools/aidlc-directive.ts
@@ -55,6 +55,14 @@ export type DirectiveKind =
 // are read straight off the compiled stage-graph.json node; consumes/produces
 // carry RESOLVED aidlc-docs/... paths (the engine resolves vocabulary names →
 // paths at emit time; the conductor never re-derives them).
+
+// One rules_in_context file, with its on-disk content baked in. `path` is the
+// same projectDir-relative path that appears in rules_in_context; `text` is the
+// file's full contents at emit time. See RunStageDirective.rules_content.
+export interface RuleContent {
+  path: string;
+  text: string;
+}
 export interface RunStageDirective {
   kind: "run-stage";
   stage: string;
@@ -100,6 +108,18 @@ export interface RunStageDirective {
   // in-context, with no skill referencing that file by path. Absent on every
   // later directive (the persona persists in the session once delivered).
   conductor_persona?: string;
+  // rules_content — the CONTENT of each rules_in_context file that exists on
+  // disk with substantive (non-placeholder) text, read by the engine at
+  // directive-build time and injected here so the conductor receives its
+  // per-stage steering in-context WITHOUT having to read each path itself
+  // (the read was prose-only and skipped non-deterministically in live runs).
+  // Mirrors conductor_persona's deterministic-injection pattern. rules_in_context
+  // (the paths) is unchanged and authoritative; rules_content is an additive
+  // superset covering the files that carried real content. Absent on the
+  // ctx-less emit path (no projectDir to resolve/read against) and whenever no
+  // resolved rule file has substantive content — the directive stays
+  // well-formed without it.
+  rules_content?: RuleContent[];
   // next_stage: the display name of the in-scope stage that FOLLOWS this one,
   // resolved by the engine so the approval gate's Approve option can read
   // "Continue to <next_stage>" verbatim. null = this is the final in-scope
@@ -294,6 +314,7 @@ const RUN_STAGE_FIELDS = [
   "reviewer",
   "reviewer_max_iterations",
   "conductor_persona",
+  "rules_content",
   "next_stage",
   "unit",
   "consumes_absent",
@@ -456,6 +477,9 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // rules_content: optional (present only on the live emit path when at least one
+  // rules_in_context file had substantive content). Each entry {path, text}.
+  checkOptionalRulesContent(o, "rules_content", kind, errors);
   // next_stage: optional-nullable on a run-stage directive. Present as a string
   // names the following in-scope stage; null means this is the final in-scope
   // stage; absent carries no name. So string OR null validates; any other
@@ -615,6 +639,42 @@ function checkOptionalConsumesAbsent(
     if (typeof item.expected !== "boolean") {
       errors.push(
         `${kind}: ${field}[${i}].expected must be boolean, got ${describe(item.expected)}`,
+      );
+    }
+  });
+}
+
+// rules_content — optional (present only on the live emit path with at least
+// one substantive rule file). Each entry must be {path: string, text: string}.
+// Mirrors checkOptionalConsumesAbsent's shape discipline.
+function checkOptionalRulesContent(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o)) return;
+  const v: unknown = o[field];
+  if (!Array.isArray(v)) {
+    errors.push(`${kind}: ${field} must be array, got ${describe(v)}`);
+    return;
+  }
+  const arr: unknown[] = v;
+  arr.forEach((item: unknown, i: number) => {
+    if (!isPlainObject(item)) {
+      errors.push(
+        `${kind}: ${field}[${i}] must be object, got ${describe(item)}`,
+      );
+      return;
+    }
+    if (typeof item.path !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].path must be string, got ${describe(item.path)}`,
+      );
+    }
+    if (typeof item.text !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].text must be string, got ${describe(item.text)}`,
       );
     }
   });

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -78,6 +78,7 @@ import {
   type GateValue,
   type ParkedDirective,
   type PrintDirective,
+  type RuleContent,
   type RunStageDirective,
   validateDirective,
 } from "./aidlc-directive.ts";
@@ -1290,6 +1291,42 @@ function inlineContextPaths(node: GraphStage, codekbCtx?: CodekbCtx): string[] {
   return [...new Set(paths)];
 }
 
+// A rule file is "substantive" when it carries at least one content line —
+// something other than a blank line, a Markdown heading, an HTML comment, or a
+// blockquote. The shipped team.md / project.md seeds are pure scaffolding
+// (heading + `>` guidance + `<!-- ... -->` examples, no affirmed rules), so this
+// drops them; org.md / phases/<phase>.md, which carry real rules, pass. Keeping
+// placeholders out of rules_content avoids injecting empty noise into every
+// directive.
+function ruleTextIsSubstantive(text: string): boolean {
+  return text.split("\n").some((line) => {
+    const t = line.trim();
+    if (t === "") return false;
+    if (t.startsWith("#")) return false; // heading
+    if (t.startsWith(">")) return false; // blockquote (seed guidance)
+    if (t.startsWith("<!--") || t.startsWith("-->")) return false; // HTML comment fence
+    return true;
+  });
+}
+
+// Read one rules_in_context file (a projectDir-relative path) and return its
+// content, or null when the file is absent, unreadable, or placeholder-only.
+// Path resolution mirrors splitConsumesByPresence: join(projectDir, ...split("/"))
+// so it is OS-correct and cwd-independent. Best-effort by design — a missing or
+// placeholder rule is not a routing error; the directive stays well-formed
+// without its entry. See RunStageDirective.rules_content.
+function readRuleContent(projectDir: string, relPath: string): RuleContent | null {
+  const abs = join(projectDir, ...relPath.split("/"));
+  if (!existsSync(abs)) return null;
+  try {
+    const text = readFileSync(abs, "utf-8");
+    if (!ruleTextIsSubstantive(text)) return null;
+    return { path: relPath, text };
+  } catch {
+    return null;
+  }
+}
+
 // Build a run-stage directive by reading the routing fields straight off the
 // compiled graph node. consumes/produces carry resolved active-record paths:
 // the engine resolves the node's vocabulary names → paths at emit time (so the
@@ -1335,6 +1372,19 @@ function buildRunStageDirective(
     stage_file: stageFileFor(node.phase, node.slug),
   };
   if (absent.length > 0) directive.consumes_absent = absent;
+  // rules_content — deterministically inject the CONTENT of each rules_in_context
+  // file so per-stage steering reaches the conductor without depending on it
+  // reading each path (the read is prose-only and was observed skipped across
+  // whole stages). Only on the live path (codekbCtx present gives the projectDir
+  // base); the ctx-less test/default path stays byte-identical, mirroring
+  // splitConsumesByPresence's own no-ctx skip. Placeholder-only files (team.md /
+  // project.md seeds) are dropped by readRuleContent.
+  if (codekbCtx) {
+    const rulesContent = (node.rules_in_context ?? [])
+      .map((r) => readRuleContent(codekbCtx.projectDir, r.path))
+      .filter((r): r is RuleContent => r !== null);
+    if (rulesContent.length > 0) directive.rules_content = rulesContent;
+  }
   // next_stage: the display name of the in-scope stage that follows this one, so
   // the approval gate's Approve option reads "Continue to <next_stage>" verbatim
   // instead of a guessed constant. Computed here at emit time: the gate is

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.14";

--- a/dist/kiro-ide/.kiro/tools/aidlc-directive.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-directive.ts
@@ -55,6 +55,14 @@ export type DirectiveKind =
 // are read straight off the compiled stage-graph.json node; consumes/produces
 // carry RESOLVED aidlc-docs/... paths (the engine resolves vocabulary names →
 // paths at emit time; the conductor never re-derives them).
+
+// One rules_in_context file, with its on-disk content baked in. `path` is the
+// same projectDir-relative path that appears in rules_in_context; `text` is the
+// file's full contents at emit time. See RunStageDirective.rules_content.
+export interface RuleContent {
+  path: string;
+  text: string;
+}
 export interface RunStageDirective {
   kind: "run-stage";
   stage: string;
@@ -100,6 +108,18 @@ export interface RunStageDirective {
   // in-context, with no skill referencing that file by path. Absent on every
   // later directive (the persona persists in the session once delivered).
   conductor_persona?: string;
+  // rules_content — the CONTENT of each rules_in_context file that exists on
+  // disk with substantive (non-placeholder) text, read by the engine at
+  // directive-build time and injected here so the conductor receives its
+  // per-stage steering in-context WITHOUT having to read each path itself
+  // (the read was prose-only and skipped non-deterministically in live runs).
+  // Mirrors conductor_persona's deterministic-injection pattern. rules_in_context
+  // (the paths) is unchanged and authoritative; rules_content is an additive
+  // superset covering the files that carried real content. Absent on the
+  // ctx-less emit path (no projectDir to resolve/read against) and whenever no
+  // resolved rule file has substantive content — the directive stays
+  // well-formed without it.
+  rules_content?: RuleContent[];
   // next_stage: the display name of the in-scope stage that FOLLOWS this one,
   // resolved by the engine so the approval gate's Approve option can read
   // "Continue to <next_stage>" verbatim. null = this is the final in-scope
@@ -294,6 +314,7 @@ const RUN_STAGE_FIELDS = [
   "reviewer",
   "reviewer_max_iterations",
   "conductor_persona",
+  "rules_content",
   "next_stage",
   "unit",
   "consumes_absent",
@@ -456,6 +477,9 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // rules_content: optional (present only on the live emit path when at least one
+  // rules_in_context file had substantive content). Each entry {path, text}.
+  checkOptionalRulesContent(o, "rules_content", kind, errors);
   // next_stage: optional-nullable on a run-stage directive. Present as a string
   // names the following in-scope stage; null means this is the final in-scope
   // stage; absent carries no name. So string OR null validates; any other
@@ -615,6 +639,42 @@ function checkOptionalConsumesAbsent(
     if (typeof item.expected !== "boolean") {
       errors.push(
         `${kind}: ${field}[${i}].expected must be boolean, got ${describe(item.expected)}`,
+      );
+    }
+  });
+}
+
+// rules_content — optional (present only on the live emit path with at least
+// one substantive rule file). Each entry must be {path: string, text: string}.
+// Mirrors checkOptionalConsumesAbsent's shape discipline.
+function checkOptionalRulesContent(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o)) return;
+  const v: unknown = o[field];
+  if (!Array.isArray(v)) {
+    errors.push(`${kind}: ${field} must be array, got ${describe(v)}`);
+    return;
+  }
+  const arr: unknown[] = v;
+  arr.forEach((item: unknown, i: number) => {
+    if (!isPlainObject(item)) {
+      errors.push(
+        `${kind}: ${field}[${i}] must be object, got ${describe(item)}`,
+      );
+      return;
+    }
+    if (typeof item.path !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].path must be string, got ${describe(item.path)}`,
+      );
+    }
+    if (typeof item.text !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].text must be string, got ${describe(item.text)}`,
       );
     }
   });

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -78,6 +78,7 @@ import {
   type GateValue,
   type ParkedDirective,
   type PrintDirective,
+  type RuleContent,
   type RunStageDirective,
   validateDirective,
 } from "./aidlc-directive.ts";
@@ -1290,6 +1291,42 @@ function inlineContextPaths(node: GraphStage, codekbCtx?: CodekbCtx): string[] {
   return [...new Set(paths)];
 }
 
+// A rule file is "substantive" when it carries at least one content line —
+// something other than a blank line, a Markdown heading, an HTML comment, or a
+// blockquote. The shipped team.md / project.md seeds are pure scaffolding
+// (heading + `>` guidance + `<!-- ... -->` examples, no affirmed rules), so this
+// drops them; org.md / phases/<phase>.md, which carry real rules, pass. Keeping
+// placeholders out of rules_content avoids injecting empty noise into every
+// directive.
+function ruleTextIsSubstantive(text: string): boolean {
+  return text.split("\n").some((line) => {
+    const t = line.trim();
+    if (t === "") return false;
+    if (t.startsWith("#")) return false; // heading
+    if (t.startsWith(">")) return false; // blockquote (seed guidance)
+    if (t.startsWith("<!--") || t.startsWith("-->")) return false; // HTML comment fence
+    return true;
+  });
+}
+
+// Read one rules_in_context file (a projectDir-relative path) and return its
+// content, or null when the file is absent, unreadable, or placeholder-only.
+// Path resolution mirrors splitConsumesByPresence: join(projectDir, ...split("/"))
+// so it is OS-correct and cwd-independent. Best-effort by design — a missing or
+// placeholder rule is not a routing error; the directive stays well-formed
+// without its entry. See RunStageDirective.rules_content.
+function readRuleContent(projectDir: string, relPath: string): RuleContent | null {
+  const abs = join(projectDir, ...relPath.split("/"));
+  if (!existsSync(abs)) return null;
+  try {
+    const text = readFileSync(abs, "utf-8");
+    if (!ruleTextIsSubstantive(text)) return null;
+    return { path: relPath, text };
+  } catch {
+    return null;
+  }
+}
+
 // Build a run-stage directive by reading the routing fields straight off the
 // compiled graph node. consumes/produces carry resolved active-record paths:
 // the engine resolves the node's vocabulary names → paths at emit time (so the
@@ -1335,6 +1372,19 @@ function buildRunStageDirective(
     stage_file: stageFileFor(node.phase, node.slug),
   };
   if (absent.length > 0) directive.consumes_absent = absent;
+  // rules_content — deterministically inject the CONTENT of each rules_in_context
+  // file so per-stage steering reaches the conductor without depending on it
+  // reading each path (the read is prose-only and was observed skipped across
+  // whole stages). Only on the live path (codekbCtx present gives the projectDir
+  // base); the ctx-less test/default path stays byte-identical, mirroring
+  // splitConsumesByPresence's own no-ctx skip. Placeholder-only files (team.md /
+  // project.md seeds) are dropped by readRuleContent.
+  if (codekbCtx) {
+    const rulesContent = (node.rules_in_context ?? [])
+      .map((r) => readRuleContent(codekbCtx.projectDir, r.path))
+      .filter((r): r is RuleContent => r !== null);
+    if (rulesContent.length > 0) directive.rules_content = rulesContent;
+  }
   // next_stage: the display name of the in-scope stage that follows this one, so
   // the approval gate's Approve option reads "Continue to <next_stage>" verbatim
   // instead of a guessed constant. Computed here at emit time: the gate is

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.14";

--- a/dist/kiro/.kiro/tools/aidlc-directive.ts
+++ b/dist/kiro/.kiro/tools/aidlc-directive.ts
@@ -55,6 +55,14 @@ export type DirectiveKind =
 // are read straight off the compiled stage-graph.json node; consumes/produces
 // carry RESOLVED aidlc-docs/... paths (the engine resolves vocabulary names →
 // paths at emit time; the conductor never re-derives them).
+
+// One rules_in_context file, with its on-disk content baked in. `path` is the
+// same projectDir-relative path that appears in rules_in_context; `text` is the
+// file's full contents at emit time. See RunStageDirective.rules_content.
+export interface RuleContent {
+  path: string;
+  text: string;
+}
 export interface RunStageDirective {
   kind: "run-stage";
   stage: string;
@@ -100,6 +108,18 @@ export interface RunStageDirective {
   // in-context, with no skill referencing that file by path. Absent on every
   // later directive (the persona persists in the session once delivered).
   conductor_persona?: string;
+  // rules_content — the CONTENT of each rules_in_context file that exists on
+  // disk with substantive (non-placeholder) text, read by the engine at
+  // directive-build time and injected here so the conductor receives its
+  // per-stage steering in-context WITHOUT having to read each path itself
+  // (the read was prose-only and skipped non-deterministically in live runs).
+  // Mirrors conductor_persona's deterministic-injection pattern. rules_in_context
+  // (the paths) is unchanged and authoritative; rules_content is an additive
+  // superset covering the files that carried real content. Absent on the
+  // ctx-less emit path (no projectDir to resolve/read against) and whenever no
+  // resolved rule file has substantive content — the directive stays
+  // well-formed without it.
+  rules_content?: RuleContent[];
   // next_stage: the display name of the in-scope stage that FOLLOWS this one,
   // resolved by the engine so the approval gate's Approve option can read
   // "Continue to <next_stage>" verbatim. null = this is the final in-scope
@@ -294,6 +314,7 @@ const RUN_STAGE_FIELDS = [
   "reviewer",
   "reviewer_max_iterations",
   "conductor_persona",
+  "rules_content",
   "next_stage",
   "unit",
   "consumes_absent",
@@ -456,6 +477,9 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // rules_content: optional (present only on the live emit path when at least one
+  // rules_in_context file had substantive content). Each entry {path, text}.
+  checkOptionalRulesContent(o, "rules_content", kind, errors);
   // next_stage: optional-nullable on a run-stage directive. Present as a string
   // names the following in-scope stage; null means this is the final in-scope
   // stage; absent carries no name. So string OR null validates; any other
@@ -615,6 +639,42 @@ function checkOptionalConsumesAbsent(
     if (typeof item.expected !== "boolean") {
       errors.push(
         `${kind}: ${field}[${i}].expected must be boolean, got ${describe(item.expected)}`,
+      );
+    }
+  });
+}
+
+// rules_content — optional (present only on the live emit path with at least
+// one substantive rule file). Each entry must be {path: string, text: string}.
+// Mirrors checkOptionalConsumesAbsent's shape discipline.
+function checkOptionalRulesContent(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o)) return;
+  const v: unknown = o[field];
+  if (!Array.isArray(v)) {
+    errors.push(`${kind}: ${field} must be array, got ${describe(v)}`);
+    return;
+  }
+  const arr: unknown[] = v;
+  arr.forEach((item: unknown, i: number) => {
+    if (!isPlainObject(item)) {
+      errors.push(
+        `${kind}: ${field}[${i}] must be object, got ${describe(item)}`,
+      );
+      return;
+    }
+    if (typeof item.path !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].path must be string, got ${describe(item.path)}`,
+      );
+    }
+    if (typeof item.text !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].text must be string, got ${describe(item.text)}`,
       );
     }
   });

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -78,6 +78,7 @@ import {
   type GateValue,
   type ParkedDirective,
   type PrintDirective,
+  type RuleContent,
   type RunStageDirective,
   validateDirective,
 } from "./aidlc-directive.ts";
@@ -1290,6 +1291,42 @@ function inlineContextPaths(node: GraphStage, codekbCtx?: CodekbCtx): string[] {
   return [...new Set(paths)];
 }
 
+// A rule file is "substantive" when it carries at least one content line —
+// something other than a blank line, a Markdown heading, an HTML comment, or a
+// blockquote. The shipped team.md / project.md seeds are pure scaffolding
+// (heading + `>` guidance + `<!-- ... -->` examples, no affirmed rules), so this
+// drops them; org.md / phases/<phase>.md, which carry real rules, pass. Keeping
+// placeholders out of rules_content avoids injecting empty noise into every
+// directive.
+function ruleTextIsSubstantive(text: string): boolean {
+  return text.split("\n").some((line) => {
+    const t = line.trim();
+    if (t === "") return false;
+    if (t.startsWith("#")) return false; // heading
+    if (t.startsWith(">")) return false; // blockquote (seed guidance)
+    if (t.startsWith("<!--") || t.startsWith("-->")) return false; // HTML comment fence
+    return true;
+  });
+}
+
+// Read one rules_in_context file (a projectDir-relative path) and return its
+// content, or null when the file is absent, unreadable, or placeholder-only.
+// Path resolution mirrors splitConsumesByPresence: join(projectDir, ...split("/"))
+// so it is OS-correct and cwd-independent. Best-effort by design — a missing or
+// placeholder rule is not a routing error; the directive stays well-formed
+// without its entry. See RunStageDirective.rules_content.
+function readRuleContent(projectDir: string, relPath: string): RuleContent | null {
+  const abs = join(projectDir, ...relPath.split("/"));
+  if (!existsSync(abs)) return null;
+  try {
+    const text = readFileSync(abs, "utf-8");
+    if (!ruleTextIsSubstantive(text)) return null;
+    return { path: relPath, text };
+  } catch {
+    return null;
+  }
+}
+
 // Build a run-stage directive by reading the routing fields straight off the
 // compiled graph node. consumes/produces carry resolved active-record paths:
 // the engine resolves the node's vocabulary names → paths at emit time (so the
@@ -1335,6 +1372,19 @@ function buildRunStageDirective(
     stage_file: stageFileFor(node.phase, node.slug),
   };
   if (absent.length > 0) directive.consumes_absent = absent;
+  // rules_content — deterministically inject the CONTENT of each rules_in_context
+  // file so per-stage steering reaches the conductor without depending on it
+  // reading each path (the read is prose-only and was observed skipped across
+  // whole stages). Only on the live path (codekbCtx present gives the projectDir
+  // base); the ctx-less test/default path stays byte-identical, mirroring
+  // splitConsumesByPresence's own no-ctx skip. Placeholder-only files (team.md /
+  // project.md seeds) are dropped by readRuleContent.
+  if (codekbCtx) {
+    const rulesContent = (node.rules_in_context ?? [])
+      .map((r) => readRuleContent(codekbCtx.projectDir, r.path))
+      .filter((r): r is RuleContent => r !== null);
+    if (rulesContent.length > 0) directive.rules_content = rulesContent;
+  }
   // next_stage: the display name of the in-scope stage that follows this one, so
   // the approval gate's Approve option reads "Continue to <next_stage>" verbatim
   // instead of a guessed constant. Computed here at emit time: the gate is

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.14";

--- a/dist/opencode/.aidlc/tools/aidlc-directive.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-directive.ts
@@ -55,6 +55,14 @@ export type DirectiveKind =
 // are read straight off the compiled stage-graph.json node; consumes/produces
 // carry RESOLVED aidlc-docs/... paths (the engine resolves vocabulary names →
 // paths at emit time; the conductor never re-derives them).
+
+// One rules_in_context file, with its on-disk content baked in. `path` is the
+// same projectDir-relative path that appears in rules_in_context; `text` is the
+// file's full contents at emit time. See RunStageDirective.rules_content.
+export interface RuleContent {
+  path: string;
+  text: string;
+}
 export interface RunStageDirective {
   kind: "run-stage";
   stage: string;
@@ -100,6 +108,18 @@ export interface RunStageDirective {
   // in-context, with no skill referencing that file by path. Absent on every
   // later directive (the persona persists in the session once delivered).
   conductor_persona?: string;
+  // rules_content — the CONTENT of each rules_in_context file that exists on
+  // disk with substantive (non-placeholder) text, read by the engine at
+  // directive-build time and injected here so the conductor receives its
+  // per-stage steering in-context WITHOUT having to read each path itself
+  // (the read was prose-only and skipped non-deterministically in live runs).
+  // Mirrors conductor_persona's deterministic-injection pattern. rules_in_context
+  // (the paths) is unchanged and authoritative; rules_content is an additive
+  // superset covering the files that carried real content. Absent on the
+  // ctx-less emit path (no projectDir to resolve/read against) and whenever no
+  // resolved rule file has substantive content — the directive stays
+  // well-formed without it.
+  rules_content?: RuleContent[];
   // next_stage: the display name of the in-scope stage that FOLLOWS this one,
   // resolved by the engine so the approval gate's Approve option can read
   // "Continue to <next_stage>" verbatim. null = this is the final in-scope
@@ -294,6 +314,7 @@ const RUN_STAGE_FIELDS = [
   "reviewer",
   "reviewer_max_iterations",
   "conductor_persona",
+  "rules_content",
   "next_stage",
   "unit",
   "consumes_absent",
@@ -456,6 +477,9 @@ function checkRunStageShared(
   checkStringArray(o, "sensors_applicable", kind, errors);
   checkString(o, "stage_file", kind, errors);
   checkOptionalString(o, "conductor_persona", kind, errors);
+  // rules_content: optional (present only on the live emit path when at least one
+  // rules_in_context file had substantive content). Each entry {path, text}.
+  checkOptionalRulesContent(o, "rules_content", kind, errors);
   // next_stage: optional-nullable on a run-stage directive. Present as a string
   // names the following in-scope stage; null means this is the final in-scope
   // stage; absent carries no name. So string OR null validates; any other
@@ -615,6 +639,42 @@ function checkOptionalConsumesAbsent(
     if (typeof item.expected !== "boolean") {
       errors.push(
         `${kind}: ${field}[${i}].expected must be boolean, got ${describe(item.expected)}`,
+      );
+    }
+  });
+}
+
+// rules_content — optional (present only on the live emit path with at least
+// one substantive rule file). Each entry must be {path: string, text: string}.
+// Mirrors checkOptionalConsumesAbsent's shape discipline.
+function checkOptionalRulesContent(
+  o: Record<string, unknown>,
+  field: string,
+  kind: DirectiveKind,
+  errors: string[],
+): void {
+  if (!(field in o)) return;
+  const v: unknown = o[field];
+  if (!Array.isArray(v)) {
+    errors.push(`${kind}: ${field} must be array, got ${describe(v)}`);
+    return;
+  }
+  const arr: unknown[] = v;
+  arr.forEach((item: unknown, i: number) => {
+    if (!isPlainObject(item)) {
+      errors.push(
+        `${kind}: ${field}[${i}] must be object, got ${describe(item)}`,
+      );
+      return;
+    }
+    if (typeof item.path !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].path must be string, got ${describe(item.path)}`,
+      );
+    }
+    if (typeof item.text !== "string") {
+      errors.push(
+        `${kind}: ${field}[${i}].text must be string, got ${describe(item.text)}`,
       );
     }
   });

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -78,6 +78,7 @@ import {
   type GateValue,
   type ParkedDirective,
   type PrintDirective,
+  type RuleContent,
   type RunStageDirective,
   validateDirective,
 } from "./aidlc-directive.ts";
@@ -1290,6 +1291,42 @@ function inlineContextPaths(node: GraphStage, codekbCtx?: CodekbCtx): string[] {
   return [...new Set(paths)];
 }
 
+// A rule file is "substantive" when it carries at least one content line —
+// something other than a blank line, a Markdown heading, an HTML comment, or a
+// blockquote. The shipped team.md / project.md seeds are pure scaffolding
+// (heading + `>` guidance + `<!-- ... -->` examples, no affirmed rules), so this
+// drops them; org.md / phases/<phase>.md, which carry real rules, pass. Keeping
+// placeholders out of rules_content avoids injecting empty noise into every
+// directive.
+function ruleTextIsSubstantive(text: string): boolean {
+  return text.split("\n").some((line) => {
+    const t = line.trim();
+    if (t === "") return false;
+    if (t.startsWith("#")) return false; // heading
+    if (t.startsWith(">")) return false; // blockquote (seed guidance)
+    if (t.startsWith("<!--") || t.startsWith("-->")) return false; // HTML comment fence
+    return true;
+  });
+}
+
+// Read one rules_in_context file (a projectDir-relative path) and return its
+// content, or null when the file is absent, unreadable, or placeholder-only.
+// Path resolution mirrors splitConsumesByPresence: join(projectDir, ...split("/"))
+// so it is OS-correct and cwd-independent. Best-effort by design — a missing or
+// placeholder rule is not a routing error; the directive stays well-formed
+// without its entry. See RunStageDirective.rules_content.
+function readRuleContent(projectDir: string, relPath: string): RuleContent | null {
+  const abs = join(projectDir, ...relPath.split("/"));
+  if (!existsSync(abs)) return null;
+  try {
+    const text = readFileSync(abs, "utf-8");
+    if (!ruleTextIsSubstantive(text)) return null;
+    return { path: relPath, text };
+  } catch {
+    return null;
+  }
+}
+
 // Build a run-stage directive by reading the routing fields straight off the
 // compiled graph node. consumes/produces carry resolved active-record paths:
 // the engine resolves the node's vocabulary names → paths at emit time (so the
@@ -1335,6 +1372,19 @@ function buildRunStageDirective(
     stage_file: stageFileFor(node.phase, node.slug),
   };
   if (absent.length > 0) directive.consumes_absent = absent;
+  // rules_content — deterministically inject the CONTENT of each rules_in_context
+  // file so per-stage steering reaches the conductor without depending on it
+  // reading each path (the read is prose-only and was observed skipped across
+  // whole stages). Only on the live path (codekbCtx present gives the projectDir
+  // base); the ctx-less test/default path stays byte-identical, mirroring
+  // splitConsumesByPresence's own no-ctx skip. Placeholder-only files (team.md /
+  // project.md seeds) are dropped by readRuleContent.
+  if (codekbCtx) {
+    const rulesContent = (node.rules_in_context ?? [])
+      .map((r) => readRuleContent(codekbCtx.projectDir, r.path))
+      .filter((r): r is RuleContent => r !== null);
+    if (rulesContent.length > 0) directive.rules_content = rulesContent;
+  }
   // next_stage: the display name of the in-scope stage that follows this one, so
   // the approval gate's Approve option reads "Continue to <next_stage>" verbatim
   // instead of a guessed constant. Computed here at emit time: the gate is

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.11";
+export const AIDLC_VERSION = "2.5.14";

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -96,7 +96,6 @@ delivered (`reviewer_max_iterations` + HITL escalation, reading
 
 ## Known gaps not on the minor ladder
 
-- Rules enforcement (#495): `rules_in_context` paths are emitted but nothing forces the conductor to read them; quietly undermines Goal 2 at runtime.
 - Stage-level rules layer (`aidlc-stage-<slug>.md`): reserved, unbuilt (Goal 2).
 - Plugin deferred surfaces: agents/scopes/memory/knowledge projection, `when:` evaluation, marketplace (Goal 2).
 - Sensor blocking severity (#431): sensors are advisory-only; a gate cannot be halted by a machine check (adjacent to Goal 4, deliberately out of 2.4.0).

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -881,6 +881,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t242-state-transition-guard.test.ts",
     "unit/t243-doctor-bundle.test.ts",
     "unit/t247-claim-sources-sensor.test.ts",
+    "unit/t248-directive-rules-content.test.ts",
     "unit/t27.test.ts",
     "unit/t29.test.ts",
     "unit/t30-hook-session-end.test.ts",

--- a/tests/unit/t248-directive-rules-content.test.ts
+++ b/tests/unit/t248-directive-rules-content.test.ts
@@ -1,0 +1,244 @@
+// covers: subcommand:aidlc-orchestrate:next
+//
+// t248 — rules_content: the run-stage directive carries the CONTENT of each
+// resolved rule file, not just its path (#495). Mechanism = cli.
+//
+// The defect: `buildRunStageDirective` shipped `rules_in_context` as paths only
+// and nothing in the engine forced the conductor to read them, so per-stage
+// steering (org / phase memory) could be skipped silently. The fix mirrors the
+// existing `conductor_persona` injection: the engine reads each resolved rule
+// file at directive-build time and bakes its text into a new optional
+// `rules_content` array. `rules_in_context` is unchanged and stays
+// authoritative; `rules_content` is an additive superset over the files that
+// carried real content.
+//
+// Source under test (dist/claude/.claude/tools/aidlc-orchestrate.ts):
+//   ruleTextIsSubstantive(text)   — a rule file counts only when it has at least
+//                                   one line that is not blank / heading / `>`
+//                                   blockquote / HTML-comment fence. The shipped
+//                                   team.md + project.md seeds are pure
+//                                   scaffolding and are therefore dropped.
+//   readRuleContent(dir, relPath) — best-effort read; null on absent,
+//                                   unreadable, or placeholder-only.
+//   buildRunStageDirective(...)   — injects rules_content ONLY when codekbCtx is
+//                                   present (the live path supplies projectDir)
+//                                   and at least one file was substantive.
+// None are exported, so the behaviour is observable only on the directive the
+// spawned engine writes to stdout — hence MECHANISM = cli, matching t116's
+// vehicle for the same builder.
+//
+// VEHICLE (same as t116): seed a fixture project, pivot `Current Stage` to the
+// target slug, flip its checkbox to in-flight `[-]`, then run bare `next`. That
+// lands Branch 10 and emits a run-stage for the target with rules resolved.
+//
+// NOTE on the fixture: createTestProject() only MKDIRs the memory dir — it does
+// not populate it (seedWorkspaceShell creates the cursors + registry, not the
+// method tree). The shipped rule layers must be copied in from AIDLC_MEMORY_SRC,
+// exactly as setupIntegrationProject does. Without that copy every
+// rules_in_context path resolves to a missing file and rules_content is
+// correctly absent — which is itself the "6: no memory tree" case below.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, cpSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  AIDLC_MEMORY_SRC,
+  cleanupTestProject,
+  createTestProject,
+  DEFAULT_SPACE,
+  resetAidlcEnv,
+  seededStateFile,
+  seedStateFile,
+  sedReplaceInFile,
+} from "../harness/fixtures.ts";
+
+const BUN = process.execPath;
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const ORCH = join(
+  REPO_ROOT,
+  "dist",
+  "claude",
+  ".claude",
+  "tools",
+  "aidlc-orchestrate.ts",
+);
+const FIXTURES_DIR = join(REPO_ROOT, "tests", "fixtures");
+
+// The memory layer the workspace shell seeds, projectDir-relative — the same
+// form rules_in_context (and therefore rules_content[].path) uses.
+const MEM = `aidlc/spaces/${DEFAULT_SPACE}/memory`;
+const ORG = `${MEM}/org.md`;
+const TEAM = `${MEM}/team.md`;
+const PROJECT = `${MEM}/project.md`;
+
+resetAidlcEnv();
+
+const tempDirs: string[] = [];
+afterAll(() => {
+  for (const d of tempDirs) cleanupTestProject(d);
+});
+
+interface RuleContent {
+  path: string;
+  text: string;
+}
+interface RunStageDirective {
+  kind: string;
+  stage: string;
+  rules_in_context: string[];
+  rules_content?: RuleContent[];
+}
+
+/**
+ * Seed a fresh project from `fixture` WITH the shipped method tree, optionally
+ * mutate its memory layer, pivot to `slug`, and return the parsed run-stage
+ * directive from a bare `next`. Pass `seedMemory: false` to leave the memory dir
+ * empty (the no-rules-on-disk case).
+ */
+function emitFor(
+  fixture: string,
+  slug: string,
+  mutate?: (proj: string) => void,
+  seedMemory = true,
+): RunStageDirective {
+  const proj = createTestProject();
+  tempDirs.push(proj);
+  // The rule layers live at the dist tree root beside .claude/; copy them in so
+  // the resolved rules_in_context paths point at real files (setupIntegrationProject
+  // does the same).
+  if (seedMemory) {
+    cpSync(AIDLC_MEMORY_SRC, join(proj, "aidlc"), { recursive: true });
+  }
+  seedStateFile(proj, join(FIXTURES_DIR, fixture));
+  mutate?.(proj);
+  const state = seededStateFile(proj);
+  sedReplaceInFile(
+    state,
+    /^- \*\*Current Stage\*\*:.*$/m,
+    `- **Current Stage**: ${slug}`,
+  );
+  sedReplaceInFile(
+    state,
+    new RegExp(`^- \\[.\\] ${slug} — EXECUTE`, "m"),
+    `- [-] ${slug} — EXECUTE`,
+  );
+  const res = spawnSync(BUN, [ORCH, "next", "--project-dir", proj], {
+    encoding: "utf-8",
+    env: (() => {
+      const e = { ...process.env };
+      delete e.AWS_AIDLC_DEFAULT_SCOPE;
+      return e;
+    })(),
+  });
+  let dir: RunStageDirective;
+  try {
+    dir = JSON.parse((res.stdout ?? "").trim());
+  } catch {
+    throw new Error(
+      `emitFor(${fixture}, ${slug}) emitted no parseable JSON. status=${res.status}\n${res.stdout ?? ""}${res.stderr ?? ""}`,
+    );
+  }
+  expect(dir.kind).toBe("run-stage");
+  expect(dir.stage).toBe(slug);
+  return dir;
+}
+
+/** The rules_content entry for a projectDir-relative rule path, if present. */
+function entryFor(dir: RunStageDirective, path: string): RuleContent | undefined {
+  return (dir.rules_content ?? []).find((r) => r.path === path);
+}
+
+describe("t248 run-stage rules_content (#495 — steering arrives as content, not a path)", () => {
+  // === 1. the field exists on a live emit, and carries real text ============
+  test("1: a live run-stage carries rules_content with the org rule's full text", () => {
+    const dir = emitFor("state-brownfield-feature.md", "application-design");
+    expect(dir.rules_content).toBeDefined();
+    const org = entryFor(dir, ORG);
+    expect(org, `${ORG} must appear in rules_content`).toBeDefined();
+    // Not a path, not a stub: the shipped org.md body, verbatim from disk.
+    expect((org as RuleContent).text.length).toBeGreaterThan(100);
+    expect((org as RuleContent).text).toContain("## ");
+  });
+
+  // === 2. rules_in_context stays authoritative and unchanged ===============
+  test("2: every rules_content path is one of the resolved rules_in_context paths", () => {
+    const dir = emitFor("state-brownfield-feature.md", "application-design");
+    // rules_content is a SUBSET of rules_in_context (the substantive files) —
+    // it never introduces a path the roster does not already carry.
+    for (const entry of dir.rules_content ?? []) {
+      expect(dir.rules_in_context, `${entry.path} must be in rules_in_context`).toContain(
+        entry.path,
+      );
+    }
+    // The paths roster itself is unaffected by the injection.
+    expect(dir.rules_in_context).toContain(ORG);
+    expect(dir.rules_in_context).toContain(TEAM);
+    expect(dir.rules_in_context).toContain(PROJECT);
+  });
+
+  // === 3. placeholder-only seeds are dropped ===============================
+  test("3: the shipped team.md / project.md seeds are excluded (scaffolding only)", () => {
+    const dir = emitFor("state-brownfield-feature.md", "application-design");
+    // Both are RESOLVED (they are in the roster) but carry no affirmed rule, so
+    // injecting them would put pure noise — headings, `>` guidance, and HTML
+    // comment examples — into every directive.
+    expect(entryFor(dir, TEAM)).toBeUndefined();
+    expect(entryFor(dir, PROJECT)).toBeUndefined();
+  });
+
+  // === 4. a team rule with real content IS injected ========================
+  test("4: team.md is injected once it carries an affirmed rule", () => {
+    const marker = "ALWAYS write commit messages in imperative mood.";
+    const dir = emitFor("state-brownfield-feature.md", "application-design", (proj) => {
+      appendFileSync(
+        join(proj, ...TEAM.split("/")),
+        `\n## Affirmed\n\n- ${marker}\n`,
+        "utf-8",
+      );
+    });
+    const team = entryFor(dir, TEAM);
+    expect(team, "a substantive team.md must be injected").toBeDefined();
+    expect((team as RuleContent).text).toContain(marker);
+  });
+
+  // === 5. an emptied rule file drops out without breaking the directive ====
+  test("5: an emptied org.md drops from rules_content, directive stays well-formed", () => {
+    const dir = emitFor("state-brownfield-feature.md", "application-design", (proj) => {
+      // Heading + blockquote + comment only — the placeholder shape.
+      writeFileSync(
+        join(proj, ...ORG.split("/")),
+        "# Org Rules\n\n> Guidance for this layer.\n\n<!-- example -->\n",
+        "utf-8",
+      );
+    });
+    expect(entryFor(dir, ORG)).toBeUndefined();
+    // The roster still names it — resolution is unchanged, only the content
+    // injection self-gates.
+    expect(dir.rules_in_context).toContain(ORG);
+    expect(dir.kind).toBe("run-stage");
+  });
+
+  // === 6. the phase rule follows the stage's phase =========================
+  test("6: the injected phase rule is the one matching the stage's phase", () => {
+    const dir = emitFor("state-brownfield-feature.md", "application-design");
+    // application-design is an INCEPTION stage, so phases/inception.md is the
+    // attached phase rule — not ideation's.
+    const phaseRule = `${MEM}/phases/inception.md`;
+    expect(dir.rules_in_context).toContain(phaseRule);
+    const entry = entryFor(dir, phaseRule);
+    expect(entry, "the stage's phase rule must be injected").toBeDefined();
+    expect((entry as RuleContent).text.length).toBeGreaterThan(0);
+  });
+
+  // === 7. no memory tree on disk — resolution unchanged, no field ==========
+  test("7: with no rule files on disk the field is absent and routing is unaffected", () => {
+    const dir = emitFor("state-brownfield-feature.md", "application-design", undefined, false);
+    // Every resolved path is missing, so nothing is injected. The roster and the
+    // directive kind are untouched: the injection is strictly additive and never
+    // a routing error.
+    expect(dir.rules_content).toBeUndefined();
+    expect(dir.rules_in_context).toContain(ORG);
+    expect(dir.kind).toBe("run-stage");
+  });
+});


### PR DESCRIPTION
Fixes #495.

`buildRunStageDirective` ships `rules_in_context` as paths only, and nothing in
the engine forces the conductor to read them. Per-stage steering could therefore
be skipped silently — the paths listed, the files present with substantive
content, the artifacts written without them.

The engine already has the pattern this needs, twelve lines below the defect:
`conductor_persona` is delivered by reading `aidlc-common/conductor.md` at
directive-build time and baking in its contents, so no skill references it by
path. This applies the same treatment to the rule layers.

## The change

- **`aidlc-directive.ts`** — new `RuleContent` type; optional
  `rules_content?: RuleContent[]` on `run-stage`, registered in
  `RUN_STAGE_FIELDS`, validated by `checkOptionalRulesContent` (shape discipline
  mirrors `checkOptionalConsumesAbsent`).
- **`aidlc-orchestrate.ts`** — `readRuleContent` reads each resolved path
  best-effort; absent, unreadable, or placeholder-only yields no entry. Gated on
  `codekbCtx` so the ctx-less emit path stays byte-identical, mirroring
  `splitConsumesByPresence`'s own no-ctx skip.
- **`ruleTextIsSubstantive`** drops files whose every line is blank, a heading, a
  `>` blockquote, or an HTML-comment fence — the exact shape of the shipped
  `team.md` / `project.md` seeds, so an untouched install gains no directive
  noise. They appear as soon as they carry a real rule.

`rules_in_context` is unchanged and remains the authoritative roster;
`rules_content` is an additive subset over the files that carried content.

**Limitation — this reads the `default` space only.** `readRuleContent` resolves
each entry of `node.rules_in_context`, and those paths are baked by
`memoryDisplayPath()` whenever the graph is compiled — pinned to
`MEMORY_SPACE = "default"`, as is the `rulesDir()` the roster is walked from. Nothing
on this path consults the active-space cursor, so with a cursor on `teamB` the
injected content is still `aidlc/spaces/default/memory/`. That pin is the shipped
COMPILE/DISPLAY-family behaviour documented in `aidlc-graph.ts` and this PR does
not change it — but it is worth stating plainly, because injection makes the
default content deterministic rather than merely listed, and the conductor
demonstrably stops reading paths it has already been given (see the run below).
Making rule resolution cursor-aware is a separate, harness-wide question.

## No skill or protocol prose changes — and a live run explains why

I first rewrote the conductor's "read every file in `rules_in_context`" clause in
all five harness `SKILL.md` files, then measured whether it was needed. It is
not, so I reverted it and this PR touches no prose.

A live Kiro IDE 1.0.212 run, instrumented with a temporary `PreToolUse` probe on
`read_file|read_files` (the framework's own hooks cannot see reads — their
matchers are write/shell only), produced this in a single `read_files` call at
`intent-capture`:

| rule file | in `rules_content` | conductor read it |
|---|---|---|
| `org.md` (5439 chars) | yes | **no** |
| `phases/ideation.md` (1158) | yes | **no** |
| `team.md` (placeholder) | no | yes |
| `project.md` (placeholder) | no | yes |

The read boundary matched `rules_content` membership exactly: the conductor
skipped precisely the two files whose contents it had already received, and read
the two it had not — in the same call as the stage file and stage protocol, so
this was not laziness. Injection adds no duplicate read, and the existing prose
needs no change.

## Tests

New `t248-directive-rules-content.test.ts`, CLI-boundary (the builder has no
exports), 7 tests: content present and verbatim, subset-of-roster, placeholder
exclusion, a substantive `team.md` appearing, an emptied `org.md` dropping out,
the phase rule tracking the stage's phase, and the no-memory-tree case leaving
the field absent with routing unaffected. Registered in the coverage registry's
`none->cli` spawner list (the honesty ratchet requires the explicit edit).

## Verification

- `bun run check` — green (parity 5 harnesses, typecheck, lint 540 files)
- `bun tests/run-tests.ts --smoke --unit` — 178 files, 0 failed, 4395 assertions
- `bun scripts/ci-changelog-guard.ts <base>` — OK, 137 preserved, 1 new
- Fixture emit: `org.md` + `phases/ideation.md` injected, both placeholder seeds
  dropped; adding a rule to `team.md` makes it appear immediately

The integration tier's `t66` and `t89` also fail on base `257b43a3` (2.5.11 added
the `claim-sources` sensor without refreshing the designer-export golden fixture
or the sensor-import fixture dir). Both are outside the PR gate's tiers and
unrelated to this change; happy to file that separately.

Version bumped to 2.5.14 (2.5.12 is #615, 2.5.13 is #653) with a matching
CHANGELOG entry and README badge. `docs/roadmap.md` drops #495 from "Known gaps".

**Scope note:** the two edited files are shared core — byte-identical in all five
`dist/` trees — so the behaviour lands on every harness, not just one. Worth
naming the asymmetry: the harnesses with a native include (Kiro CLI's agent
`resources` glob, Claude's `@`-import stub, Codex's `AIDLC_RULES_DIR`,
opencode's `instructions`) already carry the memory tree in ambient context, so
for them this is a per-stage determinism guarantee over a roster the glob does
not distinguish rather than newly available content. On Kiro IDE, which has no
such native include, the injected content is the deterministic path. In both
cases the determinism is over the `default` space, per the limitation above.

