### PR TITLE
fix: guard the shared codekb against silent narrower-rerun overwrites (2.5.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.35] - 2026-08-03
+
+Reverse Engineering no longer silently discards a prior intent's code knowledge on rerun. The shared per-repository codekb now records and compares actual scan coverage before replacement, keeps full-root freshness checks stable, and resolves every repository before advancing a multi-repo stage. **Upgrade:** re-copy your `dist/<harness>/` shell into the project; existing stores predate scope tracking and report `UNKNOWN_SCOPE` until their first post-upgrade scan writes the new scope block.
+
+* `reverse-engineering-timestamp.md` now ends with a structured `## Scope of Analysis` block recording full/partial coverage, analyzed and shallow paths, components, intent, and a content fingerprint.
+* The direct `aidlc-utility codekb-scope-diff` verb reports `NO_STORE`/`CURRENT`/`STALE`/`UNVERIFIED`/`UNKNOWN_SCOPE`, compares incoming coverage as `COVERS` or `NARROWER`, and mints working-tree fingerprints for recorded paths.
+* Full-root fingerprints exclude the framework-owned `aidlc/` tree so writing codekb, scope-draft, state, and audit files does not immediately make a store stale. Invalid or unmatched pathspecs now produce `unknown`/`UNVERIFIED` instead of Git's stable empty-tree hash.
+* `kind: full` now requires explicit repository-root (`./`) coverage, and a full store can only be replaced without warning by another valid full scan.
+* Multi-repo reruns resolve all reuse/rescan decisions before one lifecycle report, scan only repositories that need replacement, and use repository-specific scope drafts so parallel scans cannot overwrite one another.
+
 ## [2.5.34] - 2026-08-03
 
 The plugin contribution seam now merges `adds.scopes`: a plugin can put an existing core stage under one of its OWN scopes, so a single plugin scope can carry a run through both the plugin's stages and the core stages it routes onto. Previously the surface was declared-but-deferred (drop-logged, never merged). **Upgrade:** re-copy your `dist/<harness>/` shell and re-install/re-sync your plugins so the updated compose hook and `select-plugins` strip are in place; already-installed plugins recompose automatically on the next session start.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.34-blue)
+![version](https://img.shields.io/badge/version-2.5.35-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/stages/inception/reverse-engineering.md
+++ b/core/aidlc-common/stages/inception/reverse-engineering.md
@@ -2,7 +2,7 @@
 slug: reverse-engineering
 phase: inception
 execution: CONDITIONAL
-condition: Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.
+condition: Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.
 lead_agent: aidlc-developer-agent
 support_agents:
   - aidlc-architect-agent
@@ -60,25 +60,92 @@ The engine records the skip and advances to the next in-scope stage.
 
 #### Resolve the intent's repo set (multi-repo)
 
-This stage runs **per repo** the intent touches. Resolve the repo set from the
-intent's registry row before scanning:
+This stage runs **per repo** the intent touches. Resolve the complete repo set
+from the intent's registry row before making any reuse or scan decision:
 
 1. Read the active intent's `repos` array from
    `aidlc/spaces/<active-space>/intents/intents.json` (the row whose `uuid`/`slug`
    matches the active intent). This is the set captured at intent birth (an explicit
    `--repos a,b` or sibling auto-discovery).
 2. **Single-repo / unrecorded:** if `repos` is absent, empty, or has exactly one
-   entry, RE runs once against the lone repo — the same flow as before. (An
+   entry, RE runs once against the lone repo - the same flow as before. (An
    unrecorded set means the workspace root is itself the single repo.)
-3. **Multi-repo:** if `repos` has more than one entry, run Steps 2–3 **once per
-   repo**, scanning that repo's sibling directory (`<workspace>/<repo>/`) and writing
-   its 9 artifacts to the directory `codekb-path --repo <repo>` prints (the
-   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each repo's codekb is independent;
-   nothing in one repo's scan blocks another's, so the per-repo scans may run as
-   parallel subagents.
+3. **Multi-repo:** if `repos` has more than one entry, resolve the Step 1 guard
+   decision for every repo, then run Steps 2-3 once for each repo selected for a
+   scan. Scan that repo's sibling directory (`<workspace>/<repo>/`) and write its
+   9 artifacts to the directory `codekb-path --repo <repo>` prints (the
+   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each
+   repo's codekb is independent, so selected scans may run as parallel subagents.
 
-In the steps below, `<repo>` is the repo currently being scanned; repeat for each
-repo in the set.
+In the steps below, `<repo>` is the repository whose decision or scan is being
+processed.
+
+#### Rerun guard: check each existing store before scanning
+
+The codekb is a space-level store shared across intents; a rerun REPLACES it.
+For every repo in the resolved set, run the read-only check:
+
+```
+bun {{HARNESS_DIR}}/tools/aidlc-utility.ts codekb-scope-diff --repo <repo>
+```
+
+- **NO_STORE** - first scan for this repo. Proceed to Step 2; no question.
+- **CURRENT** - the store's analyzed paths are unchanged since it was built.
+  If the recorded coverage plausibly serves this intent's area, present the
+  reuse question below. If this intent clearly targets code OUTSIDE the
+  store's analyzed paths, skip the reuse option and ask rescan vs focused only.
+- **STALE / UNVERIFIED / UNKNOWN_SCOPE** - the store's knowledge is out of
+  date, unverifiable, or predates scope tracking. Present the rescan question
+  below WITHOUT the reuse option.
+
+Reuse question (CURRENT + coverage fits the intent) - fold the tool's output
+(store intent, analyzed paths) into the prompt so the human decides on
+evidence:
+
+```question
+prompt: "An up-to-date code knowledge base exists for <repo> (built by intent <store-intent>; verified unchanged). Deep coverage: <analyzed paths>. Reuse it, or rescan?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Reuse existing knowledge base"
+    description: "Skip the scan; downstream stages read the current store as-is"
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - the store will describe ONLY that area afterward"
+```
+
+Rescan question (STALE / UNVERIFIED / UNKNOWN_SCOPE, or CURRENT with coverage
+that does not fit) - include the verdict line in the prompt:
+
+```question
+prompt: "A code knowledge base exists for <repo> but <verdict summary - e.g. its analyzed paths have changed since it was built / it does not cover this intent's area>. Rescanning replaces it. How should the scan run?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - prior deep knowledge outside it is discarded (recoverable from git history)"
+```
+
+Record one decision per repo: reuse, full rescan, or focused scan. A reuse
+decision does NOT report or advance the stage while another repository may
+still need scanning. On a scan choice, also record its breadth; that choice
+sets the developer brief, and Step 3's scope block records what the scan
+actually covered.
+
+Only after every repository decision has been resolved:
+
+- If every repo is reused on an ordinary workflow run, report the stage as
+  skipped exactly once:
+  `bun {{HARNESS_DIR}}/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result skipped --reason "codekb reuse: all resolved stores CURRENT, human chose reuse"`.
+- If every repo is reused on an isolated run (`directive.single === true`), do
+  NOT call the main-workflow skipped report. Return the reused-repositories
+  summary to the orchestrator's isolated stage-runner branch; it owns the
+  single `report --single --stage "reverse-engineering" --result completed`.
+- If any repo needs scanning, do not report a skip. Proceed to Steps 2-3 for
+  only the full/focused scan repos; leave each reused repo's store unchanged.
 
 ### Step 2: Developer Code Scan
 
@@ -87,8 +154,14 @@ Delegate to Task tool with aidlc-developer-agent:
 - The agent persona and knowledge are loaded automatically. Do NOT manually inject the persona.
 - Include workspace state from aidlc-state.md as context
 
-Developer scans `<repo>`'s codebase (the sibling dir `<workspace>/<repo>/`; for a
-single-repo intent this is the whole codebase) for:
+Brief the developer with the scan breadth chosen at the Step 1 guard (full
+rescan = the whole repo; focused scan = the intent's area, named explicitly in
+the brief) and require the scan results' Scan Coverage section (re-artifacts.md
+template) to list what was actually analyzed deeply vs skimmed.
+
+For each repo selected for scanning, the developer scans `<repo>`'s codebase
+(the sibling dir `<workspace>/<repo>/`; for a single-repo intent this is the
+whole codebase) for:
 - All packages, modules, and their purposes
 - Build systems, configuration, and dependency relationships
 - External and internal APIs (endpoints, contracts, methods)
@@ -118,7 +191,11 @@ Architect synthesizes scan results into 9 artifacts:
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis). This is the freshness/staleness marker for the per-repo codekb store — a stale timestamp triggers a rerun (see the `condition` frontmatter: "Always rerun for freshness").
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) and MUST end with the structured `## Scope of Analysis` block from the re-artifacts.md template, filled from the developer's Scan Coverage - what the run ACTUALLY analyzed deeply, not what was aspired to. This is the freshness/staleness marker the Step 1 rerun guard reads. For the block's `fingerprint:` line, run the mint command with the analyzed paths (comma-separated) and paste its output verbatim:
+
+   ```
+   bun {{HARNESS_DIR}}/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --mint --paths <analyzed paths>
+   ```
 
 **Resolve the write directory with the engine, do NOT compose the path yourself.**
 Run the read-only tool
@@ -129,14 +206,35 @@ bun {{HARNESS_DIR}}/tools/aidlc-utility.ts codekb-path --repo <repo>
 
 (omit `--repo` for a single/unrecorded repo — the engine resolves the repo name).
 It prints ONE line: the exact directory, e.g. `aidlc/spaces/<active-space>/codekb/<repo>/`.
-Write all 9 artifacts into the directory the tool printed — verbatim, creating it if
-absent. This is the durable per-repo code knowledge base, a space-level store shared
-across every intent in the space. Never substitute the intent slug, the record dir, or
-a hand-composed path for what the tool prints.
+
+**Overwrite backstop - run BEFORE writing (the compare needs the store still
+un-replaced).** When the Step 1 guard found an existing store (any verdict but
+NO_STORE), write the new timestamp content to
+`<record>/inception/reverse-engineering/scope-draft-<repo>.md` (one draft per
+repo; NOT the timestamp filename - record-dir placement checks key on the
+artifact stems) and run
+
+```
+bun {{HARNESS_DIR}}/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --compare <record>/inception/reverse-engineering/scope-draft-<repo>.md
+```
+
+Keep the output keyed by `<repo>` for Step 5's completion summary. This is the
+deterministic check that the scan delivered the breadth chosen at Step 1 - a
+focused run after a "Full rescan" choice surfaces here as NARROWER, before
+approval. Delete that repo's `scope-draft-<repo>.md` immediately after
+preserving the compare output; scope drafts are temporary and MUST NOT remain
+in the intent record.
+
+Write all 9 artifacts into the directory `codekb-path` printed - verbatim,
+creating it if absent. This is the durable per-repo code knowledge base, a
+space-level store shared across every intent in the space. Never substitute
+the intent slug, the record dir, or a hand-composed path for what the tool
+prints.
 
 ### Step 4: Completion Handoff
 
-Hand completion to `stage-protocol.md` via
+After every selected repo scan has completed, hand completion to
+`stage-protocol.md` exactly once via
 `bun {{HARNESS_DIR}}/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result <outcome>`.
 The engine owns all lifecycle transitions and advancement.
 
@@ -146,9 +244,22 @@ Use stage-protocol.md completion template:
 - Announcement with completion summary
 - Summary of all 9 artifacts produced **per repo** (for a multi-repo intent, list
   each repo's `aidlc/spaces/<active-space>/codekb/<repo>/` set — the directory
-  `codekb-path --repo <repo>` printed in Step 3)
+  `codekb-path --repo <repo>` printed in Step 3); identify reused repos whose
+  existing stores were left unchanged
+- **For every repo whose Step 3 compare returned NARROWER**, the summary MUST
+  carry a repo-labeled warning before the question, quoting that repo's tool
+  discard list verbatim:
+
+  ```
+  WARNING for <repo>: this scan covered less than the store it replaced. Deep
+  knowledge of the following was discarded (recoverable from git history):
+  <discarded paths and components from the compare output>
+  Choose Request Changes to widen the scan instead.
+  ```
+
+  (COVERS, or no prior store, needs no warning line.)
 - Review path: `aidlc/spaces/<active-space>/codekb/<repo>/` for each repo in the set
-- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes
+- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes. If any repo returned NARROWER, the Approve option's description must say which stores were replaced by narrower scans (e.g. "Accept the narrower stores for <repos>; continue to Requirements Analysis").
 
 ## Sensors
 

--- a/core/knowledge/aidlc-developer-agent/re-artifacts.md
+++ b/core/knowledge/aidlc-developer-agent/re-artifacts.md
@@ -14,12 +14,16 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis)
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) plus the structured Scope of Analysis block (template below). The scope block is machine-read by `codekb-scope-diff` on the next rerun, so its accuracy decides whether a future intent is warned before overwriting this run's knowledge.
 
 ### Developer Code Scan Template
 
 ```markdown
 ## Developer Code Scan Results
+
+### Scan Coverage
+- **Analyzed deeply**: [repo-relative dirs/files actually read and understood, one per line]
+- **Skimmed only**: [areas noted at directory granularity without deep reading]
 
 ### Packages Found
 - [package name] — [type] — [language] — [purpose]
@@ -72,3 +76,33 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 ### Improvement Opportunities
 [Areas where the architecture could be strengthened]
 ```
+
+### Scope of Analysis Block (reverse-engineering-timestamp.md)
+
+End reverse-engineering-timestamp.md with exactly this fenced block, filled
+honestly from the Scan Coverage the developer reported - record what the run
+ACTUALLY covered deeply, not what the stage aspired to cover:
+
+````markdown
+## Scope of Analysis
+
+```yaml
+scope_version: 1
+kind: partial
+intent: [active intent slug]
+fingerprint: [output of the mint command in stage Step 3 - verbatim; it prints "unknown" when not computable]
+analyzed:
+  paths:
+    - [repo-relative dir (trailing slash) or file analyzed deeply, one per line]
+  components:
+    - [component names exactly as they appear in component-inventory.md]
+shallow:
+  paths:
+    - [areas only skimmed]
+```
+````
+
+Rules:
+- `kind: full` only when the scan genuinely covered the whole repo deeply; `analyzed.paths` MUST include the repo root (`./`). Anything less is `kind: partial`.
+- `analyzed.paths` entries are repo-relative, directories end with `/`, no glob characters.
+- Component names must match `component-inventory.md` headings verbatim - the rerun guard compares them literally.

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, appendFileSync, constants as fsConstants, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
@@ -1128,6 +1129,208 @@ export function relativeCodekbDir(projectDir: string, repo: string, space?: stri
 export function codekbRepoName(projectDir: string, space?: string): string {
   const repos = intentRepos(projectDir, undefined, space);
   return repos.length === 1 ? repos[0] : basename(projectDir);
+}
+
+// --- Codekb scope of analysis -------------------------------------------------
+//
+// The reverse-engineering stage records WHAT its scan covered in a fenced yaml
+// block inside reverse-engineering-timestamp.md (the store's freshness marker).
+// The parser + fingerprint here are the deterministic half of the rerun
+// guard: `codekb-scope-diff` compares a store's recorded scope against the
+// live working tree (status) or an incoming run's scope (compare), so the
+// human at the RE gate decides reuse/rescan/replace on evidence instead of
+// silently losing a prior intent's knowledge to a narrower overwrite.
+//
+// Block shape (scope_version 1 - authored by the architect at synthesis,
+// behind the RE approval gate):
+//
+//   ```yaml
+//   scope_version: 1
+//   kind: partial            # or: full
+//   intent: fix-payment-timeout
+//   fingerprint: 3f2a9c...   # codekbScopeFingerprint over analyzed.paths
+//   analyzed:
+//     paths:
+//       - src/payments/
+//     components:
+//       - payment-gateway
+//   shallow:
+//     paths:
+//       - src/
+//   ```
+//
+// Pure data - no model call. Same idiom as parseBoltDag: a constrained
+// line-walker, no YAML dependency.
+
+export type ReScope = {
+  kind: "full" | "partial";
+  intent: string;
+  fingerprint: string | null;
+  analyzedPaths: string[];
+  analyzedComponents: string[];
+  shallowPaths: string[];
+};
+
+export type ReScopeParse =
+  | { ok: true; scope: ReScope }
+  | { ok: false; reason: "absent" | "malformed"; detail: string };
+
+// Find the fenced yaml block carrying `scope_version:` anywhere in the body
+// (keyed on the version line, not a heading, so prose edits around the block
+// don't break parsing). Returns the inner lines, or null when no block exists.
+function extractScopeBlock(body: string): string | null {
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```ya?ml\s*$/.test(lines[i].trim())) {
+      const inner: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^```\s*$/.test(lines[j].trim())) break;
+        inner.push(lines[j]);
+      }
+      const block = inner.join("\n");
+      if (/^\s*scope_version\s*:/m.test(block)) return block;
+      i = j; // not the scope block - resume past its close fence
+    }
+  }
+  return null;
+}
+
+// Parse the scope block out of a reverse-engineering-timestamp.md body.
+// Unknown scope_version parses as malformed (a future writer must not be
+// half-read by an old reader); a missing block is "absent" (legacy store).
+export function parseReScope(body: string): ReScopeParse {
+  const block = extractScopeBlock(body);
+  if (block === null) {
+    return { ok: false, reason: "absent", detail: "no fenced yaml scope_version block found" };
+  }
+  const scope: ReScope = {
+    kind: "partial",
+    intent: "",
+    fingerprint: null,
+    analyzedPaths: [],
+    analyzedComponents: [],
+    shallowPaths: [],
+  };
+  let section: "analyzed" | "shallow" | null = null;
+  let list: "paths" | "components" | null = null;
+  let sawKind = false;
+  for (const raw of block.split("\n")) {
+    const t = raw.trim();
+    if (t === "" || t.startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (indent === 0) {
+      section = null;
+      list = null;
+      if (t.startsWith("scope_version:")) {
+        const v = t.slice("scope_version:".length).trim();
+        if (v !== "1") {
+          return { ok: false, reason: "malformed", detail: `unknown scope_version: ${v}` };
+        }
+      } else if (t.startsWith("kind:")) {
+        const k = t.slice("kind:".length).trim();
+        if (k !== "full" && k !== "partial") {
+          return { ok: false, reason: "malformed", detail: `kind must be full|partial, got: ${k}` };
+        }
+        scope.kind = k;
+        sawKind = true;
+      } else if (t.startsWith("intent:")) {
+        scope.intent = t.slice("intent:".length).trim();
+      } else if (t.startsWith("fingerprint:")) {
+        const f = t.slice("fingerprint:".length).trim();
+        scope.fingerprint = f === "" || f === "unknown" ? null : f;
+      } else if (t === "analyzed:") {
+        section = "analyzed";
+      } else if (t === "shallow:") {
+        section = "shallow";
+      }
+    } else if (section !== null && !t.startsWith("-") && t.endsWith(":")) {
+      list = t === "paths:" ? "paths" : t === "components:" ? "components" : null;
+    } else if (section !== null && list !== null && t.startsWith("-")) {
+      const item = t.slice(1).trim();
+      if (item === "") continue;
+      if (section === "analyzed" && list === "paths") scope.analyzedPaths.push(item);
+      else if (section === "analyzed" && list === "components") scope.analyzedComponents.push(item);
+      else if (section === "shallow" && list === "paths") scope.shallowPaths.push(item);
+    }
+  }
+  if (!sawKind) {
+    return { ok: false, reason: "malformed", detail: "missing kind: line" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.length === 0) {
+    return { ok: false, reason: "malformed", detail: "kind: partial requires analyzed.paths entries" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "repository-root coverage (./) requires kind: full",
+    };
+  }
+  if (scope.kind === "full" && !scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "kind: full requires repository-root coverage (analyzed.paths must include ./)",
+    };
+  }
+  return { ok: true, scope };
+}
+
+// Content fingerprint of the WORKING TREE restricted to the scope's analyzed
+// paths: `git write-tree` over a temporary index populated by `git add -A --
+// <paths>`. Hashes what is actually on disk (uncommitted edits included), so
+// rebases/squashes/amends that vaporise a recorded commit hash cannot break
+// the comparison, and reverting an edit restores the original fingerprint.
+// Ignored files stay excluded (git add semantics). Callers may exclude generated
+// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// Returns null when repoDir is not a git work tree, git is unavailable, or any
+// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+export function codekbScopeFingerprint(
+  repoDir: string,
+  paths: string[],
+  excludedPaths: string[] = [],
+): string | null {
+  if (paths.length === 0) return null;
+  const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: repoDir,
+    encoding: "utf-8",
+  });
+  if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+  const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+  try {
+    const exclusions = excludedPaths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "")
+      .map((p) => `:(exclude,literal)${p}`);
+    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+      cwd: repoDir,
+      env,
+      encoding: "utf-8",
+    });
+    if (add.status !== 0) return null;
+    const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
+    if (wt.status !== 0) return null;
+    const hash = wt.stdout.trim();
+    return /^[0-9a-f]{40,64}$/.test(hash) ? hash : null;
+  } finally {
+    try {
+      unlinkSync(indexFile);
+    } catch {
+      // best-effort cleanup - a leaked temp index is inert
+    }
+  }
+}
+
+// Coverage test for the compare mode: does the incoming run's analyzed set
+// cover a store entry? Literal match, or an incoming DIRECTORY prefix (entry
+// ending "/") subsuming the store path. Deliberately prefix-only - scope
+// paths are authored as repo-relative dirs/files, not globs.
+export function scopePathCovered(incoming: string[], storePath: string): boolean {
+  return incoming.some(
+    (p) => p === storePath || (p.endsWith("/") && storePath.startsWith(p)),
+  );
 }
 
 // The bare SPACE record root: `aidlc/spaces/<space>/intents/`. The absolute path

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -54,8 +54,11 @@ import {
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
+  codekbScopeFingerprint,
+  parseReScope,
   relativeCodekbDir,
   RESERVED_RECORD_NAMES,
+  scopePathCovered,
   gridCostSummary,
   listIntents,
   listSpaces,
@@ -4207,6 +4210,171 @@ function handleCodekbPath(projectDir: string, flags: Record<string, string>): vo
   process.stdout.write(`${dir}/\n`);
 }
 
+// `aidlc-utility.ts codekb-scope-diff [--repo <name>] [--compare <timestamp.md>]
+// [--json]` - read-only. The deterministic half of the reverse-engineering
+// rerun guard (the store is shared space-level knowledge; a narrower rerun
+// overwrites it last-writer-wins, so the human decides on evidence).
+//
+// Status mode (default): parse the STORE's reverse-engineering-timestamp.md
+// scope block and recompute the content fingerprint over its analyzed paths.
+//   NO_STORE       no store timestamp - first scan, nothing to guard
+//   CURRENT        fingerprint matches - the store's deep knowledge is exact
+//   STALE          analyzed paths changed since the store was built
+//   UNVERIFIED     scope parsed but no/uncomputable fingerprint (non-git)
+//   UNKNOWN_SCOPE  block absent (legacy store) or malformed
+//
+// Compare mode (--compare <incoming timestamp.md>): does the incoming run's
+// analyzed scope cover the store's? COVERS, or NARROWER + the exact paths and
+// components an overwrite would discard.
+//
+// Mint mode (--mint --paths <a,b,...>): print the content fingerprint over
+// the given repo-relative paths - the value the architect writes into the
+// scope block's `fingerprint:` line at synthesis time. Prints `unknown` when
+// not computable (non-git or invalid pathspec), which the block records
+// verbatim.
+//
+// Always exits 0 with the verdict in the output (read-only query - mirrors
+// codekb-path; refusals are for lifecycle verbs). No mkdir, no state write,
+// no audit.
+function handleCodekbScopeDiff(projectDir: string, flags: Record<string, string>): void {
+  const asJson = flags.json === "true";
+  const space = activeSpace(projectDir);
+  const repo = flags.repo && flags.repo.length > 0 ? flags.repo : codekbRepoName(projectDir, space);
+  const storeDir = relativeCodekbDir(projectDir, repo, space);
+  const storePath = join(projectDir, ...storeDir.split("/"), "reverse-engineering-timestamp.md");
+
+  // The repo's source root: the sibling dir `<workspace>/<repo>/` when it
+  // exists (the multi-repo layout reverse-engineering.md Step 1 scans), else
+  // the workspace root itself (the lone-repo case, where codekbRepoName is
+  // basename(projectDir)).
+  const siblingDir = join(projectDir, repo);
+  const repoDir = existsSync(siblingDir) && statSync(siblingDir).isDirectory() ? siblingDir : projectDir;
+  // In the lone-repo layout the framework-owned aidlc workspace tree lives
+  // under the repository root. Exclude it from full-root fingerprints so
+  // writing the scope draft, codekb, audit, or state cannot stale its own hash.
+  const fingerprintExcludes = repoDir === projectDir ? ["aidlc"] : [];
+
+  if (flags.mint === "true") {
+    const paths = (flags.paths ?? "")
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p !== "");
+    if (paths.length === 0) {
+      die("codekb-scope-diff --mint: pass --paths <comma-separated repo-relative paths>");
+    }
+    const fp = codekbScopeFingerprint(repoDir, paths, fingerprintExcludes) ?? "unknown";
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, fingerprint: fp, paths })}\n`);
+    else process.stdout.write(`${fp}\n`);
+    return;
+  }
+
+  const emit = (payload: Record<string, unknown>, human: string): void => {
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, store: `${storeDir}/`, ...payload })}\n`);
+    else process.stdout.write(`${human}\n`);
+  };
+
+  if (!existsSync(storePath)) {
+    emit(
+      { verdict: "NO_STORE" },
+      `NO_STORE: no reverse-engineering-timestamp.md at ${storeDir}/ - first scan, nothing to compare.`,
+    );
+    return;
+  }
+  const parsed = parseReScope(readFileSync(storePath, "utf-8"));
+  if (!parsed.ok) {
+    emit(
+      { verdict: "UNKNOWN_SCOPE", reason: parsed.reason, detail: parsed.detail },
+      `UNKNOWN_SCOPE (${parsed.reason}): ${parsed.detail}. The store predates scope tracking - a rerun replaces it without a coverage comparison.`,
+    );
+    return;
+  }
+  const store = parsed.scope;
+
+  if (flags.compare !== undefined) {
+    const incomingPath = flags.compare;
+    if (!incomingPath || !existsSync(incomingPath)) {
+      die(`codekb-scope-diff --compare: file not found: ${incomingPath || "(missing path)"}`);
+    }
+    const incomingParsed = parseReScope(readFileSync(incomingPath, "utf-8"));
+    if (!incomingParsed.ok) {
+      emit(
+        { verdict: "UNKNOWN_SCOPE", reason: incomingParsed.reason, detail: `incoming: ${incomingParsed.detail}` },
+        `UNKNOWN_SCOPE (incoming ${incomingParsed.reason}): ${incomingParsed.detail}.`,
+      );
+      return;
+    }
+    const incoming = incomingParsed.scope;
+    const fullScopeDowngrade = store.kind === "full" && incoming.kind !== "full";
+    const discardedPaths =
+      incoming.kind === "full"
+        ? []
+        : fullScopeDowngrade
+          ? [...store.analyzedPaths]
+          : store.analyzedPaths.filter((p) => !scopePathCovered(incoming.analyzedPaths, p));
+    const discardedComponents =
+      incoming.kind === "full"
+        ? []
+        : store.analyzedComponents.filter((c) => !incoming.analyzedComponents.includes(c));
+    const narrower = discardedPaths.length > 0 || discardedComponents.length > 0;
+    const payload = {
+      verdict: narrower ? "NARROWER" : "COVERS",
+      store_intent: store.intent,
+      incoming_intent: incoming.intent,
+      discarded_paths: discardedPaths,
+      discarded_components: discardedComponents,
+    };
+    if (narrower) {
+      emit(
+        payload,
+        `NARROWER: replacing the store discards deep knowledge of:\n` +
+          discardedPaths.map((p) => `  - ${p}`).join("\n") +
+          (discardedComponents.length > 0
+            ? `\n  components: ${discardedComponents.join(", ")}`
+            : "") +
+          `\n(store intent: ${store.intent || "unrecorded"}; incoming intent: ${incoming.intent || "unrecorded"})`,
+      );
+    } else {
+      emit(payload, `COVERS: the incoming scan covers everything the store analyzed.`);
+    }
+    return;
+  }
+
+  // Status mode.
+  const currentFingerprint =
+    store.analyzedPaths.length > 0
+      ? codekbScopeFingerprint(repoDir, store.analyzedPaths, fingerprintExcludes)
+      : null;
+  const scopeLines = store.analyzedPaths.map((p) => `  - ${p}`).join("\n");
+  if (store.fingerprint === null || currentFingerprint === null) {
+    emit(
+      {
+        verdict: "UNVERIFIED",
+        store_intent: store.intent,
+        kind: store.kind,
+        analyzed_paths: store.analyzedPaths,
+        detail: store.fingerprint === null ? "store has no fingerprint" : "fingerprint not computable here",
+      },
+      `UNVERIFIED: the store (intent: ${store.intent || "unrecorded"}) analyzed:\n${scopeLines}\n` +
+        `but ${store.fingerprint === null ? "recorded no fingerprint" : "the current tree's fingerprint cannot be computed"} - freshness unknown.`,
+    );
+    return;
+  }
+  const current = store.fingerprint === currentFingerprint;
+  emit(
+    {
+      verdict: current ? "CURRENT" : "STALE",
+      store_intent: store.intent,
+      kind: store.kind,
+      analyzed_paths: store.analyzedPaths,
+      store_fingerprint: store.fingerprint,
+      current_fingerprint: currentFingerprint,
+    },
+    current
+      ? `CURRENT: the analyzed paths are unchanged since the store was built (intent: ${store.intent || "unrecorded"}, coverage: ${store.kind}):\n${scopeLines}`
+      : `STALE: the analyzed paths have changed since the store was built (intent: ${store.intent || "unrecorded"}):\n${scopeLines}`,
+  );
+}
+
 // `detect [--json]` - read-only. Runs the workspace scan (detectWorkspace) on
 // the bare project dir - it needs no aidlc/ workspace; it scans the app root -
 // and prints projectType (Greenfield/Brownfield), languages, frameworks, and
