### PR TITLE
fix: make sensor output parsing robust to leading stdout noise (2.5.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.31] - 2026-07-31
+
+Sensor output parsing now tolerates leading stdout noise. When a sensor runs against a sibling repository, that repo's package manager (pnpm and similar) can print a run banner or lockfile warning before the wrapped tool's JSON; previously the dispatcher and the linter sensor did a bare parse of that stdout, so any preamble made the parse throw and the sensor's real verdict was silently discarded as an advisory PASS. Both parse sites now slice stdout to the first structural JSON character before parsing, and still degrade gracefully when even the sliced output is not JSON. **Upgrade:** re-copy your `dist/<harness>/` shell into the project so the updated `aidlc-sensor` dispatcher and `linter` sensor are installed. No configuration or command changes.
+
+* The sensor dispatcher (`aidlc-sensor fire`) and the `linter` sensor now strip package-manager banners and lockfile warnings that precede a wrapped tool's JSON, so a real FAILED or clean PASS verdict is no longer masked as `script-error: bad-output` when firing against a sibling repo.
+
 ## [2.5.30] - 2026-07-30
 
 The default-scope resolver is now bundle-aware, so an install that disables the core scopes through plugin selection (a plugin-only install) no longer crashes or routes to a disabled scope when a default is needed. A scope can nominate itself as the install's freeform default with a new `freeform_default: true` frontmatter key; when the core preferred default (feature/poc) is not enabled the resolver picks the nominated scope, else the sole enabled plugin's alphabetically-first scope, else surfaces a descriptive error. Agent-facing prose that stated fixed stage and persona counts now points at the compiled graph and `--doctor` so it stays true under plugin selection. **Upgrade:** re-copy your `dist/<harness>/` shell into the project. No action is needed for a stock (no-plugin) install; behavior there is unchanged.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.30-blue)
