### PR TITLE
fix: route plugin slash commands through terminal dispatch (v2.5.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.45] - 2026-08-06
+
+Plugin management commands now route deterministically through every `/aidlc` slash-command harness instead of being misread as freeform workflow requests. **Upgrade:** re-copy your `dist/<harness>/` shell into the project so the shared plugin parser and harness routing updates are installed.
+
+* `/aidlc plugin list [--json]`, `/aidlc plugin sync`, and `/aidlc plugin select [names]` now dispatch to their existing utility handlers without asking to compose a scope or advancing an active workflow.
+* `/aidlc plugin help`, a missing plugin verb, and unknown plugin verbs now produce deterministic help or errors across the dispatcher, orchestrator, and Kiro pre-LLM interceptor.
+* Kiro terminal-command interception now latches plugin utilities for the current turn, preventing a conductor retry from rolling the workflow forward after the plugin command completes.
+
 ## [2.5.44] - 2026-08-06
 
 Human-readable AI-DLC artifacts now follow the conversation language instead of defaulting to English. The framework rule layer gains four `## Mandated` rules in `org.md` that define how the conversation language is resolved, why it stays stable across short turns like `Approve`, which artifacts are localized, and which protocol tokens stay English. The rules travel to delegated agents and reviewers inside the active-stage rule bundle the dispatch-rules hook already delivers, so a subagent that never sees the conversation can still resolve the language from the rule layer, `aidlc-state.md`, or the upstream artifacts it consumes. **Upgrade:** fresh installs receive the rules with their seeded `default` space. An existing workspace keeps its own memory tree — runtime self-healing intentionally does not overwrite one — so merge the four rules into each `aidlc/spaces/<space>/memory/org.md` by hand and start a fresh session for them to load.