@@ -5404,6 +5572,12 @@ export async function main(argv: string[]): Promise<void> {
     case "codekb-path":
       handleCodekbPath(projectDir, flags);
       break;
+    // codekb-scope-diff - read-only query verb. Compares the codekb store's
+    // recorded scope of analysis against the live tree (status) or an
+    // incoming run's timestamp (--compare). The RE stage's rerun guard.
+    case "codekb-scope-diff":
+      handleCodekbScopeDiff(projectDir, flags);
+      break;
     // detect - read-only query verb. Prints the workspace scan
     // (greenfield/brownfield, languages) + the resolved scope-registry paths so
     // the composer agent is told where scope data lives. No mutation, no audit.
@@ -5466,7 +5640,7 @@ export async function main(argv: string[]): Promise<void> {
       break;
     default:
       die(
-        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
+        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|codekb-scope-diff|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
       );
   }
 }

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.34";
+export const AIDLC_VERSION = "2.5.35";

--- a/dist/claude/.claude/aidlc-common/stages/inception/reverse-engineering.md
+++ b/dist/claude/.claude/aidlc-common/stages/inception/reverse-engineering.md
@@ -2,7 +2,7 @@
 slug: reverse-engineering
 phase: inception
 execution: CONDITIONAL
-condition: Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.
+condition: Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.
 lead_agent: aidlc-developer-agent
 support_agents:
   - aidlc-architect-agent
@@ -60,25 +60,92 @@ The engine records the skip and advances to the next in-scope stage.
 
 #### Resolve the intent's repo set (multi-repo)
 
-This stage runs **per repo** the intent touches. Resolve the repo set from the
-intent's registry row before scanning:
+This stage runs **per repo** the intent touches. Resolve the complete repo set
+from the intent's registry row before making any reuse or scan decision:
 
 1. Read the active intent's `repos` array from
    `aidlc/spaces/<active-space>/intents/intents.json` (the row whose `uuid`/`slug`
    matches the active intent). This is the set captured at intent birth (an explicit
    `--repos a,b` or sibling auto-discovery).
 2. **Single-repo / unrecorded:** if `repos` is absent, empty, or has exactly one
-   entry, RE runs once against the lone repo — the same flow as before. (An
+   entry, RE runs once against the lone repo - the same flow as before. (An
    unrecorded set means the workspace root is itself the single repo.)
-3. **Multi-repo:** if `repos` has more than one entry, run Steps 2–3 **once per
-   repo**, scanning that repo's sibling directory (`<workspace>/<repo>/`) and writing
-   its 9 artifacts to the directory `codekb-path --repo <repo>` prints (the
-   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each repo's codekb is independent;
-   nothing in one repo's scan blocks another's, so the per-repo scans may run as
-   parallel subagents.
+3. **Multi-repo:** if `repos` has more than one entry, resolve the Step 1 guard
+   decision for every repo, then run Steps 2-3 once for each repo selected for a
+   scan. Scan that repo's sibling directory (`<workspace>/<repo>/`) and write its
+   9 artifacts to the directory `codekb-path --repo <repo>` prints (the
+   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each
+   repo's codekb is independent, so selected scans may run as parallel subagents.
 
-In the steps below, `<repo>` is the repo currently being scanned; repeat for each
-repo in the set.
+In the steps below, `<repo>` is the repository whose decision or scan is being
+processed.
+
+#### Rerun guard: check each existing store before scanning
+
+The codekb is a space-level store shared across intents; a rerun REPLACES it.
+For every repo in the resolved set, run the read-only check:
+
+```
+bun .claude/tools/aidlc-utility.ts codekb-scope-diff --repo <repo>
+```
+
+- **NO_STORE** - first scan for this repo. Proceed to Step 2; no question.
+- **CURRENT** - the store's analyzed paths are unchanged since it was built.
+  If the recorded coverage plausibly serves this intent's area, present the
+  reuse question below. If this intent clearly targets code OUTSIDE the
+  store's analyzed paths, skip the reuse option and ask rescan vs focused only.
+- **STALE / UNVERIFIED / UNKNOWN_SCOPE** - the store's knowledge is out of
+  date, unverifiable, or predates scope tracking. Present the rescan question
+  below WITHOUT the reuse option.
+
+Reuse question (CURRENT + coverage fits the intent) - fold the tool's output
+(store intent, analyzed paths) into the prompt so the human decides on
+evidence:
+
+```question
+prompt: "An up-to-date code knowledge base exists for <repo> (built by intent <store-intent>; verified unchanged). Deep coverage: <analyzed paths>. Reuse it, or rescan?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Reuse existing knowledge base"
+    description: "Skip the scan; downstream stages read the current store as-is"
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - the store will describe ONLY that area afterward"
+```
+
+Rescan question (STALE / UNVERIFIED / UNKNOWN_SCOPE, or CURRENT with coverage
+that does not fit) - include the verdict line in the prompt:
+
+```question
+prompt: "A code knowledge base exists for <repo> but <verdict summary - e.g. its analyzed paths have changed since it was built / it does not cover this intent's area>. Rescanning replaces it. How should the scan run?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - prior deep knowledge outside it is discarded (recoverable from git history)"
+```
+
+Record one decision per repo: reuse, full rescan, or focused scan. A reuse
+decision does NOT report or advance the stage while another repository may
+still need scanning. On a scan choice, also record its breadth; that choice
+sets the developer brief, and Step 3's scope block records what the scan
+actually covered.
+
+Only after every repository decision has been resolved:
+
+- If every repo is reused on an ordinary workflow run, report the stage as
+  skipped exactly once:
+  `bun .claude/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result skipped --reason "codekb reuse: all resolved stores CURRENT, human chose reuse"`.
+- If every repo is reused on an isolated run (`directive.single === true`), do
+  NOT call the main-workflow skipped report. Return the reused-repositories
+  summary to the orchestrator's isolated stage-runner branch; it owns the
+  single `report --single --stage "reverse-engineering" --result completed`.
+- If any repo needs scanning, do not report a skip. Proceed to Steps 2-3 for
+  only the full/focused scan repos; leave each reused repo's store unchanged.
 
 ### Step 2: Developer Code Scan
 
@@ -87,8 +154,14 @@ Delegate to Task tool with aidlc-developer-agent:
 - The agent persona and knowledge are loaded automatically. Do NOT manually inject the persona.
 - Include workspace state from aidlc-state.md as context
 
-Developer scans `<repo>`'s codebase (the sibling dir `<workspace>/<repo>/`; for a
-single-repo intent this is the whole codebase) for:
+Brief the developer with the scan breadth chosen at the Step 1 guard (full
+rescan = the whole repo; focused scan = the intent's area, named explicitly in
+the brief) and require the scan results' Scan Coverage section (re-artifacts.md
+template) to list what was actually analyzed deeply vs skimmed.
+
+For each repo selected for scanning, the developer scans `<repo>`'s codebase
+(the sibling dir `<workspace>/<repo>/`; for a single-repo intent this is the
+whole codebase) for:
 - All packages, modules, and their purposes
 - Build systems, configuration, and dependency relationships
 - External and internal APIs (endpoints, contracts, methods)
@@ -118,7 +191,11 @@ Architect synthesizes scan results into 9 artifacts:
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis). This is the freshness/staleness marker for the per-repo codekb store — a stale timestamp triggers a rerun (see the `condition` frontmatter: "Always rerun for freshness").
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) and MUST end with the structured `## Scope of Analysis` block from the re-artifacts.md template, filled from the developer's Scan Coverage - what the run ACTUALLY analyzed deeply, not what was aspired to. This is the freshness/staleness marker the Step 1 rerun guard reads. For the block's `fingerprint:` line, run the mint command with the analyzed paths (comma-separated) and paste its output verbatim:
+
+   ```
+   bun .claude/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --mint --paths <analyzed paths>
+   ```
 
 **Resolve the write directory with the engine, do NOT compose the path yourself.**
 Run the read-only tool
@@ -129,14 +206,35 @@ bun .claude/tools/aidlc-utility.ts codekb-path --repo <repo>
 
 (omit `--repo` for a single/unrecorded repo — the engine resolves the repo name).
 It prints ONE line: the exact directory, e.g. `aidlc/spaces/<active-space>/codekb/<repo>/`.
-Write all 9 artifacts into the directory the tool printed — verbatim, creating it if
-absent. This is the durable per-repo code knowledge base, a space-level store shared
-across every intent in the space. Never substitute the intent slug, the record dir, or
-a hand-composed path for what the tool prints.
+
+**Overwrite backstop - run BEFORE writing (the compare needs the store still
+un-replaced).** When the Step 1 guard found an existing store (any verdict but
+NO_STORE), write the new timestamp content to
+`<record>/inception/reverse-engineering/scope-draft-<repo>.md` (one draft per
+repo; NOT the timestamp filename - record-dir placement checks key on the
+artifact stems) and run
+
+```
+bun .claude/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --compare <record>/inception/reverse-engineering/scope-draft-<repo>.md
+```
+
+Keep the output keyed by `<repo>` for Step 5's completion summary. This is the
+deterministic check that the scan delivered the breadth chosen at Step 1 - a
+focused run after a "Full rescan" choice surfaces here as NARROWER, before
+approval. Delete that repo's `scope-draft-<repo>.md` immediately after
+preserving the compare output; scope drafts are temporary and MUST NOT remain
+in the intent record.
+
+Write all 9 artifacts into the directory `codekb-path` printed - verbatim,
+creating it if absent. This is the durable per-repo code knowledge base, a
+space-level store shared across every intent in the space. Never substitute
+the intent slug, the record dir, or a hand-composed path for what the tool
+prints.
 
 ### Step 4: Completion Handoff
 
-Hand completion to `stage-protocol.md` via
+After every selected repo scan has completed, hand completion to
+`stage-protocol.md` exactly once via
 `bun .claude/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result <outcome>`.
 The engine owns all lifecycle transitions and advancement.
 
@@ -146,9 +244,22 @@ Use stage-protocol.md completion template:
 - Announcement with completion summary
 - Summary of all 9 artifacts produced **per repo** (for a multi-repo intent, list
   each repo's `aidlc/spaces/<active-space>/codekb/<repo>/` set — the directory
-  `codekb-path --repo <repo>` printed in Step 3)
+  `codekb-path --repo <repo>` printed in Step 3); identify reused repos whose
+  existing stores were left unchanged
+- **For every repo whose Step 3 compare returned NARROWER**, the summary MUST
+  carry a repo-labeled warning before the question, quoting that repo's tool
+  discard list verbatim:
+
+  ```
+  WARNING for <repo>: this scan covered less than the store it replaced. Deep
+  knowledge of the following was discarded (recoverable from git history):
+  <discarded paths and components from the compare output>
+  Choose Request Changes to widen the scan instead.
+  ```
+
+  (COVERS, or no prior store, needs no warning line.)
 - Review path: `aidlc/spaces/<active-space>/codekb/<repo>/` for each repo in the set
-- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes
+- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes. If any repo returned NARROWER, the Approve option's description must say which stores were replaced by narrower scans (e.g. "Accept the narrower stores for <repos>; continue to Requirements Analysis").
 
 ## Sensors
 

--- a/dist/claude/.claude/knowledge/aidlc-developer-agent/re-artifacts.md
+++ b/dist/claude/.claude/knowledge/aidlc-developer-agent/re-artifacts.md
@@ -14,12 +14,16 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis)
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) plus the structured Scope of Analysis block (template below). The scope block is machine-read by `codekb-scope-diff` on the next rerun, so its accuracy decides whether a future intent is warned before overwriting this run's knowledge.
 
 ### Developer Code Scan Template
 
 ```markdown
 ## Developer Code Scan Results
+
+### Scan Coverage
+- **Analyzed deeply**: [repo-relative dirs/files actually read and understood, one per line]
+- **Skimmed only**: [areas noted at directory granularity without deep reading]
 
 ### Packages Found
 - [package name] — [type] — [language] — [purpose]
@@ -72,3 +76,33 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 ### Improvement Opportunities
 [Areas where the architecture could be strengthened]
 ```
+
+### Scope of Analysis Block (reverse-engineering-timestamp.md)
+
+End reverse-engineering-timestamp.md with exactly this fenced block, filled
+honestly from the Scan Coverage the developer reported - record what the run
+ACTUALLY covered deeply, not what the stage aspired to cover:
+
+````markdown
+## Scope of Analysis
+
+```yaml
+scope_version: 1
+kind: partial
+intent: [active intent slug]
+fingerprint: [output of the mint command in stage Step 3 - verbatim; it prints "unknown" when not computable]
+analyzed:
+  paths:
+    - [repo-relative dir (trailing slash) or file analyzed deeply, one per line]
+  components:
+    - [component names exactly as they appear in component-inventory.md]
+shallow:
+  paths:
+    - [areas only skimmed]
+```
+````
+
+Rules:
+- `kind: full` only when the scan genuinely covered the whole repo deeply; `analyzed.paths` MUST include the repo root (`./`). Anything less is `kind: partial`.
+- `analyzed.paths` entries are repo-relative, directories end with `/`, no glob characters.
+- Component names must match `component-inventory.md` headings verbatim - the rerun guard compares them literally.

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, appendFileSync, constants as fsConstants, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
@@ -1128,6 +1129,208 @@ export function relativeCodekbDir(projectDir: string, repo: string, space?: stri
 export function codekbRepoName(projectDir: string, space?: string): string {
   const repos = intentRepos(projectDir, undefined, space);
   return repos.length === 1 ? repos[0] : basename(projectDir);
+}
+
+// --- Codekb scope of analysis -------------------------------------------------
+//
+// The reverse-engineering stage records WHAT its scan covered in a fenced yaml
+// block inside reverse-engineering-timestamp.md (the store's freshness marker).
+// The parser + fingerprint here are the deterministic half of the rerun
+// guard: `codekb-scope-diff` compares a store's recorded scope against the
+// live working tree (status) or an incoming run's scope (compare), so the
+// human at the RE gate decides reuse/rescan/replace on evidence instead of
+// silently losing a prior intent's knowledge to a narrower overwrite.
+//
+// Block shape (scope_version 1 - authored by the architect at synthesis,
+// behind the RE approval gate):
+//
+//   ```yaml
+//   scope_version: 1
+//   kind: partial            # or: full
+//   intent: fix-payment-timeout
+//   fingerprint: 3f2a9c...   # codekbScopeFingerprint over analyzed.paths
+//   analyzed:
+//     paths:
+//       - src/payments/
+//     components:
+//       - payment-gateway
+//   shallow:
+//     paths:
+//       - src/
+//   ```
+//
+// Pure data - no model call. Same idiom as parseBoltDag: a constrained
+// line-walker, no YAML dependency.
+
+export type ReScope = {
+  kind: "full" | "partial";
+  intent: string;
+  fingerprint: string | null;
+  analyzedPaths: string[];
+  analyzedComponents: string[];
+  shallowPaths: string[];
+};
+
+export type ReScopeParse =
+  | { ok: true; scope: ReScope }
+  | { ok: false; reason: "absent" | "malformed"; detail: string };
+
+// Find the fenced yaml block carrying `scope_version:` anywhere in the body
+// (keyed on the version line, not a heading, so prose edits around the block
+// don't break parsing). Returns the inner lines, or null when no block exists.
+function extractScopeBlock(body: string): string | null {
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```ya?ml\s*$/.test(lines[i].trim())) {
+      const inner: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^```\s*$/.test(lines[j].trim())) break;
+        inner.push(lines[j]);
+      }
+      const block = inner.join("\n");
+      if (/^\s*scope_version\s*:/m.test(block)) return block;
+      i = j; // not the scope block - resume past its close fence
+    }
+  }
+  return null;
+}
+
+// Parse the scope block out of a reverse-engineering-timestamp.md body.
+// Unknown scope_version parses as malformed (a future writer must not be
+// half-read by an old reader); a missing block is "absent" (legacy store).
+export function parseReScope(body: string): ReScopeParse {
+  const block = extractScopeBlock(body);
+  if (block === null) {
+    return { ok: false, reason: "absent", detail: "no fenced yaml scope_version block found" };
+  }
+  const scope: ReScope = {
+    kind: "partial",
+    intent: "",
+    fingerprint: null,
+    analyzedPaths: [],
+    analyzedComponents: [],
+    shallowPaths: [],
+  };
+  let section: "analyzed" | "shallow" | null = null;
+  let list: "paths" | "components" | null = null;
+  let sawKind = false;
+  for (const raw of block.split("\n")) {
+    const t = raw.trim();
+    if (t === "" || t.startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (indent === 0) {
+      section = null;
+      list = null;
+      if (t.startsWith("scope_version:")) {
+        const v = t.slice("scope_version:".length).trim();
+        if (v !== "1") {
+          return { ok: false, reason: "malformed", detail: `unknown scope_version: ${v}` };
+        }
+      } else if (t.startsWith("kind:")) {
+        const k = t.slice("kind:".length).trim();
+        if (k !== "full" && k !== "partial") {
+          return { ok: false, reason: "malformed", detail: `kind must be full|partial, got: ${k}` };
+        }
+        scope.kind = k;
+        sawKind = true;
+      } else if (t.startsWith("intent:")) {
+        scope.intent = t.slice("intent:".length).trim();
+      } else if (t.startsWith("fingerprint:")) {
+        const f = t.slice("fingerprint:".length).trim();
+        scope.fingerprint = f === "" || f === "unknown" ? null : f;
+      } else if (t === "analyzed:") {
+        section = "analyzed";
+      } else if (t === "shallow:") {
+        section = "shallow";
+      }
+    } else if (section !== null && !t.startsWith("-") && t.endsWith(":")) {
+      list = t === "paths:" ? "paths" : t === "components:" ? "components" : null;
+    } else if (section !== null && list !== null && t.startsWith("-")) {
+      const item = t.slice(1).trim();
+      if (item === "") continue;
+      if (section === "analyzed" && list === "paths") scope.analyzedPaths.push(item);
+      else if (section === "analyzed" && list === "components") scope.analyzedComponents.push(item);
+      else if (section === "shallow" && list === "paths") scope.shallowPaths.push(item);
+    }
+  }
+  if (!sawKind) {
+    return { ok: false, reason: "malformed", detail: "missing kind: line" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.length === 0) {
+    return { ok: false, reason: "malformed", detail: "kind: partial requires analyzed.paths entries" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "repository-root coverage (./) requires kind: full",
+    };
+  }
+  if (scope.kind === "full" && !scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "kind: full requires repository-root coverage (analyzed.paths must include ./)",
+    };
+  }
+  return { ok: true, scope };
+}
+
+// Content fingerprint of the WORKING TREE restricted to the scope's analyzed
+// paths: `git write-tree` over a temporary index populated by `git add -A --
+// <paths>`. Hashes what is actually on disk (uncommitted edits included), so
+// rebases/squashes/amends that vaporise a recorded commit hash cannot break
+// the comparison, and reverting an edit restores the original fingerprint.
+// Ignored files stay excluded (git add semantics). Callers may exclude generated
+// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// Returns null when repoDir is not a git work tree, git is unavailable, or any
+// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+export function codekbScopeFingerprint(
+  repoDir: string,
+  paths: string[],
+  excludedPaths: string[] = [],
+): string | null {
+  if (paths.length === 0) return null;
+  const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: repoDir,
+    encoding: "utf-8",
+  });
+  if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+  const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+  try {
+    const exclusions = excludedPaths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "")
+      .map((p) => `:(exclude,literal)${p}`);
+    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+      cwd: repoDir,
+      env,
+      encoding: "utf-8",
+    });
+    if (add.status !== 0) return null;
+    const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
+    if (wt.status !== 0) return null;
+    const hash = wt.stdout.trim();
+    return /^[0-9a-f]{40,64}$/.test(hash) ? hash : null;
+  } finally {
+    try {
+      unlinkSync(indexFile);
+    } catch {
+      // best-effort cleanup - a leaked temp index is inert
+    }
+  }
+}
+
+// Coverage test for the compare mode: does the incoming run's analyzed set
+// cover a store entry? Literal match, or an incoming DIRECTORY prefix (entry
+// ending "/") subsuming the store path. Deliberately prefix-only - scope
+// paths are authored as repo-relative dirs/files, not globs.
+export function scopePathCovered(incoming: string[], storePath: string): boolean {
+  return incoming.some(
+    (p) => p === storePath || (p.endsWith("/") && storePath.startsWith(p)),
+  );
 }
 
 // The bare SPACE record root: `aidlc/spaces/<space>/intents/`. The absolute path

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -54,8 +54,11 @@ import {
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
+  codekbScopeFingerprint,
+  parseReScope,
   relativeCodekbDir,
   RESERVED_RECORD_NAMES,
+  scopePathCovered,
   gridCostSummary,
   listIntents,
   listSpaces,
@@ -4207,6 +4210,171 @@ function handleCodekbPath(projectDir: string, flags: Record<string, string>): vo
   process.stdout.write(`${dir}/\n`);
 }
 
+// `aidlc-utility.ts codekb-scope-diff [--repo <name>] [--compare <timestamp.md>]
+// [--json]` - read-only. The deterministic half of the reverse-engineering
+// rerun guard (the store is shared space-level knowledge; a narrower rerun
+// overwrites it last-writer-wins, so the human decides on evidence).
+//
+// Status mode (default): parse the STORE's reverse-engineering-timestamp.md
+// scope block and recompute the content fingerprint over its analyzed paths.
+//   NO_STORE       no store timestamp - first scan, nothing to guard
+//   CURRENT        fingerprint matches - the store's deep knowledge is exact
+//   STALE          analyzed paths changed since the store was built
+//   UNVERIFIED     scope parsed but no/uncomputable fingerprint (non-git)
+//   UNKNOWN_SCOPE  block absent (legacy store) or malformed
+//
+// Compare mode (--compare <incoming timestamp.md>): does the incoming run's
+// analyzed scope cover the store's? COVERS, or NARROWER + the exact paths and
+// components an overwrite would discard.
+//
+// Mint mode (--mint --paths <a,b,...>): print the content fingerprint over
+// the given repo-relative paths - the value the architect writes into the
+// scope block's `fingerprint:` line at synthesis time. Prints `unknown` when
+// not computable (non-git or invalid pathspec), which the block records
+// verbatim.
+//
+// Always exits 0 with the verdict in the output (read-only query - mirrors
+// codekb-path; refusals are for lifecycle verbs). No mkdir, no state write,
+// no audit.
+function handleCodekbScopeDiff(projectDir: string, flags: Record<string, string>): void {
+  const asJson = flags.json === "true";
+  const space = activeSpace(projectDir);
+  const repo = flags.repo && flags.repo.length > 0 ? flags.repo : codekbRepoName(projectDir, space);
+  const storeDir = relativeCodekbDir(projectDir, repo, space);
+  const storePath = join(projectDir, ...storeDir.split("/"), "reverse-engineering-timestamp.md");
+
+  // The repo's source root: the sibling dir `<workspace>/<repo>/` when it
+  // exists (the multi-repo layout reverse-engineering.md Step 1 scans), else
+  // the workspace root itself (the lone-repo case, where codekbRepoName is
+  // basename(projectDir)).
+  const siblingDir = join(projectDir, repo);
+  const repoDir = existsSync(siblingDir) && statSync(siblingDir).isDirectory() ? siblingDir : projectDir;
+  // In the lone-repo layout the framework-owned aidlc workspace tree lives
+  // under the repository root. Exclude it from full-root fingerprints so
+  // writing the scope draft, codekb, audit, or state cannot stale its own hash.
+  const fingerprintExcludes = repoDir === projectDir ? ["aidlc"] : [];
+
+  if (flags.mint === "true") {
+    const paths = (flags.paths ?? "")
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p !== "");
+    if (paths.length === 0) {
+      die("codekb-scope-diff --mint: pass --paths <comma-separated repo-relative paths>");
+    }
+    const fp = codekbScopeFingerprint(repoDir, paths, fingerprintExcludes) ?? "unknown";
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, fingerprint: fp, paths })}\n`);
+    else process.stdout.write(`${fp}\n`);
+    return;
+  }
+
+  const emit = (payload: Record<string, unknown>, human: string): void => {
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, store: `${storeDir}/`, ...payload })}\n`);
+    else process.stdout.write(`${human}\n`);
+  };
+
+  if (!existsSync(storePath)) {
+    emit(
+      { verdict: "NO_STORE" },
+      `NO_STORE: no reverse-engineering-timestamp.md at ${storeDir}/ - first scan, nothing to compare.`,
+    );
+    return;
+  }
+  const parsed = parseReScope(readFileSync(storePath, "utf-8"));
+  if (!parsed.ok) {
+    emit(
+      { verdict: "UNKNOWN_SCOPE", reason: parsed.reason, detail: parsed.detail },
+      `UNKNOWN_SCOPE (${parsed.reason}): ${parsed.detail}. The store predates scope tracking - a rerun replaces it without a coverage comparison.`,
+    );
+    return;
+  }
+  const store = parsed.scope;
+
+  if (flags.compare !== undefined) {
+    const incomingPath = flags.compare;
+    if (!incomingPath || !existsSync(incomingPath)) {
+      die(`codekb-scope-diff --compare: file not found: ${incomingPath || "(missing path)"}`);
+    }
+    const incomingParsed = parseReScope(readFileSync(incomingPath, "utf-8"));
+    if (!incomingParsed.ok) {
+      emit(
+        { verdict: "UNKNOWN_SCOPE", reason: incomingParsed.reason, detail: `incoming: ${incomingParsed.detail}` },
+        `UNKNOWN_SCOPE (incoming ${incomingParsed.reason}): ${incomingParsed.detail}.`,
+      );
+      return;
+    }
+    const incoming = incomingParsed.scope;
+    const fullScopeDowngrade = store.kind === "full" && incoming.kind !== "full";
+    const discardedPaths =
+      incoming.kind === "full"
+        ? []
+        : fullScopeDowngrade
+          ? [...store.analyzedPaths]
+          : store.analyzedPaths.filter((p) => !scopePathCovered(incoming.analyzedPaths, p));
+    const discardedComponents =
+      incoming.kind === "full"
+        ? []
+        : store.analyzedComponents.filter((c) => !incoming.analyzedComponents.includes(c));
+    const narrower = discardedPaths.length > 0 || discardedComponents.length > 0;
+    const payload = {
+      verdict: narrower ? "NARROWER" : "COVERS",
+      store_intent: store.intent,
+      incoming_intent: incoming.intent,
+      discarded_paths: discardedPaths,
+      discarded_components: discardedComponents,
+    };
+    if (narrower) {
+      emit(
+        payload,
+        `NARROWER: replacing the store discards deep knowledge of:\n` +
+          discardedPaths.map((p) => `  - ${p}`).join("\n") +
+          (discardedComponents.length > 0
+            ? `\n  components: ${discardedComponents.join(", ")}`
+            : "") +
+          `\n(store intent: ${store.intent || "unrecorded"}; incoming intent: ${incoming.intent || "unrecorded"})`,
+      );
+    } else {
+      emit(payload, `COVERS: the incoming scan covers everything the store analyzed.`);
+    }
+    return;
+  }
+
+  // Status mode.
+  const currentFingerprint =
+    store.analyzedPaths.length > 0
+      ? codekbScopeFingerprint(repoDir, store.analyzedPaths, fingerprintExcludes)
+      : null;
+  const scopeLines = store.analyzedPaths.map((p) => `  - ${p}`).join("\n");
+  if (store.fingerprint === null || currentFingerprint === null) {
+    emit(
+      {
+        verdict: "UNVERIFIED",
+        store_intent: store.intent,
+        kind: store.kind,
+        analyzed_paths: store.analyzedPaths,
+        detail: store.fingerprint === null ? "store has no fingerprint" : "fingerprint not computable here",
+      },
+      `UNVERIFIED: the store (intent: ${store.intent || "unrecorded"}) analyzed:\n${scopeLines}\n` +
+        `but ${store.fingerprint === null ? "recorded no fingerprint" : "the current tree's fingerprint cannot be computed"} - freshness unknown.`,
+    );
+    return;
+  }
+  const current = store.fingerprint === currentFingerprint;
+  emit(
+    {
+      verdict: current ? "CURRENT" : "STALE",
+      store_intent: store.intent,
+      kind: store.kind,
+      analyzed_paths: store.analyzedPaths,
+      store_fingerprint: store.fingerprint,
+      current_fingerprint: currentFingerprint,
+    },
+    current
+      ? `CURRENT: the analyzed paths are unchanged since the store was built (intent: ${store.intent || "unrecorded"}, coverage: ${store.kind}):\n${scopeLines}`
+      : `STALE: the analyzed paths have changed since the store was built (intent: ${store.intent || "unrecorded"}):\n${scopeLines}`,
+  );
+}
+
 // `detect [--json]` - read-only. Runs the workspace scan (detectWorkspace) on
 // the bare project dir - it needs no aidlc/ workspace; it scans the app root -
 // and prints projectType (Greenfield/Brownfield), languages, frameworks, and
