### PR TITLE
test: --no-llm CI profile + hermetic git in run-tests

### DIFF
--- a/docs/reference/09-testing.md
+++ b/docs/reference/09-testing.md
@@ -317,9 +317,8 @@ bash tests/run-tests.sh       # POSIX compatibility wrapper
 
 # Output modifiers
 --verbose       # Write per-test logs to tests/logs/
---no-llm        # Force the Claude gate closed: real-LLM integration/e2e files
-                # SKIP while deterministic tests in those tiers still run.
-                # Also via AIDLC_NO_LLM=1.
+--no-llm        # Force all live-model gates closed while deterministic
+                # integration/e2e tests still run. Also via AIDLC_NO_LLM=1.
 --debug         # Implies --verbose; streams per-test output and writes SDK/TUI
                 # driver traces to tests/logs/
 --filter PAT    # Only run tests whose filename matches extended regex PAT
@@ -327,14 +326,12 @@ bash tests/run-tests.sh       # POSIX compatibility wrapper
                 # Default: 1 (serial). Smoke and unit tiers are always serial.
 ```
 
-`--no-llm` (or `AIDLC_NO_LLM=1`) forces the Claude gate closed even when the
-`claude` CLI is present on PATH. Real-LLM integration and e2e files (the derived
-Claude-dependent set) take their per-file `SKIP` path, while the deterministic
-tests in those same tiers still run. This gives CI a full-tier deterministic
-profile: complete deterministic coverage across every level, without the cost or
-flakiness of live-LLM turns. Without the flag the gate only closes when the
-`claude` CLI is missing (or the preflight fails), so `--no-llm` is the explicit
-way to get the deterministic slice on a machine that does have the CLI.
+`--no-llm` (or `AIDLC_NO_LLM=1`) closes the derived Claude gate and forces every
+live-model opt-in to `0`: Claude TUI, Kiro ACP/TUI/IDE, Codex exec, and opencode
+run. Deterministic tests in those tiers still run, including the token-free TUI
+substrate preflight. This gives CI a full-tier deterministic profile without
+live-model cost or flakiness, even when CLIs are installed and live variables
+were inherited as `1`.
 
 Live SDK and TUI harness drivers default to project-only Claude setting sources.
 That means they load the copied test `.claude/` project settings and hooks while

--- a/docs/reference/09-testing.md
+++ b/docs/reference/09-testing.md
@@ -317,12 +317,24 @@ bash tests/run-tests.sh       # POSIX compatibility wrapper
 
 # Output modifiers
 --verbose       # Write per-test logs to tests/logs/
+--no-llm        # Force the Claude gate closed: real-LLM integration/e2e files
+                # SKIP while deterministic tests in those tiers still run.
+                # Also via AIDLC_NO_LLM=1.
 --debug         # Implies --verbose; streams per-test output and writes SDK/TUI
                 # driver traces to tests/logs/
 --filter PAT    # Only run tests whose filename matches extended regex PAT
 --parallel N    # Run up to N test files concurrently within a tier (alias: -P N).
                 # Default: 1 (serial). Smoke and unit tiers are always serial.
 ```
+
+`--no-llm` (or `AIDLC_NO_LLM=1`) forces the Claude gate closed even when the
+`claude` CLI is present on PATH. Real-LLM integration and e2e files (the derived
+Claude-dependent set) take their per-file `SKIP` path, while the deterministic
+tests in those same tiers still run. This gives CI a full-tier deterministic
+profile: complete deterministic coverage across every level, without the cost or
+flakiness of live-LLM turns. Without the flag the gate only closes when the
+`claude` CLI is missing (or the preflight fails), so `--no-llm` is the explicit
+way to get the deterministic slice on a machine that does have the CLI.
 
 Live SDK and TUI harness drivers default to project-only Claude setting sources.
 That means they load the copied test `.claude/` project settings and hooks while