+![version](https://img.shields.io/badge/version-2.5.31-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-sensor-linter.ts
+++ b/core/tools/aidlc-sensor-linter.ts
@@ -293,6 +293,18 @@ function runEslint(
 
 // --- result parsing ---------------------------------------------------------
 
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). `bunx` and the project's package manager can print run banners
+// or lockfile warnings (pnpm etc.) before eslint's `--format json` array when
+// the sensor fires against a sibling repo; without this the payload never
+// parses and the linter verdict is silently discarded. When startChar is
+// absent the string is returned unchanged so the caller's JSON.parse still
+// throws and the graceful eslint-bad-output degradation holds.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 function buildViolations(results: ESLintResult[]): Violation[] {
 	const out: Violation[] = [];
 	for (const r of results) {
@@ -337,7 +349,7 @@ export function main(argv: string[]): void {
 	// — eslint always writes JSON to stdout on either path.
 	let parsed: ESLintResult[];
 	try {
-		parsed = JSON.parse(stdout);
+		parsed = JSON.parse(stripStdoutNoise(stdout, "["));
 	} catch {
 		process.stderr.write("eslint-bad-output\n");
 		process.exit(1);

--- a/core/tools/aidlc-sensor.ts
+++ b/core/tools/aidlc-sensor.ts
@@ -554,6 +554,20 @@ function handleFire(args: string[]): void {
 	process.exit(0);
 }
 
+// --- Stdout noise stripping ---
+//
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). Package managers such as pnpm print run banners and lockfile
+// warnings before a wrapped tool's JSON when a sensor runs against a sibling
+// repo; without this the payload never parses and the verdict is silently
+// discarded as script-error: bad-output. When startChar is absent the string
+// is returned unchanged so the caller's JSON.parse still throws and degrades
+// gracefully.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 // --- Truth table ---
 //
 // Branch ordering is LOAD-BEARING: branch a (timeout) precedes branch 0
@@ -608,7 +622,7 @@ function decideOutcome(
 			// spawnSync's overload set isn't narrowed by encoding alone; check
 			// with typeof to keep TS narrowing.
 			const stdout = typeof result.stdout === "string" ? result.stdout : "";
-			parsed = JSON.parse(stdout);
+			parsed = JSON.parse(stripStdoutNoise(stdout, "{"));
 		} catch {
 			return {
 				kind: "passed",

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.30";
+export const AIDLC_VERSION = "2.5.31";

--- a/dist/claude/.claude/tools/aidlc-sensor-linter.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-linter.ts
@@ -293,6 +293,18 @@ function runEslint(
 
 // --- result parsing ---------------------------------------------------------
 
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). `bunx` and the project's package manager can print run banners
+// or lockfile warnings (pnpm etc.) before eslint's `--format json` array when
+// the sensor fires against a sibling repo; without this the payload never
+// parses and the linter verdict is silently discarded. When startChar is
+// absent the string is returned unchanged so the caller's JSON.parse still
+// throws and the graceful eslint-bad-output degradation holds.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 function buildViolations(results: ESLintResult[]): Violation[] {
 	const out: Violation[] = [];
 	for (const r of results) {
@@ -337,7 +349,7 @@ export function main(argv: string[]): void {
 	// — eslint always writes JSON to stdout on either path.
 	let parsed: ESLintResult[];
 	try {
-		parsed = JSON.parse(stdout);
+		parsed = JSON.parse(stripStdoutNoise(stdout, "["));
 	} catch {
 		process.stderr.write("eslint-bad-output\n");
 		process.exit(1);

--- a/dist/claude/.claude/tools/aidlc-sensor.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor.ts
@@ -554,6 +554,20 @@ function handleFire(args: string[]): void {
 	process.exit(0);
 }
 
+// --- Stdout noise stripping ---
+//
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). Package managers such as pnpm print run banners and lockfile
+// warnings before a wrapped tool's JSON when a sensor runs against a sibling
+// repo; without this the payload never parses and the verdict is silently
+// discarded as script-error: bad-output. When startChar is absent the string
+// is returned unchanged so the caller's JSON.parse still throws and degrades
+// gracefully.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 // --- Truth table ---
 //
 // Branch ordering is LOAD-BEARING: branch a (timeout) precedes branch 0
@@ -608,7 +622,7 @@ function decideOutcome(
 			// spawnSync's overload set isn't narrowed by encoding alone; check
 			// with typeof to keep TS narrowing.
 			const stdout = typeof result.stdout === "string" ? result.stdout : "";
-			parsed = JSON.parse(stdout);
+			parsed = JSON.parse(stripStdoutNoise(stdout, "{"));
 		} catch {
 			return {
 				kind: "passed",

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.30";
+export const AIDLC_VERSION = "2.5.31";

--- a/dist/codex/.codex/tools/aidlc-sensor-linter.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-linter.ts
@@ -293,6 +293,18 @@ function runEslint(
 
 // --- result parsing ---------------------------------------------------------
 
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). `bunx` and the project's package manager can print run banners
+// or lockfile warnings (pnpm etc.) before eslint's `--format json` array when
+// the sensor fires against a sibling repo; without this the payload never
+// parses and the linter verdict is silently discarded. When startChar is
+// absent the string is returned unchanged so the caller's JSON.parse still
+// throws and the graceful eslint-bad-output degradation holds.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 function buildViolations(results: ESLintResult[]): Violation[] {
 	const out: Violation[] = [];
 	for (const r of results) {
@@ -337,7 +349,7 @@ export function main(argv: string[]): void {
 	// — eslint always writes JSON to stdout on either path.
 	let parsed: ESLintResult[];
 	try {
-		parsed = JSON.parse(stdout);
+		parsed = JSON.parse(stripStdoutNoise(stdout, "["));
 	} catch {
 		process.stderr.write("eslint-bad-output\n");
 		process.exit(1);

--- a/dist/codex/.codex/tools/aidlc-sensor.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor.ts
@@ -554,6 +554,20 @@ function handleFire(args: string[]): void {
 	process.exit(0);
 }
 
+// --- Stdout noise stripping ---
+//
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). Package managers such as pnpm print run banners and lockfile
+// warnings before a wrapped tool's JSON when a sensor runs against a sibling
+// repo; without this the payload never parses and the verdict is silently
+// discarded as script-error: bad-output. When startChar is absent the string
+// is returned unchanged so the caller's JSON.parse still throws and degrades
+// gracefully.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 // --- Truth table ---
 //
 // Branch ordering is LOAD-BEARING: branch a (timeout) precedes branch 0
@@ -608,7 +622,7 @@ function decideOutcome(
 			// spawnSync's overload set isn't narrowed by encoding alone; check
 			// with typeof to keep TS narrowing.
 			const stdout = typeof result.stdout === "string" ? result.stdout : "";
-			parsed = JSON.parse(stdout);
+			parsed = JSON.parse(stripStdoutNoise(stdout, "{"));
 		} catch {
 			return {
 				kind: "passed",

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.30";
+export const AIDLC_VERSION = "2.5.31";

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-linter.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-linter.ts
@@ -293,6 +293,18 @@ function runEslint(
 
 // --- result parsing ---------------------------------------------------------
 
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). `bunx` and the project's package manager can print run banners
+// or lockfile warnings (pnpm etc.) before eslint's `--format json` array when
+// the sensor fires against a sibling repo; without this the payload never
+// parses and the linter verdict is silently discarded. When startChar is
+// absent the string is returned unchanged so the caller's JSON.parse still
+// throws and the graceful eslint-bad-output degradation holds.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 function buildViolations(results: ESLintResult[]): Violation[] {
 	const out: Violation[] = [];
 	for (const r of results) {
@@ -337,7 +349,7 @@ export function main(argv: string[]): void {
 	// — eslint always writes JSON to stdout on either path.
 	let parsed: ESLintResult[];
 	try {
-		parsed = JSON.parse(stdout);
+		parsed = JSON.parse(stripStdoutNoise(stdout, "["));
 	} catch {
 		process.stderr.write("eslint-bad-output\n");
 		process.exit(1);

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor.ts
@@ -554,6 +554,20 @@ function handleFire(args: string[]): void {
 	process.exit(0);
 }
 
+// --- Stdout noise stripping ---
+//
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). Package managers such as pnpm print run banners and lockfile
+// warnings before a wrapped tool's JSON when a sensor runs against a sibling
+// repo; without this the payload never parses and the verdict is silently
+// discarded as script-error: bad-output. When startChar is absent the string
+// is returned unchanged so the caller's JSON.parse still throws and degrades
+// gracefully.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 // --- Truth table ---
 //
 // Branch ordering is LOAD-BEARING: branch a (timeout) precedes branch 0
@@ -608,7 +622,7 @@ function decideOutcome(
 			// spawnSync's overload set isn't narrowed by encoding alone; check
 			// with typeof to keep TS narrowing.
 			const stdout = typeof result.stdout === "string" ? result.stdout : "";
-			parsed = JSON.parse(stdout);
+			parsed = JSON.parse(stripStdoutNoise(stdout, "{"));
 		} catch {
 			return {
 				kind: "passed",

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.30";
+export const AIDLC_VERSION = "2.5.31";

--- a/dist/kiro/.kiro/tools/aidlc-sensor-linter.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-linter.ts
@@ -293,6 +293,18 @@ function runEslint(
 
 // --- result parsing ---------------------------------------------------------
 
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). `bunx` and the project's package manager can print run banners
+// or lockfile warnings (pnpm etc.) before eslint's `--format json` array when
+// the sensor fires against a sibling repo; without this the payload never
+// parses and the linter verdict is silently discarded. When startChar is
+// absent the string is returned unchanged so the caller's JSON.parse still
+// throws and the graceful eslint-bad-output degradation holds.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 function buildViolations(results: ESLintResult[]): Violation[] {
 	const out: Violation[] = [];
 	for (const r of results) {
@@ -337,7 +349,7 @@ export function main(argv: string[]): void {
 	// — eslint always writes JSON to stdout on either path.
 	let parsed: ESLintResult[];
 	try {
-		parsed = JSON.parse(stdout);
+		parsed = JSON.parse(stripStdoutNoise(stdout, "["));
 	} catch {
 		process.stderr.write("eslint-bad-output\n");
 		process.exit(1);

--- a/dist/kiro/.kiro/tools/aidlc-sensor.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor.ts
@@ -554,6 +554,20 @@ function handleFire(args: string[]): void {
 	process.exit(0);
 }
 
+// --- Stdout noise stripping ---
+//
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). Package managers such as pnpm print run banners and lockfile
+// warnings before a wrapped tool's JSON when a sensor runs against a sibling
+// repo; without this the payload never parses and the verdict is silently
+// discarded as script-error: bad-output. When startChar is absent the string
+// is returned unchanged so the caller's JSON.parse still throws and degrades
+// gracefully.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 // --- Truth table ---
 //
 // Branch ordering is LOAD-BEARING: branch a (timeout) precedes branch 0
@@ -608,7 +622,7 @@ function decideOutcome(
 			// spawnSync's overload set isn't narrowed by encoding alone; check
 			// with typeof to keep TS narrowing.
 			const stdout = typeof result.stdout === "string" ? result.stdout : "";
-			parsed = JSON.parse(stdout);
+			parsed = JSON.parse(stripStdoutNoise(stdout, "{"));
 		} catch {
 			return {
 				kind: "passed",

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.30";
+export const AIDLC_VERSION = "2.5.31";

--- a/dist/opencode/.aidlc/tools/aidlc-sensor-linter.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor-linter.ts
@@ -293,6 +293,18 @@ function runEslint(
 
 // --- result parsing ---------------------------------------------------------
 
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). `bunx` and the project's package manager can print run banners
+// or lockfile warnings (pnpm etc.) before eslint's `--format json` array when
+// the sensor fires against a sibling repo; without this the payload never
+// parses and the linter verdict is silently discarded. When startChar is
+// absent the string is returned unchanged so the caller's JSON.parse still
+// throws and the graceful eslint-bad-output degradation holds.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 function buildViolations(results: ESLintResult[]): Violation[] {
 	const out: Violation[] = [];
 	for (const r of results) {
@@ -337,7 +349,7 @@ export function main(argv: string[]): void {
 	// — eslint always writes JSON to stdout on either path.
 	let parsed: ESLintResult[];
 	try {
-		parsed = JSON.parse(stdout);
+		parsed = JSON.parse(stripStdoutNoise(stdout, "["));
 	} catch {
 		process.stderr.write("eslint-bad-output\n");
 		process.exit(1);

--- a/dist/opencode/.aidlc/tools/aidlc-sensor.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor.ts
@@ -554,6 +554,20 @@ function handleFire(args: string[]): void {
 	process.exit(0);
 }
 
+// --- Stdout noise stripping ---
+//
+// Slice leading stdout noise down to the first structural JSON character
+// (startChar). Package managers such as pnpm print run banners and lockfile
+// warnings before a wrapped tool's JSON when a sensor runs against a sibling
+// repo; without this the payload never parses and the verdict is silently
+// discarded as script-error: bad-output. When startChar is absent the string
+// is returned unchanged so the caller's JSON.parse still throws and degrades
+// gracefully.
+export function stripStdoutNoise(stdout: string, startChar: string): string {
+	const idx = stdout.indexOf(startChar);
+	return idx >= 0 ? stdout.slice(idx) : stdout;
+}
+
 // --- Truth table ---
 //
 // Branch ordering is LOAD-BEARING: branch a (timeout) precedes branch 0
@@ -608,7 +622,7 @@ function decideOutcome(
 			// spawnSync's overload set isn't narrowed by encoding alone; check
 			// with typeof to keep TS narrowing.
 			const stdout = typeof result.stdout === "string" ? result.stdout : "";
-			parsed = JSON.parse(stdout);
+			parsed = JSON.parse(stripStdoutNoise(stdout, "{"));
 		} catch {
 			return {
 				kind: "passed",

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.30";
+export const AIDLC_VERSION = "2.5.31";

--- a/tests/unit/t251-sensor-stdout-noise.test.ts
+++ b/tests/unit/t251-sensor-stdout-noise.test.ts
@@ -1,0 +1,80 @@
+// covers: tool:aidlc-sensor, tool:aidlc-sensor-linter
+//
+// t251 - sensor output parsing is robust to leading stdout noise.
+//
+// Both sensor parse sites JSON.parse a wrapped tool's stdout on exit 0: the
+// dispatcher (aidlc-sensor.ts) parses a per-sensor script's result object; the
+// linter sensor (aidlc-sensor-linter.ts) parses eslint's `--format json`
+// array. When a sensor fires against a sibling repo, that repo's package
+// manager (pnpm and friends) can print a run banner or lockfile warning BEFORE
+// the JSON, so a bare JSON.parse throws and the real verdict is silently
+// discarded as an advisory PASS (dispatcher: script-error: bad-output; linter:
+// eslint-bad-output). stripStdoutNoise slices the stdout down to the first
+// structural JSON character before parsing, and returns pure-noise input
+// unchanged so the existing graceful degradation still fires.
+//
+// The same normalization is applied to BOTH parse sites: the dispatcher
+// (object, startChar `{`) and the linter sensor (array, startChar `[`).
+//
+// Mechanism: none - a pure in-process exercise of the two exported helpers, no
+// spawn, no tool subprocess. The `tool:` covers ids are documentation
+// annotations (there is no enumerated "tool" unit class), matching t237's
+// convention.
+
+import { describe, expect, test } from "bun:test";
+import { stripStdoutNoise as stripDispatcher } from "../../core/tools/aidlc-sensor.ts";
+import { stripStdoutNoise as stripLinter } from "../../core/tools/aidlc-sensor-linter.ts";
+
+// A realistic package-manager banner printed before the wrapped tool's JSON.
+// Deliberately contains no `{` or `[` so a pure-noise slice finds no structural
+// character and returns the input unchanged.
+const PM_NOISE = [
+  "Scope: all 3 workspace projects",
+  "Lockfile is up to date, resolution step is skipped",
+  " WARN  deprecated subdependency found in the workspace",
+  "",
+].join("\n");
+
+describe("t251 dispatcher stdout-noise stripping (result object, startChar '{')", () => {
+  test("a result object preceded by package-manager noise parses to the real verdict", () => {
+    const verdict = { pass: false, findings_count: 3 };
+    const stdout = `${PM_NOISE}${JSON.stringify(verdict)}\n`;
+    const parsed = JSON.parse(stripDispatcher(stdout, "{"));
+    expect(parsed).toEqual(verdict);
+    // The real failing verdict survives, rather than degrading to an advisory PASS.
+    expect(parsed.pass).toBe(false);
+  });
+
+  test("pure noise (no object) is returned unchanged and still fails to parse", () => {
+    const stripped = stripDispatcher(PM_NOISE, "{");
+    expect(stripped).toBe(PM_NOISE);
+    expect(() => JSON.parse(stripped)).toThrow();
+  });
+
+  test("clean JSON is returned byte-for-byte unchanged", () => {
+    const clean = `${JSON.stringify({ pass: true })}\n`;
+    expect(stripDispatcher(clean, "{")).toBe(clean);
+  });
+});
+
+describe("t251 linter stdout-noise stripping (eslint array, startChar '[')", () => {
+  test("an eslint result array preceded by package-manager noise parses to the real results", () => {
+    const results = [
+      { filePath: "a.ts", messages: [], errorCount: 0, warningCount: 0 },
+    ];
+    const stdout = `${PM_NOISE}${JSON.stringify(results)}\n`;
+    const parsed = JSON.parse(stripLinter(stdout, "["));
+    expect(parsed).toEqual(results);
+  });
+
+  test("pure noise (no array) is returned unchanged and still fails to parse", () => {
+    const stripped = stripLinter(PM_NOISE, "[");
+    expect(stripped).toBe(PM_NOISE);
+    expect(() => JSON.parse(stripped)).toThrow();
+  });
+
+  test("clean JSON is returned byte-for-byte unchanged", () => {
+    const clean = `${JSON.stringify([{ errorCount: 1, messages: [] }])}\n`;
+    expect(stripLinter(clean, "[")).toBe(clean);
+  });
+});


### PR DESCRIPTION
## Problem

Both sensor JSON parse sites do a bare JSON.parse of a wrapped tool's exit-0 stdout: the dispatcher (aidlc-sensor.ts) on a per-sensor script's result object, and the linter sensor (aidlc-sensor-linter.ts) on eslint's --format json array. When a sensor fires against a repo whose package manager prints a run banner or lockfile warning before the JSON (pnpm is the canonical case, common when sensors run against sibling repos in a multi-repo workspace), the parse throws and the sensor's real verdict is silently discarded as an advisory PASS (script-error: bad-output / eslint-bad-output). The user-visible symptom is an absence: findings that should have surfaced at the gate never appear, and the run reads clean.

## What changes

- New exported stripStdoutNoise(stdout, startChar): slice leading noise down to the first structural JSON character. Applied at both sites: the dispatcher slices to the first `{`, the linter sensor to the first `[` (self-contained script keeps its own copy - no cross-import).
- Graceful degradation preserved: pure-noise input returns unchanged, so JSON.parse still throws and the existing bad-output advisory paths fire exactly as before. ESLINT_SPEC pin, base-path handling, and all other sensor semantics untouched.
- New unit test t251-sensor-stdout-noise: JSON preceded by noise parses to the real verdict; pure noise still degrades; clean JSON unchanged.

Version 2.5.31 + CHANGELOG + README badge (re-bumped past 2.5.30 on rebase onto v2 tip d0cd10a6).

## Testing

- smoke+unit: 179 files, 4402 assertions, 0 failed (t251 6/6)
- integration sensor slice (t95 sensor-fire, t49 bolt-sensor-failures): 2 files, 0 failed - live dispatch semantics unchanged
- bun scripts/package.ts --check clean across all 5 harnesses; bun run typecheck clean; coverage registry check fresh