@@ -5404,6 +5572,12 @@ export async function main(argv: string[]): Promise<void> {
     case "codekb-path":
       handleCodekbPath(projectDir, flags);
       break;
+    // codekb-scope-diff - read-only query verb. Compares the codekb store's
+    // recorded scope of analysis against the live tree (status) or an
+    // incoming run's timestamp (--compare). The RE stage's rerun guard.
+    case "codekb-scope-diff":
+      handleCodekbScopeDiff(projectDir, flags);
+      break;
     // detect - read-only query verb. Prints the workspace scan
     // (greenfield/brownfield, languages) + the resolved scope-registry paths so
     // the composer agent is told where scope data lives. No mutation, no audit.
@@ -5466,7 +5640,7 @@ export async function main(argv: string[]): Promise<void> {
       break;
     default:
       die(
-        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
+        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|codekb-scope-diff|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
       );
   }
 }

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.34";
+export const AIDLC_VERSION = "2.5.35";

--- a/dist/claude/.claude/tools/data/stage-graph.json
+++ b/dist/claude/.claude/tools/data/stage-graph.json
@@ -690,7 +690,7 @@
     "name": "Reverse Engineering",
     "phase": "inception",
     "execution": "CONDITIONAL",
-    "condition": "Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.",
+    "condition": "Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.",
     "lead_agent": "aidlc-developer-agent",
     "support_agents": [
       "aidlc-architect-agent"

--- a/dist/codex/.codex/aidlc-common/stages/inception/reverse-engineering.md
+++ b/dist/codex/.codex/aidlc-common/stages/inception/reverse-engineering.md
@@ -2,7 +2,7 @@
 slug: reverse-engineering
 phase: inception
 execution: CONDITIONAL
-condition: Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.
+condition: Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.
 lead_agent: aidlc-developer-agent
 support_agents:
   - aidlc-architect-agent
@@ -60,25 +60,92 @@ The engine records the skip and advances to the next in-scope stage.
 
 #### Resolve the intent's repo set (multi-repo)
 
-This stage runs **per repo** the intent touches. Resolve the repo set from the
-intent's registry row before scanning:
+This stage runs **per repo** the intent touches. Resolve the complete repo set
+from the intent's registry row before making any reuse or scan decision:
 
 1. Read the active intent's `repos` array from
    `aidlc/spaces/<active-space>/intents/intents.json` (the row whose `uuid`/`slug`
    matches the active intent). This is the set captured at intent birth (an explicit
    `--repos a,b` or sibling auto-discovery).
 2. **Single-repo / unrecorded:** if `repos` is absent, empty, or has exactly one
-   entry, RE runs once against the lone repo — the same flow as before. (An
+   entry, RE runs once against the lone repo - the same flow as before. (An
    unrecorded set means the workspace root is itself the single repo.)
-3. **Multi-repo:** if `repos` has more than one entry, run Steps 2–3 **once per
-   repo**, scanning that repo's sibling directory (`<workspace>/<repo>/`) and writing
-   its 9 artifacts to the directory `codekb-path --repo <repo>` prints (the
-   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each repo's codekb is independent;
-   nothing in one repo's scan blocks another's, so the per-repo scans may run as
-   parallel subagents.
+3. **Multi-repo:** if `repos` has more than one entry, resolve the Step 1 guard
+   decision for every repo, then run Steps 2-3 once for each repo selected for a
+   scan. Scan that repo's sibling directory (`<workspace>/<repo>/`) and write its
+   9 artifacts to the directory `codekb-path --repo <repo>` prints (the
+   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each
+   repo's codekb is independent, so selected scans may run as parallel subagents.
 
-In the steps below, `<repo>` is the repo currently being scanned; repeat for each
-repo in the set.
+In the steps below, `<repo>` is the repository whose decision or scan is being
+processed.
+
+#### Rerun guard: check each existing store before scanning
+
+The codekb is a space-level store shared across intents; a rerun REPLACES it.
+For every repo in the resolved set, run the read-only check:
+
+```
+bun .codex/tools/aidlc-utility.ts codekb-scope-diff --repo <repo>
+```
+
+- **NO_STORE** - first scan for this repo. Proceed to Step 2; no question.
+- **CURRENT** - the store's analyzed paths are unchanged since it was built.
+  If the recorded coverage plausibly serves this intent's area, present the
+  reuse question below. If this intent clearly targets code OUTSIDE the
+  store's analyzed paths, skip the reuse option and ask rescan vs focused only.
+- **STALE / UNVERIFIED / UNKNOWN_SCOPE** - the store's knowledge is out of
+  date, unverifiable, or predates scope tracking. Present the rescan question
+  below WITHOUT the reuse option.
+
+Reuse question (CURRENT + coverage fits the intent) - fold the tool's output
+(store intent, analyzed paths) into the prompt so the human decides on
+evidence:
+
+```question
+prompt: "An up-to-date code knowledge base exists for <repo> (built by intent <store-intent>; verified unchanged). Deep coverage: <analyzed paths>. Reuse it, or rescan?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Reuse existing knowledge base"
+    description: "Skip the scan; downstream stages read the current store as-is"
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - the store will describe ONLY that area afterward"
+```
+
+Rescan question (STALE / UNVERIFIED / UNKNOWN_SCOPE, or CURRENT with coverage
+that does not fit) - include the verdict line in the prompt:
+
+```question
+prompt: "A code knowledge base exists for <repo> but <verdict summary - e.g. its analyzed paths have changed since it was built / it does not cover this intent's area>. Rescanning replaces it. How should the scan run?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - prior deep knowledge outside it is discarded (recoverable from git history)"
+```
+
+Record one decision per repo: reuse, full rescan, or focused scan. A reuse
+decision does NOT report or advance the stage while another repository may
+still need scanning. On a scan choice, also record its breadth; that choice
+sets the developer brief, and Step 3's scope block records what the scan
+actually covered.
+
+Only after every repository decision has been resolved:
+
+- If every repo is reused on an ordinary workflow run, report the stage as
+  skipped exactly once:
+  `bun .codex/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result skipped --reason "codekb reuse: all resolved stores CURRENT, human chose reuse"`.
+- If every repo is reused on an isolated run (`directive.single === true`), do
+  NOT call the main-workflow skipped report. Return the reused-repositories
+  summary to the orchestrator's isolated stage-runner branch; it owns the
+  single `report --single --stage "reverse-engineering" --result completed`.
+- If any repo needs scanning, do not report a skip. Proceed to Steps 2-3 for
+  only the full/focused scan repos; leave each reused repo's store unchanged.
 
 ### Step 2: Developer Code Scan
 
@@ -87,8 +154,14 @@ Delegate to Task tool with aidlc-developer-agent:
 - The agent persona and knowledge are loaded automatically. Do NOT manually inject the persona.
 - Include workspace state from aidlc-state.md as context
 
-Developer scans `<repo>`'s codebase (the sibling dir `<workspace>/<repo>/`; for a
-single-repo intent this is the whole codebase) for:
+Brief the developer with the scan breadth chosen at the Step 1 guard (full
+rescan = the whole repo; focused scan = the intent's area, named explicitly in
+the brief) and require the scan results' Scan Coverage section (re-artifacts.md
+template) to list what was actually analyzed deeply vs skimmed.
+
+For each repo selected for scanning, the developer scans `<repo>`'s codebase
+(the sibling dir `<workspace>/<repo>/`; for a single-repo intent this is the
+whole codebase) for:
 - All packages, modules, and their purposes
 - Build systems, configuration, and dependency relationships
 - External and internal APIs (endpoints, contracts, methods)
@@ -118,7 +191,11 @@ Architect synthesizes scan results into 9 artifacts:
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis). This is the freshness/staleness marker for the per-repo codekb store — a stale timestamp triggers a rerun (see the `condition` frontmatter: "Always rerun for freshness").
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) and MUST end with the structured `## Scope of Analysis` block from the re-artifacts.md template, filled from the developer's Scan Coverage - what the run ACTUALLY analyzed deeply, not what was aspired to. This is the freshness/staleness marker the Step 1 rerun guard reads. For the block's `fingerprint:` line, run the mint command with the analyzed paths (comma-separated) and paste its output verbatim:
+
+   ```
+   bun .codex/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --mint --paths <analyzed paths>
+   ```
 
 **Resolve the write directory with the engine, do NOT compose the path yourself.**
 Run the read-only tool
@@ -129,14 +206,35 @@ bun .codex/tools/aidlc-utility.ts codekb-path --repo <repo>
 
 (omit `--repo` for a single/unrecorded repo — the engine resolves the repo name).
 It prints ONE line: the exact directory, e.g. `aidlc/spaces/<active-space>/codekb/<repo>/`.
-Write all 9 artifacts into the directory the tool printed — verbatim, creating it if
-absent. This is the durable per-repo code knowledge base, a space-level store shared
-across every intent in the space. Never substitute the intent slug, the record dir, or
-a hand-composed path for what the tool prints.
+
+**Overwrite backstop - run BEFORE writing (the compare needs the store still
+un-replaced).** When the Step 1 guard found an existing store (any verdict but
+NO_STORE), write the new timestamp content to
+`<record>/inception/reverse-engineering/scope-draft-<repo>.md` (one draft per
+repo; NOT the timestamp filename - record-dir placement checks key on the
+artifact stems) and run
+
+```
+bun .codex/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --compare <record>/inception/reverse-engineering/scope-draft-<repo>.md
+```
+
+Keep the output keyed by `<repo>` for Step 5's completion summary. This is the
+deterministic check that the scan delivered the breadth chosen at Step 1 - a
+focused run after a "Full rescan" choice surfaces here as NARROWER, before
+approval. Delete that repo's `scope-draft-<repo>.md` immediately after
+preserving the compare output; scope drafts are temporary and MUST NOT remain
+in the intent record.
+
+Write all 9 artifacts into the directory `codekb-path` printed - verbatim,
+creating it if absent. This is the durable per-repo code knowledge base, a
+space-level store shared across every intent in the space. Never substitute
+the intent slug, the record dir, or a hand-composed path for what the tool
+prints.
 
 ### Step 4: Completion Handoff
 
-Hand completion to `stage-protocol.md` via
+After every selected repo scan has completed, hand completion to
+`stage-protocol.md` exactly once via
 `bun .codex/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result <outcome>`.
 The engine owns all lifecycle transitions and advancement.
 
@@ -146,9 +244,22 @@ Use stage-protocol.md completion template:
 - Announcement with completion summary
 - Summary of all 9 artifacts produced **per repo** (for a multi-repo intent, list
   each repo's `aidlc/spaces/<active-space>/codekb/<repo>/` set — the directory
-  `codekb-path --repo <repo>` printed in Step 3)
+  `codekb-path --repo <repo>` printed in Step 3); identify reused repos whose
+  existing stores were left unchanged
+- **For every repo whose Step 3 compare returned NARROWER**, the summary MUST
+  carry a repo-labeled warning before the question, quoting that repo's tool
+  discard list verbatim:
+
+  ```
+  WARNING for <repo>: this scan covered less than the store it replaced. Deep
+  knowledge of the following was discarded (recoverable from git history):
+  <discarded paths and components from the compare output>
+  Choose Request Changes to widen the scan instead.
+  ```
+
+  (COVERS, or no prior store, needs no warning line.)
 - Review path: `aidlc/spaces/<active-space>/codekb/<repo>/` for each repo in the set
-- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes
+- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes. If any repo returned NARROWER, the Approve option's description must say which stores were replaced by narrower scans (e.g. "Accept the narrower stores for <repos>; continue to Requirements Analysis").
 
 ## Sensors
 

--- a/dist/codex/.codex/knowledge/aidlc-developer-agent/re-artifacts.md
+++ b/dist/codex/.codex/knowledge/aidlc-developer-agent/re-artifacts.md
@@ -14,12 +14,16 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis)
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) plus the structured Scope of Analysis block (template below). The scope block is machine-read by `codekb-scope-diff` on the next rerun, so its accuracy decides whether a future intent is warned before overwriting this run's knowledge.
 
 ### Developer Code Scan Template
 
 ```markdown
 ## Developer Code Scan Results
+
+### Scan Coverage
+- **Analyzed deeply**: [repo-relative dirs/files actually read and understood, one per line]
+- **Skimmed only**: [areas noted at directory granularity without deep reading]
 
 ### Packages Found
 - [package name] — [type] — [language] — [purpose]
@@ -72,3 +76,33 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 ### Improvement Opportunities
 [Areas where the architecture could be strengthened]
 ```
+
+### Scope of Analysis Block (reverse-engineering-timestamp.md)
+
+End reverse-engineering-timestamp.md with exactly this fenced block, filled
+honestly from the Scan Coverage the developer reported - record what the run
+ACTUALLY covered deeply, not what the stage aspired to cover:
+
+````markdown
+## Scope of Analysis
+
+```yaml
+scope_version: 1
+kind: partial
+intent: [active intent slug]
+fingerprint: [output of the mint command in stage Step 3 - verbatim; it prints "unknown" when not computable]
+analyzed:
+  paths:
+    - [repo-relative dir (trailing slash) or file analyzed deeply, one per line]
+  components:
+    - [component names exactly as they appear in component-inventory.md]
+shallow:
+  paths:
+    - [areas only skimmed]
+```
+````
+
+Rules:
+- `kind: full` only when the scan genuinely covered the whole repo deeply; `analyzed.paths` MUST include the repo root (`./`). Anything less is `kind: partial`.
+- `analyzed.paths` entries are repo-relative, directories end with `/`, no glob characters.
+- Component names must match `component-inventory.md` headings verbatim - the rerun guard compares them literally.

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, appendFileSync, constants as fsConstants, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
@@ -1128,6 +1129,208 @@ export function relativeCodekbDir(projectDir: string, repo: string, space?: stri
 export function codekbRepoName(projectDir: string, space?: string): string {
   const repos = intentRepos(projectDir, undefined, space);
   return repos.length === 1 ? repos[0] : basename(projectDir);
+}
+
+// --- Codekb scope of analysis -------------------------------------------------
+//
+// The reverse-engineering stage records WHAT its scan covered in a fenced yaml
+// block inside reverse-engineering-timestamp.md (the store's freshness marker).
+// The parser + fingerprint here are the deterministic half of the rerun
+// guard: `codekb-scope-diff` compares a store's recorded scope against the
+// live working tree (status) or an incoming run's scope (compare), so the
+// human at the RE gate decides reuse/rescan/replace on evidence instead of
+// silently losing a prior intent's knowledge to a narrower overwrite.
+//
+// Block shape (scope_version 1 - authored by the architect at synthesis,
+// behind the RE approval gate):
+//
+//   ```yaml
+//   scope_version: 1
+//   kind: partial            # or: full
+//   intent: fix-payment-timeout
+//   fingerprint: 3f2a9c...   # codekbScopeFingerprint over analyzed.paths
+//   analyzed:
+//     paths:
+//       - src/payments/
+//     components:
+//       - payment-gateway
+//   shallow:
+//     paths:
+//       - src/
+//   ```
+//
+// Pure data - no model call. Same idiom as parseBoltDag: a constrained
+// line-walker, no YAML dependency.
+
+export type ReScope = {
+  kind: "full" | "partial";
+  intent: string;
+  fingerprint: string | null;
+  analyzedPaths: string[];
+  analyzedComponents: string[];
+  shallowPaths: string[];
+};
+
+export type ReScopeParse =
+  | { ok: true; scope: ReScope }
+  | { ok: false; reason: "absent" | "malformed"; detail: string };
+
+// Find the fenced yaml block carrying `scope_version:` anywhere in the body
+// (keyed on the version line, not a heading, so prose edits around the block
+// don't break parsing). Returns the inner lines, or null when no block exists.
+function extractScopeBlock(body: string): string | null {
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```ya?ml\s*$/.test(lines[i].trim())) {
+      const inner: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^```\s*$/.test(lines[j].trim())) break;
+        inner.push(lines[j]);
+      }
+      const block = inner.join("\n");
+      if (/^\s*scope_version\s*:/m.test(block)) return block;
+      i = j; // not the scope block - resume past its close fence
+    }
+  }
+  return null;
+}
+
+// Parse the scope block out of a reverse-engineering-timestamp.md body.
+// Unknown scope_version parses as malformed (a future writer must not be
+// half-read by an old reader); a missing block is "absent" (legacy store).
+export function parseReScope(body: string): ReScopeParse {
+  const block = extractScopeBlock(body);
+  if (block === null) {
+    return { ok: false, reason: "absent", detail: "no fenced yaml scope_version block found" };
+  }
+  const scope: ReScope = {
+    kind: "partial",
+    intent: "",
+    fingerprint: null,
+    analyzedPaths: [],
+    analyzedComponents: [],
+    shallowPaths: [],
+  };
+  let section: "analyzed" | "shallow" | null = null;
+  let list: "paths" | "components" | null = null;
+  let sawKind = false;
+  for (const raw of block.split("\n")) {
+    const t = raw.trim();
+    if (t === "" || t.startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (indent === 0) {
+      section = null;
+      list = null;
+      if (t.startsWith("scope_version:")) {
+        const v = t.slice("scope_version:".length).trim();
+        if (v !== "1") {
+          return { ok: false, reason: "malformed", detail: `unknown scope_version: ${v}` };
+        }
+      } else if (t.startsWith("kind:")) {
+        const k = t.slice("kind:".length).trim();
+        if (k !== "full" && k !== "partial") {
+          return { ok: false, reason: "malformed", detail: `kind must be full|partial, got: ${k}` };
+        }
+        scope.kind = k;
+        sawKind = true;
+      } else if (t.startsWith("intent:")) {
+        scope.intent = t.slice("intent:".length).trim();
+      } else if (t.startsWith("fingerprint:")) {
+        const f = t.slice("fingerprint:".length).trim();
+        scope.fingerprint = f === "" || f === "unknown" ? null : f;
+      } else if (t === "analyzed:") {
+        section = "analyzed";
+      } else if (t === "shallow:") {
+        section = "shallow";
+      }
+    } else if (section !== null && !t.startsWith("-") && t.endsWith(":")) {
+      list = t === "paths:" ? "paths" : t === "components:" ? "components" : null;
+    } else if (section !== null && list !== null && t.startsWith("-")) {
+      const item = t.slice(1).trim();
+      if (item === "") continue;
+      if (section === "analyzed" && list === "paths") scope.analyzedPaths.push(item);
+      else if (section === "analyzed" && list === "components") scope.analyzedComponents.push(item);
+      else if (section === "shallow" && list === "paths") scope.shallowPaths.push(item);
+    }
+  }
+  if (!sawKind) {
+    return { ok: false, reason: "malformed", detail: "missing kind: line" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.length === 0) {
+    return { ok: false, reason: "malformed", detail: "kind: partial requires analyzed.paths entries" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "repository-root coverage (./) requires kind: full",
+    };
+  }
+  if (scope.kind === "full" && !scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "kind: full requires repository-root coverage (analyzed.paths must include ./)",
+    };
+  }
+  return { ok: true, scope };
+}
+
+// Content fingerprint of the WORKING TREE restricted to the scope's analyzed
+// paths: `git write-tree` over a temporary index populated by `git add -A --
+// <paths>`. Hashes what is actually on disk (uncommitted edits included), so
+// rebases/squashes/amends that vaporise a recorded commit hash cannot break
+// the comparison, and reverting an edit restores the original fingerprint.
+// Ignored files stay excluded (git add semantics). Callers may exclude generated
+// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// Returns null when repoDir is not a git work tree, git is unavailable, or any
+// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+export function codekbScopeFingerprint(
+  repoDir: string,
+  paths: string[],
+  excludedPaths: string[] = [],
+): string | null {
+  if (paths.length === 0) return null;
+  const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: repoDir,
+    encoding: "utf-8",
+  });
+  if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+  const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+  try {
+    const exclusions = excludedPaths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "")
+      .map((p) => `:(exclude,literal)${p}`);
+    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+      cwd: repoDir,
+      env,
+      encoding: "utf-8",
+    });
+    if (add.status !== 0) return null;
+    const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
+    if (wt.status !== 0) return null;
+    const hash = wt.stdout.trim();
+    return /^[0-9a-f]{40,64}$/.test(hash) ? hash : null;
+  } finally {
+    try {
+      unlinkSync(indexFile);
+    } catch {
+      // best-effort cleanup - a leaked temp index is inert
+    }
+  }
+}
+
+// Coverage test for the compare mode: does the incoming run's analyzed set
+// cover a store entry? Literal match, or an incoming DIRECTORY prefix (entry
+// ending "/") subsuming the store path. Deliberately prefix-only - scope
+// paths are authored as repo-relative dirs/files, not globs.
+export function scopePathCovered(incoming: string[], storePath: string): boolean {
+  return incoming.some(
+    (p) => p === storePath || (p.endsWith("/") && storePath.startsWith(p)),
+  );
 }
 
 // The bare SPACE record root: `aidlc/spaces/<space>/intents/`. The absolute path

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -54,8 +54,11 @@ import {
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
+  codekbScopeFingerprint,
+  parseReScope,
   relativeCodekbDir,
   RESERVED_RECORD_NAMES,
+  scopePathCovered,
   gridCostSummary,
   listIntents,
   listSpaces,
@@ -4207,6 +4210,171 @@ function handleCodekbPath(projectDir: string, flags: Record<string, string>): vo
   process.stdout.write(`${dir}/\n`);
 }
 