--- a/tests/gen-coverage-registry.ts
+++ b/tests/gen-coverage-registry.ts
@@ -700,7 +700,10 @@ export function claudeDependenciesOf(_fileName: string, src: string): ClaudeDepe
   const code = codeView(src);
   const found = new Set<ClaudeDependency>();
   if (/\bdriveAidlc\s*\(/.test(code)) found.add("sdk");
-  if (/tui-drive\.ts/.test(code)) found.add("tui");
+  // tui-drive is a terminal substrate, not inherently a Claude dependency: the
+  // deterministic preflight targets printf/cmd and Kiro TUI tests target
+  // kiro-cli. Require the executable code to name the Claude binary as well.
+  if (/tui-drive\.ts/.test(code) && /["']claude["']/.test(code)) found.add("tui");
   if (drivesClaudePrintSurface(code)) found.add("cli-claude");
   return CLAUDE_DEPENDENCIES.filter((m) => found.has(m));
 }

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -27,9 +27,17 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const BUN = process.execPath;
 
-// Platform null device, for pointing GIT_CONFIG_GLOBAL/SYSTEM at nothing so
-// spawned git ignores the developer's ~/.gitconfig (see the env block below).
+// Platform null device, used for the system config after the protected
+// safe.directory entries have been copied into the suite's isolated config.
 const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
+const LIVE_MODEL_GATES = [
+  "AIDLC_TUI_LIVE",
+  "AIDLC_KIRO_ACP_LIVE",
+  "AIDLC_KIRO_TUI_LIVE",
+  "AIDLC_CODEX_EXEC_LIVE",
+  "AIDLC_KIRO_IDE_LIVE",
+  "AIDLC_OPENCODE_RUN_LIVE",
+] as const;
 
 type Level = "smoke" | "unit" | "integration" | "e2e";
 type Status = "PASS" | "FAIL" | "SKIP";
@@ -44,8 +52,8 @@ interface ParsedArgs {
   filter: string;
   parallel: number;
   fullProfile: boolean;
-  // Force the Claude gate closed so real-LLM integration/e2e files SKIP while
-  // deterministic tests in those tiers still run. Also via AIDLC_NO_LLM=1.
+  // Force every live-model gate closed so deterministic tests in integration
+  // and e2e still run. Also via AIDLC_NO_LLM=1.
   noLlm: boolean;
 }
 
@@ -75,9 +83,8 @@ PROFILE FLAGS (shortcuts -- map to test pyramid layers):
 
 OUTPUT MODIFIERS (combinable with any tier/profile):
   --verbose       Write per-test logs to tests/logs/
-  --no-llm        Force the Claude gate closed: real-LLM integration/e2e files
-                  SKIP while deterministic tests in those tiers still run.
-                  Also via AIDLC_NO_LLM=1.
+  --no-llm        Force all live-model gates closed while deterministic
+                  integration/e2e tests still run. Also via AIDLC_NO_LLM=1.
   --debug         Implies --verbose; streams per-test output and writes SDK/TUI
                   driver traces to tests/logs/
   --filter PAT    Only run tests whose filename matches extended regex PAT
@@ -266,6 +273,10 @@ if (args.verbose) {
 const resultsDir = join(logDir, "_results");
 mkdirSync(resultsDir, { recursive: true });
 
+if (args.noLlm) {
+  for (const gate of LIVE_MODEL_GATES) process.env[gate] = "0";
+}
+
 if (args.debug) {
   process.env.AIDLC_TEST_DEBUG = "true";
   process.stdout.write(`Debug driver traces: ${logDir}/{sdk,tui,kiro-acp}-drive-*.ndjson\n`);
@@ -286,13 +297,11 @@ if (args.fullProfile && args.debug) {
 
 let claudeGateOpen = true;
 if (needsLlm && args.noLlm) {
-  // --no-llm (or AIDLC_NO_LLM=1) forces the Claude gate closed even when the
-  // claude CLI is present, so real-LLM integration/e2e files SKIP while the
-  // deterministic tests in those tiers still run. This is the full-tier
-  // deterministic CI profile: complete deterministic coverage without incurring
-  // live-LLM cost or flakiness.
+  // --no-llm (or AIDLC_NO_LLM=1) closes the derived Claude gate and every
+  // independent live-model opt-in, even when CLIs and inherited live variables
+  // are present. Deterministic tests in those tiers still run.
   process.stdout.write(
-    "--no-llm: forcing Claude gate closed -- real-LLM integration/e2e files will SKIP; deterministic tests still run\n",
+    "--no-llm: forcing all live-model gates closed; deterministic tests still run\n",
   );
   claudeGateOpen = false;
 } else if (needsLlm && !commandExists("claude")) {
@@ -433,6 +442,87 @@ function displayLogDirPath(path: string): string {
   return rel.startsWith("..") ? path : rel.replace(/\\/g, "/");
 }
 
+function protectedGitConfigValues(scope: "--system" | "--global", key: string): string[] {
+  const result = spawnSync("git", ["config", "--null", scope, "--get-all", key], {
+    // Preserve gitdir-conditional protected includes for this checkout.
+    cwd: REPO_ROOT,
+    env: process.env,
+    encoding: "utf8",
+  });
+  if (result.status === 1) return [];
+  if (result.status !== 0) {
+    process.stderr.write(
+      `WARNING: could not read git ${scope.slice(2)} ${key}: ${result.stderr ?? ""}`,
+    );
+    return [];
+  }
+  const values = (result.stdout ?? "").split("\0");
+  if (values.at(-1) === "") values.pop();
+  return values;
+}
+
+function commandGitConfigValues(key: string): string[] {
+  const result = spawnSync("git", ["config", "--null", "--show-scope", "--get-all", key], {
+    cwd: tmpdir(),
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: NULL_DEVICE,
+      GIT_CONFIG_SYSTEM: NULL_DEVICE,
+    },
+    encoding: "utf8",
+  });
+  if (result.status === 1) return [];
+  if (result.status !== 0) {
+    process.stderr.write(
+      `WARNING: could not read git command ${key}: ${result.stderr ?? ""}`,
+    );
+    return [];
+  }
+
+  const fields = (result.stdout ?? "").split("\0");
+  if (fields.at(-1) === "") fields.pop();
+  const values: string[] = [];
+  for (let i = 0; i + 1 < fields.length; i += 2) {
+    if (fields[i] === "command") values.push(fields[i + 1]);
+  }
+  return values;
+}
+
+function createIsolatedGitConfig(): string {
+  if (!commandExists("git")) return NULL_DEVICE;
+
+  const configPath = join(logDir, `.gitconfig-aidlc-tests-${process.pid}`);
+  writeFileSync(configPath, "", { encoding: "utf8", mode: 0o600 });
+  const entries: Array<[string, string]> = [
+    ["commit.gpgsign", "false"],
+    ["tag.gpgsign", "false"],
+  ];
+  for (const safeDirectory of [
+    ...protectedGitConfigValues("--system", "safe.directory"),
+    ...protectedGitConfigValues("--global", "safe.directory"),
+    ...commandGitConfigValues("safe.directory"),
+  ]) {
+    entries.push(["safe.directory", safeDirectory]);
+  }
+
+  for (const [key, value] of entries) {
+    const result = spawnSync("git", ["config", "--file", configPath, "--add", key, value], {
+      cwd: tmpdir(),
+      env: process.env,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      process.stderr.write(
+        `ERROR: could not create isolated git config (${key}): ${result.stderr ?? ""}`,
+      );
+      process.exit(2);
+    }
+  }
+  return configPath;
+}
+
+const isolatedGitConfig = createIsolatedGitConfig();
+
 async function runSpawnCapture(
   cmd: string,
   cmdArgs: string[],
@@ -525,26 +615,32 @@ async function runBunTestFile(file: string, parallelMode = false): Promise<void>
   // reconciled out from under them. The dedicated test (t205-gate-revision-
   // backstop) clears this var in its own tool spawns to exercise the backfill.
   //
-  // Hermetic git for the whole suite. Several tiers (worktree/Bolt/swarm/
-  // multi-repo) drive REAL `git` against throwaway temp repos, and every spawned
-  // git otherwise inherits the developer's ~/.gitconfig. On a machine that sets
-  // commit.gpgsign=true with an SSH/GPG signer (e.g. 1Password's op-ssh-sign),
-  // a fixture's seed `commit` tries to sign, and dies "Could not connect to
-  // socket" whenever the agent is down, failing the suite for a reason that has
-  // nothing to do with the code under test. Pointing GIT_CONFIG_GLOBAL/SYSTEM at
-  // the null device makes git read NO user/system config, so no signing, no
-  // identity leakage, deterministic on any machine or CI box. Fixtures already
-  // pass their own `-c user.email/-c user.name` per commit, so identity is still
-  // satisfied.
+  // Isolate git for the whole suite. The generated global config carries forward
+  // protected safe.directory entries needed by mounted/foreign-owned CI
+  // workspaces, but excludes developer settings and explicitly disables commit
+  // and tag signing. Fixtures pass their own identity per commit.
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     AIDLC_TEST_NAME: base,
     AIDLC_SKIP_ARTIFACT_GUARD: "1",
     AIDLC_SKIP_HUMAN_PRESENCE_GUARD: "1",
     AIDLC_SKIP_REVISION_BACKSTOP: "1",
-    GIT_CONFIG_GLOBAL: NULL_DEVICE,
-    GIT_CONFIG_SYSTEM: NULL_DEVICE,
   };
+  // Command-scope config outranks the isolated global file. Preserve its safety
+  // entries above, then remove all command-scope injection before spawning tests.
+  for (const key of Object.keys(env)) {
+    const upper = key.toUpperCase();
+    if (
+      upper === "GIT_CONFIG" ||
+      upper === "GIT_CONFIG_COUNT" ||
+      upper === "GIT_CONFIG_PARAMETERS" ||
+      /^GIT_CONFIG_(KEY|VALUE)_[0-9]+$/.test(upper)
+    ) {
+      delete env[key];
+    }
+  }
+  env.GIT_CONFIG_GLOBAL = isolatedGitConfig;
+  env.GIT_CONFIG_SYSTEM = NULL_DEVICE;
   process.stdout.write(`\n=== START ${base} ===\n`);
 
   const junitXml = tmpFile("aidlc-run-tests-junit");
@@ -893,10 +989,12 @@ async function main(): Promise<number> {
 
 try {
   const rc = await main();
+  if (isolatedGitConfig !== NULL_DEVICE) rmSync(isolatedGitConfig, { force: true });
   if (cleanupLogDir) rmSync(logDir, { recursive: true, force: true });
   process.exit(rc);
 } catch (err) {
   appendFileSync(2, `${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  if (isolatedGitConfig !== NULL_DEVICE) rmSync(isolatedGitConfig, { force: true });
   if (cleanupLogDir) rmSync(logDir, { recursive: true, force: true });
   process.exit(1);
 }

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -27,6 +27,10 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const BUN = process.execPath;
 
+// Platform null device, for pointing GIT_CONFIG_GLOBAL/SYSTEM at nothing so
+// spawned git ignores the developer's ~/.gitconfig (see the env block below).
+const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
+
 type Level = "smoke" | "unit" | "integration" | "e2e";
 type Status = "PASS" | "FAIL" | "SKIP";
 
@@ -40,6 +44,9 @@ interface ParsedArgs {
   filter: string;
   parallel: number;
   fullProfile: boolean;
+  // Force the Claude gate closed so real-LLM integration/e2e files SKIP while
+  // deterministic tests in those tiers still run. Also via AIDLC_NO_LLM=1.
+  noLlm: boolean;
 }
 
 interface ResultRow {
@@ -68,6 +75,9 @@ PROFILE FLAGS (shortcuts -- map to test pyramid layers):
 
 OUTPUT MODIFIERS (combinable with any tier/profile):
   --verbose       Write per-test logs to tests/logs/
+  --no-llm        Force the Claude gate closed: real-LLM integration/e2e files
+                  SKIP while deterministic tests in those tiers still run.
+                  Also via AIDLC_NO_LLM=1.
   --debug         Implies --verbose; streams per-test output and writes SDK/TUI
                   driver traces to tests/logs/
   --filter PAT    Only run tests whose filename matches extended regex PAT
@@ -106,6 +116,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     filter: "",
     parallel: 1,
     fullProfile: false,
+    noLlm: process.env.AIDLC_NO_LLM === "1",
   };
   let levelSelected = false;
 
@@ -145,6 +156,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case "--verbose":
         out.verbose = true;
+        break;
+      case "--no-llm":
+        out.noLlm = true;
         break;
       case "--debug":
         out.debug = true;
@@ -271,7 +285,17 @@ if (args.fullProfile && args.debug) {
 }
 
 let claudeGateOpen = true;
-if (needsLlm && !commandExists("claude")) {
+if (needsLlm && args.noLlm) {
+  // --no-llm (or AIDLC_NO_LLM=1) forces the Claude gate closed even when the
+  // claude CLI is present, so real-LLM integration/e2e files SKIP while the
+  // deterministic tests in those tiers still run. This is the full-tier
+  // deterministic CI profile: complete deterministic coverage without incurring
+  // live-LLM cost or flakiness.
+  process.stdout.write(
+    "--no-llm: forcing Claude gate closed -- real-LLM integration/e2e files will SKIP; deterministic tests still run\n",
+  );
+  claudeGateOpen = false;
+} else if (needsLlm && !commandExists("claude")) {
   process.stdout.write("WARNING: claude CLI not found -- live integration/e2e tests may fail or skip\n");
   claudeGateOpen = false;
 }
@@ -500,12 +524,26 @@ async function runBunTestFile(file: string, parallelMode = false): Promise<void>
   // against bare fixtures and must not have their Revision Count / audit trail
   // reconciled out from under them. The dedicated test (t205-gate-revision-
   // backstop) clears this var in its own tool spawns to exercise the backfill.
+  //
+  // Hermetic git for the whole suite. Several tiers (worktree/Bolt/swarm/
+  // multi-repo) drive REAL `git` against throwaway temp repos, and every spawned
+  // git otherwise inherits the developer's ~/.gitconfig. On a machine that sets
+  // commit.gpgsign=true with an SSH/GPG signer (e.g. 1Password's op-ssh-sign),
+  // a fixture's seed `commit` tries to sign, and dies "Could not connect to
+  // socket" whenever the agent is down, failing the suite for a reason that has
+  // nothing to do with the code under test. Pointing GIT_CONFIG_GLOBAL/SYSTEM at
+  // the null device makes git read NO user/system config, so no signing, no
+  // identity leakage, deterministic on any machine or CI box. Fixtures already
+  // pass their own `-c user.email/-c user.name` per commit, so identity is still
+  // satisfied.
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     AIDLC_TEST_NAME: base,
     AIDLC_SKIP_ARTIFACT_GUARD: "1",
     AIDLC_SKIP_HUMAN_PRESENCE_GUARD: "1",
     AIDLC_SKIP_REVISION_BACKSTOP: "1",
+    GIT_CONFIG_GLOBAL: NULL_DEVICE,
+    GIT_CONFIG_SYSTEM: NULL_DEVICE,
   };
   process.stdout.write(`\n=== START ${base} ===\n`);
 

--- a/tests/smoke/t05-run-tests-parallel.test.ts
+++ b/tests/smoke/t05-run-tests-parallel.test.ts
@@ -75,7 +75,8 @@
 
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { REPO_ROOT } from "../harness/fixtures.ts";
 
@@ -448,17 +449,19 @@ describe("t05 run-tests.sh --parallel flag (migrated from t05-run-tests-parallel
     );
     expect(explicitOff.status).toBe(0);
     expect(explicitOff.out).toContain("Live TUI coverage: AIDLC_TUI_LIVE=0 (explicit");
+
+    const noLlm = run(
+      ["--all", "--debug", "--no-llm", "--filter", "NO_SUCH_T05_TEST"],
+      { AIDLC_TUI_LIVE: undefined },
+    );
+    expect(noLlm.status).toBe(0);
+    expect(noLlm.out).toContain("Live TUI coverage: AIDLC_TUI_LIVE=0 (explicit");
+    expect(noLlm.out).not.toContain("AIDLC_TUI_LIVE=1 (defaulted");
   }, PER_TEST_TIMEOUT);
 
-  // --- --no-llm forces the Claude gate closed -------------------------------
-  // run-tests.ts: --no-llm (and AIDLC_NO_LLM=1) sets claudeGateOpen=false even
-  // when the claude CLI is present, so a claude-required integration file lands
-  // on the per-file SKIP path (=== DONE <name> (SKIP) ===) while a deterministic
-  // sibling in the same tier still RUNs to completion. The filter selects one of
-  // each: t141-enterprise-scope-routing is claude-required (SKIPs), and
-  // t12-state-fixture-validation is deterministic (runs). Using --filter also
-  // means the live preflight (t19) does NOT run, so this stays deterministic and
-  // needs no claude substrate regardless of whether the CLI is on PATH.
+  // --- --no-llm closes every live-model gate --------------------------------
+  // The derived Claude gate skips Claude-dependent files while deterministic
+  // siblings run. Independent harness live gates are forced to 0 below.
   const NO_LLM_FILTER = "t141-enterprise-scope-routing|t12-state-fixture-validation";
   const NO_LLM_LIVE = "t141-enterprise-scope-routing.test.ts";
   const NO_LLM_DETERMINISTIC = "t12-state-fixture-validation.test.ts";
@@ -466,7 +469,7 @@ describe("t05 run-tests.sh --parallel flag (migrated from t05-run-tests-parallel
   test("--no-llm skips claude-required integration files while deterministic ones run", () => {
     const r = run(["--integration", "--no-llm", "--filter", NO_LLM_FILTER]);
     // The gate-closed banner is emitted.
-    expect(r.out).toContain("--no-llm: forcing Claude gate closed");
+    expect(r.out).toContain("--no-llm: forcing all live-model gates closed");
     // The claude-required file is SKIPPED (per-file SKIP done marker).
     expect(r.out).toContain(`=== DONE ${NO_LLM_LIVE} (SKIP) ===`);
     // The deterministic file actually RAN (its START marker fired and it did not
@@ -482,9 +485,134 @@ describe("t05 run-tests.sh --parallel flag (migrated from t05-run-tests-parallel
     const r = run(["--integration", "--filter", NO_LLM_FILTER], {
       AIDLC_NO_LLM: "1",
     });
-    expect(r.out).toContain("--no-llm: forcing Claude gate closed");
+    expect(r.out).toContain("--no-llm: forcing all live-model gates closed");
     expect(r.out).toContain(`=== DONE ${NO_LLM_LIVE} (SKIP) ===`);
     expect(r.out).toContain(`=== START ${NO_LLM_DETERMINISTIC} ===`);
     expect(r.status).toBe(0);
+  }, PER_TEST_TIMEOUT);
+
+  test("--no-llm closes every live-model environment gate", () => {
+    const plant = join(TESTS_ROOT, "integration", "tZZ-no-llm-gates-t05.test.ts");
+    const gates = [
+      "AIDLC_TUI_LIVE",
+      "AIDLC_KIRO_ACP_LIVE",
+      "AIDLC_KIRO_TUI_LIVE",
+      "AIDLC_CODEX_EXEC_LIVE",
+      "AIDLC_KIRO_IDE_LIVE",
+      "AIDLC_OPENCODE_RUN_LIVE",
+    ];
+    writeFileSync(
+      plant,
+      plantedBunTestSource(
+        "all live-model gates are forced closed",
+        [
+          `  const gates = ${JSON.stringify(gates)};`,
+          '  for (const gate of gates) expect(process.env[gate]).toBe("0");',
+        ].join("\n"),
+      ),
+      "utf8",
+    );
+    try {
+      const liveEnv = Object.fromEntries(gates.map((gate) => [gate, "1"]));
+      const r = run(
+        ["--integration", "--no-llm", "--filter", "tZZ-no-llm-gates-t05"],
+        liveEnv,
+      );
+      expect(r.status).toBe(0);
+      expect(r.out).toContain("=== START tZZ-no-llm-gates-t05.test.ts ===");
+    } finally {
+      rmSync(plant, { force: true });
+    }
+  }, PER_TEST_TIMEOUT);
+
+  test("--no-llm runs the deterministic TUI substrate preflight", () => {
+    const r = run(["--e2e", "--no-llm", "--filter", "t-tui-preflight"]);
+    expect(r.status).toBe(0);
+    expect(r.out).toContain("=== START t-tui-preflight.serial.test.ts ===");
+    expect(r.out).not.toContain("=== DONE t-tui-preflight.serial.test.ts (SKIP) ===");
+  }, PER_TEST_TIMEOUT);
+
+  test("isolated git config preserves safe.directory and disables signing", () => {
+    const plant = join(TESTS_ROOT, "integration", "tZZ-git-config-t05.test.ts");
+    const fixtureDir = mkdtempSync(join(tmpdir(), "aidlc-t05-git-config-"));
+    const inheritedGlobalConfig = join(fixtureDir, "global.gitconfig");
+    const inheritedSystemConfig = join(fixtureDir, "system.gitconfig");
+    const globalSafeDirectory = "/aidlc/t05-global-safe-directory";
+    const systemSafeDirectory = "/aidlc/t05-system-safe-directory";
+    const countSafeDirectory = "/aidlc/t05-count-safe-directory";
+    const parametersSafeDirectory = "/aidlc/t05-parameters-safe-directory";
+    writeFileSync(
+      inheritedGlobalConfig,
+      [
+        "[safe]",
+        `\tdirectory = ${globalSafeDirectory}`,
+        "[commit]",
+        "\tgpgsign = true",
+        "[tag]",
+        "\tgpgsign = true",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      inheritedSystemConfig,
+      ["[safe]", `\tdirectory = ${systemSafeDirectory}`, ""].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      plant,
+      [
+        'import { expect, test } from "bun:test";',
+        'import { spawnSync } from "node:child_process";',
+        'import { tmpdir } from "node:os";',
+        "",
+        'function config(...args: string[]): string {',
+        '  const result = spawnSync("git", ["config", ...args], { cwd: tmpdir(), encoding: "utf8" });',
+        "  expect(result.status).toBe(0);",
+        '  return (result.stdout ?? "").trim();',
+        "}",
+        "",
+        'test("git config is isolated without losing protected safety entries", () => {',
+        '  const safeDirectories = config("--get-all", "safe.directory").split(/\\r?\\n/);',
+        `  expect(safeDirectories).toContain(${JSON.stringify(globalSafeDirectory)});`,
+        `  expect(safeDirectories).toContain(${JSON.stringify(systemSafeDirectory)});`,
+        `  expect(safeDirectories).toContain(${JSON.stringify(countSafeDirectory)});`,
+        `  expect(safeDirectories).toContain(${JSON.stringify(parametersSafeDirectory)});`,
+        '  expect(config("--get", "commit.gpgsign")).toBe("false");',
+        '  expect(config("--get", "tag.gpgsign")).toBe("false");',
+        '  expect(process.env.GIT_CONFIG_GLOBAL).not.toBe("/dev/null");',
+        '  expect(process.env.GIT_CONFIG_GLOBAL).not.toBe("NUL");',
+        '  expect(process.env.GIT_CONFIG_GLOBAL).toMatch(/\\.gitconfig-aidlc-tests-[0-9]+$/);',
+        "  expect(process.env.GIT_CONFIG_COUNT).toBeUndefined();",
+        "  expect(process.env.GIT_CONFIG_PARAMETERS).toBeUndefined();",
+        "});",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    try {
+      const r = run(
+        ["--integration", "--filter", "tZZ-git-config-t05"],
+        {
+          GIT_CONFIG_GLOBAL: inheritedGlobalConfig,
+          GIT_CONFIG_SYSTEM: inheritedSystemConfig,
+          GIT_CONFIG_COUNT: "3",
+          GIT_CONFIG_KEY_0: "safe.directory",
+          GIT_CONFIG_VALUE_0: countSafeDirectory,
+          GIT_CONFIG_KEY_1: "commit.gpgsign",
+          GIT_CONFIG_VALUE_1: "true",
+          GIT_CONFIG_KEY_2: "tag.gpgsign",
+          GIT_CONFIG_VALUE_2: "true",
+          GIT_CONFIG_PARAMETERS:
+            `'safe.directory'='${parametersSafeDirectory}' ` +
+            "'commit.gpgsign'='true'",
+        },
+      );
+      expect(r.status).toBe(0);
+      expect(r.out).toContain("=== START tZZ-git-config-t05.test.ts ===");
+    } finally {
+      rmSync(plant, { force: true });
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
   }, PER_TEST_TIMEOUT);
 });

--- a/tests/smoke/t05-run-tests-parallel.test.ts
+++ b/tests/smoke/t05-run-tests-parallel.test.ts
@@ -449,4 +449,42 @@ describe("t05 run-tests.sh --parallel flag (migrated from t05-run-tests-parallel
     expect(explicitOff.status).toBe(0);
     expect(explicitOff.out).toContain("Live TUI coverage: AIDLC_TUI_LIVE=0 (explicit");
   }, PER_TEST_TIMEOUT);
+
+  // --- --no-llm forces the Claude gate closed -------------------------------
+  // run-tests.ts: --no-llm (and AIDLC_NO_LLM=1) sets claudeGateOpen=false even
+  // when the claude CLI is present, so a claude-required integration file lands
+  // on the per-file SKIP path (=== DONE <name> (SKIP) ===) while a deterministic
+  // sibling in the same tier still RUNs to completion. The filter selects one of
+  // each: t141-enterprise-scope-routing is claude-required (SKIPs), and
+  // t12-state-fixture-validation is deterministic (runs). Using --filter also
+  // means the live preflight (t19) does NOT run, so this stays deterministic and
+  // needs no claude substrate regardless of whether the CLI is on PATH.
+  const NO_LLM_FILTER = "t141-enterprise-scope-routing|t12-state-fixture-validation";
+  const NO_LLM_LIVE = "t141-enterprise-scope-routing.test.ts";
+  const NO_LLM_DETERMINISTIC = "t12-state-fixture-validation.test.ts";
+
+  test("--no-llm skips claude-required integration files while deterministic ones run", () => {
+    const r = run(["--integration", "--no-llm", "--filter", NO_LLM_FILTER]);
+    // The gate-closed banner is emitted.
+    expect(r.out).toContain("--no-llm: forcing Claude gate closed");
+    // The claude-required file is SKIPPED (per-file SKIP done marker).
+    expect(r.out).toContain(`=== DONE ${NO_LLM_LIVE} (SKIP) ===`);
+    // The deterministic file actually RAN (its START marker fired and it did not
+    // take the SKIP path).
+    expect(r.out).toContain(`=== START ${NO_LLM_DETERMINISTIC} ===`);
+    expect(r.out).not.toContain(`=== DONE ${NO_LLM_DETERMINISTIC} (SKIP) ===`);
+    // A gate-closed run over deterministic content still passes and exits 0.
+    expect(r.status).toBe(0);
+    expect(r.out.split("\n").some((l) => l.startsWith("RESULT: PASS"))).toBe(true);
+  }, PER_TEST_TIMEOUT);
+
+  test("AIDLC_NO_LLM=1 forces the Claude gate closed like --no-llm", () => {
+    const r = run(["--integration", "--filter", NO_LLM_FILTER], {
+      AIDLC_NO_LLM: "1",
+    });
+    expect(r.out).toContain("--no-llm: forcing Claude gate closed");
+    expect(r.out).toContain(`=== DONE ${NO_LLM_LIVE} (SKIP) ===`);
+    expect(r.out).toContain(`=== START ${NO_LLM_DETERMINISTIC} ===`);
+    expect(r.status).toBe(0);
+  }, PER_TEST_TIMEOUT);
 });

--- a/tests/unit/t134-mechanism-honesty.test.ts
+++ b/tests/unit/t134-mechanism-honesty.test.ts
@@ -123,7 +123,12 @@ describe("t134 mechanism honesty and runner Claude gate", () => {
       {
         file: "tests/e2e/t-tui-preflight.serial.test.ts",
         mechanisms: ["tui"],
-        claudeDependencies: ["tui"],
+        claudeDependencies: [],
+      },
+      {
+        file: "tests/e2e/t-tui-kiro-status.serial.test.ts",
+        mechanisms: ["tui"],
+        claudeDependencies: [],
       },
       {
         file: "tests/unit/t34.test.ts",


### PR DESCRIPTION
## What

Two test-runner hardening changes, ported from the SEEK AI-DLC pilot fork (SEEK-Jobs/aide-ai-dlc-pilot-external, drift commit by Helen Giapitzakis), where both have been running as the fork's CI profile. Test infrastructure only: no core/, no harness/, dist/ untouched, no version bump per the changelog policy.

### 1. --no-llm flag (or AIDLC_NO_LLM=1)

Forces the Claude gate closed even when the claude CLI is on PATH, so real-LLM integration/e2e files take their per-file SKIP path while deterministic tests in those same tiers still run. Today the only way to avoid live-LLM cost/flakiness in --integration is to skip the tier entirely, losing its deterministic files too.

This gives CI a full-tier deterministic profile. It would pair well with the new v2 PR gate: the ci.yml workflow currently runs smoke/unit, and --no-llm makes adding the deterministic integration tier affordable.

Verified: with claude on PATH, `--integration --no-llm` skipped 24 Claude-required files and ran 79 deterministic files; a banner names the forced-closed gate so a skipped-green run cannot be mistaken for live coverage.

### 2. Hermetic git for spawned test files

GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM point at the platform null device in every spawned test file's env, so test git reads no developer/system gitconfig. The worktree/Bolt/swarm/multi-repo tiers drive real git against throwaway temp repos; on a machine with commit.gpgsign=true and an SSH signer (e.g. 1Password's op-ssh-sign), a fixture seed commit tries to sign and dies "Could not connect to socket" whenever the signing agent is down - a suite failure unrelated to the code under test. Fixtures already pass -c user.email/-c user.name per commit, so identity is unaffected.

## Changes

- tests/run-tests.ts: noLlm flag + env default, usage help, gate-closed branch ahead of the missing-CLI branch, NULL_DEVICE git config env
- tests/smoke/t05-run-tests-parallel.test.ts: two self-tests driving the real runner (flag and env forms), each proving a claude-required file SKIPs while a deterministic sibling PASSes
- docs/reference/09-testing.md: flag documented

## Testing

- smoke+unit: 178 files, 0 failed
- --integration --no-llm: 24 skipped / 79 ran, deterministic files all green (3 pre-existing base reds on v2 - t66 designer-export golden, t89 claim-sources sensor fixture, t163 reaper steal race - reproduce identically on 9f914544 without this change; happy to file them as a separate issue)
- bun run typecheck clean