@@ -166,7 +174,6 @@ Closes the payload boundary 2.5.10 left open on Kiro IDE 1.x: the hook adapter n
 * Payload acquisition is gated to `audit-and-sensors` and `log-subagent`; every other target - including the per-tool-call `block` floor - touches neither channel. `SUBAGENT_COMPLETED` is recorded again on IDE 1.x: that generation sends `subagent_<agent>` rather than the 0.12 `invoke_sub_agent`, so the registration matcher reaches any delegate name, the adapter drops the `subagent_response` shell, and the row's `Agent Type` comes from the platform-provided `subagent_<agent>` tool name - agent-authored result prose can no longer misattribute a completion to another persona, and the `**Reviewer:**` / `**Agent:**` marker remains the identity source on the 0.12 `invoke_sub_agent` shape (#459/#543).
 * Both payload-dependent targets record a visible hook drop when neither channel yields a payload, so a broken context channel surfaces in `/aidlc --doctor` instead of exiting as a silent no-op.
 * Docs updated (`docs/reference/kiro-ide-hook-payload.md` documents both context channels, the timeout override, and scopes empty inputs to captured PostToolUse events; `docs/guide/harnesses/kiro-ide.md`; `docs/reference/06-hooks-and-tools.md`; `docs/roadmap.md` marks only #555's hook-registration portion resolved). No command or flag changes; no breaking change for CI or scripts.
-
 ## [2.5.11] - 2026-07-24
 
 Intent Capture now keeps generated intent and stakeholder claims grounded in the user's description, confirmed answers, workflow-selected scope, or explicitly registered memory. Unsupported content is omitted, elicited, or surfaced as a human-owned assumption instead of being presented as fact. **Upgrade:** re-copy your `dist/<harness>/` shell into the project so the updated stage, Product Lead reviewer contract, and `claim-sources` sensor are installed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.44-blue)
+![version](https://img.shields.io/badge/version-2.5.45-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -680,7 +680,64 @@ export interface TerminalCommand {
   args?: string[];
   error?: string;
   display?: string;
-  source: "read-only-flag" | "workspace-verb";
+  source: "read-only-flag" | "workspace-verb" | "plugin-verb";
+}
+
+export type PluginCommand =
+  | { kind: "not-plugin" }
+  | { kind: "help" }
+  | { kind: "error"; message: string }
+  | { kind: "run"; argv: string[] };
+
+// Parse the public `plugin` noun once for every entrypoint. The slash
+// orchestrator, Kiro's pre-LLM interceptor, and the binary dispatcher must all
+// agree that these are terminal utilities rather than freeform workflow text.
+export function parsePluginCommand(args: string[]): PluginCommand {
+  if (args[0] !== "plugin") return { kind: "not-plugin" };
+  const verb = args[1];
+  if (verb === "help" || verb === "-h" || verb === "--help") {
+    return { kind: "help" };
+  }
+  const target = verb === "select"
+    ? "select-plugins"
+    : verb === "list"
+      ? "plugin-list"
+      : verb === "sync"
+        ? "plugin-sync"
+        : undefined;
+  if (target !== undefined) {
+    return { kind: "run", argv: [target, ...args.slice(2)] };
+  }
+  const detail = verb ? `unknown verb '${verb}'` : "missing verb";
+  return {
+    kind: "error",
+    message: `aidlc: ${detail} for noun 'plugin'; try 'aidlc help --all'`,
+  };
+}
+
+function terminalCommandFromPluginCommand(
+  command: PluginCommand,
+  originalArgs: string[],
+): TerminalCommand | null {
+  if (command.kind === "not-plugin") return null;
+  if (command.kind === "help") {
+    return { subcommand: "help", display: originalArgs.join(" "), source: "plugin-verb" };
+  }
+  if (command.kind === "error") {
+    return {
+      subcommand: "error",
+      error: command.message,
+      display: originalArgs.join(" "),
+      source: "plugin-verb",
+    };
+  }
+  const [subcommand, ...tail] = command.argv;
+  return {
+    subcommand,
+    ...(tail.length > 0 ? { args: tail } : {}),
+    display: originalArgs.join(" "),
+    source: "plugin-verb",
+  };
 }
 
 // The allowlisted trailing flags `--doctor` accepts (diagnostic export). Kept
@@ -753,6 +810,10 @@ export function classifyTerminalCommand(args: string[]): TerminalCommand | null 
   // "help". Sole-token only: `help` inside a longer description stays freeform.
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { subcommand: "help", source: "read-only-flag" };
+  }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") {
+    return terminalCommandFromPluginCommand(pluginCommand, args);
   }
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -113,6 +113,8 @@ import {
   loadScopeMapping,
   nextInScopeStage,
   parseCheckboxes,
+  type PluginCommand,
+  parsePluginCommand,
   parseStateStageSuffixes,
   PHASE_NUMBERS,
   PHASES,
@@ -343,6 +345,7 @@ interface ParsedFlags {
   newIntent?: boolean; // --new-intent: the conductor confirmed new-work alongside an active intent → emit the SAME birth directive (with the --label seam) the fresh-start path uses, instead of constructing intent-birth from SKILL.md prose
   intent?: string; // freeform request text (no leading --flag)
   workspaceCommand?: WorkspaceCommand; // leading workspace command (space/space-create/intent)
+  pluginCommand?: Exclude<PluginCommand, { kind: "not-plugin" }>; // leading plugin noun: terminal list/sync/select/help/error
   compose?: boolean; // leading `compose` verb: force the composer (front or in-flight)
   newScope?: boolean; // --new-scope: force the composer to SYNTHESIZE a custom scope even when a stock scope matches
   report?: string; // --report <path>: compose from a scan report (the composer triages the file)
@@ -366,6 +369,8 @@ function parseNextFlags(args: string[]): ParsedFlags {
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { readOnly: "--help" };
   }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") return { pluginCommand };
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the
   // public grammar promises leading-token semantics.
@@ -2018,7 +2023,7 @@ function handleNext(args: string[], projectDir: string | undefined): void {
   // swallowed. Inert on Claude/Codex: the latch files are never written there (no
   // seam) → fresh is always false → falls through. Advisory: any failure fails
   // open to the normal `next`.
-  if (!flags.readOnly && !flags.workspaceCommand && !flags.stage && !flags.phase &&
+  if (!flags.readOnly && !flags.workspaceCommand && !flags.pluginCommand && !flags.stage && !flags.phase &&
       !flags.scope && !flags.positionalScope && !flags.intent && !flags.resume &&
       !flags.depth && !flags.testStrategy &&
       !flags.single && !flags.compose && !flags.newScope && !flags.report) {
@@ -2104,6 +2109,24 @@ function handleNext(args: string[], projectDir: string | undefined): void {
     const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
     emit(printDirective(
       `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop.`,
+    ));
+    return;
+  }
+
+  // Branch 1c - plugin utilities are terminal commands, never freeform intent
+  // text. The shared parser also feeds the binary dispatcher and Kiro seam, so
+  // every harness preserves the same list/sync/select argv and error grammar.
+  if (flags.pluginCommand) {
+    const command = flags.pluginCommand;
+    if (command.kind === "error") {
+      emit(errorDirective(command.message));
+      return;
+    }
+    const argv = command.kind === "help" ? ["help"] : command.argv;
+    const [verb, ...tail] = argv;
+    const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
+    emit(printDirective(
+      `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop. This is a terminal utility, NOT workflow work: do NOT run \`next\` and do NOT advance, resume, or run any workflow stage.`,
     ));
     return;
   }

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -2042,8 +2042,9 @@ function handleNext(args: string[], projectDir: string | undefined): void {
         const lr = JSON.parse(readFileSync(latchPath, "utf-8")) as { turn?: number; flag?: string; source?: string };
         if (typeof lr.turn === "number") latchTurn = lr.turn;
         if (typeof lr.flag === "string") {
-          // read-only flags render with a leading `--`; workspace verbs are bare.
-          label = lr.source === "workspace-verb" ? `\`${lr.flag}\`` : `--${lr.flag}`;
+          // Read-only flags render with `--`; noun commands render as typed.
+          const nounCommand = lr.source === "workspace-verb" || lr.source === "plugin-verb";
+          label = nounCommand ? `\`${lr.flag}\`` : `--${lr.flag}`;
         }
       }
       if (counter >= 0 && latchTurn === counter) {

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -218,6 +218,7 @@ Utilities:
   config get <key>  Show active workflow config (depth, test-strategy)
   config set <key> <value>  Change active workflow config (depth, test-strategy)
   config list       List active workflow config (--json for structured output)
+  plugin select [names]  Show or set the enabled plugin list
   plugin list       List installed plugins and enabled state (--json for structured output)
   plugin sync       Compose installed plugins into the current install
   --doctor          Run health check on hooks, settings, and directory structure

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.44";
+export const AIDLC_VERSION = "2.5.45";

--- a/core/tools/aidlc.ts
+++ b/core/tools/aidlc.ts
@@ -4,6 +4,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   errorMessage,
+  parsePluginCommand,
   parseWorkspaceCommand,
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
@@ -585,17 +586,18 @@ function handleConfig(route: Route, argv: string[]): Action {
   return nounError("config", key ? `set ${key}` : "set");
 }
 
-function handlePlugin(route: Route, argv: string[]): Action {
-  const verb = argv[1];
-  if (verb === "select") {
-    const target = route.targets?.select ?? "select-plugins";
-    return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+function handlePlugin(argv: string[]): Action {
+  const command = parsePluginCommand(argv);
+  if (command.kind === "help") {
+    return { type: "help", all: false };
   }
-  if (verb === "sync" || verb === "list") {
-    const target = route.targets?.[verb];
-    if (target) return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+  if (command.kind === "error") {
+    return { type: "error", code: 1, message: `${command.message}\n` };
   }
-  return nounError("plugin", verb);
+  if (command.kind === "run") {
+    return { type: "delegate", tool: TOOLS.utility, args: command.argv };
+  }
+  return nounError("plugin", argv[1]);
 }
 
 function handleGen(argv: string[]): Action {
@@ -623,7 +625,7 @@ function handleGen(argv: string[]): Action {
 function handleCustom(route: Route, argv: string[]): Action {
   if (route.custom === "workspace") return handleWorkspace(argv);
   if (route.custom === "config") return handleConfig(route, argv);
-  if (route.custom === "plugin") return handlePlugin(route, argv);
+  if (route.custom === "plugin") return handlePlugin(argv);
   if (route.custom === "gen") return handleGen(argv);
   return nounError(argv[0], argv[1]);
 }

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -680,7 +680,64 @@ export interface TerminalCommand {
   args?: string[];
   error?: string;
   display?: string;
-  source: "read-only-flag" | "workspace-verb";
+  source: "read-only-flag" | "workspace-verb" | "plugin-verb";
+}
+
+export type PluginCommand =
+  | { kind: "not-plugin" }
+  | { kind: "help" }
+  | { kind: "error"; message: string }
+  | { kind: "run"; argv: string[] };
+
+// Parse the public `plugin` noun once for every entrypoint. The slash
+// orchestrator, Kiro's pre-LLM interceptor, and the binary dispatcher must all
+// agree that these are terminal utilities rather than freeform workflow text.
+export function parsePluginCommand(args: string[]): PluginCommand {
+  if (args[0] !== "plugin") return { kind: "not-plugin" };
+  const verb = args[1];
+  if (verb === "help" || verb === "-h" || verb === "--help") {
+    return { kind: "help" };
+  }
+  const target = verb === "select"
+    ? "select-plugins"
+    : verb === "list"
+      ? "plugin-list"
+      : verb === "sync"
+        ? "plugin-sync"
+        : undefined;
+  if (target !== undefined) {
+    return { kind: "run", argv: [target, ...args.slice(2)] };
+  }
+  const detail = verb ? `unknown verb '${verb}'` : "missing verb";
+  return {
+    kind: "error",
+    message: `aidlc: ${detail} for noun 'plugin'; try 'aidlc help --all'`,
+  };
+}
+
+function terminalCommandFromPluginCommand(
+  command: PluginCommand,
+  originalArgs: string[],
+): TerminalCommand | null {
+  if (command.kind === "not-plugin") return null;
+  if (command.kind === "help") {
+    return { subcommand: "help", display: originalArgs.join(" "), source: "plugin-verb" };
+  }
+  if (command.kind === "error") {
+    return {
+      subcommand: "error",
+      error: command.message,
+      display: originalArgs.join(" "),
+      source: "plugin-verb",
+    };
+  }
+  const [subcommand, ...tail] = command.argv;
+  return {
+    subcommand,
+    ...(tail.length > 0 ? { args: tail } : {}),
+    display: originalArgs.join(" "),
+    source: "plugin-verb",
+  };
 }
 
 // The allowlisted trailing flags `--doctor` accepts (diagnostic export). Kept
@@ -753,6 +810,10 @@ export function classifyTerminalCommand(args: string[]): TerminalCommand | null 
   // "help". Sole-token only: `help` inside a longer description stays freeform.
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { subcommand: "help", source: "read-only-flag" };
+  }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") {
+    return terminalCommandFromPluginCommand(pluginCommand, args);
   }
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -113,6 +113,8 @@ import {
   loadScopeMapping,
   nextInScopeStage,
   parseCheckboxes,
+  type PluginCommand,
+  parsePluginCommand,
   parseStateStageSuffixes,
   PHASE_NUMBERS,
   PHASES,
@@ -343,6 +345,7 @@ interface ParsedFlags {
   newIntent?: boolean; // --new-intent: the conductor confirmed new-work alongside an active intent → emit the SAME birth directive (with the --label seam) the fresh-start path uses, instead of constructing intent-birth from SKILL.md prose
   intent?: string; // freeform request text (no leading --flag)
   workspaceCommand?: WorkspaceCommand; // leading workspace command (space/space-create/intent)
+  pluginCommand?: Exclude<PluginCommand, { kind: "not-plugin" }>; // leading plugin noun: terminal list/sync/select/help/error
   compose?: boolean; // leading `compose` verb: force the composer (front or in-flight)
   newScope?: boolean; // --new-scope: force the composer to SYNTHESIZE a custom scope even when a stock scope matches
   report?: string; // --report <path>: compose from a scan report (the composer triages the file)
@@ -366,6 +369,8 @@ function parseNextFlags(args: string[]): ParsedFlags {
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { readOnly: "--help" };
   }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") return { pluginCommand };
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the
   // public grammar promises leading-token semantics.
@@ -2018,7 +2023,7 @@ function handleNext(args: string[], projectDir: string | undefined): void {
   // swallowed. Inert on Claude/Codex: the latch files are never written there (no
   // seam) → fresh is always false → falls through. Advisory: any failure fails
   // open to the normal `next`.
-  if (!flags.readOnly && !flags.workspaceCommand && !flags.stage && !flags.phase &&
+  if (!flags.readOnly && !flags.workspaceCommand && !flags.pluginCommand && !flags.stage && !flags.phase &&
       !flags.scope && !flags.positionalScope && !flags.intent && !flags.resume &&
       !flags.depth && !flags.testStrategy &&
       !flags.single && !flags.compose && !flags.newScope && !flags.report) {
@@ -2104,6 +2109,24 @@ function handleNext(args: string[], projectDir: string | undefined): void {
     const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
     emit(printDirective(
       `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop.`,
+    ));
+    return;
+  }
+
+  // Branch 1c - plugin utilities are terminal commands, never freeform intent
+  // text. The shared parser also feeds the binary dispatcher and Kiro seam, so
+  // every harness preserves the same list/sync/select argv and error grammar.
+  if (flags.pluginCommand) {
+    const command = flags.pluginCommand;
+    if (command.kind === "error") {
+      emit(errorDirective(command.message));
+      return;
+    }
+    const argv = command.kind === "help" ? ["help"] : command.argv;
+    const [verb, ...tail] = argv;
+    const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
+    emit(printDirective(
+      `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop. This is a terminal utility, NOT workflow work: do NOT run \`next\` and do NOT advance, resume, or run any workflow stage.`,
     ));
     return;
   }

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -2042,8 +2042,9 @@ function handleNext(args: string[], projectDir: string | undefined): void {
         const lr = JSON.parse(readFileSync(latchPath, "utf-8")) as { turn?: number; flag?: string; source?: string };
         if (typeof lr.turn === "number") latchTurn = lr.turn;
         if (typeof lr.flag === "string") {
-          // read-only flags render with a leading `--`; workspace verbs are bare.
-          label = lr.source === "workspace-verb" ? `\`${lr.flag}\`` : `--${lr.flag}`;
+          // Read-only flags render with `--`; noun commands render as typed.
+          const nounCommand = lr.source === "workspace-verb" || lr.source === "plugin-verb";
+          label = nounCommand ? `\`${lr.flag}\`` : `--${lr.flag}`;
         }
       }
       if (counter >= 0 && latchTurn === counter) {

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -218,6 +218,7 @@ Utilities:
   config get <key>  Show active workflow config (depth, test-strategy)
   config set <key> <value>  Change active workflow config (depth, test-strategy)
   config list       List active workflow config (--json for structured output)
+  plugin select [names]  Show or set the enabled plugin list
   plugin list       List installed plugins and enabled state (--json for structured output)
   plugin sync       Compose installed plugins into the current install
   --doctor          Run health check on hooks, settings, and directory structure

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.44";
+export const AIDLC_VERSION = "2.5.45";

--- a/dist/claude/.claude/tools/aidlc.ts
+++ b/dist/claude/.claude/tools/aidlc.ts
@@ -4,6 +4,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   errorMessage,
+  parsePluginCommand,
   parseWorkspaceCommand,
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
@@ -585,17 +586,18 @@ function handleConfig(route: Route, argv: string[]): Action {
   return nounError("config", key ? `set ${key}` : "set");
 }
 
-function handlePlugin(route: Route, argv: string[]): Action {
-  const verb = argv[1];
-  if (verb === "select") {
-    const target = route.targets?.select ?? "select-plugins";
-    return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+function handlePlugin(argv: string[]): Action {
+  const command = parsePluginCommand(argv);
+  if (command.kind === "help") {
+    return { type: "help", all: false };
   }
-  if (verb === "sync" || verb === "list") {
-    const target = route.targets?.[verb];
-    if (target) return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+  if (command.kind === "error") {
+    return { type: "error", code: 1, message: `${command.message}\n` };
   }
-  return nounError("plugin", verb);
+  if (command.kind === "run") {
+    return { type: "delegate", tool: TOOLS.utility, args: command.argv };
+  }
+  return nounError("plugin", argv[1]);
 }
 
 function handleGen(argv: string[]): Action {
@@ -623,7 +625,7 @@ function handleGen(argv: string[]): Action {
 function handleCustom(route: Route, argv: string[]): Action {
   if (route.custom === "workspace") return handleWorkspace(argv);
   if (route.custom === "config") return handleConfig(route, argv);
-  if (route.custom === "plugin") return handlePlugin(route, argv);
+  if (route.custom === "plugin") return handlePlugin(argv);
   if (route.custom === "gen") return handleGen(argv);
   return nounError(argv[0], argv[1]);
 }

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -680,7 +680,64 @@ export interface TerminalCommand {
   args?: string[];
   error?: string;
   display?: string;
-  source: "read-only-flag" | "workspace-verb";
+  source: "read-only-flag" | "workspace-verb" | "plugin-verb";
+}
+
+export type PluginCommand =
+  | { kind: "not-plugin" }
+  | { kind: "help" }
+  | { kind: "error"; message: string }
+  | { kind: "run"; argv: string[] };
+
+// Parse the public `plugin` noun once for every entrypoint. The slash
+// orchestrator, Kiro's pre-LLM interceptor, and the binary dispatcher must all
+// agree that these are terminal utilities rather than freeform workflow text.
+export function parsePluginCommand(args: string[]): PluginCommand {
+  if (args[0] !== "plugin") return { kind: "not-plugin" };
+  const verb = args[1];
+  if (verb === "help" || verb === "-h" || verb === "--help") {
+    return { kind: "help" };
+  }
+  const target = verb === "select"
+    ? "select-plugins"
+    : verb === "list"
+      ? "plugin-list"
+      : verb === "sync"
+        ? "plugin-sync"
+        : undefined;
+  if (target !== undefined) {
+    return { kind: "run", argv: [target, ...args.slice(2)] };
+  }
+  const detail = verb ? `unknown verb '${verb}'` : "missing verb";
+  return {
+    kind: "error",
+    message: `aidlc: ${detail} for noun 'plugin'; try 'aidlc help --all'`,
+  };
+}
+
+function terminalCommandFromPluginCommand(
+  command: PluginCommand,
+  originalArgs: string[],
+): TerminalCommand | null {
+  if (command.kind === "not-plugin") return null;
+  if (command.kind === "help") {
+    return { subcommand: "help", display: originalArgs.join(" "), source: "plugin-verb" };
+  }
+  if (command.kind === "error") {
+    return {
+      subcommand: "error",
+      error: command.message,
+      display: originalArgs.join(" "),
+      source: "plugin-verb",
+    };
+  }
+  const [subcommand, ...tail] = command.argv;
+  return {
+    subcommand,
+    ...(tail.length > 0 ? { args: tail } : {}),
+    display: originalArgs.join(" "),
+    source: "plugin-verb",
+  };
 }
 
 // The allowlisted trailing flags `--doctor` accepts (diagnostic export). Kept
@@ -753,6 +810,10 @@ export function classifyTerminalCommand(args: string[]): TerminalCommand | null 
   // "help". Sole-token only: `help` inside a longer description stays freeform.
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { subcommand: "help", source: "read-only-flag" };
+  }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") {
+    return terminalCommandFromPluginCommand(pluginCommand, args);
   }
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -113,6 +113,8 @@ import {
   loadScopeMapping,
   nextInScopeStage,
   parseCheckboxes,
+  type PluginCommand,
+  parsePluginCommand,
   parseStateStageSuffixes,
   PHASE_NUMBERS,
   PHASES,
@@ -343,6 +345,7 @@ interface ParsedFlags {
   newIntent?: boolean; // --new-intent: the conductor confirmed new-work alongside an active intent → emit the SAME birth directive (with the --label seam) the fresh-start path uses, instead of constructing intent-birth from SKILL.md prose
   intent?: string; // freeform request text (no leading --flag)
   workspaceCommand?: WorkspaceCommand; // leading workspace command (space/space-create/intent)
+  pluginCommand?: Exclude<PluginCommand, { kind: "not-plugin" }>; // leading plugin noun: terminal list/sync/select/help/error
   compose?: boolean; // leading `compose` verb: force the composer (front or in-flight)
   newScope?: boolean; // --new-scope: force the composer to SYNTHESIZE a custom scope even when a stock scope matches
   report?: string; // --report <path>: compose from a scan report (the composer triages the file)
@@ -366,6 +369,8 @@ function parseNextFlags(args: string[]): ParsedFlags {
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { readOnly: "--help" };
   }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") return { pluginCommand };
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the
   // public grammar promises leading-token semantics.
@@ -2018,7 +2023,7 @@ function handleNext(args: string[], projectDir: string | undefined): void {
   // swallowed. Inert on Claude/Codex: the latch files are never written there (no
   // seam) → fresh is always false → falls through. Advisory: any failure fails
   // open to the normal `next`.
-  if (!flags.readOnly && !flags.workspaceCommand && !flags.stage && !flags.phase &&
+  if (!flags.readOnly && !flags.workspaceCommand && !flags.pluginCommand && !flags.stage && !flags.phase &&
       !flags.scope && !flags.positionalScope && !flags.intent && !flags.resume &&
       !flags.depth && !flags.testStrategy &&
       !flags.single && !flags.compose && !flags.newScope && !flags.report) {
@@ -2104,6 +2109,24 @@ function handleNext(args: string[], projectDir: string | undefined): void {
     const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
     emit(printDirective(
       `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop.`,
+    ));
+    return;
+  }
+
+  // Branch 1c - plugin utilities are terminal commands, never freeform intent
+  // text. The shared parser also feeds the binary dispatcher and Kiro seam, so
+  // every harness preserves the same list/sync/select argv and error grammar.
+  if (flags.pluginCommand) {
+    const command = flags.pluginCommand;
+    if (command.kind === "error") {
+      emit(errorDirective(command.message));
+      return;
+    }
+    const argv = command.kind === "help" ? ["help"] : command.argv;
+    const [verb, ...tail] = argv;
+    const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
+    emit(printDirective(
+      `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop. This is a terminal utility, NOT workflow work: do NOT run \`next\` and do NOT advance, resume, or run any workflow stage.`,
     ));
     return;
   }

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -2042,8 +2042,9 @@ function handleNext(args: string[], projectDir: string | undefined): void {
         const lr = JSON.parse(readFileSync(latchPath, "utf-8")) as { turn?: number; flag?: string; source?: string };
         if (typeof lr.turn === "number") latchTurn = lr.turn;
         if (typeof lr.flag === "string") {
-          // read-only flags render with a leading `--`; workspace verbs are bare.
-          label = lr.source === "workspace-verb" ? `\`${lr.flag}\`` : `--${lr.flag}`;
+          // Read-only flags render with `--`; noun commands render as typed.
+          const nounCommand = lr.source === "workspace-verb" || lr.source === "plugin-verb";
+          label = nounCommand ? `\`${lr.flag}\`` : `--${lr.flag}`;
         }
       }
       if (counter >= 0 && latchTurn === counter) {

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -218,6 +218,7 @@ Utilities:
   config get <key>  Show active workflow config (depth, test-strategy)
   config set <key> <value>  Change active workflow config (depth, test-strategy)
   config list       List active workflow config (--json for structured output)
+  plugin select [names]  Show or set the enabled plugin list
   plugin list       List installed plugins and enabled state (--json for structured output)
   plugin sync       Compose installed plugins into the current install
   --doctor          Run health check on hooks, settings, and directory structure

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.44";
+export const AIDLC_VERSION = "2.5.45";

--- a/dist/codex/.codex/tools/aidlc.ts
+++ b/dist/codex/.codex/tools/aidlc.ts
@@ -4,6 +4,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   errorMessage,
+  parsePluginCommand,
   parseWorkspaceCommand,
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
@@ -585,17 +586,18 @@ function handleConfig(route: Route, argv: string[]): Action {
   return nounError("config", key ? `set ${key}` : "set");
 }
 
-function handlePlugin(route: Route, argv: string[]): Action {
-  const verb = argv[1];
-  if (verb === "select") {
-    const target = route.targets?.select ?? "select-plugins";
-    return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+function handlePlugin(argv: string[]): Action {
+  const command = parsePluginCommand(argv);
+  if (command.kind === "help") {
+    return { type: "help", all: false };
   }
-  if (verb === "sync" || verb === "list") {
-    const target = route.targets?.[verb];
-    if (target) return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+  if (command.kind === "error") {
+    return { type: "error", code: 1, message: `${command.message}\n` };
   }
-  return nounError("plugin", verb);
+  if (command.kind === "run") {
+    return { type: "delegate", tool: TOOLS.utility, args: command.argv };
+  }
+  return nounError("plugin", argv[1]);
 }
 
 function handleGen(argv: string[]): Action {
@@ -623,7 +625,7 @@ function handleGen(argv: string[]): Action {
 function handleCustom(route: Route, argv: string[]): Action {
   if (route.custom === "workspace") return handleWorkspace(argv);
   if (route.custom === "config") return handleConfig(route, argv);
-  if (route.custom === "plugin") return handlePlugin(route, argv);
+  if (route.custom === "plugin") return handlePlugin(argv);
   if (route.custom === "gen") return handleGen(argv);
   return nounError(argv[0], argv[1]);
 }

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -680,7 +680,64 @@ export interface TerminalCommand {
   args?: string[];
   error?: string;
   display?: string;
-  source: "read-only-flag" | "workspace-verb";
+  source: "read-only-flag" | "workspace-verb" | "plugin-verb";
+}
+
+export type PluginCommand =
+  | { kind: "not-plugin" }
+  | { kind: "help" }
+  | { kind: "error"; message: string }
+  | { kind: "run"; argv: string[] };
+
+// Parse the public `plugin` noun once for every entrypoint. The slash
+// orchestrator, Kiro's pre-LLM interceptor, and the binary dispatcher must all
+// agree that these are terminal utilities rather than freeform workflow text.
+export function parsePluginCommand(args: string[]): PluginCommand {
+  if (args[0] !== "plugin") return { kind: "not-plugin" };
+  const verb = args[1];
+  if (verb === "help" || verb === "-h" || verb === "--help") {
+    return { kind: "help" };
+  }
+  const target = verb === "select"
+    ? "select-plugins"
+    : verb === "list"
+      ? "plugin-list"
+      : verb === "sync"
+        ? "plugin-sync"
+        : undefined;
+  if (target !== undefined) {
+    return { kind: "run", argv: [target, ...args.slice(2)] };
+  }
+  const detail = verb ? `unknown verb '${verb}'` : "missing verb";
+  return {
+    kind: "error",
+    message: `aidlc: ${detail} for noun 'plugin'; try 'aidlc help --all'`,
+  };
+}
+
+function terminalCommandFromPluginCommand(
+  command: PluginCommand,
+  originalArgs: string[],
+): TerminalCommand | null {
+  if (command.kind === "not-plugin") return null;
+  if (command.kind === "help") {
+    return { subcommand: "help", display: originalArgs.join(" "), source: "plugin-verb" };
+  }
+  if (command.kind === "error") {
+    return {
+      subcommand: "error",
+      error: command.message,
+      display: originalArgs.join(" "),
+      source: "plugin-verb",
+    };
+  }
+  const [subcommand, ...tail] = command.argv;
+  return {
+    subcommand,
+    ...(tail.length > 0 ? { args: tail } : {}),
+    display: originalArgs.join(" "),
+    source: "plugin-verb",
+  };
 }
 
 // The allowlisted trailing flags `--doctor` accepts (diagnostic export). Kept
@@ -753,6 +810,10 @@ export function classifyTerminalCommand(args: string[]): TerminalCommand | null 
   // "help". Sole-token only: `help` inside a longer description stays freeform.
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { subcommand: "help", source: "read-only-flag" };
+  }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") {
+    return terminalCommandFromPluginCommand(pluginCommand, args);
   }
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -113,6 +113,8 @@ import {
   loadScopeMapping,
   nextInScopeStage,
   parseCheckboxes,
+  type PluginCommand,
+  parsePluginCommand,
   parseStateStageSuffixes,
   PHASE_NUMBERS,
   PHASES,
@@ -343,6 +345,7 @@ interface ParsedFlags {
   newIntent?: boolean; // --new-intent: the conductor confirmed new-work alongside an active intent → emit the SAME birth directive (with the --label seam) the fresh-start path uses, instead of constructing intent-birth from SKILL.md prose
   intent?: string; // freeform request text (no leading --flag)
   workspaceCommand?: WorkspaceCommand; // leading workspace command (space/space-create/intent)
+  pluginCommand?: Exclude<PluginCommand, { kind: "not-plugin" }>; // leading plugin noun: terminal list/sync/select/help/error
   compose?: boolean; // leading `compose` verb: force the composer (front or in-flight)
   newScope?: boolean; // --new-scope: force the composer to SYNTHESIZE a custom scope even when a stock scope matches
   report?: string; // --report <path>: compose from a scan report (the composer triages the file)
@@ -366,6 +369,8 @@ function parseNextFlags(args: string[]): ParsedFlags {
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { readOnly: "--help" };
   }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") return { pluginCommand };
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the
   // public grammar promises leading-token semantics.
@@ -2018,7 +2023,7 @@ function handleNext(args: string[], projectDir: string | undefined): void {
   // swallowed. Inert on Claude/Codex: the latch files are never written there (no
   // seam) → fresh is always false → falls through. Advisory: any failure fails
   // open to the normal `next`.
-  if (!flags.readOnly && !flags.workspaceCommand && !flags.stage && !flags.phase &&
+  if (!flags.readOnly && !flags.workspaceCommand && !flags.pluginCommand && !flags.stage && !flags.phase &&
       !flags.scope && !flags.positionalScope && !flags.intent && !flags.resume &&
       !flags.depth && !flags.testStrategy &&
       !flags.single && !flags.compose && !flags.newScope && !flags.report) {
@@ -2104,6 +2109,24 @@ function handleNext(args: string[], projectDir: string | undefined): void {
     const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
     emit(printDirective(
       `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop.`,
+    ));
+    return;
+  }
+
+  // Branch 1c - plugin utilities are terminal commands, never freeform intent
+  // text. The shared parser also feeds the binary dispatcher and Kiro seam, so
+  // every harness preserves the same list/sync/select argv and error grammar.
+  if (flags.pluginCommand) {
+    const command = flags.pluginCommand;
+    if (command.kind === "error") {
+      emit(errorDirective(command.message));
+      return;
+    }
+    const argv = command.kind === "help" ? ["help"] : command.argv;
+    const [verb, ...tail] = argv;
+    const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
+    emit(printDirective(
+      `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop. This is a terminal utility, NOT workflow work: do NOT run \`next\` and do NOT advance, resume, or run any workflow stage.`,
     ));
     return;
   }

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -2042,8 +2042,9 @@ function handleNext(args: string[], projectDir: string | undefined): void {
         const lr = JSON.parse(readFileSync(latchPath, "utf-8")) as { turn?: number; flag?: string; source?: string };
         if (typeof lr.turn === "number") latchTurn = lr.turn;
         if (typeof lr.flag === "string") {
-          // read-only flags render with a leading `--`; workspace verbs are bare.
-          label = lr.source === "workspace-verb" ? `\`${lr.flag}\`` : `--${lr.flag}`;
+          // Read-only flags render with `--`; noun commands render as typed.
+          const nounCommand = lr.source === "workspace-verb" || lr.source === "plugin-verb";
+          label = nounCommand ? `\`${lr.flag}\`` : `--${lr.flag}`;
         }
       }
       if (counter >= 0 && latchTurn === counter) {

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -218,6 +218,7 @@ Utilities:
   config get <key>  Show active workflow config (depth, test-strategy)
   config set <key> <value>  Change active workflow config (depth, test-strategy)
   config list       List active workflow config (--json for structured output)
+  plugin select [names]  Show or set the enabled plugin list
   plugin list       List installed plugins and enabled state (--json for structured output)
   plugin sync       Compose installed plugins into the current install
   --doctor          Run health check on hooks, settings, and directory structure

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.44";
+export const AIDLC_VERSION = "2.5.45";

--- a/dist/kiro-ide/.kiro/tools/aidlc.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc.ts
@@ -4,6 +4,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   errorMessage,
+  parsePluginCommand,
   parseWorkspaceCommand,
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
@@ -585,17 +586,18 @@ function handleConfig(route: Route, argv: string[]): Action {
   return nounError("config", key ? `set ${key}` : "set");
 }
 
-function handlePlugin(route: Route, argv: string[]): Action {
-  const verb = argv[1];
-  if (verb === "select") {
-    const target = route.targets?.select ?? "select-plugins";
-    return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+function handlePlugin(argv: string[]): Action {
+  const command = parsePluginCommand(argv);
+  if (command.kind === "help") {
+    return { type: "help", all: false };
   }
-  if (verb === "sync" || verb === "list") {
-    const target = route.targets?.[verb];
-    if (target) return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+  if (command.kind === "error") {
+    return { type: "error", code: 1, message: `${command.message}\n` };
   }
-  return nounError("plugin", verb);
+  if (command.kind === "run") {
+    return { type: "delegate", tool: TOOLS.utility, args: command.argv };
+  }
+  return nounError("plugin", argv[1]);
 }
 
 function handleGen(argv: string[]): Action {
@@ -623,7 +625,7 @@ function handleGen(argv: string[]): Action {
 function handleCustom(route: Route, argv: string[]): Action {
   if (route.custom === "workspace") return handleWorkspace(argv);
   if (route.custom === "config") return handleConfig(route, argv);
-  if (route.custom === "plugin") return handlePlugin(route, argv);
+  if (route.custom === "plugin") return handlePlugin(argv);
   if (route.custom === "gen") return handleGen(argv);
   return nounError(argv[0], argv[1]);
 }

--- a/dist/kiro/.kiro/hooks/aidlc-kiro-adapter.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-kiro-adapter.ts
@@ -300,6 +300,12 @@ if (target === "verb-intercept") {
   } else {
     const executable = process.env.AIDLC_COMPILED_EXECUTABLE;
     const compiledArgs = (() => {
+      if (cmd.source === "plugin-verb") {
+        if (cmd.subcommand === "plugin-list") return ["plugin", "list", ...forwarded];
+        if (cmd.subcommand === "plugin-sync") return ["plugin", "sync", ...forwarded];
+        if (cmd.subcommand === "select-plugins") return ["plugin", "select", ...forwarded];
+        if (cmd.subcommand === "help") return ["plugin", "help"];
+      }
       if (cmd.subcommand === "space-create") return ["space", "create", ...forwarded];
       if (cmd.subcommand === "intent-birth") return ["intent", "birth", ...forwarded];
       return [cmd.subcommand, ...forwarded];

--- a/dist/kiro/.kiro/hooks/aidlc-kiro-adapter.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-kiro-adapter.ts
@@ -318,30 +318,28 @@ if (target === "verb-intercept") {
   // seam ran the tool; the conductor only relays). Stamp the latch with the
   // CURRENT turn counter so the engine done-guard + preToolUse backstop know a
   // bare advancing `next` THIS SAME turn is the spurious roll-forward and must
-  // be neutralized. Read-only flags (--status/--doctor/--help/--version) and
-  // workspace verbs (space/space-create/intent) both arm it, so the same guard
-  // catches the read-only AND the nav roll-forward. Best-effort; fails open.
-  if (cmd.source === "read-only-flag" || cmd.source === "workspace-verb") {
-    try {
-      const cwd = projectDir;
-      mkdirSync(join(cwd, "aidlc"), { recursive: true });
-      const flag = cmd.source === "read-only-flag"
-        ? cmd.subcommand
-        : (cmd.display ?? [cmd.subcommand, ...forwarded].join(" "));
-      writeFileSync(
-        join(cwd, "aidlc", ".aidlc-readonly-latch"),
-        JSON.stringify({ turn, flag, source: cmd.source, ts: Date.now() }) + "\n",
-        "utf-8",
-      );
-    } catch { /* latch best-effort */ }
-  }
+  // be neutralized. Every classified terminal family arms it, including plugin
+  // utilities, so the same guard catches a spurious workflow roll-forward.
+  // Best-effort; fails open.
+  try {
+    const cwd = projectDir;
+    mkdirSync(join(cwd, "aidlc"), { recursive: true });
+    const flag = cmd.source === "read-only-flag"
+      ? cmd.subcommand
+      : (cmd.display ?? [cmd.subcommand, ...forwarded].join(" "));
+    writeFileSync(
+      join(cwd, "aidlc", ".aidlc-readonly-latch"),
+      JSON.stringify({ turn, flag, source: cmd.source, ts: Date.now() }) + "\n",
+      "utf-8",
+    );
+  } catch { /* latch best-effort */ }
   // Echo the command the way the user typed it (verb + arg, or the --flag) so the
   // short-circuit message is legible.
   const typed = cmd.source === "read-only-flag"
     ? `--${cmd.subcommand}`
     : (cmd.display ?? [cmd.subcommand, ...forwarded].join(" "));
   process.stdout.write(
-    `SYSTEM (deterministic harness dispatch): The command \`/aidlc ${typed}\` has ALREADY been run by the harness — it is a read-only/navigation command that carries NO workflow work. Its verbatim output is below. Your ONLY action this turn: relay that output to the user, then STOP. Do NOT run \`aidlc-orchestrate.ts next\`. Do NOT advance, resume, or run any workflow stage.\n\n--- OUTPUT ---\n${out}\n--- END OUTPUT ---\n`,
+    `SYSTEM (deterministic harness dispatch): The command \`/aidlc ${typed}\` has ALREADY been run by the harness — it is a terminal utility that carries NO workflow work. Its verbatim output is below. Your ONLY action this turn: relay that output to the user, then STOP. Do NOT run \`aidlc-orchestrate.ts next\`. Do NOT advance, resume, or run any workflow stage.\n\n--- OUTPUT ---\n${out}\n--- END OUTPUT ---\n`,
   );
   return 0;
 }

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -680,7 +680,64 @@ export interface TerminalCommand {
   args?: string[];
   error?: string;
   display?: string;
-  source: "read-only-flag" | "workspace-verb";
+  source: "read-only-flag" | "workspace-verb" | "plugin-verb";
+}
+
+export type PluginCommand =
+  | { kind: "not-plugin" }
+  | { kind: "help" }
+  | { kind: "error"; message: string }
+  | { kind: "run"; argv: string[] };
+
+// Parse the public `plugin` noun once for every entrypoint. The slash
+// orchestrator, Kiro's pre-LLM interceptor, and the binary dispatcher must all
+// agree that these are terminal utilities rather than freeform workflow text.
+export function parsePluginCommand(args: string[]): PluginCommand {
+  if (args[0] !== "plugin") return { kind: "not-plugin" };
+  const verb = args[1];
+  if (verb === "help" || verb === "-h" || verb === "--help") {
+    return { kind: "help" };
+  }
+  const target = verb === "select"
+    ? "select-plugins"
+    : verb === "list"
+      ? "plugin-list"
+      : verb === "sync"
+        ? "plugin-sync"
+        : undefined;
+  if (target !== undefined) {
+    return { kind: "run", argv: [target, ...args.slice(2)] };
+  }
+  const detail = verb ? `unknown verb '${verb}'` : "missing verb";
+  return {
+    kind: "error",
+    message: `aidlc: ${detail} for noun 'plugin'; try 'aidlc help --all'`,
+  };
+}
+
+function terminalCommandFromPluginCommand(
+  command: PluginCommand,
+  originalArgs: string[],
+): TerminalCommand | null {
+  if (command.kind === "not-plugin") return null;
+  if (command.kind === "help") {
+    return { subcommand: "help", display: originalArgs.join(" "), source: "plugin-verb" };
+  }
+  if (command.kind === "error") {
+    return {
+      subcommand: "error",
+      error: command.message,
+      display: originalArgs.join(" "),
+      source: "plugin-verb",
+    };
+  }
+  const [subcommand, ...tail] = command.argv;
+  return {
+    subcommand,
+    ...(tail.length > 0 ? { args: tail } : {}),
+    display: originalArgs.join(" "),
+    source: "plugin-verb",
+  };
 }
 
 // The allowlisted trailing flags `--doctor` accepts (diagnostic export). Kept
@@ -753,6 +810,10 @@ export function classifyTerminalCommand(args: string[]): TerminalCommand | null 
   // "help". Sole-token only: `help` inside a longer description stays freeform.
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { subcommand: "help", source: "read-only-flag" };
+  }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") {
+    return terminalCommandFromPluginCommand(pluginCommand, args);
   }
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -113,6 +113,8 @@ import {
   loadScopeMapping,
   nextInScopeStage,
   parseCheckboxes,
+  type PluginCommand,
+  parsePluginCommand,
   parseStateStageSuffixes,
   PHASE_NUMBERS,
   PHASES,
@@ -343,6 +345,7 @@ interface ParsedFlags {
   newIntent?: boolean; // --new-intent: the conductor confirmed new-work alongside an active intent → emit the SAME birth directive (with the --label seam) the fresh-start path uses, instead of constructing intent-birth from SKILL.md prose
   intent?: string; // freeform request text (no leading --flag)
   workspaceCommand?: WorkspaceCommand; // leading workspace command (space/space-create/intent)
+  pluginCommand?: Exclude<PluginCommand, { kind: "not-plugin" }>; // leading plugin noun: terminal list/sync/select/help/error
   compose?: boolean; // leading `compose` verb: force the composer (front or in-flight)
   newScope?: boolean; // --new-scope: force the composer to SYNTHESIZE a custom scope even when a stock scope matches
   report?: string; // --report <path>: compose from a scan report (the composer triages the file)
@@ -366,6 +369,8 @@ function parseNextFlags(args: string[]): ParsedFlags {
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { readOnly: "--help" };
   }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") return { pluginCommand };
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the
   // public grammar promises leading-token semantics.
@@ -2018,7 +2023,7 @@ function handleNext(args: string[], projectDir: string | undefined): void {
   // swallowed. Inert on Claude/Codex: the latch files are never written there (no
   // seam) → fresh is always false → falls through. Advisory: any failure fails
   // open to the normal `next`.
-  if (!flags.readOnly && !flags.workspaceCommand && !flags.stage && !flags.phase &&
+  if (!flags.readOnly && !flags.workspaceCommand && !flags.pluginCommand && !flags.stage && !flags.phase &&
       !flags.scope && !flags.positionalScope && !flags.intent && !flags.resume &&
       !flags.depth && !flags.testStrategy &&
       !flags.single && !flags.compose && !flags.newScope && !flags.report) {
@@ -2104,6 +2109,24 @@ function handleNext(args: string[], projectDir: string | undefined): void {
     const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
     emit(printDirective(
       `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop.`,
+    ));
+    return;
+  }
+
+  // Branch 1c - plugin utilities are terminal commands, never freeform intent
+  // text. The shared parser also feeds the binary dispatcher and Kiro seam, so
+  // every harness preserves the same list/sync/select argv and error grammar.
+  if (flags.pluginCommand) {
+    const command = flags.pluginCommand;
+    if (command.kind === "error") {
+      emit(errorDirective(command.message));
+      return;
+    }
+    const argv = command.kind === "help" ? ["help"] : command.argv;
+    const [verb, ...tail] = argv;
+    const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
+    emit(printDirective(
+      `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop. This is a terminal utility, NOT workflow work: do NOT run \`next\` and do NOT advance, resume, or run any workflow stage.`,
     ));
     return;
   }

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -2042,8 +2042,9 @@ function handleNext(args: string[], projectDir: string | undefined): void {
         const lr = JSON.parse(readFileSync(latchPath, "utf-8")) as { turn?: number; flag?: string; source?: string };
         if (typeof lr.turn === "number") latchTurn = lr.turn;
         if (typeof lr.flag === "string") {
-          // read-only flags render with a leading `--`; workspace verbs are bare.
-          label = lr.source === "workspace-verb" ? `\`${lr.flag}\`` : `--${lr.flag}`;
+          // Read-only flags render with `--`; noun commands render as typed.
+          const nounCommand = lr.source === "workspace-verb" || lr.source === "plugin-verb";
+          label = nounCommand ? `\`${lr.flag}\`` : `--${lr.flag}`;
         }
       }
       if (counter >= 0 && latchTurn === counter) {

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -218,6 +218,7 @@ Utilities:
   config get <key>  Show active workflow config (depth, test-strategy)
   config set <key> <value>  Change active workflow config (depth, test-strategy)
   config list       List active workflow config (--json for structured output)
+  plugin select [names]  Show or set the enabled plugin list
   plugin list       List installed plugins and enabled state (--json for structured output)
   plugin sync       Compose installed plugins into the current install
   --doctor          Run health check on hooks, settings, and directory structure

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.44";
+export const AIDLC_VERSION = "2.5.45";

--- a/dist/kiro/.kiro/tools/aidlc.ts
+++ b/dist/kiro/.kiro/tools/aidlc.ts
@@ -4,6 +4,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   errorMessage,
+  parsePluginCommand,
   parseWorkspaceCommand,
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
@@ -585,17 +586,18 @@ function handleConfig(route: Route, argv: string[]): Action {
   return nounError("config", key ? `set ${key}` : "set");
 }
 
-function handlePlugin(route: Route, argv: string[]): Action {
-  const verb = argv[1];
-  if (verb === "select") {
-    const target = route.targets?.select ?? "select-plugins";
-    return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+function handlePlugin(argv: string[]): Action {
+  const command = parsePluginCommand(argv);
+  if (command.kind === "help") {
+    return { type: "help", all: false };
   }
-  if (verb === "sync" || verb === "list") {
-    const target = route.targets?.[verb];
-    if (target) return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+  if (command.kind === "error") {
+    return { type: "error", code: 1, message: `${command.message}\n` };
   }
-  return nounError("plugin", verb);
+  if (command.kind === "run") {
+    return { type: "delegate", tool: TOOLS.utility, args: command.argv };
+  }
+  return nounError("plugin", argv[1]);
 }
 
 function handleGen(argv: string[]): Action {
@@ -623,7 +625,7 @@ function handleGen(argv: string[]): Action {
 function handleCustom(route: Route, argv: string[]): Action {
   if (route.custom === "workspace") return handleWorkspace(argv);
   if (route.custom === "config") return handleConfig(route, argv);
-  if (route.custom === "plugin") return handlePlugin(route, argv);
+  if (route.custom === "plugin") return handlePlugin(argv);
   if (route.custom === "gen") return handleGen(argv);
   return nounError(argv[0], argv[1]);
 }

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -680,7 +680,64 @@ export interface TerminalCommand {
   args?: string[];
   error?: string;
   display?: string;
-  source: "read-only-flag" | "workspace-verb";
+  source: "read-only-flag" | "workspace-verb" | "plugin-verb";
+}
+
+export type PluginCommand =
+  | { kind: "not-plugin" }
+  | { kind: "help" }
+  | { kind: "error"; message: string }
+  | { kind: "run"; argv: string[] };
+
+// Parse the public `plugin` noun once for every entrypoint. The slash
+// orchestrator, Kiro's pre-LLM interceptor, and the binary dispatcher must all
+// agree that these are terminal utilities rather than freeform workflow text.
+export function parsePluginCommand(args: string[]): PluginCommand {
+  if (args[0] !== "plugin") return { kind: "not-plugin" };
+  const verb = args[1];
+  if (verb === "help" || verb === "-h" || verb === "--help") {
+    return { kind: "help" };
+  }
+  const target = verb === "select"
+    ? "select-plugins"
+    : verb === "list"
+      ? "plugin-list"
+      : verb === "sync"
+        ? "plugin-sync"
+        : undefined;
+  if (target !== undefined) {
+    return { kind: "run", argv: [target, ...args.slice(2)] };
+  }
+  const detail = verb ? `unknown verb '${verb}'` : "missing verb";
+  return {
+    kind: "error",
+    message: `aidlc: ${detail} for noun 'plugin'; try 'aidlc help --all'`,
+  };
+}
+
+function terminalCommandFromPluginCommand(
+  command: PluginCommand,
+  originalArgs: string[],
+): TerminalCommand | null {
+  if (command.kind === "not-plugin") return null;
+  if (command.kind === "help") {
+    return { subcommand: "help", display: originalArgs.join(" "), source: "plugin-verb" };
+  }
+  if (command.kind === "error") {
+    return {
+      subcommand: "error",
+      error: command.message,
+      display: originalArgs.join(" "),
+      source: "plugin-verb",
+    };
+  }
+  const [subcommand, ...tail] = command.argv;
+  return {
+    subcommand,
+    ...(tail.length > 0 ? { args: tail } : {}),
+    display: originalArgs.join(" "),
+    source: "plugin-verb",
+  };
 }
 
 // The allowlisted trailing flags `--doctor` accepts (diagnostic export). Kept
@@ -753,6 +810,10 @@ export function classifyTerminalCommand(args: string[]): TerminalCommand | null 
   // "help". Sole-token only: `help` inside a longer description stays freeform.
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { subcommand: "help", source: "read-only-flag" };
+  }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") {
+    return terminalCommandFromPluginCommand(pluginCommand, args);
   }
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -113,6 +113,8 @@ import {
   loadScopeMapping,
   nextInScopeStage,
   parseCheckboxes,
+  type PluginCommand,
+  parsePluginCommand,
   parseStateStageSuffixes,
   PHASE_NUMBERS,
   PHASES,
@@ -343,6 +345,7 @@ interface ParsedFlags {
   newIntent?: boolean; // --new-intent: the conductor confirmed new-work alongside an active intent → emit the SAME birth directive (with the --label seam) the fresh-start path uses, instead of constructing intent-birth from SKILL.md prose
   intent?: string; // freeform request text (no leading --flag)
   workspaceCommand?: WorkspaceCommand; // leading workspace command (space/space-create/intent)
+  pluginCommand?: Exclude<PluginCommand, { kind: "not-plugin" }>; // leading plugin noun: terminal list/sync/select/help/error
   compose?: boolean; // leading `compose` verb: force the composer (front or in-flight)
   newScope?: boolean; // --new-scope: force the composer to SYNTHESIZE a custom scope even when a stock scope matches
   report?: string; // --report <path>: compose from a scan report (the composer triages the file)
@@ -366,6 +369,8 @@ function parseNextFlags(args: string[]): ParsedFlags {
   if (args.length === 1 && (args[0] === "help" || args[0] === "-h")) {
     return { readOnly: "--help" };
   }
+  const pluginCommand = parsePluginCommand(args);
+  if (pluginCommand.kind !== "not-plugin") return { pluginCommand };
   // Leading workspace nouns own the command. Any later read-only-looking token
   // is part of that workspace command's argv, not a mode switch, because the
   // public grammar promises leading-token semantics.
@@ -2018,7 +2023,7 @@ function handleNext(args: string[], projectDir: string | undefined): void {
   // swallowed. Inert on Claude/Codex: the latch files are never written there (no
   // seam) → fresh is always false → falls through. Advisory: any failure fails
   // open to the normal `next`.
-  if (!flags.readOnly && !flags.workspaceCommand && !flags.stage && !flags.phase &&
+  if (!flags.readOnly && !flags.workspaceCommand && !flags.pluginCommand && !flags.stage && !flags.phase &&
       !flags.scope && !flags.positionalScope && !flags.intent && !flags.resume &&
       !flags.depth && !flags.testStrategy &&
       !flags.single && !flags.compose && !flags.newScope && !flags.report) {
@@ -2104,6 +2109,24 @@ function handleNext(args: string[], projectDir: string | undefined): void {
     const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
     emit(printDirective(
       `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop.`,
+    ));
+    return;
+  }
+
+  // Branch 1c - plugin utilities are terminal commands, never freeform intent
+  // text. The shared parser also feeds the binary dispatcher and Kiro seam, so
+  // every harness preserves the same list/sync/select argv and error grammar.
+  if (flags.pluginCommand) {
+    const command = flags.pluginCommand;
+    if (command.kind === "error") {
+      emit(errorDirective(command.message));
+      return;
+    }
+    const argv = command.kind === "help" ? ["help"] : command.argv;
+    const [verb, ...tail] = argv;
+    const suffix = tail.length > 0 ? ` ${tail.map(shellArg).join(" ")}` : "";
+    emit(printDirective(
+      `Run \`bun ${harnessDir()}/tools/aidlc-utility.ts ${verb}${suffix}\`, print its output verbatim, then stop. This is a terminal utility, NOT workflow work: do NOT run \`next\` and do NOT advance, resume, or run any workflow stage.`,
     ));
     return;
   }

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -2042,8 +2042,9 @@ function handleNext(args: string[], projectDir: string | undefined): void {
         const lr = JSON.parse(readFileSync(latchPath, "utf-8")) as { turn?: number; flag?: string; source?: string };
         if (typeof lr.turn === "number") latchTurn = lr.turn;
         if (typeof lr.flag === "string") {
-          // read-only flags render with a leading `--`; workspace verbs are bare.
-          label = lr.source === "workspace-verb" ? `\`${lr.flag}\`` : `--${lr.flag}`;
+          // Read-only flags render with `--`; noun commands render as typed.
+          const nounCommand = lr.source === "workspace-verb" || lr.source === "plugin-verb";
+          label = nounCommand ? `\`${lr.flag}\`` : `--${lr.flag}`;
         }
       }
       if (counter >= 0 && latchTurn === counter) {

--- a/dist/opencode/.aidlc/tools/aidlc-utility.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-utility.ts
@@ -218,6 +218,7 @@ Utilities:
   config get <key>  Show active workflow config (depth, test-strategy)
   config set <key> <value>  Change active workflow config (depth, test-strategy)
   config list       List active workflow config (--json for structured output)
+  plugin select [names]  Show or set the enabled plugin list
   plugin list       List installed plugins and enabled state (--json for structured output)
   plugin sync       Compose installed plugins into the current install
   --doctor          Run health check on hooks, settings, and directory structure

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.44";
+export const AIDLC_VERSION = "2.5.45";

--- a/dist/opencode/.aidlc/tools/aidlc.ts
+++ b/dist/opencode/.aidlc/tools/aidlc.ts
@@ -4,6 +4,7 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   errorMessage,
+  parsePluginCommand,
   parseWorkspaceCommand,
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
@@ -585,17 +586,18 @@ function handleConfig(route: Route, argv: string[]): Action {
   return nounError("config", key ? `set ${key}` : "set");
 }
 
-function handlePlugin(route: Route, argv: string[]): Action {
-  const verb = argv[1];
-  if (verb === "select") {
-    const target = route.targets?.select ?? "select-plugins";
-    return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+function handlePlugin(argv: string[]): Action {
+  const command = parsePluginCommand(argv);
+  if (command.kind === "help") {
+    return { type: "help", all: false };
   }
-  if (verb === "sync" || verb === "list") {
-    const target = route.targets?.[verb];
-    if (target) return { type: "delegate", tool: TOOLS.utility, args: [target, ...argv.slice(2)] };
+  if (command.kind === "error") {
+    return { type: "error", code: 1, message: `${command.message}\n` };
   }
-  return nounError("plugin", verb);
+  if (command.kind === "run") {
+    return { type: "delegate", tool: TOOLS.utility, args: command.argv };
+  }
+  return nounError("plugin", argv[1]);
 }
 
 function handleGen(argv: string[]): Action {
@@ -623,7 +625,7 @@ function handleGen(argv: string[]): Action {
 function handleCustom(route: Route, argv: string[]): Action {
   if (route.custom === "workspace") return handleWorkspace(argv);
   if (route.custom === "config") return handleConfig(route, argv);
-  if (route.custom === "plugin") return handlePlugin(route, argv);
+  if (route.custom === "plugin") return handlePlugin(argv);
   if (route.custom === "gen") return handleGen(argv);
   return nounError(argv[0], argv[1]);
 }

--- a/docs/guide/12-cli-commands.md
+++ b/docs/guide/12-cli-commands.md
@@ -37,11 +37,12 @@ All AI-DLC commands start with the orchestrator invocation. This chapter is a co
 | `/aidlc config get <key>` | Print active workflow config (`depth`, `test-strategy`) |
 | `/aidlc config set <key> <value>` | Change active workflow config (`depth`, `test-strategy`) |
 | `/aidlc config list` | List active workflow config (`--json` for structured output) |
+| `/aidlc plugin select [names]` | Show or set the enabled plugin list for this install |
 | `/aidlc plugin list` | List installed plugins and enabled state |
 | `/aidlc plugin sync` | Compose installed plugin roots into the current install |
 | `/aidlc --version` | Print the framework version |
 | `/aidlc --help` | Display usage information |
-| `bun .claude/tools/aidlc-utility.ts select-plugins [names]` | Direct-only: show or set the enabled plugin list for this install |
+| `bun .claude/tools/aidlc-utility.ts select-plugins [names]` | Direct utility form of plugin selection |
 
 ---
 
@@ -666,7 +667,8 @@ doctor exit code.
 ### `aidlc-utility select-plugins` - install plugin selection
 
 `/aidlc plugin list` prints installed plugin names and whether each is enabled.
-`select-plugins` is a **direct utility invocation**, not an `/aidlc select-plugins` command.
+`/aidlc plugin select [names]` is the public command. `select-plugins` is its
+direct utility form; it is not an `/aidlc select-plugins` command.
 `bun .claude/tools/aidlc-utility.ts select-plugins` prints the current selection
 (`all enabled (no selection)` when the `plugins` key is absent) and the known
 plugin names. Pass a comma-separated list to set it:

--- a/harness/kiro/hooks/aidlc-kiro-adapter.ts
+++ b/harness/kiro/hooks/aidlc-kiro-adapter.ts
@@ -300,6 +300,12 @@ if (target === "verb-intercept") {
   } else {
     const executable = process.env.AIDLC_COMPILED_EXECUTABLE;
     const compiledArgs = (() => {
+      if (cmd.source === "plugin-verb") {
+        if (cmd.subcommand === "plugin-list") return ["plugin", "list", ...forwarded];
+        if (cmd.subcommand === "plugin-sync") return ["plugin", "sync", ...forwarded];
+        if (cmd.subcommand === "select-plugins") return ["plugin", "select", ...forwarded];
+        if (cmd.subcommand === "help") return ["plugin", "help"];
+      }
       if (cmd.subcommand === "space-create") return ["space", "create", ...forwarded];
       if (cmd.subcommand === "intent-birth") return ["intent", "birth", ...forwarded];
       return [cmd.subcommand, ...forwarded];

--- a/harness/kiro/hooks/aidlc-kiro-adapter.ts
+++ b/harness/kiro/hooks/aidlc-kiro-adapter.ts
@@ -318,30 +318,28 @@ if (target === "verb-intercept") {
   // seam ran the tool; the conductor only relays). Stamp the latch with the
   // CURRENT turn counter so the engine done-guard + preToolUse backstop know a
   // bare advancing `next` THIS SAME turn is the spurious roll-forward and must
-  // be neutralized. Read-only flags (--status/--doctor/--help/--version) and
-  // workspace verbs (space/space-create/intent) both arm it, so the same guard
-  // catches the read-only AND the nav roll-forward. Best-effort; fails open.
-  if (cmd.source === "read-only-flag" || cmd.source === "workspace-verb") {
-    try {
-      const cwd = projectDir;
-      mkdirSync(join(cwd, "aidlc"), { recursive: true });
-      const flag = cmd.source === "read-only-flag"
-        ? cmd.subcommand
-        : (cmd.display ?? [cmd.subcommand, ...forwarded].join(" "));
-      writeFileSync(
-        join(cwd, "aidlc", ".aidlc-readonly-latch"),
-        JSON.stringify({ turn, flag, source: cmd.source, ts: Date.now() }) + "\n",
-        "utf-8",
-      );
-    } catch { /* latch best-effort */ }
-  }
+  // be neutralized. Every classified terminal family arms it, including plugin
+  // utilities, so the same guard catches a spurious workflow roll-forward.
+  // Best-effort; fails open.
+  try {
+    const cwd = projectDir;
+    mkdirSync(join(cwd, "aidlc"), { recursive: true });
+    const flag = cmd.source === "read-only-flag"
+      ? cmd.subcommand
+      : (cmd.display ?? [cmd.subcommand, ...forwarded].join(" "));
+    writeFileSync(
+      join(cwd, "aidlc", ".aidlc-readonly-latch"),
+      JSON.stringify({ turn, flag, source: cmd.source, ts: Date.now() }) + "\n",
+      "utf-8",
+    );
+  } catch { /* latch best-effort */ }
   // Echo the command the way the user typed it (verb + arg, or the --flag) so the
   // short-circuit message is legible.
   const typed = cmd.source === "read-only-flag"
     ? `--${cmd.subcommand}`
     : (cmd.display ?? [cmd.subcommand, ...forwarded].join(" "));
   process.stdout.write(
-    `SYSTEM (deterministic harness dispatch): The command \`/aidlc ${typed}\` has ALREADY been run by the harness — it is a read-only/navigation command that carries NO workflow work. Its verbatim output is below. Your ONLY action this turn: relay that output to the user, then STOP. Do NOT run \`aidlc-orchestrate.ts next\`. Do NOT advance, resume, or run any workflow stage.\n\n--- OUTPUT ---\n${out}\n--- END OUTPUT ---\n`,
+    `SYSTEM (deterministic harness dispatch): The command \`/aidlc ${typed}\` has ALREADY been run by the harness — it is a terminal utility that carries NO workflow work. Its verbatim output is below. Your ONLY action this turn: relay that output to the user, then STOP. Do NOT run \`aidlc-orchestrate.ts next\`. Do NOT advance, resume, or run any workflow stage.\n\n--- OUTPUT ---\n${out}\n--- END OUTPUT ---\n`,
   );
   return 0;
 }

--- a/tests/.coverage-ratchet.json
+++ b/tests/.coverage-ratchet.json
@@ -1,7 +1,7 @@
 {
   "note": "Committed baseline: covered-unit count per class. The --check ratchet fails CI if any class's covered count DROPS below these numbers without a reviewed deferred entry. Monotonic anti-regression: you can cover more, never silently less. Regenerate with: bun tests/gen-coverage-registry.ts",
   "coveredByClass": {
-    "function": 118,
+    "function": 119,
     "audit": 36,
     "scope": 9,
     "stage": 9,

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -2347,6 +2347,18 @@
     },
     {
       "unitClass": "function",
+      "unitId": "function:parsePluginCommand",
+      "minMechanism": "none",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t178-classify-terminal-command.test.ts",
+          "mechanism": "none"
+        }
+      ],
+      "status": "covered"
+    },
+    {
+      "unitClass": "function",
       "unitId": "function:parseRefsList",
       "minMechanism": "none",
       "coveredBy": [],

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -20,9 +20,9 @@
     "render-surface": "tui"
   },
   "counts": {
-    "total": 505,
+    "total": 506,
     "enumeratedByClass": {
-      "function": 265,
+      "function": 266,
       "audit": 77,
       "scope": 9,
       "stage": 32,
@@ -31,7 +31,7 @@
       "render-surface": 7
     },
     "coveredByClass": {
-      "function": 118,
+      "function": 119,
       "audit": 36,
       "scope": 9,
       "stage": 9,

--- a/tests/unit/t114-orchestrate-next.test.ts
+++ b/tests/unit/t114-orchestrate-next.test.ts
@@ -30,7 +30,7 @@
 // the `next --args` wrapper is absent).
 //
 // FIXTURE DISCIPLINE: each case builds a fresh temp project via
-// createTestProject() + seedStateFile() (the .ts analogues of fixtures.sh's
+// createOrchestrationTestProject() + seedStateFile() (the .ts analogues of fixtures.sh's
 // create_test_project / seed_state_file), torn down in afterEach. resetAidlcEnv()
 // clears AWS_AIDLC_DEFAULT_SCOPE so a developer's exported value can't shadow the
 // fixtures — exactly the .sh's top-of-file reset_aidlc_env. The env-precedence
@@ -308,7 +308,7 @@ describe("t114 help-request routing", () => {
 
 describe("t114 plugin terminal routing", () => {
   test("plugin list preserves --json and never enters the workflow funnel", () => {
-    proj = createTestProject();
+    proj = createOrchestrationTestProject();
     seedStateFile(proj, MID_IDEATION);
     const out = runNext(proj, ["plugin", "list", "--json"]).out;
     expect(out).toContain('"kind":"print"');
@@ -317,21 +317,21 @@ describe("t114 plugin terminal routing", () => {
   });
 
   test("plugin sync routes to the terminal utility", () => {
-    proj = createTestProject();
+    proj = createOrchestrationTestProject();
     const out = runNext(proj, ["plugin", "sync"]).out;
     expect(out).toContain('"kind":"print"');
     expect(out).toContain("aidlc-utility.ts plugin-sync");
   });
 
   test("plugin select preserves the selected names", () => {
-    proj = createTestProject();
+    proj = createOrchestrationTestProject();
     const out = runNext(proj, ["plugin", "select", "aidlc,test-pro"]).out;
     expect(out).toContain('"kind":"print"');
     expect(out).toContain("aidlc-utility.ts select-plugins aidlc,test-pro");
   });
 
   test("plugin help routes to global help", () => {
-    proj = createTestProject();
+    proj = createOrchestrationTestProject();
     const out = runNext(proj, ["plugin", "help"]).out;
     expect(out).toContain('"kind":"print"');
     expect(out).toContain("aidlc-utility.ts help");
@@ -339,7 +339,7 @@ describe("t114 plugin terminal routing", () => {
   });
 
   test("missing and unknown plugin verbs are deterministic errors", () => {
-    proj = createTestProject();
+    proj = createOrchestrationTestProject();
     const missing = runNext(proj, ["plugin"]).out;
     const unknown = runNext(proj, ["plugin", "remove"]).out;
     expect(missing).toContain('"kind":"error"');

--- a/tests/unit/t114-orchestrate-next.test.ts
+++ b/tests/unit/t114-orchestrate-next.test.ts
@@ -306,6 +306,50 @@ describe("t114 help-request routing", () => {
   });
 });
 
+describe("t114 plugin terminal routing", () => {
+  test("plugin list preserves --json and never enters the workflow funnel", () => {
+    proj = createTestProject();
+    seedStateFile(proj, MID_IDEATION);
+    const out = runNext(proj, ["plugin", "list", "--json"]).out;
+    expect(out).toContain('"kind":"print"');
+    expect(out).toContain("aidlc-utility.ts plugin-list --json");
+    expect(out).not.toContain('"kind":"run-stage"');
+  });
+
+  test("plugin sync routes to the terminal utility", () => {
+    proj = createTestProject();
+    const out = runNext(proj, ["plugin", "sync"]).out;
+    expect(out).toContain('"kind":"print"');
+    expect(out).toContain("aidlc-utility.ts plugin-sync");
+  });
+
+  test("plugin select preserves the selected names", () => {
+    proj = createTestProject();
+    const out = runNext(proj, ["plugin", "select", "aidlc,test-pro"]).out;
+    expect(out).toContain('"kind":"print"');
+    expect(out).toContain("aidlc-utility.ts select-plugins aidlc,test-pro");
+  });
+
+  test("plugin help routes to global help", () => {
+    proj = createTestProject();
+    const out = runNext(proj, ["plugin", "help"]).out;
+    expect(out).toContain('"kind":"print"');
+    expect(out).toContain("aidlc-utility.ts help");
+    expect(out).not.toContain('"kind":"ask"');
+  });
+
+  test("missing and unknown plugin verbs are deterministic errors", () => {
+    proj = createTestProject();
+    const missing = runNext(proj, ["plugin"]).out;
+    const unknown = runNext(proj, ["plugin", "remove"]).out;
+    expect(missing).toContain('"kind":"error"');
+    expect(missing).toContain("missing verb for noun 'plugin'");
+    expect(unknown).toContain('"kind":"error"');
+    expect(unknown).toContain("unknown verb 'remove' for noun 'plugin'");
+    expect(`${missing}${unknown}`).not.toContain('"kind":"ask"');
+  });
+});
+
 // ===========================================================================
 // With-state jump commits via an `execute` print directive (.sh test 12)
 // ===========================================================================

--- a/tests/unit/t178-classify-terminal-command.test.ts
+++ b/tests/unit/t178-classify-terminal-command.test.ts
@@ -1,4 +1,4 @@
-// covers: function:classifyTerminalCommand function:RESERVED_RECORD_NAMES
+// covers: function:classifyTerminalCommand function:parsePluginCommand function:RESERVED_RECORD_NAMES
 // covers: function:READ_ONLY_FLAGS function:WORKSPACE_VERBS
 //
 // t178 — classifyTerminalCommand() in aidlc-lib.ts, plus the two exported sets
@@ -217,6 +217,46 @@ describe("classifyTerminalCommand() - sole bare help tokens are terminal", () =>
   test("`help` inside a longer description stays freeform -> null", () => {
     expect(classifyTerminalCommand(["help", "me", "build", "auth"])).toBeNull();
     expect(classifyTerminalCommand(["build", "a", "help", "desk"])).toBeNull();
+  });
+});
+
+describe("classifyTerminalCommand() - plugin utilities", () => {
+  test("list, sync, and select map to their utility subcommands", () => {
+    expect(classifyTerminalCommand(["plugin", "list", "--json"])).toEqual({
+      subcommand: "plugin-list",
+      args: ["--json"],
+      display: "plugin list --json",
+      source: "plugin-verb",
+    });
+    expect(classifyTerminalCommand(["plugin", "sync"])).toEqual({
+      subcommand: "plugin-sync",
+      display: "plugin sync",
+      source: "plugin-verb",
+    });
+    expect(classifyTerminalCommand(["plugin", "select", "aidlc,test-pro"])).toEqual({
+      subcommand: "select-plugins",
+      args: ["aidlc,test-pro"],
+      display: "plugin select aidlc,test-pro",
+      source: "plugin-verb",
+    });
+  });
+
+  test("plugin help and malformed forms stay terminal", () => {
+    expect(classifyTerminalCommand(["plugin", "help"])).toEqual({
+      subcommand: "help",
+      display: "plugin help",
+      source: "plugin-verb",
+    });
+    expect(classifyTerminalCommand(["plugin"])).toMatchObject({
+      subcommand: "error",
+      display: "plugin",
+      source: "plugin-verb",
+    });
+    expect(classifyTerminalCommand(["plugin", "remove"])).toMatchObject({
+      subcommand: "error",
+      display: "plugin remove",
+      source: "plugin-verb",
+    });
   });
 });
 

--- a/tests/unit/t179-orchestrate-rollforward-guard.test.ts
+++ b/tests/unit/t179-orchestrate-rollforward-guard.test.ts
@@ -69,13 +69,19 @@ function runNext(proj: string, args: string[]): RunResult {
 // Stamp the per-turn counter + the read-only latch the Kiro seam writes, at the
 // SAME paths the engine reads (resolveProjectDir(--project-dir)/aidlc/...). The
 // latch JSON shape matches aidlc-kiro-adapter.ts:137 ({turn,flag,source,ts}).
-function seedLatch(proj: string, counter: number, latchTurn: number): void {
+function seedLatch(
+  proj: string,
+  counter: number,
+  latchTurn: number,
+  flag = "status",
+  source = "read-only-flag",
+): void {
   const aidlc = join(proj, "aidlc");
   mkdirSync(aidlc, { recursive: true }); // already created by the fixture; idempotent
   writeFileSync(join(aidlc, ".aidlc-turn-counter"), `${counter}\n`, "utf-8");
   writeFileSync(
     join(aidlc, ".aidlc-readonly-latch"),
-    `${JSON.stringify({ turn: latchTurn, flag: "status", source: "read-only-flag", ts: Date.now() })}\n`,
+    `${JSON.stringify({ turn: latchTurn, flag, source, ts: Date.now() })}\n`,
     "utf-8",
   );
 }
@@ -109,6 +115,15 @@ describe("t179 Branch 0: fresh latch -> done", () => {
     expect(out).toContain("nothing to advance");
     // It MUST NOT have routed into the active stage.
     expect(out).not.toContain('"kind":"run-stage"');
+  });
+
+  test("1b: plugin latch renders the noun command without a leading --", () => {
+    proj = createTestProject();
+    seedStateFile(proj, MID_IDEATION);
+    seedLatch(proj, 3, 3, "plugin list --json", "plugin-verb");
+    const out = runNext(proj, []).out;
+    expect(out).toContain("(`plugin list --json`)");
+    expect(out).not.toContain("--plugin list --json");
   });
 });
 

--- a/tests/unit/t179-orchestrate-rollforward-guard.test.ts
+++ b/tests/unit/t179-orchestrate-rollforward-guard.test.ts
@@ -118,7 +118,7 @@ describe("t179 Branch 0: fresh latch -> done", () => {
   });
 
   test("1b: plugin latch renders the noun command without a leading --", () => {
-    proj = createTestProject();
+    proj = createOrchestrationTestProject();
     seedStateFile(proj, MID_IDEATION);
     seedLatch(proj, 3, 3, "plugin list --json", "plugin-verb");
     const out = runNext(proj, []).out;

--- a/tests/unit/t180-kiro-rollforward-seam.test.ts
+++ b/tests/unit/t180-kiro-rollforward-seam.test.ts
@@ -122,6 +122,29 @@ describe("t180 verb-intercept turn-clock + read-only/nav latch", () => {
     }
   });
 
+  test("2b: plugin list dispatches off-band and stamps the plugin-verb latch", () => {
+    const dir = scratchProject();
+    try {
+      const r = runAdapter(dir, "verb-intercept", {
+        prompt: promptWithNext("plugin list --json"),
+        cwd: dir,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("SYSTEM (deterministic harness dispatch)");
+      expect(r.stdout).toContain("/aidlc plugin list --json");
+      const latch = JSON.parse(readFileSync(latchPath(dir), "utf-8")) as {
+        turn?: number;
+        flag?: string;
+        source?: string;
+      };
+      expect(latch.turn).toBe(1);
+      expect(latch.source).toBe("plugin-verb");
+      expect(latch.flag).toBe("plugin list --json");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("3: non-terminal freeform input stamps a turn-bound forwarding latch", () => {
     const dir = scratchProject();
     try {

--- a/tests/unit/t180-kiro-rollforward-seam.test.ts
+++ b/tests/unit/t180-kiro-rollforward-seam.test.ts
@@ -28,7 +28,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,15 +52,27 @@ function runAdapter(
   projectDir: string,
   target: string,
   payload: unknown,
+  env: NodeJS.ProcessEnv = {},
 ): { stdout: string; code: number } {
   const r = spawnSync("bun", [join(projectDir, ".kiro", "hooks", "aidlc-kiro-adapter.ts"), target], {
     cwd: projectDir,
     input: typeof payload === "string" ? payload : JSON.stringify(payload),
     encoding: "utf-8",
-    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir, ...env },
     timeout: 30_000,
   });
   return { stdout: r.stdout ?? "", code: r.status ?? -1 };
+}
+
+function fakeCompiledExecutable(projectDir: string): string {
+  const path = join(projectDir, process.platform === "win32" ? "fake-aidlc.cmd" : "fake-aidlc");
+  if (process.platform === "win32") {
+    writeFileSync(path, "@echo off\r\necho %*\r\n", "utf-8");
+  } else {
+    writeFileSync(path, "#!/bin/sh\nprintf '%s\\n' \"$*\"\n", "utf-8");
+    chmodSync(path, 0o755);
+  }
+  return path;
 }
 
 // Build an expanded-prompt body carrying the forwarding-loop anchor the seam
@@ -140,6 +152,30 @@ describe("t180 verb-intercept turn-clock + read-only/nav latch", () => {
       expect(latch.turn).toBe(1);
       expect(latch.source).toBe("plugin-verb");
       expect(latch.flag).toBe("plugin list --json");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("2c: compiled plugin dispatch translates internal utility names back to public argv", () => {
+    const dir = scratchProject();
+    try {
+      const executable = fakeCompiledExecutable(dir);
+      for (const command of [
+        "plugin list --json",
+        "plugin sync",
+        "plugin select test-pro another-plugin",
+      ]) {
+        const r = runAdapter(
+          dir,
+          "verb-intercept",
+          { prompt: promptWithNext(command), cwd: dir },
+          { AIDLC_COMPILED_EXECUTABLE: executable },
+        );
+        expect(r.code, command).toBe(0);
+        const relayed = r.stdout.match(/--- OUTPUT ---\n([\s\S]*?)\n--- END OUTPUT ---/)?.[1].trim();
+        expect(relayed, command).toBe(command);
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/t230-dispatcher-routes.test.ts
+++ b/tests/unit/t230-dispatcher-routes.test.ts
@@ -631,6 +631,18 @@ describe("t230 dispatcher help and errors", () => {
     expect(res.stderr.toString("utf-8")).toBe("aidlc: unknown verb 'bogus' for noun 'state'; try 'aidlc help --all'\n");
   });
 
+  test("plugin help and invalid plugin verbs use the shared noun grammar", () => {
+    const help = viaDispatcher(["plugin", "help"], REPO_ROOT);
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout.toString("utf-8")).toContain("plugin select [names]");
+
+    const invalid = viaDispatcher(["plugin", "remove"], REPO_ROOT);
+    expect(invalid.exitCode).toBe(1);
+    expect(invalid.stderr.toString("utf-8")).toBe(
+      "aidlc: unknown verb 'remove' for noun 'plugin'; try 'aidlc help --all'\n",
+    );
+  });
+
   test("formerly stubbed routes now reach utility handlers", () => {
     const projectDir = makeProject();
     writeMinimalState(projectDir);


### PR DESCRIPTION
## Summary

Fix `/aidlc plugin ...` slash commands being interpreted as freeform workflow requests.

Before this change, commands such as `/aidlc plugin list` reached `aidlc-orchestrate.ts next plugin list`. Because the orchestrator did not classify the leading `plugin` noun as a terminal command, it could ask the user to compose a scope or advance an active workflow instead of invoking the plugin utility.

This change introduces one shared plugin-command grammar used by the public dispatcher, orchestration engine, and Kiro pre-LLM interceptor.

## Behavior

The following commands now dispatch directly to their existing utility handlers:

| Slash command | Utility command |
| --- | --- |
| `/aidlc plugin list` | `aidlc-utility.ts plugin-list` |
| `/aidlc plugin list --json` | `aidlc-utility.ts plugin-list --json` |
| `/aidlc plugin sync` | `aidlc-utility.ts plugin-sync` |
| `/aidlc plugin select [names]` | `aidlc-utility.ts select-plugins [names]` |
| `/aidlc plugin help` | Global AI-DLC help |

Plugin commands are terminal utilities. They do not enter the scope-selection funnel, resume a workflow, or advance the active stage.

Missing and unknown plugin verbs now produce deterministic errors rather than being interpreted as intent descriptions.

## Implementation

- Add `parsePluginCommand()` as the shared parser for the `plugin` noun.
- Extend `classifyTerminalCommand()` with the `plugin-verb` command family.
- Use the shared parser from the public `aidlc` dispatcher.
- Add an orchestrator terminal branch before workflow state inspection.
- Preserve trailing arguments such as `--json` and plugin selection names.
- Extend Kiro turn-scoped terminal latching to cover plugin commands.
- Prevent a Kiro conductor retry from issuing a bare `next` after a plugin command.
- Add `plugin select [names]` to user-facing help.
- Correct the CLI guide stale direct-only plugin-selection wording.
- Regenerate Claude, Codex, Kiro CLI, Kiro IDE, and OpenCode distributions.

## Regression Coverage

- Plugin list routing with `--json`.
- Plugin sync routing.
- Plugin selection argument preservation.
- Plugin help routing.
- Missing and unknown plugin verb errors.
- Shared terminal-command classification.
- Public dispatcher parity.
- Kiro off-band dispatch and `plugin-verb` latch creation.
- Active-workflow protection preventing plugin commands from emitting `run-stage`.
- Coverage registry freshness.

## Version and Upgrade

Bumps AI-DLC from `2.5.11` to `2.5.12` across all generated harness distributions.

**Upgrade:** re-copy the appropriate `dist/<harness>/` shell into the project.

## Validation

- `bash tests/run-tests.sh --unit`: 166 test files, 3,287 assertions, zero failures.
- `bun run check`: package parity, TypeScript, and Biome passed.
- `bun scripts/build-binaries.ts`: native binary build passed.

The native artifact was produced under `build/binaries/native/aidlc`. Release binary artifacts are ignored and are not committed.