+// `aidlc-utility.ts codekb-scope-diff [--repo <name>] [--compare <timestamp.md>]
+// [--json]` - read-only. The deterministic half of the reverse-engineering
+// rerun guard (the store is shared space-level knowledge; a narrower rerun
+// overwrites it last-writer-wins, so the human decides on evidence).
+//
+// Status mode (default): parse the STORE's reverse-engineering-timestamp.md
+// scope block and recompute the content fingerprint over its analyzed paths.
+//   NO_STORE       no store timestamp - first scan, nothing to guard
+//   CURRENT        fingerprint matches - the store's deep knowledge is exact
+//   STALE          analyzed paths changed since the store was built
+//   UNVERIFIED     scope parsed but no/uncomputable fingerprint (non-git)
+//   UNKNOWN_SCOPE  block absent (legacy store) or malformed
+//
+// Compare mode (--compare <incoming timestamp.md>): does the incoming run's
+// analyzed scope cover the store's? COVERS, or NARROWER + the exact paths and
+// components an overwrite would discard.
+//
+// Mint mode (--mint --paths <a,b,...>): print the content fingerprint over
+// the given repo-relative paths - the value the architect writes into the
+// scope block's `fingerprint:` line at synthesis time. Prints `unknown` when
+// not computable (non-git or invalid pathspec), which the block records
+// verbatim.
+//
+// Always exits 0 with the verdict in the output (read-only query - mirrors
+// codekb-path; refusals are for lifecycle verbs). No mkdir, no state write,
+// no audit.
+function handleCodekbScopeDiff(projectDir: string, flags: Record<string, string>): void {
+  const asJson = flags.json === "true";
+  const space = activeSpace(projectDir);
+  const repo = flags.repo && flags.repo.length > 0 ? flags.repo : codekbRepoName(projectDir, space);
+  const storeDir = relativeCodekbDir(projectDir, repo, space);
+  const storePath = join(projectDir, ...storeDir.split("/"), "reverse-engineering-timestamp.md");
+
+  // The repo's source root: the sibling dir `<workspace>/<repo>/` when it
+  // exists (the multi-repo layout reverse-engineering.md Step 1 scans), else
+  // the workspace root itself (the lone-repo case, where codekbRepoName is
+  // basename(projectDir)).
+  const siblingDir = join(projectDir, repo);
+  const repoDir = existsSync(siblingDir) && statSync(siblingDir).isDirectory() ? siblingDir : projectDir;
+  // In the lone-repo layout the framework-owned aidlc workspace tree lives
+  // under the repository root. Exclude it from full-root fingerprints so
+  // writing the scope draft, codekb, audit, or state cannot stale its own hash.
+  const fingerprintExcludes = repoDir === projectDir ? ["aidlc"] : [];
+
+  if (flags.mint === "true") {
+    const paths = (flags.paths ?? "")
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p !== "");
+    if (paths.length === 0) {
+      die("codekb-scope-diff --mint: pass --paths <comma-separated repo-relative paths>");
+    }
+    const fp = codekbScopeFingerprint(repoDir, paths, fingerprintExcludes) ?? "unknown";
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, fingerprint: fp, paths })}\n`);
+    else process.stdout.write(`${fp}\n`);
+    return;
+  }
+
+  const emit = (payload: Record<string, unknown>, human: string): void => {
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, store: `${storeDir}/`, ...payload })}\n`);
+    else process.stdout.write(`${human}\n`);
+  };
+
+  if (!existsSync(storePath)) {
+    emit(
+      { verdict: "NO_STORE" },
+      `NO_STORE: no reverse-engineering-timestamp.md at ${storeDir}/ - first scan, nothing to compare.`,
+    );
+    return;
+  }
+  const parsed = parseReScope(readFileSync(storePath, "utf-8"));
+  if (!parsed.ok) {
+    emit(
+      { verdict: "UNKNOWN_SCOPE", reason: parsed.reason, detail: parsed.detail },
+      `UNKNOWN_SCOPE (${parsed.reason}): ${parsed.detail}. The store predates scope tracking - a rerun replaces it without a coverage comparison.`,
+    );
+    return;
+  }
+  const store = parsed.scope;
+
+  if (flags.compare !== undefined) {
+    const incomingPath = flags.compare;
+    if (!incomingPath || !existsSync(incomingPath)) {
+      die(`codekb-scope-diff --compare: file not found: ${incomingPath || "(missing path)"}`);
+    }
+    const incomingParsed = parseReScope(readFileSync(incomingPath, "utf-8"));
+    if (!incomingParsed.ok) {
+      emit(
+        { verdict: "UNKNOWN_SCOPE", reason: incomingParsed.reason, detail: `incoming: ${incomingParsed.detail}` },
+        `UNKNOWN_SCOPE (incoming ${incomingParsed.reason}): ${incomingParsed.detail}.`,
+      );
+      return;
+    }
+    const incoming = incomingParsed.scope;
+    const fullScopeDowngrade = store.kind === "full" && incoming.kind !== "full";
+    const discardedPaths =
+      incoming.kind === "full"
+        ? []
+        : fullScopeDowngrade
+          ? [...store.analyzedPaths]
+          : store.analyzedPaths.filter((p) => !scopePathCovered(incoming.analyzedPaths, p));
+    const discardedComponents =
+      incoming.kind === "full"
+        ? []
+        : store.analyzedComponents.filter((c) => !incoming.analyzedComponents.includes(c));
+    const narrower = discardedPaths.length > 0 || discardedComponents.length > 0;
+    const payload = {
+      verdict: narrower ? "NARROWER" : "COVERS",
+      store_intent: store.intent,
+      incoming_intent: incoming.intent,
+      discarded_paths: discardedPaths,
+      discarded_components: discardedComponents,
+    };
+    if (narrower) {
+      emit(
+        payload,
+        `NARROWER: replacing the store discards deep knowledge of:\n` +
+          discardedPaths.map((p) => `  - ${p}`).join("\n") +
+          (discardedComponents.length > 0
+            ? `\n  components: ${discardedComponents.join(", ")}`
+            : "") +
+          `\n(store intent: ${store.intent || "unrecorded"}; incoming intent: ${incoming.intent || "unrecorded"})`,
+      );
+    } else {
+      emit(payload, `COVERS: the incoming scan covers everything the store analyzed.`);
+    }
+    return;
+  }
+
+  // Status mode.
+  const currentFingerprint =
+    store.analyzedPaths.length > 0
+      ? codekbScopeFingerprint(repoDir, store.analyzedPaths, fingerprintExcludes)
+      : null;
+  const scopeLines = store.analyzedPaths.map((p) => `  - ${p}`).join("\n");
+  if (store.fingerprint === null || currentFingerprint === null) {
+    emit(
+      {
+        verdict: "UNVERIFIED",
+        store_intent: store.intent,
+        kind: store.kind,
+        analyzed_paths: store.analyzedPaths,
+        detail: store.fingerprint === null ? "store has no fingerprint" : "fingerprint not computable here",
+      },
+      `UNVERIFIED: the store (intent: ${store.intent || "unrecorded"}) analyzed:\n${scopeLines}\n` +
+        `but ${store.fingerprint === null ? "recorded no fingerprint" : "the current tree's fingerprint cannot be computed"} - freshness unknown.`,
+    );
+    return;
+  }
+  const current = store.fingerprint === currentFingerprint;
+  emit(
+    {
+      verdict: current ? "CURRENT" : "STALE",
+      store_intent: store.intent,
+      kind: store.kind,
+      analyzed_paths: store.analyzedPaths,
+      store_fingerprint: store.fingerprint,
+      current_fingerprint: currentFingerprint,
+    },
+    current
+      ? `CURRENT: the analyzed paths are unchanged since the store was built (intent: ${store.intent || "unrecorded"}, coverage: ${store.kind}):\n${scopeLines}`
+      : `STALE: the analyzed paths have changed since the store was built (intent: ${store.intent || "unrecorded"}):\n${scopeLines}`,
+  );
+}
+
 // `detect [--json]` - read-only. Runs the workspace scan (detectWorkspace) on
 // the bare project dir - it needs no aidlc/ workspace; it scans the app root -
 // and prints projectType (Greenfield/Brownfield), languages, frameworks, and
@@ -5404,6 +5572,12 @@ export async function main(argv: string[]): Promise<void> {
     case "codekb-path":
       handleCodekbPath(projectDir, flags);
       break;
+    // codekb-scope-diff - read-only query verb. Compares the codekb store's
+    // recorded scope of analysis against the live tree (status) or an
+    // incoming run's timestamp (--compare). The RE stage's rerun guard.
+    case "codekb-scope-diff":
+      handleCodekbScopeDiff(projectDir, flags);
+      break;
     // detect - read-only query verb. Prints the workspace scan
     // (greenfield/brownfield, languages) + the resolved scope-registry paths so
     // the composer agent is told where scope data lives. No mutation, no audit.
@@ -5466,7 +5640,7 @@ export async function main(argv: string[]): Promise<void> {
       break;
     default:
       die(
-        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
+        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|codekb-scope-diff|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
       );
   }
 }

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.34";
+export const AIDLC_VERSION = "2.5.35";

--- a/dist/codex/.codex/tools/data/stage-graph.json
+++ b/dist/codex/.codex/tools/data/stage-graph.json
@@ -690,7 +690,7 @@
     "name": "Reverse Engineering",
     "phase": "inception",
     "execution": "CONDITIONAL",
-    "condition": "Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.",
+    "condition": "Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.",
     "lead_agent": "aidlc-developer-agent",
     "support_agents": [
       "aidlc-architect-agent"

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/inception/reverse-engineering.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/inception/reverse-engineering.md
@@ -2,7 +2,7 @@
 slug: reverse-engineering
 phase: inception
 execution: CONDITIONAL
-condition: Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.
+condition: Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.
 lead_agent: aidlc-developer-agent
 support_agents:
   - aidlc-architect-agent
@@ -60,25 +60,92 @@ The engine records the skip and advances to the next in-scope stage.
 
 #### Resolve the intent's repo set (multi-repo)
 
-This stage runs **per repo** the intent touches. Resolve the repo set from the
-intent's registry row before scanning:
+This stage runs **per repo** the intent touches. Resolve the complete repo set
+from the intent's registry row before making any reuse or scan decision:
 
 1. Read the active intent's `repos` array from
    `aidlc/spaces/<active-space>/intents/intents.json` (the row whose `uuid`/`slug`
    matches the active intent). This is the set captured at intent birth (an explicit
    `--repos a,b` or sibling auto-discovery).
 2. **Single-repo / unrecorded:** if `repos` is absent, empty, or has exactly one
-   entry, RE runs once against the lone repo — the same flow as before. (An
+   entry, RE runs once against the lone repo - the same flow as before. (An
    unrecorded set means the workspace root is itself the single repo.)
-3. **Multi-repo:** if `repos` has more than one entry, run Steps 2–3 **once per
-   repo**, scanning that repo's sibling directory (`<workspace>/<repo>/`) and writing
-   its 9 artifacts to the directory `codekb-path --repo <repo>` prints (the
-   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each repo's codekb is independent;
-   nothing in one repo's scan blocks another's, so the per-repo scans may run as
-   parallel subagents.
+3. **Multi-repo:** if `repos` has more than one entry, resolve the Step 1 guard
+   decision for every repo, then run Steps 2-3 once for each repo selected for a
+   scan. Scan that repo's sibling directory (`<workspace>/<repo>/`) and write its
+   9 artifacts to the directory `codekb-path --repo <repo>` prints (the
+   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each
+   repo's codekb is independent, so selected scans may run as parallel subagents.
 
-In the steps below, `<repo>` is the repo currently being scanned; repeat for each
-repo in the set.
+In the steps below, `<repo>` is the repository whose decision or scan is being
+processed.
+
+#### Rerun guard: check each existing store before scanning
+
+The codekb is a space-level store shared across intents; a rerun REPLACES it.
+For every repo in the resolved set, run the read-only check:
+
+```
+bun .kiro/tools/aidlc-utility.ts codekb-scope-diff --repo <repo>
+```
+
+- **NO_STORE** - first scan for this repo. Proceed to Step 2; no question.
+- **CURRENT** - the store's analyzed paths are unchanged since it was built.
+  If the recorded coverage plausibly serves this intent's area, present the
+  reuse question below. If this intent clearly targets code OUTSIDE the
+  store's analyzed paths, skip the reuse option and ask rescan vs focused only.
+- **STALE / UNVERIFIED / UNKNOWN_SCOPE** - the store's knowledge is out of
+  date, unverifiable, or predates scope tracking. Present the rescan question
+  below WITHOUT the reuse option.
+
+Reuse question (CURRENT + coverage fits the intent) - fold the tool's output
+(store intent, analyzed paths) into the prompt so the human decides on
+evidence:
+
+```question
+prompt: "An up-to-date code knowledge base exists for <repo> (built by intent <store-intent>; verified unchanged). Deep coverage: <analyzed paths>. Reuse it, or rescan?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Reuse existing knowledge base"
+    description: "Skip the scan; downstream stages read the current store as-is"
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - the store will describe ONLY that area afterward"
+```
+
+Rescan question (STALE / UNVERIFIED / UNKNOWN_SCOPE, or CURRENT with coverage
+that does not fit) - include the verdict line in the prompt:
+
+```question
+prompt: "A code knowledge base exists for <repo> but <verdict summary - e.g. its analyzed paths have changed since it was built / it does not cover this intent's area>. Rescanning replaces it. How should the scan run?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - prior deep knowledge outside it is discarded (recoverable from git history)"
+```
+
+Record one decision per repo: reuse, full rescan, or focused scan. A reuse
+decision does NOT report or advance the stage while another repository may
+still need scanning. On a scan choice, also record its breadth; that choice
+sets the developer brief, and Step 3's scope block records what the scan
+actually covered.
+
+Only after every repository decision has been resolved:
+
+- If every repo is reused on an ordinary workflow run, report the stage as
+  skipped exactly once:
+  `bun .kiro/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result skipped --reason "codekb reuse: all resolved stores CURRENT, human chose reuse"`.
+- If every repo is reused on an isolated run (`directive.single === true`), do
+  NOT call the main-workflow skipped report. Return the reused-repositories
+  summary to the orchestrator's isolated stage-runner branch; it owns the
+  single `report --single --stage "reverse-engineering" --result completed`.
+- If any repo needs scanning, do not report a skip. Proceed to Steps 2-3 for
+  only the full/focused scan repos; leave each reused repo's store unchanged.
 
 ### Step 2: Developer Code Scan
 
@@ -87,8 +154,14 @@ Delegate to Task tool with aidlc-developer-agent:
 - The agent persona and knowledge are loaded automatically. Do NOT manually inject the persona.
 - Include workspace state from aidlc-state.md as context
 
-Developer scans `<repo>`'s codebase (the sibling dir `<workspace>/<repo>/`; for a
-single-repo intent this is the whole codebase) for:
+Brief the developer with the scan breadth chosen at the Step 1 guard (full
+rescan = the whole repo; focused scan = the intent's area, named explicitly in
+the brief) and require the scan results' Scan Coverage section (re-artifacts.md
+template) to list what was actually analyzed deeply vs skimmed.
+
+For each repo selected for scanning, the developer scans `<repo>`'s codebase
+(the sibling dir `<workspace>/<repo>/`; for a single-repo intent this is the
+whole codebase) for:
 - All packages, modules, and their purposes
 - Build systems, configuration, and dependency relationships
 - External and internal APIs (endpoints, contracts, methods)
@@ -118,7 +191,11 @@ Architect synthesizes scan results into 9 artifacts:
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis). This is the freshness/staleness marker for the per-repo codekb store — a stale timestamp triggers a rerun (see the `condition` frontmatter: "Always rerun for freshness").
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) and MUST end with the structured `## Scope of Analysis` block from the re-artifacts.md template, filled from the developer's Scan Coverage - what the run ACTUALLY analyzed deeply, not what was aspired to. This is the freshness/staleness marker the Step 1 rerun guard reads. For the block's `fingerprint:` line, run the mint command with the analyzed paths (comma-separated) and paste its output verbatim:
+
+   ```
+   bun .kiro/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --mint --paths <analyzed paths>
+   ```
 
 **Resolve the write directory with the engine, do NOT compose the path yourself.**
 Run the read-only tool
@@ -129,14 +206,35 @@ bun .kiro/tools/aidlc-utility.ts codekb-path --repo <repo>
 
 (omit `--repo` for a single/unrecorded repo — the engine resolves the repo name).
 It prints ONE line: the exact directory, e.g. `aidlc/spaces/<active-space>/codekb/<repo>/`.
-Write all 9 artifacts into the directory the tool printed — verbatim, creating it if
-absent. This is the durable per-repo code knowledge base, a space-level store shared
-across every intent in the space. Never substitute the intent slug, the record dir, or
-a hand-composed path for what the tool prints.
+
+**Overwrite backstop - run BEFORE writing (the compare needs the store still
+un-replaced).** When the Step 1 guard found an existing store (any verdict but
+NO_STORE), write the new timestamp content to
+`<record>/inception/reverse-engineering/scope-draft-<repo>.md` (one draft per
+repo; NOT the timestamp filename - record-dir placement checks key on the
+artifact stems) and run
+
+```
+bun .kiro/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --compare <record>/inception/reverse-engineering/scope-draft-<repo>.md
+```
+
+Keep the output keyed by `<repo>` for Step 5's completion summary. This is the
+deterministic check that the scan delivered the breadth chosen at Step 1 - a
+focused run after a "Full rescan" choice surfaces here as NARROWER, before
+approval. Delete that repo's `scope-draft-<repo>.md` immediately after
+preserving the compare output; scope drafts are temporary and MUST NOT remain
+in the intent record.
+
+Write all 9 artifacts into the directory `codekb-path` printed - verbatim,
+creating it if absent. This is the durable per-repo code knowledge base, a
+space-level store shared across every intent in the space. Never substitute
+the intent slug, the record dir, or a hand-composed path for what the tool
+prints.
 
 ### Step 4: Completion Handoff
 
-Hand completion to `stage-protocol.md` via
+After every selected repo scan has completed, hand completion to
+`stage-protocol.md` exactly once via
 `bun .kiro/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result <outcome>`.
 The engine owns all lifecycle transitions and advancement.
 
@@ -146,9 +244,22 @@ Use stage-protocol.md completion template:
 - Announcement with completion summary
 - Summary of all 9 artifacts produced **per repo** (for a multi-repo intent, list
   each repo's `aidlc/spaces/<active-space>/codekb/<repo>/` set — the directory
-  `codekb-path --repo <repo>` printed in Step 3)
+  `codekb-path --repo <repo>` printed in Step 3); identify reused repos whose
+  existing stores were left unchanged
+- **For every repo whose Step 3 compare returned NARROWER**, the summary MUST
+  carry a repo-labeled warning before the question, quoting that repo's tool
+  discard list verbatim:
+
+  ```
+  WARNING for <repo>: this scan covered less than the store it replaced. Deep
+  knowledge of the following was discarded (recoverable from git history):
+  <discarded paths and components from the compare output>
+  Choose Request Changes to widen the scan instead.
+  ```
+
+  (COVERS, or no prior store, needs no warning line.)
 - Review path: `aidlc/spaces/<active-space>/codekb/<repo>/` for each repo in the set
-- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes
+- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes. If any repo returned NARROWER, the Approve option's description must say which stores were replaced by narrower scans (e.g. "Accept the narrower stores for <repos>; continue to Requirements Analysis").
 
 ## Sensors
 

--- a/dist/kiro-ide/.kiro/knowledge/aidlc-developer-agent/re-artifacts.md
+++ b/dist/kiro-ide/.kiro/knowledge/aidlc-developer-agent/re-artifacts.md
@@ -14,12 +14,16 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis)
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) plus the structured Scope of Analysis block (template below). The scope block is machine-read by `codekb-scope-diff` on the next rerun, so its accuracy decides whether a future intent is warned before overwriting this run's knowledge.
 
 ### Developer Code Scan Template
 
 ```markdown
 ## Developer Code Scan Results
+
+### Scan Coverage
+- **Analyzed deeply**: [repo-relative dirs/files actually read and understood, one per line]
+- **Skimmed only**: [areas noted at directory granularity without deep reading]
 
 ### Packages Found
 - [package name] — [type] — [language] — [purpose]
@@ -72,3 +76,33 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 ### Improvement Opportunities
 [Areas where the architecture could be strengthened]
 ```
+
+### Scope of Analysis Block (reverse-engineering-timestamp.md)
+
+End reverse-engineering-timestamp.md with exactly this fenced block, filled
+honestly from the Scan Coverage the developer reported - record what the run
+ACTUALLY covered deeply, not what the stage aspired to cover:
+
+````markdown
+## Scope of Analysis
+
+```yaml
+scope_version: 1
+kind: partial
+intent: [active intent slug]
+fingerprint: [output of the mint command in stage Step 3 - verbatim; it prints "unknown" when not computable]
+analyzed:
+  paths:
+    - [repo-relative dir (trailing slash) or file analyzed deeply, one per line]
+  components:
+    - [component names exactly as they appear in component-inventory.md]
+shallow:
+  paths:
+    - [areas only skimmed]
+```
+````
+
+Rules:
+- `kind: full` only when the scan genuinely covered the whole repo deeply; `analyzed.paths` MUST include the repo root (`./`). Anything less is `kind: partial`.
+- `analyzed.paths` entries are repo-relative, directories end with `/`, no glob characters.
+- Component names must match `component-inventory.md` headings verbatim - the rerun guard compares them literally.

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, appendFileSync, constants as fsConstants, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
@@ -1128,6 +1129,208 @@ export function relativeCodekbDir(projectDir: string, repo: string, space?: stri
 export function codekbRepoName(projectDir: string, space?: string): string {
   const repos = intentRepos(projectDir, undefined, space);
   return repos.length === 1 ? repos[0] : basename(projectDir);
+}
+
+// --- Codekb scope of analysis -------------------------------------------------
+//
+// The reverse-engineering stage records WHAT its scan covered in a fenced yaml
+// block inside reverse-engineering-timestamp.md (the store's freshness marker).
+// The parser + fingerprint here are the deterministic half of the rerun
+// guard: `codekb-scope-diff` compares a store's recorded scope against the
+// live working tree (status) or an incoming run's scope (compare), so the
+// human at the RE gate decides reuse/rescan/replace on evidence instead of
+// silently losing a prior intent's knowledge to a narrower overwrite.
+//
+// Block shape (scope_version 1 - authored by the architect at synthesis,
+// behind the RE approval gate):
+//
+//   ```yaml
+//   scope_version: 1
+//   kind: partial            # or: full
+//   intent: fix-payment-timeout
+//   fingerprint: 3f2a9c...   # codekbScopeFingerprint over analyzed.paths
+//   analyzed:
+//     paths:
+//       - src/payments/
+//     components:
+//       - payment-gateway
+//   shallow:
+//     paths:
+//       - src/
+//   ```
+//
+// Pure data - no model call. Same idiom as parseBoltDag: a constrained
+// line-walker, no YAML dependency.
+
+export type ReScope = {
+  kind: "full" | "partial";
+  intent: string;
+  fingerprint: string | null;
+  analyzedPaths: string[];
+  analyzedComponents: string[];
+  shallowPaths: string[];
+};
+
+export type ReScopeParse =
+  | { ok: true; scope: ReScope }
+  | { ok: false; reason: "absent" | "malformed"; detail: string };
+
+// Find the fenced yaml block carrying `scope_version:` anywhere in the body
+// (keyed on the version line, not a heading, so prose edits around the block
+// don't break parsing). Returns the inner lines, or null when no block exists.
+function extractScopeBlock(body: string): string | null {
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```ya?ml\s*$/.test(lines[i].trim())) {
+      const inner: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^```\s*$/.test(lines[j].trim())) break;
+        inner.push(lines[j]);
+      }
+      const block = inner.join("\n");
+      if (/^\s*scope_version\s*:/m.test(block)) return block;
+      i = j; // not the scope block - resume past its close fence
+    }
+  }
+  return null;
+}
+
+// Parse the scope block out of a reverse-engineering-timestamp.md body.
+// Unknown scope_version parses as malformed (a future writer must not be
+// half-read by an old reader); a missing block is "absent" (legacy store).
+export function parseReScope(body: string): ReScopeParse {
+  const block = extractScopeBlock(body);
+  if (block === null) {
+    return { ok: false, reason: "absent", detail: "no fenced yaml scope_version block found" };
+  }
+  const scope: ReScope = {
+    kind: "partial",
+    intent: "",
+    fingerprint: null,
+    analyzedPaths: [],
+    analyzedComponents: [],
+    shallowPaths: [],
+  };
+  let section: "analyzed" | "shallow" | null = null;
+  let list: "paths" | "components" | null = null;
+  let sawKind = false;
+  for (const raw of block.split("\n")) {
+    const t = raw.trim();
+    if (t === "" || t.startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (indent === 0) {
+      section = null;
+      list = null;
+      if (t.startsWith("scope_version:")) {
+        const v = t.slice("scope_version:".length).trim();
+        if (v !== "1") {
+          return { ok: false, reason: "malformed", detail: `unknown scope_version: ${v}` };
+        }
+      } else if (t.startsWith("kind:")) {
+        const k = t.slice("kind:".length).trim();
+        if (k !== "full" && k !== "partial") {
+          return { ok: false, reason: "malformed", detail: `kind must be full|partial, got: ${k}` };
+        }
+        scope.kind = k;
+        sawKind = true;
+      } else if (t.startsWith("intent:")) {
+        scope.intent = t.slice("intent:".length).trim();
+      } else if (t.startsWith("fingerprint:")) {
+        const f = t.slice("fingerprint:".length).trim();
+        scope.fingerprint = f === "" || f === "unknown" ? null : f;
+      } else if (t === "analyzed:") {
+        section = "analyzed";
+      } else if (t === "shallow:") {
+        section = "shallow";
+      }
+    } else if (section !== null && !t.startsWith("-") && t.endsWith(":")) {
+      list = t === "paths:" ? "paths" : t === "components:" ? "components" : null;
+    } else if (section !== null && list !== null && t.startsWith("-")) {
+      const item = t.slice(1).trim();
+      if (item === "") continue;
+      if (section === "analyzed" && list === "paths") scope.analyzedPaths.push(item);
+      else if (section === "analyzed" && list === "components") scope.analyzedComponents.push(item);
+      else if (section === "shallow" && list === "paths") scope.shallowPaths.push(item);
+    }
+  }
+  if (!sawKind) {
+    return { ok: false, reason: "malformed", detail: "missing kind: line" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.length === 0) {
+    return { ok: false, reason: "malformed", detail: "kind: partial requires analyzed.paths entries" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "repository-root coverage (./) requires kind: full",
+    };
+  }
+  if (scope.kind === "full" && !scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "kind: full requires repository-root coverage (analyzed.paths must include ./)",
+    };
+  }
+  return { ok: true, scope };
+}
+
+// Content fingerprint of the WORKING TREE restricted to the scope's analyzed
+// paths: `git write-tree` over a temporary index populated by `git add -A --
+// <paths>`. Hashes what is actually on disk (uncommitted edits included), so
+// rebases/squashes/amends that vaporise a recorded commit hash cannot break
+// the comparison, and reverting an edit restores the original fingerprint.
+// Ignored files stay excluded (git add semantics). Callers may exclude generated
+// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// Returns null when repoDir is not a git work tree, git is unavailable, or any
+// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+export function codekbScopeFingerprint(
+  repoDir: string,
+  paths: string[],
+  excludedPaths: string[] = [],
+): string | null {
+  if (paths.length === 0) return null;
+  const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: repoDir,
+    encoding: "utf-8",
+  });
+  if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+  const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+  try {
+    const exclusions = excludedPaths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "")
+      .map((p) => `:(exclude,literal)${p}`);
+    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+      cwd: repoDir,
+      env,
+      encoding: "utf-8",
+    });
+    if (add.status !== 0) return null;
+    const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
+    if (wt.status !== 0) return null;
+    const hash = wt.stdout.trim();
+    return /^[0-9a-f]{40,64}$/.test(hash) ? hash : null;
+  } finally {
+    try {
+      unlinkSync(indexFile);
+    } catch {
+      // best-effort cleanup - a leaked temp index is inert
+    }
+  }
+}
+
+// Coverage test for the compare mode: does the incoming run's analyzed set
+// cover a store entry? Literal match, or an incoming DIRECTORY prefix (entry
+// ending "/") subsuming the store path. Deliberately prefix-only - scope
+// paths are authored as repo-relative dirs/files, not globs.
+export function scopePathCovered(incoming: string[], storePath: string): boolean {
+  return incoming.some(
+    (p) => p === storePath || (p.endsWith("/") && storePath.startsWith(p)),
+  );
 }
 
 // The bare SPACE record root: `aidlc/spaces/<space>/intents/`. The absolute path

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -54,8 +54,11 @@ import {
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
+  codekbScopeFingerprint,
+  parseReScope,
   relativeCodekbDir,
   RESERVED_RECORD_NAMES,
+  scopePathCovered,
   gridCostSummary,
   listIntents,
   listSpaces,
@@ -4207,6 +4210,171 @@ function handleCodekbPath(projectDir: string, flags: Record<string, string>): vo
   process.stdout.write(`${dir}/\n`);
 }
 
+// `aidlc-utility.ts codekb-scope-diff [--repo <name>] [--compare <timestamp.md>]
+// [--json]` - read-only. The deterministic half of the reverse-engineering
+// rerun guard (the store is shared space-level knowledge; a narrower rerun
+// overwrites it last-writer-wins, so the human decides on evidence).
+//
+// Status mode (default): parse the STORE's reverse-engineering-timestamp.md
+// scope block and recompute the content fingerprint over its analyzed paths.
+//   NO_STORE       no store timestamp - first scan, nothing to guard
+//   CURRENT        fingerprint matches - the store's deep knowledge is exact
+//   STALE          analyzed paths changed since the store was built
+//   UNVERIFIED     scope parsed but no/uncomputable fingerprint (non-git)
+//   UNKNOWN_SCOPE  block absent (legacy store) or malformed
+//
+// Compare mode (--compare <incoming timestamp.md>): does the incoming run's
+// analyzed scope cover the store's? COVERS, or NARROWER + the exact paths and
+// components an overwrite would discard.
+//
+// Mint mode (--mint --paths <a,b,...>): print the content fingerprint over
+// the given repo-relative paths - the value the architect writes into the
+// scope block's `fingerprint:` line at synthesis time. Prints `unknown` when
+// not computable (non-git or invalid pathspec), which the block records
+// verbatim.
+//
+// Always exits 0 with the verdict in the output (read-only query - mirrors
+// codekb-path; refusals are for lifecycle verbs). No mkdir, no state write,
+// no audit.
+function handleCodekbScopeDiff(projectDir: string, flags: Record<string, string>): void {
+  const asJson = flags.json === "true";
+  const space = activeSpace(projectDir);
+  const repo = flags.repo && flags.repo.length > 0 ? flags.repo : codekbRepoName(projectDir, space);
+  const storeDir = relativeCodekbDir(projectDir, repo, space);
+  const storePath = join(projectDir, ...storeDir.split("/"), "reverse-engineering-timestamp.md");
+
+  // The repo's source root: the sibling dir `<workspace>/<repo>/` when it
+  // exists (the multi-repo layout reverse-engineering.md Step 1 scans), else
+  // the workspace root itself (the lone-repo case, where codekbRepoName is
+  // basename(projectDir)).
+  const siblingDir = join(projectDir, repo);
+  const repoDir = existsSync(siblingDir) && statSync(siblingDir).isDirectory() ? siblingDir : projectDir;
+  // In the lone-repo layout the framework-owned aidlc workspace tree lives
+  // under the repository root. Exclude it from full-root fingerprints so
+  // writing the scope draft, codekb, audit, or state cannot stale its own hash.
+  const fingerprintExcludes = repoDir === projectDir ? ["aidlc"] : [];
+
+  if (flags.mint === "true") {
+    const paths = (flags.paths ?? "")
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p !== "");
+    if (paths.length === 0) {
+      die("codekb-scope-diff --mint: pass --paths <comma-separated repo-relative paths>");
+    }
+    const fp = codekbScopeFingerprint(repoDir, paths, fingerprintExcludes) ?? "unknown";
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, fingerprint: fp, paths })}\n`);
+    else process.stdout.write(`${fp}\n`);
+    return;
+  }
+
+  const emit = (payload: Record<string, unknown>, human: string): void => {
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, store: `${storeDir}/`, ...payload })}\n`);
+    else process.stdout.write(`${human}\n`);
+  };
+
+  if (!existsSync(storePath)) {
+    emit(
+      { verdict: "NO_STORE" },
+      `NO_STORE: no reverse-engineering-timestamp.md at ${storeDir}/ - first scan, nothing to compare.`,
+    );
+    return;
+  }
+  const parsed = parseReScope(readFileSync(storePath, "utf-8"));
+  if (!parsed.ok) {
+    emit(
+      { verdict: "UNKNOWN_SCOPE", reason: parsed.reason, detail: parsed.detail },
+      `UNKNOWN_SCOPE (${parsed.reason}): ${parsed.detail}. The store predates scope tracking - a rerun replaces it without a coverage comparison.`,
+    );
+    return;
+  }
+  const store = parsed.scope;
+
+  if (flags.compare !== undefined) {
+    const incomingPath = flags.compare;
+    if (!incomingPath || !existsSync(incomingPath)) {
+      die(`codekb-scope-diff --compare: file not found: ${incomingPath || "(missing path)"}`);
+    }
+    const incomingParsed = parseReScope(readFileSync(incomingPath, "utf-8"));
+    if (!incomingParsed.ok) {
+      emit(
+        { verdict: "UNKNOWN_SCOPE", reason: incomingParsed.reason, detail: `incoming: ${incomingParsed.detail}` },
+        `UNKNOWN_SCOPE (incoming ${incomingParsed.reason}): ${incomingParsed.detail}.`,
+      );
+      return;
+    }
+    const incoming = incomingParsed.scope;
+    const fullScopeDowngrade = store.kind === "full" && incoming.kind !== "full";
+    const discardedPaths =
+      incoming.kind === "full"
+        ? []
+        : fullScopeDowngrade
+          ? [...store.analyzedPaths]
+          : store.analyzedPaths.filter((p) => !scopePathCovered(incoming.analyzedPaths, p));
+    const discardedComponents =
+      incoming.kind === "full"
+        ? []
+        : store.analyzedComponents.filter((c) => !incoming.analyzedComponents.includes(c));
+    const narrower = discardedPaths.length > 0 || discardedComponents.length > 0;
+    const payload = {
+      verdict: narrower ? "NARROWER" : "COVERS",
+      store_intent: store.intent,
+      incoming_intent: incoming.intent,
+      discarded_paths: discardedPaths,
+      discarded_components: discardedComponents,
+    };
+    if (narrower) {
+      emit(
+        payload,
+        `NARROWER: replacing the store discards deep knowledge of:\n` +
+          discardedPaths.map((p) => `  - ${p}`).join("\n") +
+          (discardedComponents.length > 0
+            ? `\n  components: ${discardedComponents.join(", ")}`
+            : "") +
+          `\n(store intent: ${store.intent || "unrecorded"}; incoming intent: ${incoming.intent || "unrecorded"})`,
+      );
+    } else {
+      emit(payload, `COVERS: the incoming scan covers everything the store analyzed.`);
+    }
+    return;
+  }
+
+  // Status mode.
+  const currentFingerprint =
+    store.analyzedPaths.length > 0
+      ? codekbScopeFingerprint(repoDir, store.analyzedPaths, fingerprintExcludes)
+      : null;
+  const scopeLines = store.analyzedPaths.map((p) => `  - ${p}`).join("\n");
+  if (store.fingerprint === null || currentFingerprint === null) {
+    emit(
+      {
+        verdict: "UNVERIFIED",
+        store_intent: store.intent,
+        kind: store.kind,
+        analyzed_paths: store.analyzedPaths,
+        detail: store.fingerprint === null ? "store has no fingerprint" : "fingerprint not computable here",
+      },
+      `UNVERIFIED: the store (intent: ${store.intent || "unrecorded"}) analyzed:\n${scopeLines}\n` +
+        `but ${store.fingerprint === null ? "recorded no fingerprint" : "the current tree's fingerprint cannot be computed"} - freshness unknown.`,
+    );
+    return;
+  }
+  const current = store.fingerprint === currentFingerprint;
+  emit(
+    {
+      verdict: current ? "CURRENT" : "STALE",
+      store_intent: store.intent,
+      kind: store.kind,
+      analyzed_paths: store.analyzedPaths,
+      store_fingerprint: store.fingerprint,
+      current_fingerprint: currentFingerprint,
+    },
+    current
+      ? `CURRENT: the analyzed paths are unchanged since the store was built (intent: ${store.intent || "unrecorded"}, coverage: ${store.kind}):\n${scopeLines}`
+      : `STALE: the analyzed paths have changed since the store was built (intent: ${store.intent || "unrecorded"}):\n${scopeLines}`,
+  );
+}
+
 // `detect [--json]` - read-only. Runs the workspace scan (detectWorkspace) on
 // the bare project dir - it needs no aidlc/ workspace; it scans the app root -
 // and prints projectType (Greenfield/Brownfield), languages, frameworks, and
@@ -5404,6 +5572,12 @@ export async function main(argv: string[]): Promise<void> {
     case "codekb-path":
       handleCodekbPath(projectDir, flags);
       break;
+    // codekb-scope-diff - read-only query verb. Compares the codekb store's
+    // recorded scope of analysis against the live tree (status) or an
+    // incoming run's timestamp (--compare). The RE stage's rerun guard.
+    case "codekb-scope-diff":
+      handleCodekbScopeDiff(projectDir, flags);
+      break;
     // detect - read-only query verb. Prints the workspace scan
     // (greenfield/brownfield, languages) + the resolved scope-registry paths so
     // the composer agent is told where scope data lives. No mutation, no audit.
@@ -5466,7 +5640,7 @@ export async function main(argv: string[]): Promise<void> {
       break;
     default:
       die(
-        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
+        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|codekb-scope-diff|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
       );
   }
 }

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.34";
+export const AIDLC_VERSION = "2.5.35";

--- a/dist/kiro-ide/.kiro/tools/data/stage-graph.json
+++ b/dist/kiro-ide/.kiro/tools/data/stage-graph.json
@@ -690,7 +690,7 @@
     "name": "Reverse Engineering",
     "phase": "inception",
     "execution": "CONDITIONAL",
-    "condition": "Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.",
+    "condition": "Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.",
     "lead_agent": "aidlc-developer-agent",
     "support_agents": [
       "aidlc-architect-agent"

--- a/dist/kiro/.kiro/aidlc-common/stages/inception/reverse-engineering.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/inception/reverse-engineering.md
@@ -2,7 +2,7 @@
 slug: reverse-engineering
 phase: inception
 execution: CONDITIONAL
-condition: Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.
+condition: Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.
 lead_agent: aidlc-developer-agent
 support_agents:
   - aidlc-architect-agent
@@ -60,25 +60,92 @@ The engine records the skip and advances to the next in-scope stage.
 
 #### Resolve the intent's repo set (multi-repo)
 
-This stage runs **per repo** the intent touches. Resolve the repo set from the
-intent's registry row before scanning:
+This stage runs **per repo** the intent touches. Resolve the complete repo set
+from the intent's registry row before making any reuse or scan decision:
 
 1. Read the active intent's `repos` array from
    `aidlc/spaces/<active-space>/intents/intents.json` (the row whose `uuid`/`slug`
    matches the active intent). This is the set captured at intent birth (an explicit
    `--repos a,b` or sibling auto-discovery).
 2. **Single-repo / unrecorded:** if `repos` is absent, empty, or has exactly one
-   entry, RE runs once against the lone repo — the same flow as before. (An
+   entry, RE runs once against the lone repo - the same flow as before. (An
    unrecorded set means the workspace root is itself the single repo.)
-3. **Multi-repo:** if `repos` has more than one entry, run Steps 2–3 **once per
-   repo**, scanning that repo's sibling directory (`<workspace>/<repo>/`) and writing
-   its 9 artifacts to the directory `codekb-path --repo <repo>` prints (the
-   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each repo's codekb is independent;
-   nothing in one repo's scan blocks another's, so the per-repo scans may run as
-   parallel subagents.
+3. **Multi-repo:** if `repos` has more than one entry, resolve the Step 1 guard
+   decision for every repo, then run Steps 2-3 once for each repo selected for a
+   scan. Scan that repo's sibling directory (`<workspace>/<repo>/`) and write its
+   9 artifacts to the directory `codekb-path --repo <repo>` prints (the
+   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each
+   repo's codekb is independent, so selected scans may run as parallel subagents.
 
-In the steps below, `<repo>` is the repo currently being scanned; repeat for each
-repo in the set.
+In the steps below, `<repo>` is the repository whose decision or scan is being
+processed.
+
+#### Rerun guard: check each existing store before scanning
+
+The codekb is a space-level store shared across intents; a rerun REPLACES it.
+For every repo in the resolved set, run the read-only check:
+
+```
+bun .kiro/tools/aidlc-utility.ts codekb-scope-diff --repo <repo>
+```
+
+- **NO_STORE** - first scan for this repo. Proceed to Step 2; no question.
+- **CURRENT** - the store's analyzed paths are unchanged since it was built.
+  If the recorded coverage plausibly serves this intent's area, present the
+  reuse question below. If this intent clearly targets code OUTSIDE the
+  store's analyzed paths, skip the reuse option and ask rescan vs focused only.
+- **STALE / UNVERIFIED / UNKNOWN_SCOPE** - the store's knowledge is out of
+  date, unverifiable, or predates scope tracking. Present the rescan question
+  below WITHOUT the reuse option.
+
+Reuse question (CURRENT + coverage fits the intent) - fold the tool's output
+(store intent, analyzed paths) into the prompt so the human decides on
+evidence:
+
+```question
+prompt: "An up-to-date code knowledge base exists for <repo> (built by intent <store-intent>; verified unchanged). Deep coverage: <analyzed paths>. Reuse it, or rescan?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Reuse existing knowledge base"
+    description: "Skip the scan; downstream stages read the current store as-is"
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - the store will describe ONLY that area afterward"
+```
+
+Rescan question (STALE / UNVERIFIED / UNKNOWN_SCOPE, or CURRENT with coverage
+that does not fit) - include the verdict line in the prompt:
+
+```question
+prompt: "A code knowledge base exists for <repo> but <verdict summary - e.g. its analyzed paths have changed since it was built / it does not cover this intent's area>. Rescanning replaces it. How should the scan run?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - prior deep knowledge outside it is discarded (recoverable from git history)"
+```
+
+Record one decision per repo: reuse, full rescan, or focused scan. A reuse
+decision does NOT report or advance the stage while another repository may
+still need scanning. On a scan choice, also record its breadth; that choice
+sets the developer brief, and Step 3's scope block records what the scan
+actually covered.
+
+Only after every repository decision has been resolved:
+
+- If every repo is reused on an ordinary workflow run, report the stage as
+  skipped exactly once:
+  `bun .kiro/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result skipped --reason "codekb reuse: all resolved stores CURRENT, human chose reuse"`.
+- If every repo is reused on an isolated run (`directive.single === true`), do
+  NOT call the main-workflow skipped report. Return the reused-repositories
+  summary to the orchestrator's isolated stage-runner branch; it owns the
+  single `report --single --stage "reverse-engineering" --result completed`.
+- If any repo needs scanning, do not report a skip. Proceed to Steps 2-3 for
+  only the full/focused scan repos; leave each reused repo's store unchanged.
 
 ### Step 2: Developer Code Scan
 
@@ -87,8 +154,14 @@ Delegate to Task tool with aidlc-developer-agent:
 - The agent persona and knowledge are loaded automatically. Do NOT manually inject the persona.
 - Include workspace state from aidlc-state.md as context
 
-Developer scans `<repo>`'s codebase (the sibling dir `<workspace>/<repo>/`; for a
-single-repo intent this is the whole codebase) for:
+Brief the developer with the scan breadth chosen at the Step 1 guard (full
+rescan = the whole repo; focused scan = the intent's area, named explicitly in
+the brief) and require the scan results' Scan Coverage section (re-artifacts.md
+template) to list what was actually analyzed deeply vs skimmed.
+
+For each repo selected for scanning, the developer scans `<repo>`'s codebase
+(the sibling dir `<workspace>/<repo>/`; for a single-repo intent this is the
+whole codebase) for:
 - All packages, modules, and their purposes
 - Build systems, configuration, and dependency relationships
 - External and internal APIs (endpoints, contracts, methods)
@@ -118,7 +191,11 @@ Architect synthesizes scan results into 9 artifacts:
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis). This is the freshness/staleness marker for the per-repo codekb store — a stale timestamp triggers a rerun (see the `condition` frontmatter: "Always rerun for freshness").
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) and MUST end with the structured `## Scope of Analysis` block from the re-artifacts.md template, filled from the developer's Scan Coverage - what the run ACTUALLY analyzed deeply, not what was aspired to. This is the freshness/staleness marker the Step 1 rerun guard reads. For the block's `fingerprint:` line, run the mint command with the analyzed paths (comma-separated) and paste its output verbatim:
+
+   ```
+   bun .kiro/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --mint --paths <analyzed paths>
+   ```
 
 **Resolve the write directory with the engine, do NOT compose the path yourself.**
 Run the read-only tool
@@ -129,14 +206,35 @@ bun .kiro/tools/aidlc-utility.ts codekb-path --repo <repo>
 
 (omit `--repo` for a single/unrecorded repo — the engine resolves the repo name).
 It prints ONE line: the exact directory, e.g. `aidlc/spaces/<active-space>/codekb/<repo>/`.
-Write all 9 artifacts into the directory the tool printed — verbatim, creating it if
-absent. This is the durable per-repo code knowledge base, a space-level store shared
-across every intent in the space. Never substitute the intent slug, the record dir, or
-a hand-composed path for what the tool prints.
+
+**Overwrite backstop - run BEFORE writing (the compare needs the store still
+un-replaced).** When the Step 1 guard found an existing store (any verdict but
+NO_STORE), write the new timestamp content to
+`<record>/inception/reverse-engineering/scope-draft-<repo>.md` (one draft per
+repo; NOT the timestamp filename - record-dir placement checks key on the
+artifact stems) and run
+
+```
+bun .kiro/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --compare <record>/inception/reverse-engineering/scope-draft-<repo>.md
+```
+
+Keep the output keyed by `<repo>` for Step 5's completion summary. This is the
+deterministic check that the scan delivered the breadth chosen at Step 1 - a
+focused run after a "Full rescan" choice surfaces here as NARROWER, before
+approval. Delete that repo's `scope-draft-<repo>.md` immediately after
+preserving the compare output; scope drafts are temporary and MUST NOT remain
+in the intent record.
+
+Write all 9 artifacts into the directory `codekb-path` printed - verbatim,
+creating it if absent. This is the durable per-repo code knowledge base, a
+space-level store shared across every intent in the space. Never substitute
+the intent slug, the record dir, or a hand-composed path for what the tool
+prints.
 
 ### Step 4: Completion Handoff
 
-Hand completion to `stage-protocol.md` via
+After every selected repo scan has completed, hand completion to
+`stage-protocol.md` exactly once via
 `bun .kiro/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result <outcome>`.
 The engine owns all lifecycle transitions and advancement.
 
@@ -146,9 +244,22 @@ Use stage-protocol.md completion template:
 - Announcement with completion summary
 - Summary of all 9 artifacts produced **per repo** (for a multi-repo intent, list
   each repo's `aidlc/spaces/<active-space>/codekb/<repo>/` set — the directory
-  `codekb-path --repo <repo>` printed in Step 3)
+  `codekb-path --repo <repo>` printed in Step 3); identify reused repos whose
+  existing stores were left unchanged
+- **For every repo whose Step 3 compare returned NARROWER**, the summary MUST
+  carry a repo-labeled warning before the question, quoting that repo's tool
+  discard list verbatim:
+
+  ```
+  WARNING for <repo>: this scan covered less than the store it replaced. Deep
+  knowledge of the following was discarded (recoverable from git history):
+  <discarded paths and components from the compare output>
+  Choose Request Changes to widen the scan instead.
+  ```
+
+  (COVERS, or no prior store, needs no warning line.)
 - Review path: `aidlc/spaces/<active-space>/codekb/<repo>/` for each repo in the set
-- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes
+- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes. If any repo returned NARROWER, the Approve option's description must say which stores were replaced by narrower scans (e.g. "Accept the narrower stores for <repos>; continue to Requirements Analysis").
 
 ## Sensors
 

--- a/dist/kiro/.kiro/knowledge/aidlc-developer-agent/re-artifacts.md
+++ b/dist/kiro/.kiro/knowledge/aidlc-developer-agent/re-artifacts.md
@@ -14,12 +14,16 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis)
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) plus the structured Scope of Analysis block (template below). The scope block is machine-read by `codekb-scope-diff` on the next rerun, so its accuracy decides whether a future intent is warned before overwriting this run's knowledge.
 
 ### Developer Code Scan Template
 
 ```markdown
 ## Developer Code Scan Results
+
+### Scan Coverage
+- **Analyzed deeply**: [repo-relative dirs/files actually read and understood, one per line]
+- **Skimmed only**: [areas noted at directory granularity without deep reading]
 
 ### Packages Found
 - [package name] — [type] — [language] — [purpose]
@@ -72,3 +76,33 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 ### Improvement Opportunities
 [Areas where the architecture could be strengthened]
 ```
+
+### Scope of Analysis Block (reverse-engineering-timestamp.md)
+
+End reverse-engineering-timestamp.md with exactly this fenced block, filled
+honestly from the Scan Coverage the developer reported - record what the run
+ACTUALLY covered deeply, not what the stage aspired to cover:
+
+````markdown
+## Scope of Analysis
+
+```yaml
+scope_version: 1
+kind: partial
+intent: [active intent slug]
+fingerprint: [output of the mint command in stage Step 3 - verbatim; it prints "unknown" when not computable]
+analyzed:
+  paths:
+    - [repo-relative dir (trailing slash) or file analyzed deeply, one per line]
+  components:
+    - [component names exactly as they appear in component-inventory.md]
+shallow:
+  paths:
+    - [areas only skimmed]
+```
+````
+
+Rules:
+- `kind: full` only when the scan genuinely covered the whole repo deeply; `analyzed.paths` MUST include the repo root (`./`). Anything less is `kind: partial`.
+- `analyzed.paths` entries are repo-relative, directories end with `/`, no glob characters.
+- Component names must match `component-inventory.md` headings verbatim - the rerun guard compares them literally.

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, appendFileSync, constants as fsConstants, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
@@ -1128,6 +1129,208 @@ export function relativeCodekbDir(projectDir: string, repo: string, space?: stri
 export function codekbRepoName(projectDir: string, space?: string): string {
   const repos = intentRepos(projectDir, undefined, space);
   return repos.length === 1 ? repos[0] : basename(projectDir);
+}
+
+// --- Codekb scope of analysis -------------------------------------------------
+//
+// The reverse-engineering stage records WHAT its scan covered in a fenced yaml
+// block inside reverse-engineering-timestamp.md (the store's freshness marker).
+// The parser + fingerprint here are the deterministic half of the rerun
+// guard: `codekb-scope-diff` compares a store's recorded scope against the
+// live working tree (status) or an incoming run's scope (compare), so the
+// human at the RE gate decides reuse/rescan/replace on evidence instead of
+// silently losing a prior intent's knowledge to a narrower overwrite.
+//
+// Block shape (scope_version 1 - authored by the architect at synthesis,
+// behind the RE approval gate):
+//
+//   ```yaml
+//   scope_version: 1
+//   kind: partial            # or: full
+//   intent: fix-payment-timeout
+//   fingerprint: 3f2a9c...   # codekbScopeFingerprint over analyzed.paths
+//   analyzed:
+//     paths:
+//       - src/payments/
+//     components:
+//       - payment-gateway
+//   shallow:
+//     paths:
+//       - src/
+//   ```
+//
+// Pure data - no model call. Same idiom as parseBoltDag: a constrained
+// line-walker, no YAML dependency.
+
+export type ReScope = {
+  kind: "full" | "partial";
+  intent: string;
+  fingerprint: string | null;
+  analyzedPaths: string[];
+  analyzedComponents: string[];
+  shallowPaths: string[];
+};
+
+export type ReScopeParse =
+  | { ok: true; scope: ReScope }
+  | { ok: false; reason: "absent" | "malformed"; detail: string };
+
+// Find the fenced yaml block carrying `scope_version:` anywhere in the body
+// (keyed on the version line, not a heading, so prose edits around the block
+// don't break parsing). Returns the inner lines, or null when no block exists.
+function extractScopeBlock(body: string): string | null {
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```ya?ml\s*$/.test(lines[i].trim())) {
+      const inner: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^```\s*$/.test(lines[j].trim())) break;
+        inner.push(lines[j]);
+      }
+      const block = inner.join("\n");
+      if (/^\s*scope_version\s*:/m.test(block)) return block;
+      i = j; // not the scope block - resume past its close fence
+    }
+  }
+  return null;
+}
+
+// Parse the scope block out of a reverse-engineering-timestamp.md body.
+// Unknown scope_version parses as malformed (a future writer must not be
+// half-read by an old reader); a missing block is "absent" (legacy store).
+export function parseReScope(body: string): ReScopeParse {
+  const block = extractScopeBlock(body);
+  if (block === null) {
+    return { ok: false, reason: "absent", detail: "no fenced yaml scope_version block found" };
+  }
+  const scope: ReScope = {
+    kind: "partial",
+    intent: "",
+    fingerprint: null,
+    analyzedPaths: [],
+    analyzedComponents: [],
+    shallowPaths: [],
+  };
+  let section: "analyzed" | "shallow" | null = null;
+  let list: "paths" | "components" | null = null;
+  let sawKind = false;
+  for (const raw of block.split("\n")) {
+    const t = raw.trim();
+    if (t === "" || t.startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (indent === 0) {
+      section = null;
+      list = null;
+      if (t.startsWith("scope_version:")) {
+        const v = t.slice("scope_version:".length).trim();
+        if (v !== "1") {
+          return { ok: false, reason: "malformed", detail: `unknown scope_version: ${v}` };
+        }
+      } else if (t.startsWith("kind:")) {
+        const k = t.slice("kind:".length).trim();
+        if (k !== "full" && k !== "partial") {
+          return { ok: false, reason: "malformed", detail: `kind must be full|partial, got: ${k}` };
+        }
+        scope.kind = k;
+        sawKind = true;
+      } else if (t.startsWith("intent:")) {
+        scope.intent = t.slice("intent:".length).trim();
+      } else if (t.startsWith("fingerprint:")) {
+        const f = t.slice("fingerprint:".length).trim();
+        scope.fingerprint = f === "" || f === "unknown" ? null : f;
+      } else if (t === "analyzed:") {
+        section = "analyzed";
+      } else if (t === "shallow:") {
+        section = "shallow";
+      }
+    } else if (section !== null && !t.startsWith("-") && t.endsWith(":")) {
+      list = t === "paths:" ? "paths" : t === "components:" ? "components" : null;
+    } else if (section !== null && list !== null && t.startsWith("-")) {
+      const item = t.slice(1).trim();
+      if (item === "") continue;
+      if (section === "analyzed" && list === "paths") scope.analyzedPaths.push(item);
+      else if (section === "analyzed" && list === "components") scope.analyzedComponents.push(item);
+      else if (section === "shallow" && list === "paths") scope.shallowPaths.push(item);
+    }
+  }
+  if (!sawKind) {
+    return { ok: false, reason: "malformed", detail: "missing kind: line" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.length === 0) {
+    return { ok: false, reason: "malformed", detail: "kind: partial requires analyzed.paths entries" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "repository-root coverage (./) requires kind: full",
+    };
+  }
+  if (scope.kind === "full" && !scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "kind: full requires repository-root coverage (analyzed.paths must include ./)",
+    };
+  }
+  return { ok: true, scope };
+}
+
+// Content fingerprint of the WORKING TREE restricted to the scope's analyzed
+// paths: `git write-tree` over a temporary index populated by `git add -A --
+// <paths>`. Hashes what is actually on disk (uncommitted edits included), so
+// rebases/squashes/amends that vaporise a recorded commit hash cannot break
+// the comparison, and reverting an edit restores the original fingerprint.
+// Ignored files stay excluded (git add semantics). Callers may exclude generated
+// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// Returns null when repoDir is not a git work tree, git is unavailable, or any
+// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+export function codekbScopeFingerprint(
+  repoDir: string,
+  paths: string[],
+  excludedPaths: string[] = [],
+): string | null {
+  if (paths.length === 0) return null;
+  const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: repoDir,
+    encoding: "utf-8",
+  });
+  if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+  const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+  try {
+    const exclusions = excludedPaths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "")
+      .map((p) => `:(exclude,literal)${p}`);
+    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+      cwd: repoDir,
+      env,
+      encoding: "utf-8",
+    });
+    if (add.status !== 0) return null;
+    const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
+    if (wt.status !== 0) return null;
+    const hash = wt.stdout.trim();
+    return /^[0-9a-f]{40,64}$/.test(hash) ? hash : null;
+  } finally {
+    try {
+      unlinkSync(indexFile);
+    } catch {
+      // best-effort cleanup - a leaked temp index is inert
+    }
+  }
+}
+
+// Coverage test for the compare mode: does the incoming run's analyzed set
+// cover a store entry? Literal match, or an incoming DIRECTORY prefix (entry
+// ending "/") subsuming the store path. Deliberately prefix-only - scope
+// paths are authored as repo-relative dirs/files, not globs.
+export function scopePathCovered(incoming: string[], storePath: string): boolean {
+  return incoming.some(
+    (p) => p === storePath || (p.endsWith("/") && storePath.startsWith(p)),
+  );
 }
 
 // The bare SPACE record root: `aidlc/spaces/<space>/intents/`. The absolute path

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -54,8 +54,11 @@ import {
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
+  codekbScopeFingerprint,
+  parseReScope,
   relativeCodekbDir,
   RESERVED_RECORD_NAMES,
+  scopePathCovered,
   gridCostSummary,
   listIntents,
   listSpaces,
@@ -4207,6 +4210,171 @@ function handleCodekbPath(projectDir: string, flags: Record<string, string>): vo
   process.stdout.write(`${dir}/\n`);
 }
 
+// `aidlc-utility.ts codekb-scope-diff [--repo <name>] [--compare <timestamp.md>]
+// [--json]` - read-only. The deterministic half of the reverse-engineering
+// rerun guard (the store is shared space-level knowledge; a narrower rerun
+// overwrites it last-writer-wins, so the human decides on evidence).
+//
+// Status mode (default): parse the STORE's reverse-engineering-timestamp.md
+// scope block and recompute the content fingerprint over its analyzed paths.
+//   NO_STORE       no store timestamp - first scan, nothing to guard
+//   CURRENT        fingerprint matches - the store's deep knowledge is exact
+//   STALE          analyzed paths changed since the store was built
+//   UNVERIFIED     scope parsed but no/uncomputable fingerprint (non-git)
+//   UNKNOWN_SCOPE  block absent (legacy store) or malformed
+//
+// Compare mode (--compare <incoming timestamp.md>): does the incoming run's
+// analyzed scope cover the store's? COVERS, or NARROWER + the exact paths and
+// components an overwrite would discard.
+//
+// Mint mode (--mint --paths <a,b,...>): print the content fingerprint over
+// the given repo-relative paths - the value the architect writes into the
+// scope block's `fingerprint:` line at synthesis time. Prints `unknown` when
+// not computable (non-git or invalid pathspec), which the block records
+// verbatim.
+//
+// Always exits 0 with the verdict in the output (read-only query - mirrors
+// codekb-path; refusals are for lifecycle verbs). No mkdir, no state write,
+// no audit.
+function handleCodekbScopeDiff(projectDir: string, flags: Record<string, string>): void {
+  const asJson = flags.json === "true";
+  const space = activeSpace(projectDir);
+  const repo = flags.repo && flags.repo.length > 0 ? flags.repo : codekbRepoName(projectDir, space);
+  const storeDir = relativeCodekbDir(projectDir, repo, space);
+  const storePath = join(projectDir, ...storeDir.split("/"), "reverse-engineering-timestamp.md");
+
+  // The repo's source root: the sibling dir `<workspace>/<repo>/` when it
+  // exists (the multi-repo layout reverse-engineering.md Step 1 scans), else
+  // the workspace root itself (the lone-repo case, where codekbRepoName is
+  // basename(projectDir)).
+  const siblingDir = join(projectDir, repo);
+  const repoDir = existsSync(siblingDir) && statSync(siblingDir).isDirectory() ? siblingDir : projectDir;
+  // In the lone-repo layout the framework-owned aidlc workspace tree lives
+  // under the repository root. Exclude it from full-root fingerprints so
+  // writing the scope draft, codekb, audit, or state cannot stale its own hash.
+  const fingerprintExcludes = repoDir === projectDir ? ["aidlc"] : [];
+
+  if (flags.mint === "true") {
+    const paths = (flags.paths ?? "")
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p !== "");
+    if (paths.length === 0) {
+      die("codekb-scope-diff --mint: pass --paths <comma-separated repo-relative paths>");
+    }
+    const fp = codekbScopeFingerprint(repoDir, paths, fingerprintExcludes) ?? "unknown";
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, fingerprint: fp, paths })}\n`);
+    else process.stdout.write(`${fp}\n`);
+    return;
+  }
+
+  const emit = (payload: Record<string, unknown>, human: string): void => {
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, store: `${storeDir}/`, ...payload })}\n`);
+    else process.stdout.write(`${human}\n`);
+  };
+
+  if (!existsSync(storePath)) {
+    emit(
+      { verdict: "NO_STORE" },
+      `NO_STORE: no reverse-engineering-timestamp.md at ${storeDir}/ - first scan, nothing to compare.`,
+    );
+    return;
+  }
+  const parsed = parseReScope(readFileSync(storePath, "utf-8"));
+  if (!parsed.ok) {
+    emit(
+      { verdict: "UNKNOWN_SCOPE", reason: parsed.reason, detail: parsed.detail },
+      `UNKNOWN_SCOPE (${parsed.reason}): ${parsed.detail}. The store predates scope tracking - a rerun replaces it without a coverage comparison.`,
+    );
+    return;
+  }
+  const store = parsed.scope;
+
+  if (flags.compare !== undefined) {
+    const incomingPath = flags.compare;
+    if (!incomingPath || !existsSync(incomingPath)) {
+      die(`codekb-scope-diff --compare: file not found: ${incomingPath || "(missing path)"}`);
+    }
+    const incomingParsed = parseReScope(readFileSync(incomingPath, "utf-8"));
+    if (!incomingParsed.ok) {
+      emit(
+        { verdict: "UNKNOWN_SCOPE", reason: incomingParsed.reason, detail: `incoming: ${incomingParsed.detail}` },
+        `UNKNOWN_SCOPE (incoming ${incomingParsed.reason}): ${incomingParsed.detail}.`,
+      );
+      return;
+    }
+    const incoming = incomingParsed.scope;
+    const fullScopeDowngrade = store.kind === "full" && incoming.kind !== "full";
+    const discardedPaths =
+      incoming.kind === "full"
+        ? []
+        : fullScopeDowngrade
+          ? [...store.analyzedPaths]
+          : store.analyzedPaths.filter((p) => !scopePathCovered(incoming.analyzedPaths, p));
+    const discardedComponents =
+      incoming.kind === "full"
+        ? []
+        : store.analyzedComponents.filter((c) => !incoming.analyzedComponents.includes(c));
+    const narrower = discardedPaths.length > 0 || discardedComponents.length > 0;
+    const payload = {
+      verdict: narrower ? "NARROWER" : "COVERS",
+      store_intent: store.intent,
+      incoming_intent: incoming.intent,
+      discarded_paths: discardedPaths,
+      discarded_components: discardedComponents,
+    };
+    if (narrower) {
+      emit(
+        payload,
+        `NARROWER: replacing the store discards deep knowledge of:\n` +
+          discardedPaths.map((p) => `  - ${p}`).join("\n") +
+          (discardedComponents.length > 0
+            ? `\n  components: ${discardedComponents.join(", ")}`
+            : "") +
+          `\n(store intent: ${store.intent || "unrecorded"}; incoming intent: ${incoming.intent || "unrecorded"})`,
+      );
+    } else {
+      emit(payload, `COVERS: the incoming scan covers everything the store analyzed.`);
+    }
+    return;
+  }
+
+  // Status mode.
+  const currentFingerprint =
+    store.analyzedPaths.length > 0
+      ? codekbScopeFingerprint(repoDir, store.analyzedPaths, fingerprintExcludes)
+      : null;
+  const scopeLines = store.analyzedPaths.map((p) => `  - ${p}`).join("\n");
+  if (store.fingerprint === null || currentFingerprint === null) {
+    emit(
+      {
+        verdict: "UNVERIFIED",
+        store_intent: store.intent,
+        kind: store.kind,
+        analyzed_paths: store.analyzedPaths,
+        detail: store.fingerprint === null ? "store has no fingerprint" : "fingerprint not computable here",
+      },
+      `UNVERIFIED: the store (intent: ${store.intent || "unrecorded"}) analyzed:\n${scopeLines}\n` +
+        `but ${store.fingerprint === null ? "recorded no fingerprint" : "the current tree's fingerprint cannot be computed"} - freshness unknown.`,
+    );
+    return;
+  }
+  const current = store.fingerprint === currentFingerprint;
+  emit(
+    {
+      verdict: current ? "CURRENT" : "STALE",
+      store_intent: store.intent,
+      kind: store.kind,
+      analyzed_paths: store.analyzedPaths,
+      store_fingerprint: store.fingerprint,
+      current_fingerprint: currentFingerprint,
+    },
+    current
+      ? `CURRENT: the analyzed paths are unchanged since the store was built (intent: ${store.intent || "unrecorded"}, coverage: ${store.kind}):\n${scopeLines}`
+      : `STALE: the analyzed paths have changed since the store was built (intent: ${store.intent || "unrecorded"}):\n${scopeLines}`,
+  );
+}
+
 // `detect [--json]` - read-only. Runs the workspace scan (detectWorkspace) on
 // the bare project dir - it needs no aidlc/ workspace; it scans the app root -
 // and prints projectType (Greenfield/Brownfield), languages, frameworks, and
@@ -5404,6 +5572,12 @@ export async function main(argv: string[]): Promise<void> {
     case "codekb-path":
       handleCodekbPath(projectDir, flags);
       break;
+    // codekb-scope-diff - read-only query verb. Compares the codekb store's
+    // recorded scope of analysis against the live tree (status) or an
+    // incoming run's timestamp (--compare). The RE stage's rerun guard.
+    case "codekb-scope-diff":
+      handleCodekbScopeDiff(projectDir, flags);
+      break;
     // detect - read-only query verb. Prints the workspace scan
     // (greenfield/brownfield, languages) + the resolved scope-registry paths so
     // the composer agent is told where scope data lives. No mutation, no audit.
@@ -5466,7 +5640,7 @@ export async function main(argv: string[]): Promise<void> {
       break;
     default:
       die(
-        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
+        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|codekb-scope-diff|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
       );
   }
 }

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.34";
+export const AIDLC_VERSION = "2.5.35";

--- a/dist/kiro/.kiro/tools/data/stage-graph.json
+++ b/dist/kiro/.kiro/tools/data/stage-graph.json
@@ -690,7 +690,7 @@
     "name": "Reverse Engineering",
     "phase": "inception",
     "execution": "CONDITIONAL",
-    "condition": "Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.",
+    "condition": "Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.",
     "lead_agent": "aidlc-developer-agent",
     "support_agents": [
       "aidlc-architect-agent"

--- a/dist/opencode/.aidlc/aidlc-common/stages/inception/reverse-engineering.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/inception/reverse-engineering.md
@@ -2,7 +2,7 @@
 slug: reverse-engineering
 phase: inception
 execution: CONDITIONAL
-condition: Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.
+condition: Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.
 lead_agent: aidlc-developer-agent
 support_agents:
   - aidlc-architect-agent
@@ -60,25 +60,92 @@ The engine records the skip and advances to the next in-scope stage.
 
 #### Resolve the intent's repo set (multi-repo)
 
-This stage runs **per repo** the intent touches. Resolve the repo set from the
-intent's registry row before scanning:
+This stage runs **per repo** the intent touches. Resolve the complete repo set
+from the intent's registry row before making any reuse or scan decision:
 
 1. Read the active intent's `repos` array from
    `aidlc/spaces/<active-space>/intents/intents.json` (the row whose `uuid`/`slug`
    matches the active intent). This is the set captured at intent birth (an explicit
    `--repos a,b` or sibling auto-discovery).
 2. **Single-repo / unrecorded:** if `repos` is absent, empty, or has exactly one
-   entry, RE runs once against the lone repo — the same flow as before. (An
+   entry, RE runs once against the lone repo - the same flow as before. (An
    unrecorded set means the workspace root is itself the single repo.)
-3. **Multi-repo:** if `repos` has more than one entry, run Steps 2–3 **once per
-   repo**, scanning that repo's sibling directory (`<workspace>/<repo>/`) and writing
-   its 9 artifacts to the directory `codekb-path --repo <repo>` prints (the
-   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each repo's codekb is independent;
-   nothing in one repo's scan blocks another's, so the per-repo scans may run as
-   parallel subagents.
+3. **Multi-repo:** if `repos` has more than one entry, resolve the Step 1 guard
+   decision for every repo, then run Steps 2-3 once for each repo selected for a
+   scan. Scan that repo's sibling directory (`<workspace>/<repo>/`) and write its
+   9 artifacts to the directory `codekb-path --repo <repo>` prints (the
+   space-level `aidlc/spaces/<active-space>/codekb/<repo>/`; see Step 3). Each
+   repo's codekb is independent, so selected scans may run as parallel subagents.
 
-In the steps below, `<repo>` is the repo currently being scanned; repeat for each
-repo in the set.
+In the steps below, `<repo>` is the repository whose decision or scan is being
+processed.
+
+#### Rerun guard: check each existing store before scanning
+
+The codekb is a space-level store shared across intents; a rerun REPLACES it.
+For every repo in the resolved set, run the read-only check:
+
+```
+bun .aidlc/tools/aidlc-utility.ts codekb-scope-diff --repo <repo>
+```
+
+- **NO_STORE** - first scan for this repo. Proceed to Step 2; no question.
+- **CURRENT** - the store's analyzed paths are unchanged since it was built.
+  If the recorded coverage plausibly serves this intent's area, present the
+  reuse question below. If this intent clearly targets code OUTSIDE the
+  store's analyzed paths, skip the reuse option and ask rescan vs focused only.
+- **STALE / UNVERIFIED / UNKNOWN_SCOPE** - the store's knowledge is out of
+  date, unverifiable, or predates scope tracking. Present the rescan question
+  below WITHOUT the reuse option.
+
+Reuse question (CURRENT + coverage fits the intent) - fold the tool's output
+(store intent, analyzed paths) into the prompt so the human decides on
+evidence:
+
+```question
+prompt: "An up-to-date code knowledge base exists for <repo> (built by intent <store-intent>; verified unchanged). Deep coverage: <analyzed paths>. Reuse it, or rescan?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Reuse existing knowledge base"
+    description: "Skip the scan; downstream stages read the current store as-is"
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - the store will describe ONLY that area afterward"
+```
+
+Rescan question (STALE / UNVERIFIED / UNKNOWN_SCOPE, or CURRENT with coverage
+that does not fit) - include the verdict line in the prompt:
+
+```question
+prompt: "A code knowledge base exists for <repo> but <verdict summary - e.g. its analyzed paths have changed since it was built / it does not cover this intent's area>. Rescanning replaces it. How should the scan run?"
+header: "Code KB"
+multiSelect: false
+options:
+  - label: "Full rescan"
+    description: "Rebuild the store covering the whole repo (replaces all 9 artifacts)"
+  - label: "Focused scan"
+    description: "Scan only this intent's area - prior deep knowledge outside it is discarded (recoverable from git history)"
+```
+
+Record one decision per repo: reuse, full rescan, or focused scan. A reuse
+decision does NOT report or advance the stage while another repository may
+still need scanning. On a scan choice, also record its breadth; that choice
+sets the developer brief, and Step 3's scope block records what the scan
+actually covered.
+
+Only after every repository decision has been resolved:
+
+- If every repo is reused on an ordinary workflow run, report the stage as
+  skipped exactly once:
+  `bun .aidlc/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result skipped --reason "codekb reuse: all resolved stores CURRENT, human chose reuse"`.
+- If every repo is reused on an isolated run (`directive.single === true`), do
+  NOT call the main-workflow skipped report. Return the reused-repositories
+  summary to the orchestrator's isolated stage-runner branch; it owns the
+  single `report --single --stage "reverse-engineering" --result completed`.
+- If any repo needs scanning, do not report a skip. Proceed to Steps 2-3 for
+  only the full/focused scan repos; leave each reused repo's store unchanged.
 
 ### Step 2: Developer Code Scan
 
@@ -87,8 +154,14 @@ Delegate to Task tool with aidlc-developer-agent:
 - The agent persona and knowledge are loaded automatically. Do NOT manually inject the persona.
 - Include workspace state from aidlc-state.md as context
 
-Developer scans `<repo>`'s codebase (the sibling dir `<workspace>/<repo>/`; for a
-single-repo intent this is the whole codebase) for:
+Brief the developer with the scan breadth chosen at the Step 1 guard (full
+rescan = the whole repo; focused scan = the intent's area, named explicitly in
+the brief) and require the scan results' Scan Coverage section (re-artifacts.md
+template) to list what was actually analyzed deeply vs skimmed.
+
+For each repo selected for scanning, the developer scans `<repo>`'s codebase
+(the sibling dir `<workspace>/<repo>/`; for a single-repo intent this is the
+whole codebase) for:
 - All packages, modules, and their purposes
 - Build systems, configuration, and dependency relationships
 - External and internal APIs (endpoints, contracts, methods)
@@ -118,7 +191,11 @@ Architect synthesizes scan results into 9 artifacts:
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis). This is the freshness/staleness marker for the per-repo codekb store — a stale timestamp triggers a rerun (see the `condition` frontmatter: "Always rerun for freshness").
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) and MUST end with the structured `## Scope of Analysis` block from the re-artifacts.md template, filled from the developer's Scan Coverage - what the run ACTUALLY analyzed deeply, not what was aspired to. This is the freshness/staleness marker the Step 1 rerun guard reads. For the block's `fingerprint:` line, run the mint command with the analyzed paths (comma-separated) and paste its output verbatim:
+
+   ```
+   bun .aidlc/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --mint --paths <analyzed paths>
+   ```
 
 **Resolve the write directory with the engine, do NOT compose the path yourself.**
 Run the read-only tool
@@ -129,14 +206,35 @@ bun .aidlc/tools/aidlc-utility.ts codekb-path --repo <repo>
 
 (omit `--repo` for a single/unrecorded repo — the engine resolves the repo name).
 It prints ONE line: the exact directory, e.g. `aidlc/spaces/<active-space>/codekb/<repo>/`.
-Write all 9 artifacts into the directory the tool printed — verbatim, creating it if
-absent. This is the durable per-repo code knowledge base, a space-level store shared
-across every intent in the space. Never substitute the intent slug, the record dir, or
-a hand-composed path for what the tool prints.
+
+**Overwrite backstop - run BEFORE writing (the compare needs the store still
+un-replaced).** When the Step 1 guard found an existing store (any verdict but
+NO_STORE), write the new timestamp content to
+`<record>/inception/reverse-engineering/scope-draft-<repo>.md` (one draft per
+repo; NOT the timestamp filename - record-dir placement checks key on the
+artifact stems) and run
+
+```
+bun .aidlc/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --compare <record>/inception/reverse-engineering/scope-draft-<repo>.md
+```
+
+Keep the output keyed by `<repo>` for Step 5's completion summary. This is the
+deterministic check that the scan delivered the breadth chosen at Step 1 - a
+focused run after a "Full rescan" choice surfaces here as NARROWER, before
+approval. Delete that repo's `scope-draft-<repo>.md` immediately after
+preserving the compare output; scope drafts are temporary and MUST NOT remain
+in the intent record.
+
+Write all 9 artifacts into the directory `codekb-path` printed - verbatim,
+creating it if absent. This is the durable per-repo code knowledge base, a
+space-level store shared across every intent in the space. Never substitute
+the intent slug, the record dir, or a hand-composed path for what the tool
+prints.
 
 ### Step 4: Completion Handoff
 
-Hand completion to `stage-protocol.md` via
+After every selected repo scan has completed, hand completion to
+`stage-protocol.md` exactly once via
 `bun .aidlc/tools/aidlc-orchestrate.ts report --stage reverse-engineering --result <outcome>`.
 The engine owns all lifecycle transitions and advancement.
 
@@ -146,9 +244,22 @@ Use stage-protocol.md completion template:
 - Announcement with completion summary
 - Summary of all 9 artifacts produced **per repo** (for a multi-repo intent, list
   each repo's `aidlc/spaces/<active-space>/codekb/<repo>/` set — the directory
-  `codekb-path --repo <repo>` printed in Step 3)
+  `codekb-path --repo <repo>` printed in Step 3); identify reused repos whose
+  existing stores were left unchanged
+- **For every repo whose Step 3 compare returned NARROWER**, the summary MUST
+  carry a repo-labeled warning before the question, quoting that repo's tool
+  discard list verbatim:
+
+  ```
+  WARNING for <repo>: this scan covered less than the store it replaced. Deep
+  knowledge of the following was discarded (recoverable from git history):
+  <discarded paths and components from the compare output>
+  Choose Request Changes to widen the scan instead.
+  ```
+
+  (COVERS, or no prior store, needs no warning line.)
 - Review path: `aidlc/spaces/<active-space>/codekb/<repo>/` for each repo in the set
-- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes
+- Structured approval question with options: Approve (continue to Requirements Analysis) / Request Changes. If any repo returned NARROWER, the Approve option's description must say which stores were replaced by narrower scans (e.g. "Accept the narrower stores for <repos>; continue to Requirements Analysis").
 
 ## Sensors
 

--- a/dist/opencode/.aidlc/knowledge/aidlc-developer-agent/re-artifacts.md
+++ b/dist/opencode/.aidlc/knowledge/aidlc-developer-agent/re-artifacts.md
@@ -14,12 +14,16 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 6. **technology-stack.md** — Languages, frameworks, libraries with versions
 7. **dependencies.md** — External dependencies, internal cross-package dependencies
 8. **code-quality-assessment.md** — Test coverage, linting, CI/CD, documentation quality, tech debt
-9. **reverse-engineering-timestamp.md** — Records when reverse engineering was performed (date, commit hash if available, scope of analysis)
+9. **reverse-engineering-timestamp.md** - Records when reverse engineering was performed (date, commit hash if available) plus the structured Scope of Analysis block (template below). The scope block is machine-read by `codekb-scope-diff` on the next rerun, so its accuracy decides whether a future intent is warned before overwriting this run's knowledge.
 
 ### Developer Code Scan Template
 
 ```markdown
 ## Developer Code Scan Results
+
+### Scan Coverage
+- **Analyzed deeply**: [repo-relative dirs/files actually read and understood, one per line]
+- **Skimmed only**: [areas noted at directory granularity without deep reading]
 
 ### Packages Found
 - [package name] — [type] — [language] — [purpose]
@@ -72,3 +76,33 @@ All RE artifacts are created under `aidlc/spaces/<active-space>/codekb/<repo>/` 
 ### Improvement Opportunities
 [Areas where the architecture could be strengthened]
 ```
+
+### Scope of Analysis Block (reverse-engineering-timestamp.md)
+
+End reverse-engineering-timestamp.md with exactly this fenced block, filled
+honestly from the Scan Coverage the developer reported - record what the run
+ACTUALLY covered deeply, not what the stage aspired to cover:
+
+````markdown
+## Scope of Analysis
+
+```yaml
+scope_version: 1
+kind: partial
+intent: [active intent slug]
+fingerprint: [output of the mint command in stage Step 3 - verbatim; it prints "unknown" when not computable]
+analyzed:
+  paths:
+    - [repo-relative dir (trailing slash) or file analyzed deeply, one per line]
+  components:
+    - [component names exactly as they appear in component-inventory.md]
+shallow:
+  paths:
+    - [areas only skimmed]
+```
+````
+
+Rules:
+- `kind: full` only when the scan genuinely covered the whole repo deeply; `analyzed.paths` MUST include the repo root (`./`). Anything less is `kind: partial`.
+- `analyzed.paths` entries are repo-relative, directories end with `/`, no glob characters.
+- Component names must match `component-inventory.md` headings verbatim - the rerun guard compares them literally.

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { accessSync, appendFileSync, constants as fsConstants, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
@@ -1128,6 +1129,208 @@ export function relativeCodekbDir(projectDir: string, repo: string, space?: stri
 export function codekbRepoName(projectDir: string, space?: string): string {
   const repos = intentRepos(projectDir, undefined, space);
   return repos.length === 1 ? repos[0] : basename(projectDir);
+}
+
+// --- Codekb scope of analysis -------------------------------------------------
+//
+// The reverse-engineering stage records WHAT its scan covered in a fenced yaml
+// block inside reverse-engineering-timestamp.md (the store's freshness marker).
+// The parser + fingerprint here are the deterministic half of the rerun
+// guard: `codekb-scope-diff` compares a store's recorded scope against the
+// live working tree (status) or an incoming run's scope (compare), so the
+// human at the RE gate decides reuse/rescan/replace on evidence instead of
+// silently losing a prior intent's knowledge to a narrower overwrite.
+//
+// Block shape (scope_version 1 - authored by the architect at synthesis,
+// behind the RE approval gate):
+//
+//   ```yaml
+//   scope_version: 1
+//   kind: partial            # or: full
+//   intent: fix-payment-timeout
+//   fingerprint: 3f2a9c...   # codekbScopeFingerprint over analyzed.paths
+//   analyzed:
+//     paths:
+//       - src/payments/
+//     components:
+//       - payment-gateway
+//   shallow:
+//     paths:
+//       - src/
+//   ```
+//
+// Pure data - no model call. Same idiom as parseBoltDag: a constrained
+// line-walker, no YAML dependency.
+
+export type ReScope = {
+  kind: "full" | "partial";
+  intent: string;
+  fingerprint: string | null;
+  analyzedPaths: string[];
+  analyzedComponents: string[];
+  shallowPaths: string[];
+};
+
+export type ReScopeParse =
+  | { ok: true; scope: ReScope }
+  | { ok: false; reason: "absent" | "malformed"; detail: string };
+
+// Find the fenced yaml block carrying `scope_version:` anywhere in the body
+// (keyed on the version line, not a heading, so prose edits around the block
+// don't break parsing). Returns the inner lines, or null when no block exists.
+function extractScopeBlock(body: string): string | null {
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```ya?ml\s*$/.test(lines[i].trim())) {
+      const inner: string[] = [];
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        if (/^```\s*$/.test(lines[j].trim())) break;
+        inner.push(lines[j]);
+      }
+      const block = inner.join("\n");
+      if (/^\s*scope_version\s*:/m.test(block)) return block;
+      i = j; // not the scope block - resume past its close fence
+    }
+  }
+  return null;
+}
+
+// Parse the scope block out of a reverse-engineering-timestamp.md body.
+// Unknown scope_version parses as malformed (a future writer must not be
+// half-read by an old reader); a missing block is "absent" (legacy store).
+export function parseReScope(body: string): ReScopeParse {
+  const block = extractScopeBlock(body);
+  if (block === null) {
+    return { ok: false, reason: "absent", detail: "no fenced yaml scope_version block found" };
+  }
+  const scope: ReScope = {
+    kind: "partial",
+    intent: "",
+    fingerprint: null,
+    analyzedPaths: [],
+    analyzedComponents: [],
+    shallowPaths: [],
+  };
+  let section: "analyzed" | "shallow" | null = null;
+  let list: "paths" | "components" | null = null;
+  let sawKind = false;
+  for (const raw of block.split("\n")) {
+    const t = raw.trim();
+    if (t === "" || t.startsWith("#")) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (indent === 0) {
+      section = null;
+      list = null;
+      if (t.startsWith("scope_version:")) {
+        const v = t.slice("scope_version:".length).trim();
+        if (v !== "1") {
+          return { ok: false, reason: "malformed", detail: `unknown scope_version: ${v}` };
+        }
+      } else if (t.startsWith("kind:")) {
+        const k = t.slice("kind:".length).trim();
+        if (k !== "full" && k !== "partial") {
+          return { ok: false, reason: "malformed", detail: `kind must be full|partial, got: ${k}` };
+        }
+        scope.kind = k;
+        sawKind = true;
+      } else if (t.startsWith("intent:")) {
+        scope.intent = t.slice("intent:".length).trim();
+      } else if (t.startsWith("fingerprint:")) {
+        const f = t.slice("fingerprint:".length).trim();
+        scope.fingerprint = f === "" || f === "unknown" ? null : f;
+      } else if (t === "analyzed:") {
+        section = "analyzed";
+      } else if (t === "shallow:") {
+        section = "shallow";
+      }
+    } else if (section !== null && !t.startsWith("-") && t.endsWith(":")) {
+      list = t === "paths:" ? "paths" : t === "components:" ? "components" : null;
+    } else if (section !== null && list !== null && t.startsWith("-")) {
+      const item = t.slice(1).trim();
+      if (item === "") continue;
+      if (section === "analyzed" && list === "paths") scope.analyzedPaths.push(item);
+      else if (section === "analyzed" && list === "components") scope.analyzedComponents.push(item);
+      else if (section === "shallow" && list === "paths") scope.shallowPaths.push(item);
+    }
+  }
+  if (!sawKind) {
+    return { ok: false, reason: "malformed", detail: "missing kind: line" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.length === 0) {
+    return { ok: false, reason: "malformed", detail: "kind: partial requires analyzed.paths entries" };
+  }
+  if (scope.kind === "partial" && scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "repository-root coverage (./) requires kind: full",
+    };
+  }
+  if (scope.kind === "full" && !scope.analyzedPaths.includes("./")) {
+    return {
+      ok: false,
+      reason: "malformed",
+      detail: "kind: full requires repository-root coverage (analyzed.paths must include ./)",
+    };
+  }
+  return { ok: true, scope };
+}
+
+// Content fingerprint of the WORKING TREE restricted to the scope's analyzed
+// paths: `git write-tree` over a temporary index populated by `git add -A --
+// <paths>`. Hashes what is actually on disk (uncommitted edits included), so
+// rebases/squashes/amends that vaporise a recorded commit hash cannot break
+// the comparison, and reverting an edit restores the original fingerprint.
+// Ignored files stay excluded (git add semantics). Callers may exclude generated
+// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// Returns null when repoDir is not a git work tree, git is unavailable, or any
+// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+export function codekbScopeFingerprint(
+  repoDir: string,
+  paths: string[],
+  excludedPaths: string[] = [],
+): string | null {
+  if (paths.length === 0) return null;
+  const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd: repoDir,
+    encoding: "utf-8",
+  });
+  if (inTree.status !== 0 || inTree.stdout.trim() !== "true") return null;
+  const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
+  const env = { ...process.env, GIT_INDEX_FILE: indexFile };
+  try {
+    const exclusions = excludedPaths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "")
+      .map((p) => `:(exclude,literal)${p}`);
+    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+      cwd: repoDir,
+      env,
+      encoding: "utf-8",
+    });
+    if (add.status !== 0) return null;
+    const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
+    if (wt.status !== 0) return null;
+    const hash = wt.stdout.trim();
+    return /^[0-9a-f]{40,64}$/.test(hash) ? hash : null;
+  } finally {
+    try {
+      unlinkSync(indexFile);
+    } catch {
+      // best-effort cleanup - a leaked temp index is inert
+    }
+  }
+}
+
+// Coverage test for the compare mode: does the incoming run's analyzed set
+// cover a store entry? Literal match, or an incoming DIRECTORY prefix (entry
+// ending "/") subsuming the store path. Deliberately prefix-only - scope
+// paths are authored as repo-relative dirs/files, not globs.
+export function scopePathCovered(incoming: string[], storePath: string): boolean {
+  return incoming.some(
+    (p) => p === storePath || (p.endsWith("/") && storePath.startsWith(p)),
+  );
 }
 
 // The bare SPACE record root: `aidlc/spaces/<space>/intents/`. The absolute path

--- a/dist/opencode/.aidlc/tools/aidlc-utility.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-utility.ts
@@ -54,8 +54,11 @@ import {
   isoTimestamp,
   isPackageJson,
   codekbRepoName,
+  codekbScopeFingerprint,
+  parseReScope,
   relativeCodekbDir,
   RESERVED_RECORD_NAMES,
+  scopePathCovered,
   gridCostSummary,
   listIntents,
   listSpaces,
@@ -4207,6 +4210,171 @@ function handleCodekbPath(projectDir: string, flags: Record<string, string>): vo
   process.stdout.write(`${dir}/\n`);
 }
 
+// `aidlc-utility.ts codekb-scope-diff [--repo <name>] [--compare <timestamp.md>]
+// [--json]` - read-only. The deterministic half of the reverse-engineering
+// rerun guard (the store is shared space-level knowledge; a narrower rerun
+// overwrites it last-writer-wins, so the human decides on evidence).
+//
+// Status mode (default): parse the STORE's reverse-engineering-timestamp.md
+// scope block and recompute the content fingerprint over its analyzed paths.
+//   NO_STORE       no store timestamp - first scan, nothing to guard
+//   CURRENT        fingerprint matches - the store's deep knowledge is exact
+//   STALE          analyzed paths changed since the store was built
+//   UNVERIFIED     scope parsed but no/uncomputable fingerprint (non-git)
+//   UNKNOWN_SCOPE  block absent (legacy store) or malformed
+//
+// Compare mode (--compare <incoming timestamp.md>): does the incoming run's
+// analyzed scope cover the store's? COVERS, or NARROWER + the exact paths and
+// components an overwrite would discard.
+//
+// Mint mode (--mint --paths <a,b,...>): print the content fingerprint over
+// the given repo-relative paths - the value the architect writes into the
+// scope block's `fingerprint:` line at synthesis time. Prints `unknown` when
+// not computable (non-git or invalid pathspec), which the block records
+// verbatim.
+//
+// Always exits 0 with the verdict in the output (read-only query - mirrors
+// codekb-path; refusals are for lifecycle verbs). No mkdir, no state write,
+// no audit.
+function handleCodekbScopeDiff(projectDir: string, flags: Record<string, string>): void {
+  const asJson = flags.json === "true";
+  const space = activeSpace(projectDir);
+  const repo = flags.repo && flags.repo.length > 0 ? flags.repo : codekbRepoName(projectDir, space);
+  const storeDir = relativeCodekbDir(projectDir, repo, space);
+  const storePath = join(projectDir, ...storeDir.split("/"), "reverse-engineering-timestamp.md");
+
+  // The repo's source root: the sibling dir `<workspace>/<repo>/` when it
+  // exists (the multi-repo layout reverse-engineering.md Step 1 scans), else
+  // the workspace root itself (the lone-repo case, where codekbRepoName is
+  // basename(projectDir)).
+  const siblingDir = join(projectDir, repo);
+  const repoDir = existsSync(siblingDir) && statSync(siblingDir).isDirectory() ? siblingDir : projectDir;
+  // In the lone-repo layout the framework-owned aidlc workspace tree lives
+  // under the repository root. Exclude it from full-root fingerprints so
+  // writing the scope draft, codekb, audit, or state cannot stale its own hash.
+  const fingerprintExcludes = repoDir === projectDir ? ["aidlc"] : [];
+
+  if (flags.mint === "true") {
+    const paths = (flags.paths ?? "")
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p !== "");
+    if (paths.length === 0) {
+      die("codekb-scope-diff --mint: pass --paths <comma-separated repo-relative paths>");
+    }
+    const fp = codekbScopeFingerprint(repoDir, paths, fingerprintExcludes) ?? "unknown";
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, fingerprint: fp, paths })}\n`);
+    else process.stdout.write(`${fp}\n`);
+    return;
+  }
+
+  const emit = (payload: Record<string, unknown>, human: string): void => {
+    if (asJson) process.stdout.write(`${JSON.stringify({ repo, store: `${storeDir}/`, ...payload })}\n`);
+    else process.stdout.write(`${human}\n`);
+  };
+
+  if (!existsSync(storePath)) {
+    emit(
+      { verdict: "NO_STORE" },
+      `NO_STORE: no reverse-engineering-timestamp.md at ${storeDir}/ - first scan, nothing to compare.`,
+    );
+    return;
+  }
+  const parsed = parseReScope(readFileSync(storePath, "utf-8"));
+  if (!parsed.ok) {
+    emit(
+      { verdict: "UNKNOWN_SCOPE", reason: parsed.reason, detail: parsed.detail },
+      `UNKNOWN_SCOPE (${parsed.reason}): ${parsed.detail}. The store predates scope tracking - a rerun replaces it without a coverage comparison.`,
+    );
+    return;
+  }
+  const store = parsed.scope;
+
+  if (flags.compare !== undefined) {
+    const incomingPath = flags.compare;
+    if (!incomingPath || !existsSync(incomingPath)) {
+      die(`codekb-scope-diff --compare: file not found: ${incomingPath || "(missing path)"}`);
+    }
+    const incomingParsed = parseReScope(readFileSync(incomingPath, "utf-8"));
+    if (!incomingParsed.ok) {
+      emit(
+        { verdict: "UNKNOWN_SCOPE", reason: incomingParsed.reason, detail: `incoming: ${incomingParsed.detail}` },
+        `UNKNOWN_SCOPE (incoming ${incomingParsed.reason}): ${incomingParsed.detail}.`,
+      );
+      return;
+    }
+    const incoming = incomingParsed.scope;
+    const fullScopeDowngrade = store.kind === "full" && incoming.kind !== "full";
+    const discardedPaths =
+      incoming.kind === "full"
+        ? []
+        : fullScopeDowngrade
+          ? [...store.analyzedPaths]
+          : store.analyzedPaths.filter((p) => !scopePathCovered(incoming.analyzedPaths, p));
+    const discardedComponents =
+      incoming.kind === "full"
+        ? []
+        : store.analyzedComponents.filter((c) => !incoming.analyzedComponents.includes(c));
+    const narrower = discardedPaths.length > 0 || discardedComponents.length > 0;
+    const payload = {
+      verdict: narrower ? "NARROWER" : "COVERS",
+      store_intent: store.intent,
+      incoming_intent: incoming.intent,
+      discarded_paths: discardedPaths,
+      discarded_components: discardedComponents,
+    };
+    if (narrower) {
+      emit(
+        payload,
+        `NARROWER: replacing the store discards deep knowledge of:\n` +
+          discardedPaths.map((p) => `  - ${p}`).join("\n") +
+          (discardedComponents.length > 0
+            ? `\n  components: ${discardedComponents.join(", ")}`
+            : "") +
+          `\n(store intent: ${store.intent || "unrecorded"}; incoming intent: ${incoming.intent || "unrecorded"})`,
+      );
+    } else {
+      emit(payload, `COVERS: the incoming scan covers everything the store analyzed.`);
+    }
+    return;
+  }
+
+  // Status mode.
+  const currentFingerprint =
+    store.analyzedPaths.length > 0
+      ? codekbScopeFingerprint(repoDir, store.analyzedPaths, fingerprintExcludes)
+      : null;
+  const scopeLines = store.analyzedPaths.map((p) => `  - ${p}`).join("\n");
+  if (store.fingerprint === null || currentFingerprint === null) {
+    emit(
+      {
+        verdict: "UNVERIFIED",
+        store_intent: store.intent,
+        kind: store.kind,
+        analyzed_paths: store.analyzedPaths,
+        detail: store.fingerprint === null ? "store has no fingerprint" : "fingerprint not computable here",
+      },
+      `UNVERIFIED: the store (intent: ${store.intent || "unrecorded"}) analyzed:\n${scopeLines}\n` +
+        `but ${store.fingerprint === null ? "recorded no fingerprint" : "the current tree's fingerprint cannot be computed"} - freshness unknown.`,
+    );
+    return;
+  }
+  const current = store.fingerprint === currentFingerprint;
+  emit(
+    {
+      verdict: current ? "CURRENT" : "STALE",
+      store_intent: store.intent,
+      kind: store.kind,
+      analyzed_paths: store.analyzedPaths,
+      store_fingerprint: store.fingerprint,
+      current_fingerprint: currentFingerprint,
+    },
+    current
+      ? `CURRENT: the analyzed paths are unchanged since the store was built (intent: ${store.intent || "unrecorded"}, coverage: ${store.kind}):\n${scopeLines}`
+      : `STALE: the analyzed paths have changed since the store was built (intent: ${store.intent || "unrecorded"}):\n${scopeLines}`,
+  );
+}
+
 // `detect [--json]` - read-only. Runs the workspace scan (detectWorkspace) on
 // the bare project dir - it needs no aidlc/ workspace; it scans the app root -
 // and prints projectType (Greenfield/Brownfield), languages, frameworks, and
@@ -5404,6 +5572,12 @@ export async function main(argv: string[]): Promise<void> {
     case "codekb-path":
       handleCodekbPath(projectDir, flags);
       break;
+    // codekb-scope-diff - read-only query verb. Compares the codekb store's
+    // recorded scope of analysis against the live tree (status) or an
+    // incoming run's timestamp (--compare). The RE stage's rerun guard.
+    case "codekb-scope-diff":
+      handleCodekbScopeDiff(projectDir, flags);
+      break;
     // detect - read-only query verb. Prints the workspace scan
     // (greenfield/brownfield, languages) + the resolved scope-registry paths so
     // the composer agent is told where scope data lives. No mutation, no audit.
@@ -5466,7 +5640,7 @@ export async function main(argv: string[]): Promise<void> {
       break;
     default:
       die(
-        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
+        `Usage: aidlc-utility <help|version|status|doctor|intent-birth|intent|space|space-create|codekb-path|codekb-scope-diff|detect|select-plugins|plugin-list|plugin-sync|recompose|scope-change|config-change|config-get|config-list|set-status|detect-scope|resolve-env-scope|scope-table|stage-table|upgrade> [--project-dir <path>] [--scope <scope>] [--json]`
       );
   }
 }

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.34";
+export const AIDLC_VERSION = "2.5.35";

--- a/dist/opencode/.aidlc/tools/data/stage-graph.json
+++ b/dist/opencode/.aidlc/tools/data/stage-graph.json
@@ -690,7 +690,7 @@
     "name": "Reverse Engineering",
     "phase": "inception",
     "execution": "CONDITIONAL",
-    "condition": "Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.",
+    "condition": "Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.",
     "lead_agent": "aidlc-developer-agent",
     "support_agents": [
       "aidlc-architect-agent"

--- a/docs/guide/12-cli-commands.md
+++ b/docs/guide/12-cli-commands.md
@@ -563,6 +563,43 @@ It prints the active space's deterministic
 no audit event; reverse-engineering stage prose invokes it directly so paths
 are never derived by hand.
 
+### `aidlc-utility codekb-scope-diff` - check the code knowledge base before a rerun
+
+This is a **direct utility invocation**, not an `/aidlc codekb-scope-diff` command:
+
+```bash
+bun .claude/tools/aidlc-utility.ts codekb-scope-diff --repo <repo>
+bun .claude/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --compare <timestamp.md>
+bun .claude/tools/aidlc-utility.ts codekb-scope-diff --repo <repo> --mint --paths src/payments/,src/billing/
+```
+
+The reverse-engineering rerun guard. The codekb store is space-level and
+shared across intents; a rerun replaces it, so the stage checks first:
+
+- **Status mode** (default) reads the store's
+  `reverse-engineering-timestamp.md` Scope of Analysis block and recomputes a
+  content fingerprint over its analyzed paths. Verdicts: `NO_STORE` (first
+  scan), `CURRENT` (analyzed paths unchanged - reuse is safe), `STALE`
+  (analyzed paths changed), `UNVERIFIED` (no computable fingerprint - e.g.
+  not a git work tree), `UNKNOWN_SCOPE` (store predates scope tracking).
+- **Compare mode** (`--compare <incoming timestamp.md>`) answers whether the
+  incoming run's scope covers the store's: `COVERS`, or `NARROWER` plus the
+  exact paths and components an overwrite discards. A `kind: full` scope must
+  include repository root (`./`), and only another full scope can replace a
+  full store without a `NARROWER` warning.
+- **Mint mode** (`--mint --paths <a,b,...>`) prints the fingerprint the
+  architect pastes into the scope block at synthesis time (`unknown` outside
+  a git work tree or when a pathspec is invalid).
+
+Add `--json` for the structured shape. Always exits 0 with the verdict in the
+output (except usage errors); writes nothing, no audit event. The fingerprint
+is a `git write-tree` over a temporary index restricted to the analyzed paths,
+excluding the framework-owned `aidlc/` tree when the workspace root is the
+repository root. It tracks source working-tree content without invalidating
+itself when codekb/state artifacts are written; rebases or squashes that
+rewrite history do not fool it, and reverting an edit restores the original
+fingerprint.
+
 ### `aidlc-utility detect` - read-only workspace scan
 
 `bun .claude/tools/aidlc-utility.ts detect --json` prints the workspace scan (project type, languages, frameworks, build system, and a `submodules` array of any declared git submodules with their initialized state) plus the resolved scopes dir and scope-grid path. Pure read; the composer runs it to learn where scope data lives on the current harness.

--- a/docs/guide/14-artifacts-reference.md
+++ b/docs/guide/14-artifacts-reference.md
@@ -75,9 +75,10 @@ aidlc/spaces/<space>/intents/<YYMMDD>-<label>/   # one record dir per intent
 (`architecture.md`, `code-structure.md`, `technology-stack.md`, …) land one
 level up, in the space-level per-repo CodeKB —
 `aidlc/spaces/<space>/codekb/<repo>/` — one store per repo rather than a copy
-per intent. It is not a snapshot: the stage condition is "Always rerun for
-freshness", so every applicable brownfield intent reruns the scan and
-overwrites those nine files, last write wins
+per intent. On each applicable brownfield intent, the stage checks the store's
+recorded scope and working-tree fingerprint first. A verified-current store
+whose coverage fits the intent may be reused by human choice; otherwise a full
+or focused scan overwrites those nine files
 (`reverse-engineering-timestamp.md` records when the last scan ran and what
 it covered). Intents therefore read the newest scan of the repo, not the one
 taken when their own record dir was created. What the record dir does get is
@@ -172,7 +173,7 @@ The welcome message is rendered at session start via `companyAnnouncements` in `
 
 | Stage | Key Artifacts | Condition |
 |-------|--------------|-----------|
-| 2.1 Reverse Engineering | 9 files including `architecture.md`, `code-structure.md`, `technology-stack.md` (written to the space-level `aidlc/spaces/<active-space>/codekb/<repo>/` — one store per repo, overwritten by each brownfield rerun; only the stage's `memory.md` diary lands in the intent record) | Brownfield only |
+| 2.1 Reverse Engineering | 9 files including `architecture.md`, `code-structure.md`, `technology-stack.md` (written to the space-level `aidlc/spaces/<active-space>/codekb/<repo>/` — one shared store per repo, reused when verified current or replaced by a human-selected rescan; only the stage's `memory.md` diary lands in the intent record) | Brownfield only |
 | 2.2 Practices Discovery | `team-practices.md`, `discovered-rules.md`, `evidence.md`, `practices-discovery-timestamp.md`, plus quality/developer/devsecops contribution files (promoted to `aidlc/spaces/<active-space>/memory/team.md` and `project.md` after approval) | Conditional |
 | 2.3 Requirements Analysis | `requirements.md` | Always |
 | 2.4 User Stories | `stories.md`, `personas.md` | User-facing features |

--- a/docs/reference/03-orchestrator.md
+++ b/docs/reference/03-orchestrator.md
@@ -428,7 +428,10 @@ each link advances the work product directly:
 1. **Developer (link 1, the lead):** Scans the codebase, analyzes code structure, identifies components, maps dependencies, returns raw analysis.
 2. **Architect (link 2, the final link):** Receives the developer's raw analysis and synthesizes it into the 9 codekb artifacts under `aidlc/spaces/<active-space>/codekb/<repo>/` -- the final link leaves the `produces[]` artifacts complete, per the pipeline contract.
 
-Reverse Engineering has an **always-rerun policy**: it is always re-executed for brownfield projects even when prior artifacts exist, ensuring the analysis reflects the current codebase state.
+Reverse Engineering checks each brownfield repository's shared codekb before
+scanning. A verified-current store may be reused by human choice; stale,
+unverified, legacy, or intent-mismatched coverage is rescanned. Multi-repo
+intents resolve every repository decision before the stage reports or advances.
 
 ### Construction Execution <a id="construction-execution"></a>
 
@@ -604,7 +607,7 @@ The following intentional differences from the upstream `aidlc-workflows/` refer
 | 4 | Inline questions | All questions in files | `AskUserQuestion` for 1-3 simple options | Claude Code's structured UI |
 | 5 | Architecture Decision Records | Not present | `decisions.md` in Application Design | Architectural traceability |
 | 6 | Welcome message | Longer Unicode-based | Shorter, ASCII-safe; rendered via `companyAnnouncements` in `settings.json` (not a stage) | Fixes reference's own ascii-diagram-standards violation |
-| 7 | RE always-rerun policy | Uses cached artifacts | Always re-executes for brownfield | Ensures current codebase analysis |
+| 7 | RE rerun guard | Uses cached artifacts | Verifies scope/fingerprint, then offers reuse or rescan | Prevents stale or silently narrower analysis |
 | 8 | Session resume | File-based `[Answer]:` tag | Uses `AskUserQuestion` | More natural in Claude Code |
 | 9 | Clarification questions | Separate files | Handled inline | Typically 1-2 targeted queries |
 | 10 | Audit log formats | Single format | Three additional: Error, Recovery, Change Request | Post-hoc analysis |

--- a/docs/reference/04-stages/inception.md
+++ b/docs/reference/04-stages/inception.md
@@ -41,7 +41,8 @@ Stage 2.2, and the User Stories mob at Stage 2.4.
   requirements stage, a mob story stage, and four inline design/planning stages.
 - Stage 2.1 uses a two-link pipeline: aidlc-developer-agent scans the code,
   then aidlc-architect-agent synthesizes the scan into 9 structured artifacts. It
-  has an always-rerun policy for brownfield projects.
+  checks each brownfield repository's existing store before the human chooses
+  reuse, a full rescan, or a focused scan.
 - Stage 2.2 runs the same topology on greenfield and brownfield work:
   pipeline-deploy lead draft, mutually blind quality/developer/devsecops
   spokes, human interview, then lead integration. On affirmation, content is promoted from
@@ -96,7 +97,7 @@ Stage 2.2, and the User Stories mob at Stage 2.4.
 |------------------|------------------------------------------------------------------------|
 | Phase            | Inception                                                              |
 | Stage #          | 2.1                                                                    |
-| Condition        | CONDITIONAL -- brownfield detected; always rerun for freshness         |
+| Condition        | CONDITIONAL -- brownfield; verified-current stores may be reused        |
 | Lead Agent       | aidlc-developer-agent                                                        |
 | Support Agents   | aidlc-architect-agent                                                        |
 | Mode             | pipeline (2-link chain: aidlc-developer-agent scans, aidlc-architect-agent synthesizes and writes) |
@@ -111,9 +112,11 @@ synthesizes the scan results into 9 structured artifacts and writes them. These 
 provide the technical foundation that all subsequent Inception and Construction
 stages build upon.
 
-**Always-rerun policy:** Reverse Engineering is always re-executed for
-brownfield projects even when prior artifacts exist. This ensures the
-artifacts reflect the current state of the codebase, not a stale snapshot.
+**Rerun guard:** Reverse Engineering checks each repository's recorded scope
+and working-tree fingerprint before scanning. The human may reuse a
+verified-current store whose coverage fits the intent; stale, unverified,
+legacy, or mismatched stores require a full or focused rescan. For multi-repo
+intents, all decisions are resolved before one stage-level lifecycle report.
 
 ### Inputs
 
@@ -191,10 +194,10 @@ Standard 2-option gate: **Approve** (continue to Requirements Analysis) /
 
 ### Notes
 
-- **Always-rerun policy:** This stage is always re-executed for brownfield
-  projects even when prior artifacts exist. This is a deliberate deviation from
-  the upstream reference, documented in SKILL.md's "Deliberate Deviations"
-  section.
+- **Rerun guard:** This stage verifies each brownfield repository's recorded
+  scope and fingerprint before the human chooses reuse or rescan. It is a
+  deliberate deviation from the upstream reference, documented in SKILL.md's
+  "Deliberate Deviations" section.
 - **Two-link pipeline:** The aidlc-developer-agent performs the raw code
   scan (link 1, the lead), then the aidlc-architect-agent synthesizes the scan
   into structured artifacts and writes them (link 2, the final link). This separation ensures the scan is thorough (developer
@@ -1280,5 +1283,6 @@ narrative.
 - **Construction Phase**: Construction stages execute per the delivery plan
   produced by Stage 2.8
 - **Deliberate Deviations**: SKILL.md documents intentional differences from
-  the upstream reference, including the always-rerun RE policy, aidlc-design-agent
-  support additions, ADR artifacts, and the Delivery Planning expansion
+  the upstream reference, including the RE scope/fingerprint rerun guard,
+  aidlc-design-agent support additions, ADR artifacts, and the Delivery
+  Planning expansion

--- a/tests/.coverage-ratchet.json
+++ b/tests/.coverage-ratchet.json
@@ -1,12 +1,12 @@
 {
   "note": "Committed baseline: covered-unit count per class. The --check ratchet fails CI if any class's covered count DROPS below these numbers without a reviewed deferred entry. Monotonic anti-regression: you can cover more, never silently less. Regenerate with: bun tests/gen-coverage-registry.ts",
   "coveredByClass": {
-    "function": 104,
+    "function": 107,
     "audit": 33,
     "scope": 9,
     "stage": 9,
     "hook": 14,
-    "subcommand": 84,
+    "subcommand": 85,
     "render-surface": 7
   }
 }

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -20,23 +20,23 @@
     "render-surface": "tui"
   },
   "counts": {
-    "total": 483,
+    "total": 487,
     "enumeratedByClass": {
-      "function": 250,
+      "function": 253,
       "audit": 74,
       "scope": 9,
       "stage": 32,
       "hook": 14,
-      "subcommand": 97,
+      "subcommand": 98,
       "render-surface": 7
     },
     "coveredByClass": {
-      "function": 104,
+      "function": 107,
       "audit": 33,
       "scope": 9,
       "stage": 9,
       "hook": 14,
-      "subcommand": 84,
+      "subcommand": 85,
       "render-surface": 7
     }
   },
@@ -1182,6 +1182,18 @@
     },
     {
       "unitClass": "function",
+      "unitId": "function:codekbScopeFingerprint",
+      "minMechanism": "none",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t248-codekb-scope-diff.test.ts",
+          "mechanism": "cli"
+        }
+      ],
+      "status": "covered"
+    },
+    {
+      "unitClass": "function",
       "unitId": "function:compileStageGraph",
       "minMechanism": "none",
       "coveredBy": [
@@ -2239,6 +2251,18 @@
     },
     {
       "unitClass": "function",
+      "unitId": "function:parseReScope",
+      "minMechanism": "none",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t248-codekb-scope-diff.test.ts",
+          "mechanism": "cli"
+        }
+      ],
+      "status": "covered"
+    },
+    {
+      "unitClass": "function",
       "unitId": "function:parseStageFrontmatter",
       "minMechanism": "none",
       "coveredBy": [
@@ -2753,6 +2777,18 @@
       "minMechanism": "none",
       "coveredBy": [],
       "status": "UNCOVERED"
+    },
+    {
+      "unitClass": "function",
+      "unitId": "function:scopePathCovered",
+      "minMechanism": "none",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t248-codekb-scope-diff.test.ts",
+          "mechanism": "cli"
+        }
+      ],
+      "status": "covered"
     },
     {
       "unitClass": "function",
@@ -5107,6 +5143,18 @@
       "coveredBy": [
         {
           "file": "tests/unit/t182-codekb-placement.test.ts",
+          "mechanism": "cli"
+        }
+      ],
+      "status": "covered"
+    },
+    {
+      "unitClass": "subcommand",
+      "unitId": "aidlc-utility codekb-scope-diff",
+      "minMechanism": "cli",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t248-codekb-scope-diff.test.ts",
           "mechanism": "cli"
         }
       ],

--- a/tests/fixtures/designer-export/export.json
+++ b/tests/fixtures/designer-export/export.json
@@ -691,7 +691,7 @@
       "name": "Reverse Engineering",
       "phase": "inception",
       "execution": "CONDITIONAL",
-      "condition": "Execute when project is brownfield. Always rerun for freshness. Skip for greenfield projects.",
+      "condition": "Execute when project is brownfield. On rerun the Step 1 guard checks store freshness (codekb-scope-diff) - verified-CURRENT stores may be reused by human choice, anything else rescans. Skip for greenfield projects.",
       "lead_agent": "aidlc-developer-agent",
       "support_agents": [
         "aidlc-architect-agent"

--- a/tests/fixtures/re-artifacts/reverse-engineering-timestamp.md
+++ b/tests/fixtures/re-artifacts/reverse-engineering-timestamp.md
@@ -1,0 +1,23 @@
+# Reverse Engineering Timestamp
+
+## Run Record
+
+- Date: 2026-07-27
+- Commit: fixture (no repository)
+
+## Scope of Analysis
+
+```yaml
+scope_version: 1
+kind: partial
+intent: fixture-seed
+fingerprint: unknown
+analyzed:
+  paths:
+    - src/
+  components:
+    - fixture-component
+shallow:
+  paths:
+    - docs/
+```

--- a/tests/integration/t72-stage-reverse-engineering.test.ts
+++ b/tests/integration/t72-stage-reverse-engineering.test.ts
@@ -116,8 +116,12 @@ const RE_STEMS = [
 // Timeout budget — the .sh set AIDLC_TEST_TIMEOUT=900 (RE is a HEAVY multi-agent
 // stage). Honour it. The driver aborts ~15s before bun's per-test cap so a stuck
 // run surfaces a partial DriveResult to diagnose rather than an opaque hang.
+// Default raised 900 → 1500: the rerun guard + scope-block synthesis (Step 1
+// codekb-scope-diff check, Step 3 mint + compare backstop) add real turns to
+// an already-heavy journey; at 900 a healthy run was aborted mid-flight ~2s
+// short of the gate.
 // ---------------------------------------------------------------------------
-const TIMEOUT_S = Number.parseInt(process.env.AIDLC_TEST_TIMEOUT ?? "900", 10);
+const TIMEOUT_S = Number.parseInt(process.env.AIDLC_TEST_TIMEOUT ?? "1500", 10);
 const TEST_TIMEOUT_MS = (Number.isFinite(TIMEOUT_S) ? TIMEOUT_S : 900) * 1000;
 const DRIVE_TIMEOUT_MS = Math.max(120_000, TEST_TIMEOUT_MS - 15_000);
 

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -852,6 +852,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t179-orchestrate-rollforward-guard.test.ts",
     "unit/t180-kiro-rollforward-seam.test.ts",
     "unit/t182-codekb-placement.test.ts",
+    "unit/t248-codekb-scope-diff.test.ts",
     "unit/t184-stage-graph-drift.test.ts",
     "unit/t186-foreach-per-unit-iteration.test.ts",
     "unit/t188-human-presence-gate.test.ts",

--- a/tests/unit/t154-codekb-promotion.test.ts
+++ b/tests/unit/t154-codekb-promotion.test.ts
@@ -124,6 +124,37 @@ describe("t154 codekb promotion — RE outputs land at aidlc/spaces/<active-spac
     expect((fm.condition as string).toLowerCase()).toContain("freshness");
   });
 
+  test("multi-repo reuse decisions resolve before one aggregate lifecycle report", () => {
+    const body = stageBody("inception", "reverse-engineering");
+    expect(body.indexOf("Resolve the intent's repo set")).toBeLessThan(
+      body.indexOf("Rerun guard: check each existing store"),
+    );
+    const decisionsStart = body.indexOf("For every repo in the resolved set");
+    const aggregateStart = body.indexOf("Only after every repository decision has been resolved");
+    const step2Start = body.indexOf("### Step 2:");
+    expect(decisionsStart).toBeGreaterThan(-1);
+    expect(aggregateStart).toBeGreaterThan(decisionsStart);
+    expect(body.slice(decisionsStart, aggregateStart)).not.toContain(
+      "aidlc-orchestrate.ts report",
+    );
+    const aggregate = body.slice(aggregateStart, step2Start);
+    expect(aggregate.match(/aidlc-orchestrate\.ts report/g)).toHaveLength(1);
+    expect(aggregate).toMatch(/report the stage as\s+skipped exactly once/);
+    expect(aggregate).toContain("directive.single === true");
+    expect(aggregate).toContain('report --single --stage "reverse-engineering" --result completed');
+    expect(aggregate).toContain("If any repo needs scanning, do not report a skip");
+  });
+
+  test("parallel repository comparisons use repository-specific scope drafts", () => {
+    const body = stageBody("inception", "reverse-engineering");
+    expect(body.match(/scope-draft-<repo>\.md/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(body).toMatch(
+      /--compare <record>\/inception\/reverse-engineering\/scope-draft-<repo>\.md/,
+    );
+    expect(body).toContain("scope drafts are temporary and MUST NOT remain");
+    expect(body).not.toContain("reverse-engineering/scope-draft.md");
+  });
+
   // ── 4: frontmatter consumers — edge intact, read path re-pointed ─────────
   test("requirements-analysis keeps the reverse-engineering requires_stage edge", () => {
     const fm = stageFrontmatter("inception", "requirements-analysis");

--- a/tests/unit/t239-documentation-parity.test.ts
+++ b/tests/unit/t239-documentation-parity.test.ts
@@ -400,7 +400,7 @@ describe("documentation parity derives current behavior from authored implementa
 
     const cliGuide = read("docs", "guide", "12-cli-commands.md");
     for (const verb of workspaceVerbs) expect(cliGuide).toContain(`/aidlc ${verb}`);
-    const directOnlyVerbs = ["codekb-path", "select-plugins"];
+    const directOnlyVerbs = ["codekb-path", "codekb-scope-diff", "select-plugins"];
     for (const verb of directOnlyVerbs) {
       expect(workspaceVerbs).not.toContain(verb);
       expect(cliGuide).toContain("direct utility invocation");

--- a/tests/unit/t248-codekb-scope-diff.test.ts
+++ b/tests/unit/t248-codekb-scope-diff.test.ts
@@ -1,0 +1,543 @@
+// covers: function:parseReScope, function:codekbScopeFingerprint, function:scopePathCovered, subcommand:aidlc-utility:codekb-scope-diff
+//
+// t248 — codekb scope guard (deterministic, no-LLM). Pins the reverse-
+// engineering rerun guard at two layers:
+//
+//   1. The PURE lib helpers (imported in-process from the shipped dist tree):
+//      parseReScope (the fenced-yaml Scope of Analysis block in
+//      reverse-engineering-timestamp.md), codekbScopeFingerprint (temp-index
+//      `git write-tree` over the analyzed paths — content-addressed, so an
+//      edit flips it and a revert restores it), and scopePathCovered (the
+//      compare mode's literal/dir-prefix coverage test).
+//   2. The `codekb-scope-diff` UTILITY VERB (spawned as the real CLI surface):
+//      status verdicts NO_STORE / CURRENT / STALE / UNVERIFIED / UNKNOWN_SCOPE,
+//      compare verdicts COVERS / NARROWER (+ the exact discard list), and the
+//      --mint fingerprint printer the stage's Step 3 pastes from — each with
+//      --json shape.
+//
+// MECHANISM = cli (the subcommand claim needs a SPAWNED tool to prove routing;
+// the function claims clear `none` via the in-process imports).
+//
+// FIXTURE DISCIPLINE mirrors t182: a fresh temp project per case
+// (createTestProject), cleaned in afterAll. The fingerprint cases additionally
+// `git init` the temp project — codekbScopeFingerprint returns null outside a
+// work tree, which is itself a pinned case (UNVERIFIED, never a false verdict).
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  cleanupTestProject,
+  createTestProject,
+  DEFAULT_SPACE,
+  resetAidlcEnv,
+} from "../harness/fixtures.ts";
+import {
+  codekbScopeFingerprint,
+  parseReScope,
+  scopePathCovered,
+} from "../../dist/claude/.claude/tools/aidlc-lib.ts";
+
+const BUN = process.execPath;
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const UTILITY = join(REPO_ROOT, "dist", "claude", ".claude", "tools", "aidlc-utility.ts");
+
+resetAidlcEnv();
+
+const tempDirs: string[] = [];
+afterAll(() => {
+  for (const d of tempDirs) cleanupTestProject(d);
+});
+
+function freshProject(): string {
+  const proj = createTestProject();
+  tempDirs.push(proj);
+  return proj;
+}
+
+function gitInit(dir: string): void {
+  const r = spawnSync("git", ["init", "-q", dir], { encoding: "utf-8" });
+  expect(r.status).toBe(0);
+}
+
+const childEnv = (): NodeJS.ProcessEnv => {
+  const e = { ...process.env };
+  delete e.AWS_AIDLC_DEFAULT_SCOPE;
+  return e;
+};
+
+// A valid scope block body (the shape re-artifacts.md templates and the
+// architect writes at Step 3), parameterised for the cases below.
+function timestampBody(opts: {
+  kind?: string;
+  intent?: string;
+  fingerprint?: string;
+  analyzedPaths?: string[];
+  components?: string[];
+  version?: string;
+}): string {
+  const paths = (opts.analyzedPaths ?? ["src/payments/"]).map((p) => `    - ${p}`).join("\n");
+  const comps = (opts.components ?? ["payment-gateway"]).map((c) => `    - ${c}`).join("\n");
+  return [
+    "# Reverse Engineering Timestamp",
+    "",
+    "## Run Record",
+    "",
+    "- Date: 2026-07-27",
+    "",
+    "## Scope of Analysis",
+    "",
+    "```yaml",
+    `scope_version: ${opts.version ?? "1"}`,
+    `kind: ${opts.kind ?? "partial"}`,
+    `intent: ${opts.intent ?? "fix-payment-timeout"}`,
+    ...(opts.fingerprint !== undefined ? [`fingerprint: ${opts.fingerprint}`] : []),
+    "analyzed:",
+    "  paths:",
+    paths,
+    "  components:",
+    comps,
+    "shallow:",
+    "  paths:",
+    "    - src/",
+    "```",
+    "",
+  ].join("\n");
+}
+
+// Write a store timestamp for the project's basename-keyed repo dir (0
+// recorded repos → codekbRepoName === basename, matching t182's discipline).
+function seedStore(proj: string, body: string): string {
+  const repo = proj.split("/").pop() as string;
+  const dir = join(proj, "aidlc", "spaces", DEFAULT_SPACE, "codekb", repo);
+  mkdirSync(dir, { recursive: true });
+  const p = join(dir, "reverse-engineering-timestamp.md");
+  writeFileSync(p, body);
+  return p;
+}
+
+function runVerb(proj: string, ...args: string[]) {
+  return spawnSync(
+    BUN,
+    [UTILITY, "codekb-scope-diff", "--project-dir", proj, ...args],
+    { encoding: "utf-8", env: childEnv() },
+  );
+}
+
+// ============================================================================
+// 1. parseReScope — the block parser.
+// ============================================================================
+describe("t248 parseReScope — scope block parsing", () => {
+  test("valid partial block parses: kind/intent/fingerprint/paths/components", () => {
+    const r = parseReScope(timestampBody({ fingerprint: "abc123" }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.scope.kind).toBe("partial");
+    expect(r.scope.intent).toBe("fix-payment-timeout");
+    expect(r.scope.fingerprint).toBe("abc123");
+    expect(r.scope.analyzedPaths).toEqual(["src/payments/"]);
+    expect(r.scope.analyzedComponents).toEqual(["payment-gateway"]);
+    expect(r.scope.shallowPaths).toEqual(["src/"]);
+  });
+
+  test("no block → absent (the legacy-store case)", () => {
+    const r = parseReScope("# Timestamp\n\n- Date: 2026-07-27\n");
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("absent");
+  });
+
+  test("a non-scope yaml fence earlier in the body does not shadow the block", () => {
+    const decoy = "```yaml\nunits:\n  - name: x\n```\n\n";
+    const r = parseReScope(decoy + timestampBody({}));
+    expect(r.ok).toBe(true);
+  });
+
+  test("unknown scope_version → malformed (future writers are not half-read)", () => {
+    const r = parseReScope(timestampBody({ version: "2" }));
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("malformed");
+  });
+
+  test("kind: partial with no analyzed paths → malformed", () => {
+    const body = timestampBody({}).replace(/^ {4}- src\/payments\/$/m, "");
+    const r = parseReScope(body);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("malformed");
+  });
+
+  test("kind: full without explicit repository-root coverage → malformed", () => {
+    const r = parseReScope(timestampBody({ kind: "full", analyzedPaths: ["src/"] }));
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("malformed");
+    expect(r.detail).toContain("analyzed.paths must include ./");
+  });
+
+  test("kind: full with repository-root coverage parses", () => {
+    const r = parseReScope(timestampBody({ kind: "full", analyzedPaths: ["./"] }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.scope.kind).toBe("full");
+    expect(r.scope.analyzedPaths).toEqual(["./"]);
+  });
+
+  test("kind: partial cannot claim repository-root coverage", () => {
+    const r = parseReScope(timestampBody({ kind: "partial", analyzedPaths: ["./"] }));
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("malformed");
+    expect(r.detail).toContain("requires kind: full");
+  });
+
+  test("fingerprint: unknown parses as null (the non-git mint output)", () => {
+    const r = parseReScope(timestampBody({ fingerprint: "unknown" }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.scope.fingerprint).toBeNull();
+  });
+});
+
+// ============================================================================
+// 2. codekbScopeFingerprint — content-addressed, revert-stable, null off-git.
+// ============================================================================
+describe("t248 codekbScopeFingerprint — scoped write-tree", () => {
+  test("stable across calls; flips on edit; restores on revert", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    const f = join(proj, "src", "payments", "gw.ts");
+    writeFileSync(f, "export const a = 1;\n");
+    const fp1 = codekbScopeFingerprint(proj, ["src/payments/"]);
+    expect(fp1).not.toBeNull();
+    expect(codekbScopeFingerprint(proj, ["src/payments/"])).toBe(fp1);
+    writeFileSync(f, "export const a = 2;\n");
+    const fp2 = codekbScopeFingerprint(proj, ["src/payments/"]);
+    expect(fp2).not.toBeNull();
+    expect(fp2).not.toBe(fp1);
+    writeFileSync(f, "export const a = 1;\n");
+    expect(codekbScopeFingerprint(proj, ["src/payments/"])).toBe(fp1);
+  });
+
+  test("a change OUTSIDE the scoped paths does not move the fingerprint", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    mkdirSync(join(proj, "src", "auth"), { recursive: true });
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "a\n");
+    writeFileSync(join(proj, "src", "auth", "login.ts"), "b\n");
+    const fp1 = codekbScopeFingerprint(proj, ["src/payments/"]);
+    writeFileSync(join(proj, "src", "auth", "login.ts"), "b changed\n");
+    expect(codekbScopeFingerprint(proj, ["src/payments/"])).toBe(fp1);
+  });
+
+  test("non-git directory → null (callers report UNVERIFIED, never a verdict)", () => {
+    const proj = freshProject(); // createTestProject does NOT git init
+    expect(codekbScopeFingerprint(proj, ["src/"])).toBeNull();
+  });
+
+  test("empty path list → null", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    expect(codekbScopeFingerprint(proj, [])).toBeNull();
+  });
+
+  test("invalid or mixed valid/invalid pathspecs → null, never the empty-tree hash", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src"), { recursive: true });
+    writeFileSync(join(proj, "src", "a.ts"), "a\n");
+    expect(codekbScopeFingerprint(proj, ["missing/"])).toBeNull();
+    expect(codekbScopeFingerprint(proj, ["src/", "missing/"])).toBeNull();
+  });
+});
+
+// ============================================================================
+// 3. scopePathCovered — the compare mode's coverage test.
+// ============================================================================
+describe("t248 scopePathCovered", () => {
+  test("literal match and dir-prefix subsumption; no glob semantics", () => {
+    expect(scopePathCovered(["src/payments/"], "src/payments/")).toBe(true);
+    expect(scopePathCovered(["src/"], "src/payments/")).toBe(true);
+    expect(scopePathCovered(["src/payments/"], "src/")).toBe(false);
+    expect(scopePathCovered(["src/auth/"], "src/payments/")).toBe(false);
+    // a FILE entry (no trailing slash) covers only itself
+    expect(scopePathCovered(["src/a.ts"], "src/a.ts")).toBe(true);
+    expect(scopePathCovered(["src/a.ts"], "src/a.ts.bak")).toBe(false);
+  });
+});
+
+// ============================================================================
+// 4. The `codekb-scope-diff` VERB — spawned CLI surface.
+// ============================================================================
+describe("t248 codekb-scope-diff verb — status mode", () => {
+  test("no store timestamp → NO_STORE", () => {
+    const proj = freshProject();
+    const res = runVerb(proj, "--json");
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout).verdict).toBe("NO_STORE");
+  });
+
+  test("legacy store without a scope block → UNKNOWN_SCOPE (absent)", () => {
+    const proj = freshProject();
+    seedStore(proj, "# Timestamp\n\n- Date: 2026-07-27\n");
+    const res = runVerb(proj, "--json");
+    expect(res.status).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.verdict).toBe("UNKNOWN_SCOPE");
+    expect(parsed.reason).toBe("absent");
+  });
+
+  test("matching fingerprint → CURRENT; edit inside scope → STALE", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "a\n");
+    const fp = codekbScopeFingerprint(proj, ["src/payments/"]);
+    expect(fp).not.toBeNull();
+    seedStore(proj, timestampBody({ fingerprint: fp as string }));
+    const current = runVerb(proj, "--json");
+    expect(current.status).toBe(0);
+    expect(JSON.parse(current.stdout).verdict).toBe("CURRENT");
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "a changed\n");
+    const stale = runVerb(proj, "--json");
+    expect(stale.status).toBe(0);
+    const parsed = JSON.parse(stale.stdout);
+    expect(parsed.verdict).toBe("STALE");
+    expect(parsed.store_intent).toBe("fix-payment-timeout");
+  });
+
+  test("full-root fingerprint excludes its own codekb store", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src"), { recursive: true });
+    writeFileSync(join(proj, "src", "app.ts"), "a\n");
+
+    const mint = runVerb(proj, "--mint", "--paths", "./");
+    expect(mint.status).toBe(0);
+    const fingerprint = mint.stdout.trim();
+    expect(fingerprint).toMatch(/^[0-9a-f]{40,64}$/);
+    seedStore(
+      proj,
+      timestampBody({
+        kind: "full",
+        fingerprint,
+        analyzedPaths: ["./"],
+      }),
+    );
+
+    const current = runVerb(proj, "--json");
+    expect(current.status).toBe(0);
+    expect(JSON.parse(current.stdout).verdict).toBe("CURRENT");
+
+    writeFileSync(join(proj, "src", "app.ts"), "changed\n");
+    expect(JSON.parse(runVerb(proj, "--json").stdout).verdict).toBe("STALE");
+  });
+
+  test("full-root exclusion is relative to a nested project, not the parent git root", () => {
+    const parent = freshProject();
+    gitInit(parent);
+    const proj = join(parent, "package");
+    mkdirSync(join(proj, "src"), { recursive: true });
+    writeFileSync(join(proj, "src", "app.ts"), "a\n");
+
+    const mint = runVerb(proj, "--mint", "--paths", "./");
+    expect(mint.status).toBe(0);
+    const fingerprint = mint.stdout.trim();
+    seedStore(
+      proj,
+      timestampBody({
+        kind: "full",
+        fingerprint,
+        analyzedPaths: ["./"],
+      }),
+    );
+
+    expect(JSON.parse(runVerb(proj, "--json").stdout).verdict).toBe("CURRENT");
+  });
+
+  test("scope block without a computable fingerprint (non-git) → UNVERIFIED", () => {
+    const proj = freshProject(); // no git init
+    seedStore(proj, timestampBody({ fingerprint: "abc123" }));
+    const res = runVerb(proj, "--json");
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout).verdict).toBe("UNVERIFIED");
+  });
+
+  test("store with fingerprint: unknown → UNVERIFIED even in a git tree", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "a\n");
+    seedStore(proj, timestampBody({ fingerprint: "unknown" }));
+    const res = runVerb(proj, "--json");
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout).verdict).toBe("UNVERIFIED");
+  });
+
+  test("stored failed pathspec → UNVERIFIED, never false CURRENT on the empty tree", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    seedStore(
+      proj,
+      timestampBody({
+        analyzedPaths: ["missing/"],
+        fingerprint: "4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+      }),
+    );
+    const parsed = JSON.parse(runVerb(proj, "--json").stdout);
+    expect(parsed.verdict).toBe("UNVERIFIED");
+    expect(parsed.detail).toBe("fingerprint not computable here");
+  });
+});
+
+describe("t248 codekb-scope-diff verb — compare mode", () => {
+  test("disjoint incoming scope → NARROWER with the exact discard list", () => {
+    const proj = freshProject();
+    seedStore(proj, timestampBody({ fingerprint: "abc" }));
+    const incoming = join(proj, "incoming-ts.md");
+    writeFileSync(
+      incoming,
+      timestampBody({
+        intent: "restructure-auth",
+        analyzedPaths: ["src/auth/"],
+        components: ["auth-service"],
+      }),
+    );
+    const res = runVerb(proj, "--compare", incoming, "--json");
+    expect(res.status).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.verdict).toBe("NARROWER");
+    expect(parsed.discarded_paths).toEqual(["src/payments/"]);
+    expect(parsed.discarded_components).toEqual(["payment-gateway"]);
+    expect(parsed.store_intent).toBe("fix-payment-timeout");
+    expect(parsed.incoming_intent).toBe("restructure-auth");
+  });
+
+  test("valid incoming full root covers a partial store", () => {
+    const proj = freshProject();
+    seedStore(proj, timestampBody({ fingerprint: "abc" }));
+    const incoming = join(proj, "incoming-full.md");
+    writeFileSync(
+      incoming,
+      timestampBody({ kind: "full", intent: "rebuild", analyzedPaths: ["./"], components: [] }),
+    );
+    const res = runVerb(proj, "--compare", incoming, "--json");
+    expect(res.status).toBe(0);
+    const parsed = JSON.parse(res.stdout);
+    expect(parsed.verdict).toBe("COVERS");
+    expect(parsed.discarded_paths).toEqual([]);
+  });
+
+  test("a partial incoming scan cannot replace a full store", () => {
+    const proj = freshProject();
+    seedStore(
+      proj,
+      timestampBody({
+        kind: "full",
+        fingerprint: "abc",
+        analyzedPaths: ["./"],
+        components: [],
+      }),
+    );
+    const incoming = join(proj, "incoming-partial.md");
+    writeFileSync(
+      incoming,
+      timestampBody({ analyzedPaths: ["src/"], components: [] }),
+    );
+    const parsed = JSON.parse(runVerb(proj, "--compare", incoming, "--json").stdout);
+    expect(parsed.verdict).toBe("NARROWER");
+    expect(parsed.discarded_paths).toEqual(["./"]);
+  });
+
+  test("incoming kind: full without ./ → UNKNOWN_SCOPE", () => {
+    const proj = freshProject();
+    seedStore(proj, timestampBody({ fingerprint: "abc" }));
+    const incoming = join(proj, "incoming-invalid-full.md");
+    writeFileSync(
+      incoming,
+      timestampBody({ kind: "full", analyzedPaths: ["src/"], components: [] }),
+    );
+    const parsed = JSON.parse(runVerb(proj, "--compare", incoming, "--json").stdout);
+    expect(parsed.verdict).toBe("UNKNOWN_SCOPE");
+    expect(parsed.detail).toContain("analyzed.paths must include ./");
+  });
+
+  test("incoming kind: partial with ./ → UNKNOWN_SCOPE, never universal coverage", () => {
+    const proj = freshProject();
+    seedStore(proj, timestampBody({ fingerprint: "abc", components: [] }));
+    const incoming = join(proj, "incoming-invalid-partial.md");
+    writeFileSync(
+      incoming,
+      timestampBody({ kind: "partial", analyzedPaths: ["./"], components: [] }),
+    );
+    const parsed = JSON.parse(runVerb(proj, "--compare", incoming, "--json").stdout);
+    expect(parsed.verdict).toBe("UNKNOWN_SCOPE");
+    expect(parsed.detail).toContain("requires kind: full");
+  });
+
+  test("incoming dir-prefix superset → COVERS (src/ covers src/payments/)", () => {
+    const proj = freshProject();
+    seedStore(
+      proj,
+      timestampBody({ fingerprint: "abc", components: [] }),
+    );
+    const incoming = join(proj, "incoming-super.md");
+    writeFileSync(
+      incoming,
+      timestampBody({ intent: "wide", analyzedPaths: ["src/"], components: [] }),
+    );
+    const res = runVerb(proj, "--compare", incoming, "--json");
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout).verdict).toBe("COVERS");
+  });
+
+  test("missing --compare file → hard error (a lifecycle mistake, not a verdict)", () => {
+    const proj = freshProject();
+    seedStore(proj, timestampBody({ fingerprint: "abc" }));
+    const res = runVerb(proj, "--compare", join(proj, "does-not-exist.md"));
+    expect(res.status).not.toBe(0);
+  });
+});
+
+describe("t248 codekb-scope-diff verb — mint mode", () => {
+  test("--mint prints the same fingerprint the lib computes; --json carries paths", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "a\n");
+    const fp = codekbScopeFingerprint(proj, ["src/payments/"]);
+    expect(fp).not.toBeNull();
+    const res = runVerb(proj, "--mint", "--paths", "src/payments/");
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim()).toBe(fp as string);
+    const asJson = runVerb(proj, "--mint", "--paths", "src/payments/", "--json");
+    const parsed = JSON.parse(asJson.stdout);
+    expect(parsed.fingerprint).toBe(fp);
+    expect(parsed.paths).toEqual(["src/payments/"]);
+  });
+
+  test("--mint outside a git tree prints unknown (recorded verbatim in the block)", () => {
+    const proj = freshProject();
+    const res = runVerb(proj, "--mint", "--paths", "src/");
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim()).toBe("unknown");
+  });
+
+  test("--mint with a failed pathspec prints unknown, never the empty-tree hash", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    const res = runVerb(proj, "--mint", "--paths", "missing/");
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim()).toBe("unknown");
+  });
+
+  test("--mint without --paths → hard error", () => {
+    const proj = freshProject();
+    const res = runVerb(proj, "--mint");
+    expect(res.status).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Reverse Engineering no longer silently discards a prior intent's code knowledge when a later intent performs a narrower scan. The space-level per-repo CodeKB remains shared across intents, but its timestamp now records structured scan coverage and a content fingerprint so the stage can verify freshness before deciding whether to rescan.

Addresses #632. This PR deliberately does not move Reverse Engineering outputs into per-intent storage; it preserves the shared CodeKB design while preventing unexamined reuse and silent narrower overwrites.

## Changes

- Add a structured `Scope of Analysis` block to `reverse-engineering-timestamp.md`, recording full/partial scope, source intent, analyzed paths/components, shallow paths, and a content fingerprint.
- Add the read-only `aidlc-utility codekb-scope-diff` verb:
  - status mode reports `NO_STORE`, `CURRENT`, `STALE`, `UNVERIFIED`, or `UNKNOWN_SCOPE`;
  - `--compare <timestamp.md>` reports `COVERS` or `NARROWER` and lists coverage that would be discarded;
  - `--mint --paths <csv>` computes the fingerprint written into the timestamp;
  - all modes support `--json`.
- Compute fingerprints with `git write-tree` over a temporary index restricted to analyzed paths. The result covers working-tree content and respects gitignore rules without mutating the real index.
- Add a Reverse Engineering rerun guard. A verified-current store with relevant coverage can be reused by explicit human choice, which skips the scan; stale, unverifiable, legacy, or irrelevant stores require a full or focused rescan choice.
- Compare delivered scan coverage before replacing an existing store. A narrower result is surfaced at the approval gate with the exact paths/components being discarded.
- Add deterministic unit coverage for scope parsing, fingerprint stability, all status verdicts, comparison behavior, minting, and CLI routing.
- Bump the shipped version, README badge, and changelog to 2.5.12, then regenerate every harness distribution.

## User experience

For a current CodeKB that covers the new intent, the user can reuse it and avoid running Reverse Engineering again. When a rescan is needed, the workflow distinguishes full and focused scans. If the delivered result is narrower than the shared store it replaces, the approval gate makes that loss explicit instead of silently accepting it.

Existing CodeKB stores predate scope tracking and report `UNKNOWN_SCOPE` until one post-upgrade scan records the structured block.

## Test plan

- `bun scripts/package.ts --check`: all five harness trees in sync.
- `bun run typecheck`: passed across all three TypeScript configurations.
- `bun run lint`: 541 files checked with no warnings or errors.
- Focused unit suite: 80 passed, 0 failed across `t248-codekb-scope-diff`, `t68-version-changelog-sync`, `t239-documentation-parity`, `t244-scope-matrix-doc-sync`, and `gen-coverage-registry`.
- Rebased cleanly onto current `v2` at `207db2ea` before push.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of the project license.
