### PR TITLE
fix: ground claims whose source tags are written adjacently (2.5.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.58] - 2026-08-07
+
+The `claim-sources` sensor no longer loses source tags that are written next to
+each other. `[Q1][Q2]` is Markdown reference-link syntax only when the document
+defines the label it names; with no such definition CommonMark renders both
+tags as literal text, and the sensor now reads them the same way. Claims that
+cite two answers without a separator stop being reported as ungrounded.
+**Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* Fixed `claim block has no source tag` for claims carrying adjacent tags such
+  as `[Q1][Q2]` or a collapsed `[Q1][]`, which the sensor read as a link and
+  discarded. Inserting a space is no longer required.
+* A tag that the document really does define as a link reference, including the
+  shortcut `[Q1]` form, now correctly grounds nothing, matching what a reader
+  sees rendered.
+* A paragraph holding only link reference definitions is no longer reported as
+  a claim block missing a source tag.
+* A line that only looks like a link reference definition is inspected as the
+  prose it renders as. A malformed destination — unclosed `<...>`, unbalanced
+  parentheses, an unescaped `(` in a `(...)` title — no longer exempts its
+  paragraph from needing a source tag.
+* Definitions are read inside block quotes and list items nested in any order
+  and to any depth, so a tag that such a definition turns into a link no longer
+  grounds a claim. Five or more spaces after a list marker remain an indented
+  code block.
+
 ## [2.5.57] - 2026-08-07
 
 AI-DLC now speaks to you in your project's terms rather than its own. Three things a user reported all came from the same place: the assistant narrated its internals, hook names and messages described plumbing instead of purpose, and a new workflow opened with folders it was never going to use. Chat messages, approval gates, the composer's plan proposal, scope questions, error messages, and the onboarding doc are rewritten in plain developer terms; the sentences between steps are now written by the framework and relayed rather than improvised, with silence as the resting state; seven hooks and the intent-creation command are renamed to say what they do; and a record dir now contains only the phases your scope actually runs. Behavior is unchanged throughout: every stage, approval gate, audit event, and tool flag is identical, and the tests pinning those mechanics still pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ cite two answers without a separator stop being reported as ungrounded.
   and to any depth, so a tag that such a definition turns into a link no longer
   grounds a claim. Five or more spaces after a list marker remain an indented
   code block.
+* Definition labels, destination boundaries, title separation, title
+  continuation, and source indentation now follow the same fail-closed rule;
+  malformed or code-indented definition-shaped prose cannot bypass inspection.
+  Definitions with a destination on the following line still resolve links
+  document-wide without making their block eligible for the definition-only
+  skip.
 
 ## [2.5.57] - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.57-blue)
+![version](https://img.shields.io/badge/version-2.5.58-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)
@@ -291,7 +291,7 @@ Three zones: what AI-DLC **is**, how each harness **speaks**, and what users **c
 aidlc-claude/
 │  ─────────── HAND-AUTHORED SOURCE — edit here ───────────
 ├── core/                       # ONE harness-neutral source of truth
-│   ├── tools/                  #   34 aidlc-*.ts engine tools (+ data/scaffold/ templates)
+│   ├── tools/                  #   25 aidlc-*.ts engine tools (+ data/scaffold/ templates)
 │   ├── aidlc-common/           #   stage protocol + 32 stage files + conductor
 │   ├── agents/                 #   14 agents: 11 domain + 2 reviewers + composer
 │   ├── knowledge/ memory/ scopes/ sensors/ hooks/

--- a/core/sensors/aidlc-claim-sources.md
+++ b/core/sensors/aidlc-claim-sources.md
@@ -45,6 +45,12 @@ The sensor excludes scaffolding, fenced code, HTML comments, and reviewer-added
 stage's adversarial reviewer judges whether the cited source actually supports
 the claim.
 
+A tag counts when the rendered document shows it as literal text. Bracket pairs
+resolve as Markdown links only against a link reference definition the document
+carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
+`[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
+nothing.
+
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing missing sections, untagged

--- a/core/sensors/aidlc-claim-sources.md
+++ b/core/sensors/aidlc-claim-sources.md
@@ -49,7 +49,15 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing.
+nothing. A definition is recognised by a well-formed destination, inside a
+block quote or list item as well as at the top level; a line that merely looks
+like one, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim.
+
+Where this reading cannot afford full CommonMark, the divergence must land as a
+false failure and never as a false pass: the sensor may ask for a citation the
+document did not owe, but it must not let unsourced or invisible-tag content
+through.
 
 ## Failure mode
 

--- a/core/sensors/aidlc-claim-sources.md
+++ b/core/sensors/aidlc-claim-sources.md
@@ -49,10 +49,13 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing. A definition is recognised by a well-formed destination, inside a
-block quote or list item as well as at the top level; a line that merely looks
-like one, such as `[note]: some prose`, is the visible sentence it renders as
-and is inspected like any other claim.
+nothing. A definition requires a non-empty CommonMark label, a well-formed
+destination, and a correctly separated optional title, inside a block quote or
+list item as well as at the top level. Multiline destinations still resolve
+references across the whole document. A line that merely looks like a
+definition, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim; neither an inline title nor a different
+container can hide the following line as title continuation.
 
 Where this reading cannot afford full CommonMark, the divergence must land as a
 false failure and never as a false pass: the sensor may ask for a citation the

--- a/core/tools/aidlc-sensor-claim-sources.ts
+++ b/core/tools/aidlc-sensor-claim-sources.ts
@@ -56,6 +56,9 @@ const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
 const REFERENCE_TITLE_RE =
 	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+// The same title, when it trails the destination on the definition's own line.
+const REFERENCE_TITLE_BODY_RE =
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -727,12 +730,35 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+// A definition keeps its meaning inside a block quote or a list item, so the
+// container markers come off before the line is tested.
+function withoutContainerMarkers(line: string): string {
+	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
+	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
+	return stripped;
+}
+
+// Shape alone does not make a definition: `[label]: some prose` renders as the
+// visible sentence it is. Requiring a well-formed destination keeps a line the
+// reader can see out of the definition set, which is what stops such a line
+// from exempting its block from inspection. Where this still diverges from
+// CommonMark it must diverge toward inspecting more, never less — so a
+// destination deferred to the next line reads as prose here rather than as a
+// definition that could skip a block.
 function referenceDefinitionLabel(line: string): string | null {
-	const start = line.search(/\S/);
-	if (start < 0 || start > 3 || line[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(line, start, "[", "]");
-	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
-	return line.slice(start + 1, labelEnd);
+	const text = withoutContainerMarkers(line);
+	const start = text.search(/\S/);
+	if (start < 0 || start > 3 || text[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+
+	const rest = text.slice(labelEnd + 2).trim();
+	const destination = /^\S+/.exec(rest);
+	if (!destination) return null;
+	const trailing = rest.slice(destination[0].length).trim();
+	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+
+	return text.slice(start + 1, labelEnd);
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace

--- a/core/tools/aidlc-sensor-claim-sources.ts
+++ b/core/tools/aidlc-sensor-claim-sources.ts
@@ -54,11 +54,13 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
+// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
+// line as prose, so accepting it here would let the line exempt its block.
 const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
 // The same title, when it trails the destination on the definition's own line.
 const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -730,12 +732,55 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
-// A definition keeps its meaning inside a block quote or a list item, so the
-// container markers come off before the line is tested.
+// A definition keeps its meaning inside a block quote or a list item, and the
+// two nest in either order and to any depth. Taking one of each off would read
+// `> - [Q1]: url` and miss the equally valid `- > [Q1]: url`, so the markers
+// come off until the line stops changing. Five or more spaces after a list
+// marker start an indented code block inside the item rather than content, so
+// the marker only comes off for a run of one to four — and four spaces of
+// remaining indentation is an indented code block too, which the caller's
+// column test rejects.
 function withoutContainerMarkers(line: string): string {
-	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
-	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
-	return stripped;
+	let stripped = line;
+	for (;;) {
+		const next = stripped
+			.replace(/^ {0,3}(?:> ?)+/, "")
+			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
+		if (next === stripped) return stripped;
+		stripped = next;
+	}
+}
+
+// CommonMark's link-destination grammar, which is what separates a definition
+// from a line that merely looks like one. A destination is either an
+// angle-bracket run that has to close on the same line and hold no unescaped
+// `<`, or a bare run that ends at the first space or control character and
+// keeps its parentheses balanced. Returns the index just past the destination,
+// or -1 when the text does not carry one.
+function referenceDestinationEnd(text: string, start: number): number {
+	if (text[start] === "<") {
+		for (let index = start + 1; index < text.length; index++) {
+			if (isEscaped(text, index)) continue;
+			if (text[index] === ">") return index + 1;
+			if (text[index] === "<") return -1;
+		}
+		return -1;
+	}
+
+	let depth = 0;
+	let index = start;
+	for (; index < text.length; index++) {
+		// Space and the ASCII control range both end a bare destination.
+		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "(") {
+			depth++;
+		} else if (text[index] === ")") {
+			depth--;
+			if (depth < 0) return -1;
+		}
+	}
+	return depth === 0 && index > start ? index : -1;
 }
 
 // Shape alone does not make a definition: `[label]: some prose` renders as the
@@ -752,10 +797,12 @@ function referenceDefinitionLabel(line: string): string | null {
 	const labelEnd = matchingDelimiter(text, start, "[", "]");
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
-	const rest = text.slice(labelEnd + 2).trim();
-	const destination = /^\S+/.exec(rest);
-	if (!destination) return null;
-	const trailing = rest.slice(destination[0].length).trim();
+	const rest = text.slice(labelEnd + 2);
+	const destinationStart = rest.search(/\S/);
+	if (destinationStart < 0) return null;
+	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
+	if (destinationEnd < 0) return null;
+	const trailing = rest.slice(destinationEnd).trim();
 	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
 
 	return text.slice(start + 1, labelEnd);

--- a/core/tools/aidlc-sensor-claim-sources.ts
+++ b/core/tools/aidlc-sensor-claim-sources.ts
@@ -54,13 +54,6 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
-// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
-// line as prose, so accepting it here would let the line exempt its block.
-const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
-// The same title, when it trails the destination on the definition's own line.
-const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -524,18 +517,23 @@ function isTableLine(line: string): boolean {
 }
 
 function isListItem(line: string): boolean {
-	return /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+	return /^\s*(?:[-*+]|\d{1,9}[.)])\s+/.test(line);
 }
 
 function isNoneBlock(text: string): boolean {
 	return /^None\.?$/i.test(text.trim());
 }
 
-function claimBlocks(body: string): {
+function claimBlocks(
+	body: string,
+	definitionLines: ReadonlySet<number> = new Set(),
+): {
 	blocks: ClaimBlock[];
 	hasAssumptionsSection: boolean;
 } {
-	const lines = visibleMarkdownLines(body);
+	const lines = visibleMarkdownLines(body).map((line, index) =>
+		definitionLines.has(index) ? "" : line,
+	);
 	const tableHeaders = new Set<number>();
 	for (let index = 1; index < lines.length; index++) {
 		if (isTableSeparator(lines[index]) && isTableLine(lines[index - 1])) {
@@ -576,8 +574,13 @@ function claimBlocks(body: string): {
 			continue;
 		}
 		if (skipReview) continue;
-		if (line.trim().length === 0 || /^\s*---+\s*$/.test(line)) {
+		if (line.trim().length === 0 || isThematicBreak(line)) {
 			flush();
+			continue;
+		}
+		if (isHtmlBlockStart(line)) {
+			flush();
+			pending.push(line);
 			continue;
 		}
 		if (isTableLine(line)) {
@@ -792,6 +795,7 @@ function referenceDestinationEnd(text: string, start: number): number {
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
+			if (depth > 32) return -1;
 		} else if (text[index] === ")") {
 			depth--;
 			if (depth < 0) return -1;
@@ -800,160 +804,410 @@ function referenceDestinationEnd(text: string, start: number): number {
 	return depth === 0 && index > start ? index : -1;
 }
 
-// Shape alone does not make a definition: `[label]: some prose` renders as the
-// visible sentence it is. Requiring a well-formed destination keeps a line the
-// reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Multiline destinations are
-// collected separately for document-wide reference resolution, but stay as
-// prose here: when block removal cannot afford the complete grammar it must
-// inspect more, never less.
 interface ReferenceDefinition {
 	label: string;
-	context: string;
-	mayContinueTitle: boolean;
+	endLine: number;
 }
 
-function referenceLabelEnd(text: string, start: number): number {
-	for (let index = start + 1; index < text.length; index++) {
-		if (isEscaped(text, index)) continue;
-		if (text[index] === "[") return -1;
-		if (text[index] === "]") {
-			const label = text.slice(start + 1, index);
-			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+interface ReferenceAnalysis {
+	labels: Set<string>;
+	definitionLines: Set<number>;
+}
+
+interface ActiveListContainer {
+	beforeQuotes: number;
+	contentIndent: number;
+	listContext: string;
+}
+
+function contextParts(context: string): string[] {
+	return context.length > 0 ? context.split("/") : [];
+}
+
+function textColumns(text: string): number {
+	let column = 0;
+	for (const char of text) {
+		if (char === "\t") {
+			column += 4 - (column % 4);
+		} else {
+			column++;
 		}
 	}
-	return -1;
+	return column;
 }
 
-function referenceDefinition(line: string): ReferenceDefinition | null {
-	const container = containerLine(line);
-	const text = container.text;
-	const start = text.search(/\S/);
-	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = referenceLabelEnd(text, start);
-	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+function firstContent(text: string): { index: number; column: number } | null {
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		if (text[index] === " ") {
+			column++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			continue;
+		}
+		return { index, column };
+	}
+	return null;
+}
 
-	const rest = text.slice(labelEnd + 2);
-	const destinationStart = rest.search(/\S/);
-	if (destinationStart < 0) return null;
-	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
-	if (destinationEnd < 0) return null;
-	const rawTrailing = rest.slice(destinationEnd);
-	const trailing = rawTrailing.trim();
+function stripIndentColumns(text: string, required: number): string | null {
+	let column = 0;
+	let index = 0;
+	while (column < required && index < text.length) {
+		if (text[index] === " ") {
+			column++;
+			index++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			index++;
+			continue;
+		}
+		return null;
+	}
+	if (column < required) return null;
+	return `${" ".repeat(column - required)}${text.slice(index)}`;
+}
+
+function stripLeadingQuotes(
+	line: string,
+	count: number,
+): { text: string; contexts: string[] } | null {
+	let text = line;
+	const contexts: string[] = [];
+	for (let index = 0; index < count; index++) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) return null;
+		text = text.slice(quote[0].length);
+		contexts.push("quote");
+	}
+	return { text, contexts };
+}
+
+function explicitListContainer(
+	line: string,
+	listItem: number,
+): { line: ContainerLine; active: ActiveListContainer } | null {
+	let text = line;
+	const before: string[] = [];
+	for (;;) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) break;
+		text = text.slice(quote[0].length);
+		before.push("quote");
+	}
+
+	const marker =
+		/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(text);
+	if (!marker) return null;
+	const after = containerLine(text.slice(marker[0].length));
+	const listContext = `list#${listItem}`;
+	return {
+		line: {
+			text: after.text,
+			context: [...before, listContext, ...contextParts(after.context)].join(
+				"/",
+			),
+		},
+		active: {
+			beforeQuotes: before.length,
+			contentIndent: textColumns(marker[0]),
+			listContext,
+		},
+	};
+}
+
+// Container markers on the definition's first line are not repeated on its
+// continuation lines. Preserve the active list item's exact quote/list nesting,
+// indentation columns, and identity so continuations work through block quotes
+// and tabs but never cross into a sibling item.
+function documentContainerLines(lines: string[]): ContainerLine[] {
+	const result: ContainerLine[] = [];
+	let activeList: ActiveListContainer | null = null;
+	let listItem = 0;
+
+	for (const line of lines) {
+		const explicitList = explicitListContainer(line, listItem + 1);
+		if (explicitList) {
+			listItem++;
+			activeList = explicitList.active;
+			result.push(explicitList.line);
+			continue;
+		}
+
+		if (line.trim().length === 0) {
+			result.push({ text: line, context: activeList?.listContext ?? "" });
+			continue;
+		}
+
+		if (activeList) {
+			const quoted = stripLeadingQuotes(line, activeList.beforeQuotes);
+			if (quoted && /^[ \t]*$/.test(quoted.text)) {
+				result.push({
+					text: "",
+					context: [...quoted.contexts, activeList.listContext].join("/"),
+				});
+				continue;
+			}
+			const continuation = quoted
+				? stripIndentColumns(quoted.text, activeList.contentIndent)
+				: null;
+			if (quoted && continuation !== null) {
+				const after = containerLine(continuation);
+				result.push({
+					text: after.text,
+					context: [
+						...quoted.contexts,
+						activeList.listContext,
+						...contextParts(after.context),
+					].join("/"),
+				});
+				continue;
+			}
+		}
+
+		activeList = null;
+		result.push(containerLine(line));
+	}
+
+	return result;
+}
+
+const HTML_BLOCK_TAGS =
+	"address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul";
+const HTML_BLOCK_RE = new RegExp(
+	`^(?:<(?:script|pre|style|textarea)(?:[ \\t>]|$)|<!--|<\\?|<![A-Z]|<!\\[CDATA\\[|<\\/?(?:${HTML_BLOCK_TAGS})(?:[ \\t\\n\\f\\r\\/>]|$))`,
+	"i",
+);
+
+function isThematicBreak(line: string): boolean {
+	const content = firstContent(line);
+	if (content === null || content.column > 3) return false;
+	return /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
+		line.slice(content.index),
+	);
+}
+
+function isHtmlBlockStart(line: string): boolean {
+	const content = firstContent(line);
+	return (
+		content !== null &&
+		content.column <= 3 &&
+		HTML_BLOCK_RE.test(line.slice(content.index))
+	);
+}
+
+function interruptsReferenceContinuation(text: string): boolean {
+	const content = firstContent(text);
+	if (!content) return true;
+	// Once a reference definition has started, CommonMark accepts indented lazy
+	// continuation lines. At that point four columns are content, not a fresh
+	// indented-code block, and block-start tests do not interrupt the definition.
+	if (content.column > 3) return false;
+	const rest = text.slice(content.index);
+	return (
+		/^#{1,6}(?:[ \t]+|$)/.test(rest) ||
+		isThematicBreak(text) ||
+		/^(?:=+|-+)[ \t]*$/.test(rest) ||
+		HTML_BLOCK_RE.test(rest)
+	);
+}
+
+function canContinueReference(
+	lines: ContainerLine[],
+	index: number,
+	context: string,
+): boolean {
+	const line = lines[index];
+	if (!line) return false;
+	const sameOrLazilyElidedContext =
+		line.context === context ||
+			(line.context === "" && context !== "") ||
+			(line.context !== "" && context.startsWith(`${line.context}/`));
+	return (
+		sameOrLazilyElidedContext &&
+		!interruptsReferenceContinuation(line.text)
+	);
+}
+
+function referenceTitleEnd(
+	lines: ContainerLine[],
+	startLine: number,
+	start: number,
+): number | null {
+	const context = lines[startLine].context;
+	const opening = lines[startLine].text[start];
+	if (opening !== '"' && opening !== "'" && opening !== "(") return null;
+	const closing = opening === "(" ? ")" : opening;
+	let lineIndex = startLine;
+	let cursor = start + 1;
+
+	for (;;) {
+		const text = lines[lineIndex].text;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) continue;
+			if (opening === "(" && text[cursor] === "(") return null;
+			if (text[cursor] !== closing) continue;
+			return /^[ \t]*$/.test(text.slice(cursor + 1)) ? lineIndex : null;
+		}
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		lineIndex++;
+		cursor = 0;
+	}
+}
+
+// Parse one complete CommonMark link-reference definition. Lines are consumed
+// only after the label, destination, and optional title are certainly valid;
+// malformed candidates remain visible prose and are inspected fail-closed.
+function referenceDefinitionAt(
+	lines: ContainerLine[],
+	startLine: number,
+): ReferenceDefinition | null {
+	const context = lines[startLine].context;
+	let lineIndex = startLine;
+	let text = lines[lineIndex].text;
+	const first = firstContent(text);
+	if (!first || first.column > 3 || text[first.index] !== "[") return null;
+	const start = first.index;
+
+	let cursor = start + 1;
+	let label = "";
+	for (;;) {
+		let closed = false;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) {
+				label += text[cursor];
+				continue;
+			}
+			if (text[cursor] === "[") return null;
+			if (text[cursor] === "]") {
+				closed = true;
+				break;
+			}
+			label += text[cursor];
+		}
+		if (closed) break;
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		label += "\n";
+		lineIndex++;
+		text = next.text;
+		cursor = 0;
+	}
+
 	if (
-		trailing.length > 0 &&
-		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		text[cursor + 1] !== ":" ||
+		!/[^ \t\n\r]/.test(label) ||
+		Array.from(label).length > 999
 	) {
 		return null;
 	}
 
-	return {
-		label: text.slice(start + 1, labelEnd),
-		context: container.context,
-		mayContinueTitle: trailing.length === 0,
-	};
-}
-
-// CommonMark matches link labels case-insensitively with runs of whitespace
-// collapsed to a single space.
-function normalizedReferenceLabel(label: string): string {
-	return label.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-// The labels a document defines. A reference link resolves against the whole
-// document, so this is collected once per file and handed to every block.
-function referenceLabels(body: string): Set<string> {
-	const labels = new Set<string>();
-	const lines = visibleMarkdownLines(body);
-	let titleContinuationContext: string | null = null;
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index];
-		const container = containerLine(line);
+	let destinationLine = lineIndex;
+	let destinationOffset = cursor + 2;
+	let destinationText = text.slice(destinationOffset);
+	let destination = firstContent(destinationText);
+	if (!destination) {
+		const next = lines[destinationLine + 1];
 		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
+			!next ||
+			!canContinueReference(lines, destinationLine + 1, context)
 		) {
-			titleContinuationContext = null;
-			continue;
+			return null;
 		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			labels.add(normalizedReferenceLabel(definition.label));
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		titleContinuationContext = null;
-		const text = container.text;
-		const start = text.search(/\S/);
-		if (start < 0 || start > 3 || text[start] !== "[") continue;
-		const labelEnd = referenceLabelEnd(text, start);
-		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
-		if (text.slice(labelEnd + 2).trim().length > 0) continue;
-
-		const next = lines[index + 1];
-		if (next === undefined) continue;
-		const nextContainer = containerLine(next);
-		if (nextContainer.context !== container.context) continue;
-		const destinationStart = nextContainer.text.search(/\S/);
-		if (destinationStart < 0 || destinationStart > 3) continue;
-		const destinationEnd = referenceDestinationEnd(
-			nextContainer.text,
-			destinationStart,
-		);
-		if (destinationEnd < 0) continue;
-		const rawTrailing = nextContainer.text.slice(destinationEnd);
-		const trailing = rawTrailing.trim();
-		if (
-			trailing.length > 0 &&
-			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
-		) {
-			continue;
-		}
-		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
-		index++;
+		destinationLine++;
+		destinationOffset = 0;
+		destinationText = next.text;
+		destination = firstContent(destinationText);
+		if (!destination) return null;
 	}
-	return labels;
+	const destinationStart = destination.index;
+
+	const destinationEnd = referenceDestinationEnd(
+		destinationText,
+		destinationStart,
+	);
+	if (destinationEnd < 0) return null;
+
+	const rawTrailing = destinationText.slice(destinationEnd);
+	if (/[^ \t]/.test(rawTrailing)) {
+		if (!/^[ \t]+/.test(rawTrailing)) return null;
+		const trailing = firstContent(rawTrailing);
+		if (!trailing) return null;
+		const titleStart =
+			destinationOffset + destinationEnd + trailing.index;
+		const titleEnd = referenceTitleEnd(lines, destinationLine, titleStart);
+		return titleEnd === null ? null : { label, endLine: titleEnd };
+	}
+
+	const possibleTitle = lines[destinationLine + 1];
+	if (
+		possibleTitle &&
+		canContinueReference(lines, destinationLine + 1, context)
+	) {
+		const title = firstContent(possibleTitle.text);
+		if (
+			title &&
+			['"', "'", "("].includes(possibleTitle.text[title.index])
+		) {
+			const titleEnd = referenceTitleEnd(
+				lines,
+				destinationLine + 1,
+				title.index,
+			);
+			if (titleEnd !== null) return { label, endLine: titleEnd };
+		}
+	}
+
+	return { label, endLine: destinationLine };
+}
+
+// CommonMark label matching uses Unicode case folding after whitespace
+// normalization. The lower-then-upper sequence matches markdown-it and folds
+// variants such as `ss`, `ß`, and `ẞ` to the same key.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase().toUpperCase();
+}
+
+function referenceAnalysis(body: string): ReferenceAnalysis {
+	const visibleLines = visibleMarkdownLines(body);
+	const lines = documentContainerLines(visibleLines);
+	const labels = new Set<string>();
+	const definitionLines = new Set<number>();
+
+	for (let index = 0; index < lines.length; index++) {
+		const definition = referenceDefinitionAt(lines, index);
+		if (!definition) continue;
+		labels.add(normalizedReferenceLabel(definition.label));
+		for (let line = index; line <= definition.endLine; line++) {
+			definitionLines.add(line);
+		}
+		index = definition.endLine;
+	}
+
+	return { labels, definitionLines };
+}
+
+// A reference resolves against definitions anywhere in the document.
+function referenceLabels(body: string): Set<string> {
+	return referenceAnalysis(body).labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
-	const visible: string[] = [];
-	let titleContinuationContext: string | null = null;
-	for (const line of text.split("\n")) {
-		const container = containerLine(line);
-		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
-		) {
-			visible.push("");
-			titleContinuationContext = null;
-			continue;
-		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			visible.push("");
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		visible.push(line);
-		titleContinuationContext = null;
-	}
-	return visible.join("\n");
-}
-
-// A block that carries nothing but link reference definitions renders as
-// nothing at all, so it states no claim to ground.
-function isReferenceDefinitionBlock(text: string): boolean {
-	return withoutReferenceDefinitions(text).trim().length === 0;
+	const analysis = referenceAnalysis(text);
+	return visibleMarkdownLines(text)
+		.map((line, index) => (analysis.definitionLines.has(index) ? "" : line))
+		.join("\n");
 }
 
 function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
@@ -1024,7 +1278,7 @@ function sourceTags(text: string, labels: Set<string>): string[] {
 
 function normalizedAssumption(text: string): string {
 	return text
-		.replace(/^\s*(?:[-*+]|\d+\.)\s+/, "")
+		.replace(/^\s*(?:[-*+]|\d{1,9}[.)])\s+/, "")
 		.replace(SOURCE_TAG_RE, "")
 		.replace(/\s+/g, " ")
 		.trim()
@@ -1046,17 +1300,17 @@ function inspectDeliverable(
 		};
 	}
 
-	const parsed = claimBlocks(body);
+	const references = referenceAnalysis(body);
+	const parsed = claimBlocks(body, references.definitionLines);
 	if (!parsed.hasAssumptionsSection) {
 		findings.push(
 			`${basename(path)}: missing ## ${ASSUMPTIONS_HEADING}`,
 		);
 	}
 
-	const labels = referenceLabels(body);
+	const labels = references.labels;
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
-		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
 		const tags = sourceTags(block.text, labels);
 

--- a/core/tools/aidlc-sensor-claim-sources.ts
+++ b/core/tools/aidlc-sensor-claim-sources.ts
@@ -389,6 +389,7 @@ function parseSourceUniverse(
 	}
 
 	const lines = visibleMarkdownLines(body);
+	const labels = referenceLabels(body);
 	const authority = loadRecordAuthority(stageDir);
 	findings.push(...authority.findings);
 	const registered = new Set<string>();
@@ -493,7 +494,7 @@ function parseSourceUniverse(
 	const acceptedAssumptions = new Set(
 		confirmation
 			.filter((line) => isListItem(line))
-			.filter((line) => sourceTags(line).includes("assumption"))
+			.filter((line) => sourceTags(line, labels).includes("assumption"))
 			.map(normalizedAssumption)
 			.filter((entry) => entry.length > 0),
 	);
@@ -726,6 +727,44 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+function referenceDefinitionLabel(line: string): string | null {
+	const start = line.search(/\S/);
+	if (start < 0 || start > 3 || line[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(line, start, "[", "]");
+	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
+	return line.slice(start + 1, labelEnd);
+}
+
+// CommonMark matches link labels case-insensitively with runs of whitespace
+// collapsed to a single space.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+// The labels a document defines. A reference link resolves against the whole
+// document, so this is collected once per file and handed to every block.
+function referenceLabels(body: string): Set<string> {
+	const labels = new Set<string>();
+	let mayContinueDefinition = false;
+	for (const line of visibleMarkdownLines(body)) {
+		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const label = referenceDefinitionLabel(line);
+		if (label === null) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const normalized = normalizedReferenceLabel(label);
+		if (normalized.length > 0) labels.add(normalized);
+		mayContinueDefinition = true;
+	}
+	return labels;
+}
+
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
 	let mayContinueDefinition = false;
@@ -736,14 +775,10 @@ function withoutReferenceDefinitions(text: string): string {
 			continue;
 		}
 
-		const start = line.search(/\S/);
-		if (start >= 0 && start <= 3 && line[start] === "[") {
-			const labelEnd = matchingDelimiter(line, start, "[", "]");
-			if (labelEnd >= 0 && line[labelEnd + 1] === ":") {
-				visible.push("");
-				mayContinueDefinition = true;
-				continue;
-			}
+		if (referenceDefinitionLabel(line) !== null) {
+			visible.push("");
+			mayContinueDefinition = true;
+			continue;
 		}
 
 		visible.push(line);
@@ -752,7 +787,13 @@ function withoutReferenceDefinitions(text: string): string {
 	return visible.join("\n");
 }
 
-function visibleMarkdownLinkText(text: string): string {
+// A block that carries nothing but link reference definitions renders as
+// nothing at all, so it states no claim to ground.
+function isReferenceDefinitionBlock(text: string): boolean {
+	return withoutReferenceDefinitions(text).trim().length === 0;
+}
+
+function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
 	let visible = "";
 	for (let index = 0; index < text.length; index++) {
 		const image =
@@ -772,6 +813,7 @@ function visibleMarkdownLinkText(text: string): string {
 			continue;
 		}
 
+		const label = text.slice(labelStart + 1, labelEnd);
 		let syntaxEnd = labelEnd;
 		if (text[labelEnd + 1] === "(") {
 			const destinationEnd = matchingDelimiter(text, labelEnd + 1, "(", ")");
@@ -786,8 +828,18 @@ function visibleMarkdownLinkText(text: string): string {
 				visible += text[index];
 				continue;
 			}
+			// Full `[text][label]` and collapsed `[label][]` references. An empty
+			// second pair points back at the first, and neither is a link unless
+			// the document defines the label it names.
+			const reference = text.slice(labelEnd + 2, referenceEnd);
+			const named = reference.trim().length > 0 ? reference : label;
+			if (!labels.has(normalizedReferenceLabel(named))) {
+				visible += text[index];
+				continue;
+			}
 			syntaxEnd = referenceEnd;
-		} else if (!image) {
+		} else if (!labels.has(normalizedReferenceLabel(label))) {
+			// Shortcut `[label]` reference: also a link only once defined.
 			visible += text[index];
 			continue;
 		}
@@ -798,10 +850,11 @@ function visibleMarkdownLinkText(text: string): string {
 	return visible;
 }
 
-function sourceTags(text: string): string[] {
+function sourceTags(text: string, labels: Set<string>): string[] {
 	const withoutInlineCode = text.replace(/(`+)([\s\S]*?)\1/g, "");
 	const visibleText = visibleMarkdownLinkText(
 		withoutReferenceDefinitions(visibleHtmlText(withoutInlineCode)),
+		labels,
 	);
 	return [...visibleText.matchAll(SOURCE_TAG_RE)].map((match) => match[1]);
 }
@@ -837,10 +890,12 @@ function inspectDeliverable(
 		);
 	}
 
+	const labels = referenceLabels(body);
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
+		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
-		const tags = sourceTags(block.text);
+		const tags = sourceTags(block.text, labels);
 
 		if (block.inAssumptions) {
 			if (isNoneBlock(block.text)) continue;

--- a/core/tools/aidlc-sensor-claim-sources.ts
+++ b/core/tools/aidlc-sensor-claim-sources.ts
@@ -550,7 +550,7 @@ function claimBlocks(body: string): {
 	let pending: string[] = [];
 
 	const flush = (): void => {
-		const text = pending.join("\n").trim();
+		const text = pending.join("\n").trimEnd();
 		if (text.length > 0) {
 			blocks.push({
 				section,
@@ -593,10 +593,10 @@ function claimBlocks(body: string): {
 		}
 		if (isListItem(line)) {
 			flush();
-			pending.push(line.trim());
+			pending.push(line);
 			continue;
 		}
-		pending.push(line.trim());
+		pending.push(line);
 	}
 	flush();
 
@@ -740,14 +740,30 @@ function visibleHtmlText(text: string): string {
 // the marker only comes off for a run of one to four — and four spaces of
 // remaining indentation is an indented code block too, which the caller's
 // column test rejects.
-function withoutContainerMarkers(line: string): string {
+interface ContainerLine {
+	text: string;
+	context: string;
+}
+
+function containerLine(line: string): ContainerLine {
 	let stripped = line;
+	const context: string[] = [];
 	for (;;) {
-		const next = stripped
-			.replace(/^ {0,3}(?:> ?)+/, "")
-			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
-		if (next === stripped) return stripped;
-		stripped = next;
+		const quote = /^ {0,3}> ?/.exec(stripped);
+		if (quote) {
+			stripped = stripped.slice(quote[0].length);
+			context.push("quote");
+			continue;
+		}
+		const list = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(
+			stripped,
+		);
+		if (list) {
+			stripped = stripped.slice(list[0].length);
+			context.push("list");
+			continue;
+		}
+		return { text: stripped, context: context.join("/") };
 	}
 }
 
@@ -770,8 +786,9 @@ function referenceDestinationEnd(text: string, start: number): number {
 	let depth = 0;
 	let index = start;
 	for (; index < text.length; index++) {
-		// Space and the ASCII control range both end a bare destination.
-		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		// Space and every ASCII control character end a bare destination.
+		const codePoint = text.codePointAt(index) ?? 0;
+		if (codePoint <= 0x20 || codePoint === 0x7f) break;
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
@@ -786,15 +803,34 @@ function referenceDestinationEnd(text: string, start: number): number {
 // Shape alone does not make a definition: `[label]: some prose` renders as the
 // visible sentence it is. Requiring a well-formed destination keeps a line the
 // reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Where this still diverges from
-// CommonMark it must diverge toward inspecting more, never less — so a
-// destination deferred to the next line reads as prose here rather than as a
-// definition that could skip a block.
-function referenceDefinitionLabel(line: string): string | null {
-	const text = withoutContainerMarkers(line);
+// from exempting its block from inspection. Multiline destinations are
+// collected separately for document-wide reference resolution, but stay as
+// prose here: when block removal cannot afford the complete grammar it must
+// inspect more, never less.
+interface ReferenceDefinition {
+	label: string;
+	context: string;
+	mayContinueTitle: boolean;
+}
+
+function referenceLabelEnd(text: string, start: number): number {
+	for (let index = start + 1; index < text.length; index++) {
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "[") return -1;
+		if (text[index] === "]") {
+			const label = text.slice(start + 1, index);
+			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+		}
+	}
+	return -1;
+}
+
+function referenceDefinition(line: string): ReferenceDefinition | null {
+	const container = containerLine(line);
+	const text = container.text;
 	const start = text.search(/\S/);
 	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	const labelEnd = referenceLabelEnd(text, start);
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
 	const rest = text.slice(labelEnd + 2);
@@ -802,10 +838,20 @@ function referenceDefinitionLabel(line: string): string | null {
 	if (destinationStart < 0) return null;
 	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
 	if (destinationEnd < 0) return null;
-	const trailing = rest.slice(destinationEnd).trim();
-	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+	const rawTrailing = rest.slice(destinationEnd);
+	const trailing = rawTrailing.trim();
+	if (
+		trailing.length > 0 &&
+		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+	) {
+		return null;
+	}
 
-	return text.slice(start + 1, labelEnd);
+	return {
+		label: text.slice(start + 1, labelEnd),
+		context: container.context,
+		mayContinueTitle: trailing.length === 0,
+	};
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace
@@ -818,44 +864,88 @@ function normalizedReferenceLabel(label: string): string {
 // document, so this is collected once per file and handed to every block.
 function referenceLabels(body: string): Set<string> {
 	const labels = new Set<string>();
-	let mayContinueDefinition = false;
-	for (const line of visibleMarkdownLines(body)) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
-			mayContinueDefinition = false;
+	const lines = visibleMarkdownLines(body);
+	let titleContinuationContext: string | null = null;
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
+			titleContinuationContext = null;
 			continue;
 		}
 
-		const label = referenceDefinitionLabel(line);
-		if (label === null) {
-			mayContinueDefinition = false;
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
+			labels.add(normalizedReferenceLabel(definition.label));
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
-		const normalized = normalizedReferenceLabel(label);
-		if (normalized.length > 0) labels.add(normalized);
-		mayContinueDefinition = true;
+		titleContinuationContext = null;
+		const text = container.text;
+		const start = text.search(/\S/);
+		if (start < 0 || start > 3 || text[start] !== "[") continue;
+		const labelEnd = referenceLabelEnd(text, start);
+		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
+		if (text.slice(labelEnd + 2).trim().length > 0) continue;
+
+		const next = lines[index + 1];
+		if (next === undefined) continue;
+		const nextContainer = containerLine(next);
+		if (nextContainer.context !== container.context) continue;
+		const destinationStart = nextContainer.text.search(/\S/);
+		if (destinationStart < 0 || destinationStart > 3) continue;
+		const destinationEnd = referenceDestinationEnd(
+			nextContainer.text,
+			destinationStart,
+		);
+		if (destinationEnd < 0) continue;
+		const rawTrailing = nextContainer.text.slice(destinationEnd);
+		const trailing = rawTrailing.trim();
+		if (
+			trailing.length > 0 &&
+			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		) {
+			continue;
+		}
+		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
+		index++;
 	}
 	return labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
-	let mayContinueDefinition = false;
+	let titleContinuationContext: string | null = null;
 	for (const line of text.split("\n")) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
 			visible.push("");
-			mayContinueDefinition = false;
+			titleContinuationContext = null;
 			continue;
 		}
 
-		if (referenceDefinitionLabel(line) !== null) {
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
 			visible.push("");
-			mayContinueDefinition = true;
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
 		visible.push(line);
-		mayContinueDefinition = false;
+		titleContinuationContext = null;
 	}
 	return visible.join("\n");
 }

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.57";
+export const AIDLC_VERSION = "2.5.58";

--- a/dist/claude/.claude/sensors/aidlc-claim-sources.md
+++ b/dist/claude/.claude/sensors/aidlc-claim-sources.md
@@ -45,6 +45,12 @@ The sensor excludes scaffolding, fenced code, HTML comments, and reviewer-added
 stage's adversarial reviewer judges whether the cited source actually supports
 the claim.
 
+A tag counts when the rendered document shows it as literal text. Bracket pairs
+resolve as Markdown links only against a link reference definition the document
+carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
+`[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
+nothing.
+
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing missing sections, untagged

--- a/dist/claude/.claude/sensors/aidlc-claim-sources.md
+++ b/dist/claude/.claude/sensors/aidlc-claim-sources.md
@@ -49,7 +49,15 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing.
+nothing. A definition is recognised by a well-formed destination, inside a
+block quote or list item as well as at the top level; a line that merely looks
+like one, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim.
+
+Where this reading cannot afford full CommonMark, the divergence must land as a
+false failure and never as a false pass: the sensor may ask for a citation the
+document did not owe, but it must not let unsourced or invisible-tag content
+through.
 
 ## Failure mode
 

--- a/dist/claude/.claude/sensors/aidlc-claim-sources.md
+++ b/dist/claude/.claude/sensors/aidlc-claim-sources.md
@@ -49,10 +49,13 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing. A definition is recognised by a well-formed destination, inside a
-block quote or list item as well as at the top level; a line that merely looks
-like one, such as `[note]: some prose`, is the visible sentence it renders as
-and is inspected like any other claim.
+nothing. A definition requires a non-empty CommonMark label, a well-formed
+destination, and a correctly separated optional title, inside a block quote or
+list item as well as at the top level. Multiline destinations still resolve
+references across the whole document. A line that merely looks like a
+definition, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim; neither an inline title nor a different
+container can hide the following line as title continuation.
 
 Where this reading cannot afford full CommonMark, the divergence must land as a
 false failure and never as a false pass: the sensor may ask for a citation the

--- a/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
@@ -56,6 +56,9 @@ const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
 const REFERENCE_TITLE_RE =
 	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+// The same title, when it trails the destination on the definition's own line.
+const REFERENCE_TITLE_BODY_RE =
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -727,12 +730,35 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+// A definition keeps its meaning inside a block quote or a list item, so the
+// container markers come off before the line is tested.
+function withoutContainerMarkers(line: string): string {
+	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
+	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
+	return stripped;
+}
+
+// Shape alone does not make a definition: `[label]: some prose` renders as the
+// visible sentence it is. Requiring a well-formed destination keeps a line the
+// reader can see out of the definition set, which is what stops such a line
+// from exempting its block from inspection. Where this still diverges from
+// CommonMark it must diverge toward inspecting more, never less — so a
+// destination deferred to the next line reads as prose here rather than as a
+// definition that could skip a block.
 function referenceDefinitionLabel(line: string): string | null {
-	const start = line.search(/\S/);
-	if (start < 0 || start > 3 || line[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(line, start, "[", "]");
-	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
-	return line.slice(start + 1, labelEnd);
+	const text = withoutContainerMarkers(line);
+	const start = text.search(/\S/);
+	if (start < 0 || start > 3 || text[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+
+	const rest = text.slice(labelEnd + 2).trim();
+	const destination = /^\S+/.exec(rest);
+	if (!destination) return null;
+	const trailing = rest.slice(destination[0].length).trim();
+	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+
+	return text.slice(start + 1, labelEnd);
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace

--- a/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
@@ -54,11 +54,13 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
+// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
+// line as prose, so accepting it here would let the line exempt its block.
 const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
 // The same title, when it trails the destination on the definition's own line.
 const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -730,12 +732,55 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
-// A definition keeps its meaning inside a block quote or a list item, so the
-// container markers come off before the line is tested.
+// A definition keeps its meaning inside a block quote or a list item, and the
+// two nest in either order and to any depth. Taking one of each off would read
+// `> - [Q1]: url` and miss the equally valid `- > [Q1]: url`, so the markers
+// come off until the line stops changing. Five or more spaces after a list
+// marker start an indented code block inside the item rather than content, so
+// the marker only comes off for a run of one to four — and four spaces of
+// remaining indentation is an indented code block too, which the caller's
+// column test rejects.
 function withoutContainerMarkers(line: string): string {
-	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
-	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
-	return stripped;
+	let stripped = line;
+	for (;;) {
+		const next = stripped
+			.replace(/^ {0,3}(?:> ?)+/, "")
+			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
+		if (next === stripped) return stripped;
+		stripped = next;
+	}
+}
+
+// CommonMark's link-destination grammar, which is what separates a definition
+// from a line that merely looks like one. A destination is either an
+// angle-bracket run that has to close on the same line and hold no unescaped
+// `<`, or a bare run that ends at the first space or control character and
+// keeps its parentheses balanced. Returns the index just past the destination,
+// or -1 when the text does not carry one.
+function referenceDestinationEnd(text: string, start: number): number {
+	if (text[start] === "<") {
+		for (let index = start + 1; index < text.length; index++) {
+			if (isEscaped(text, index)) continue;
+			if (text[index] === ">") return index + 1;
+			if (text[index] === "<") return -1;
+		}
+		return -1;
+	}
+
+	let depth = 0;
+	let index = start;
+	for (; index < text.length; index++) {
+		// Space and the ASCII control range both end a bare destination.
+		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "(") {
+			depth++;
+		} else if (text[index] === ")") {
+			depth--;
+			if (depth < 0) return -1;
+		}
+	}
+	return depth === 0 && index > start ? index : -1;
 }
 
 // Shape alone does not make a definition: `[label]: some prose` renders as the
@@ -752,10 +797,12 @@ function referenceDefinitionLabel(line: string): string | null {
 	const labelEnd = matchingDelimiter(text, start, "[", "]");
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
-	const rest = text.slice(labelEnd + 2).trim();
-	const destination = /^\S+/.exec(rest);
-	if (!destination) return null;
-	const trailing = rest.slice(destination[0].length).trim();
+	const rest = text.slice(labelEnd + 2);
+	const destinationStart = rest.search(/\S/);
+	if (destinationStart < 0) return null;
+	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
+	if (destinationEnd < 0) return null;
+	const trailing = rest.slice(destinationEnd).trim();
 	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
 
 	return text.slice(start + 1, labelEnd);

--- a/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
@@ -54,13 +54,6 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
-// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
-// line as prose, so accepting it here would let the line exempt its block.
-const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
-// The same title, when it trails the destination on the definition's own line.
-const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -524,18 +517,23 @@ function isTableLine(line: string): boolean {
 }
 
 function isListItem(line: string): boolean {
-	return /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+	return /^\s*(?:[-*+]|\d{1,9}[.)])\s+/.test(line);
 }
 
 function isNoneBlock(text: string): boolean {
 	return /^None\.?$/i.test(text.trim());
 }
 
-function claimBlocks(body: string): {
+function claimBlocks(
+	body: string,
+	definitionLines: ReadonlySet<number> = new Set(),
+): {
 	blocks: ClaimBlock[];
 	hasAssumptionsSection: boolean;
 } {
-	const lines = visibleMarkdownLines(body);
+	const lines = visibleMarkdownLines(body).map((line, index) =>
+		definitionLines.has(index) ? "" : line,
+	);
 	const tableHeaders = new Set<number>();
 	for (let index = 1; index < lines.length; index++) {
 		if (isTableSeparator(lines[index]) && isTableLine(lines[index - 1])) {
@@ -576,8 +574,13 @@ function claimBlocks(body: string): {
 			continue;
 		}
 		if (skipReview) continue;
-		if (line.trim().length === 0 || /^\s*---+\s*$/.test(line)) {
+		if (line.trim().length === 0 || isThematicBreak(line)) {
 			flush();
+			continue;
+		}
+		if (isHtmlBlockStart(line)) {
+			flush();
+			pending.push(line);
 			continue;
 		}
 		if (isTableLine(line)) {
@@ -792,6 +795,7 @@ function referenceDestinationEnd(text: string, start: number): number {
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
+			if (depth > 32) return -1;
 		} else if (text[index] === ")") {
 			depth--;
 			if (depth < 0) return -1;
@@ -800,160 +804,410 @@ function referenceDestinationEnd(text: string, start: number): number {
 	return depth === 0 && index > start ? index : -1;
 }
 
-// Shape alone does not make a definition: `[label]: some prose` renders as the
-// visible sentence it is. Requiring a well-formed destination keeps a line the
-// reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Multiline destinations are
-// collected separately for document-wide reference resolution, but stay as
-// prose here: when block removal cannot afford the complete grammar it must
-// inspect more, never less.
 interface ReferenceDefinition {
 	label: string;
-	context: string;
-	mayContinueTitle: boolean;
+	endLine: number;
 }
 
-function referenceLabelEnd(text: string, start: number): number {
-	for (let index = start + 1; index < text.length; index++) {
-		if (isEscaped(text, index)) continue;
-		if (text[index] === "[") return -1;
-		if (text[index] === "]") {
-			const label = text.slice(start + 1, index);
-			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+interface ReferenceAnalysis {
+	labels: Set<string>;
+	definitionLines: Set<number>;
+}
+
+interface ActiveListContainer {
+	beforeQuotes: number;
+	contentIndent: number;
+	listContext: string;
+}
+
+function contextParts(context: string): string[] {
+	return context.length > 0 ? context.split("/") : [];
+}
+
+function textColumns(text: string): number {
+	let column = 0;
+	for (const char of text) {
+		if (char === "\t") {
+			column += 4 - (column % 4);
+		} else {
+			column++;
 		}
 	}
-	return -1;
+	return column;
 }
 
-function referenceDefinition(line: string): ReferenceDefinition | null {
-	const container = containerLine(line);
-	const text = container.text;
-	const start = text.search(/\S/);
-	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = referenceLabelEnd(text, start);
-	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+function firstContent(text: string): { index: number; column: number } | null {
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		if (text[index] === " ") {
+			column++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			continue;
+		}
+		return { index, column };
+	}
+	return null;
+}
 
-	const rest = text.slice(labelEnd + 2);
-	const destinationStart = rest.search(/\S/);
-	if (destinationStart < 0) return null;
-	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
-	if (destinationEnd < 0) return null;
-	const rawTrailing = rest.slice(destinationEnd);
-	const trailing = rawTrailing.trim();
+function stripIndentColumns(text: string, required: number): string | null {
+	let column = 0;
+	let index = 0;
+	while (column < required && index < text.length) {
+		if (text[index] === " ") {
+			column++;
+			index++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			index++;
+			continue;
+		}
+		return null;
+	}
+	if (column < required) return null;
+	return `${" ".repeat(column - required)}${text.slice(index)}`;
+}
+
+function stripLeadingQuotes(
+	line: string,
+	count: number,
+): { text: string; contexts: string[] } | null {
+	let text = line;
+	const contexts: string[] = [];
+	for (let index = 0; index < count; index++) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) return null;
+		text = text.slice(quote[0].length);
+		contexts.push("quote");
+	}
+	return { text, contexts };
+}
+
+function explicitListContainer(
+	line: string,
+	listItem: number,
+): { line: ContainerLine; active: ActiveListContainer } | null {
+	let text = line;
+	const before: string[] = [];
+	for (;;) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) break;
+		text = text.slice(quote[0].length);
+		before.push("quote");
+	}
+
+	const marker =
+		/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(text);
+	if (!marker) return null;
+	const after = containerLine(text.slice(marker[0].length));
+	const listContext = `list#${listItem}`;
+	return {
+		line: {
+			text: after.text,
+			context: [...before, listContext, ...contextParts(after.context)].join(
+				"/",
+			),
+		},
+		active: {
+			beforeQuotes: before.length,
+			contentIndent: textColumns(marker[0]),
+			listContext,
+		},
+	};
+}
+
+// Container markers on the definition's first line are not repeated on its
+// continuation lines. Preserve the active list item's exact quote/list nesting,
+// indentation columns, and identity so continuations work through block quotes
+// and tabs but never cross into a sibling item.
+function documentContainerLines(lines: string[]): ContainerLine[] {
+	const result: ContainerLine[] = [];
+	let activeList: ActiveListContainer | null = null;
+	let listItem = 0;
+
+	for (const line of lines) {
+		const explicitList = explicitListContainer(line, listItem + 1);
+		if (explicitList) {
+			listItem++;
+			activeList = explicitList.active;
+			result.push(explicitList.line);
+			continue;
+		}
+
+		if (line.trim().length === 0) {
+			result.push({ text: line, context: activeList?.listContext ?? "" });
+			continue;
+		}
+
+		if (activeList) {
+			const quoted = stripLeadingQuotes(line, activeList.beforeQuotes);
+			if (quoted && /^[ \t]*$/.test(quoted.text)) {
+				result.push({
+					text: "",
+					context: [...quoted.contexts, activeList.listContext].join("/"),
+				});
+				continue;
+			}
+			const continuation = quoted
+				? stripIndentColumns(quoted.text, activeList.contentIndent)
+				: null;
+			if (quoted && continuation !== null) {
+				const after = containerLine(continuation);
+				result.push({
+					text: after.text,
+					context: [
+						...quoted.contexts,
+						activeList.listContext,
+						...contextParts(after.context),
+					].join("/"),
+				});
+				continue;
+			}
+		}
+
+		activeList = null;
+		result.push(containerLine(line));
+	}
+
+	return result;
+}
+
+const HTML_BLOCK_TAGS =
+	"address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul";
+const HTML_BLOCK_RE = new RegExp(
+	`^(?:<(?:script|pre|style|textarea)(?:[ \\t>]|$)|<!--|<\\?|<![A-Z]|<!\\[CDATA\\[|<\\/?(?:${HTML_BLOCK_TAGS})(?:[ \\t\\n\\f\\r\\/>]|$))`,
+	"i",
+);
+
+function isThematicBreak(line: string): boolean {
+	const content = firstContent(line);
+	if (content === null || content.column > 3) return false;
+	return /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
+		line.slice(content.index),
+	);
+}
+
+function isHtmlBlockStart(line: string): boolean {
+	const content = firstContent(line);
+	return (
+		content !== null &&
+		content.column <= 3 &&
+		HTML_BLOCK_RE.test(line.slice(content.index))
+	);
+}
+
+function interruptsReferenceContinuation(text: string): boolean {
+	const content = firstContent(text);
+	if (!content) return true;
+	// Once a reference definition has started, CommonMark accepts indented lazy
+	// continuation lines. At that point four columns are content, not a fresh
+	// indented-code block, and block-start tests do not interrupt the definition.
+	if (content.column > 3) return false;
+	const rest = text.slice(content.index);
+	return (
+		/^#{1,6}(?:[ \t]+|$)/.test(rest) ||
+		isThematicBreak(text) ||
+		/^(?:=+|-+)[ \t]*$/.test(rest) ||
+		HTML_BLOCK_RE.test(rest)
+	);
+}
+
+function canContinueReference(
+	lines: ContainerLine[],
+	index: number,
+	context: string,
+): boolean {
+	const line = lines[index];
+	if (!line) return false;
+	const sameOrLazilyElidedContext =
+		line.context === context ||
+			(line.context === "" && context !== "") ||
+			(line.context !== "" && context.startsWith(`${line.context}/`));
+	return (
+		sameOrLazilyElidedContext &&
+		!interruptsReferenceContinuation(line.text)
+	);
+}
+
+function referenceTitleEnd(
+	lines: ContainerLine[],
+	startLine: number,
+	start: number,
+): number | null {
+	const context = lines[startLine].context;
+	const opening = lines[startLine].text[start];
+	if (opening !== '"' && opening !== "'" && opening !== "(") return null;
+	const closing = opening === "(" ? ")" : opening;
+	let lineIndex = startLine;
+	let cursor = start + 1;
+
+	for (;;) {
+		const text = lines[lineIndex].text;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) continue;
+			if (opening === "(" && text[cursor] === "(") return null;
+			if (text[cursor] !== closing) continue;
+			return /^[ \t]*$/.test(text.slice(cursor + 1)) ? lineIndex : null;
+		}
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		lineIndex++;
+		cursor = 0;
+	}
+}
+
+// Parse one complete CommonMark link-reference definition. Lines are consumed
+// only after the label, destination, and optional title are certainly valid;
+// malformed candidates remain visible prose and are inspected fail-closed.
+function referenceDefinitionAt(
+	lines: ContainerLine[],
+	startLine: number,
+): ReferenceDefinition | null {
+	const context = lines[startLine].context;
+	let lineIndex = startLine;
+	let text = lines[lineIndex].text;
+	const first = firstContent(text);
+	if (!first || first.column > 3 || text[first.index] !== "[") return null;
+	const start = first.index;
+
+	let cursor = start + 1;
+	let label = "";
+	for (;;) {
+		let closed = false;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) {
+				label += text[cursor];
+				continue;
+			}
+			if (text[cursor] === "[") return null;
+			if (text[cursor] === "]") {
+				closed = true;
+				break;
+			}
+			label += text[cursor];
+		}
+		if (closed) break;
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		label += "\n";
+		lineIndex++;
+		text = next.text;
+		cursor = 0;
+	}
+
 	if (
-		trailing.length > 0 &&
-		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		text[cursor + 1] !== ":" ||
+		!/[^ \t\n\r]/.test(label) ||
+		Array.from(label).length > 999
 	) {
 		return null;
 	}
 
-	return {
-		label: text.slice(start + 1, labelEnd),
-		context: container.context,
-		mayContinueTitle: trailing.length === 0,
-	};
-}
-
-// CommonMark matches link labels case-insensitively with runs of whitespace
-// collapsed to a single space.
-function normalizedReferenceLabel(label: string): string {
-	return label.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-// The labels a document defines. A reference link resolves against the whole
-// document, so this is collected once per file and handed to every block.
-function referenceLabels(body: string): Set<string> {
-	const labels = new Set<string>();
-	const lines = visibleMarkdownLines(body);
-	let titleContinuationContext: string | null = null;
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index];
-		const container = containerLine(line);
+	let destinationLine = lineIndex;
+	let destinationOffset = cursor + 2;
+	let destinationText = text.slice(destinationOffset);
+	let destination = firstContent(destinationText);
+	if (!destination) {
+		const next = lines[destinationLine + 1];
 		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
+			!next ||
+			!canContinueReference(lines, destinationLine + 1, context)
 		) {
-			titleContinuationContext = null;
-			continue;
+			return null;
 		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			labels.add(normalizedReferenceLabel(definition.label));
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		titleContinuationContext = null;
-		const text = container.text;
-		const start = text.search(/\S/);
-		if (start < 0 || start > 3 || text[start] !== "[") continue;
-		const labelEnd = referenceLabelEnd(text, start);
-		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
-		if (text.slice(labelEnd + 2).trim().length > 0) continue;
-
-		const next = lines[index + 1];
-		if (next === undefined) continue;
-		const nextContainer = containerLine(next);
-		if (nextContainer.context !== container.context) continue;
-		const destinationStart = nextContainer.text.search(/\S/);
-		if (destinationStart < 0 || destinationStart > 3) continue;
-		const destinationEnd = referenceDestinationEnd(
-			nextContainer.text,
-			destinationStart,
-		);
-		if (destinationEnd < 0) continue;
-		const rawTrailing = nextContainer.text.slice(destinationEnd);
-		const trailing = rawTrailing.trim();
-		if (
-			trailing.length > 0 &&
-			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
-		) {
-			continue;
-		}
-		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
-		index++;
+		destinationLine++;
+		destinationOffset = 0;
+		destinationText = next.text;
+		destination = firstContent(destinationText);
+		if (!destination) return null;
 	}
-	return labels;
+	const destinationStart = destination.index;
+
+	const destinationEnd = referenceDestinationEnd(
+		destinationText,
+		destinationStart,
+	);
+	if (destinationEnd < 0) return null;
+
+	const rawTrailing = destinationText.slice(destinationEnd);
+	if (/[^ \t]/.test(rawTrailing)) {
+		if (!/^[ \t]+/.test(rawTrailing)) return null;
+		const trailing = firstContent(rawTrailing);
+		if (!trailing) return null;
+		const titleStart =
+			destinationOffset + destinationEnd + trailing.index;
+		const titleEnd = referenceTitleEnd(lines, destinationLine, titleStart);
+		return titleEnd === null ? null : { label, endLine: titleEnd };
+	}
+
+	const possibleTitle = lines[destinationLine + 1];
+	if (
+		possibleTitle &&
+		canContinueReference(lines, destinationLine + 1, context)
+	) {
+		const title = firstContent(possibleTitle.text);
+		if (
+			title &&
+			['"', "'", "("].includes(possibleTitle.text[title.index])
+		) {
+			const titleEnd = referenceTitleEnd(
+				lines,
+				destinationLine + 1,
+				title.index,
+			);
+			if (titleEnd !== null) return { label, endLine: titleEnd };
+		}
+	}
+
+	return { label, endLine: destinationLine };
+}
+
+// CommonMark label matching uses Unicode case folding after whitespace
+// normalization. The lower-then-upper sequence matches markdown-it and folds
+// variants such as `ss`, `ß`, and `ẞ` to the same key.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase().toUpperCase();
+}
+
+function referenceAnalysis(body: string): ReferenceAnalysis {
+	const visibleLines = visibleMarkdownLines(body);
+	const lines = documentContainerLines(visibleLines);
+	const labels = new Set<string>();
+	const definitionLines = new Set<number>();
+
+	for (let index = 0; index < lines.length; index++) {
+		const definition = referenceDefinitionAt(lines, index);
+		if (!definition) continue;
+		labels.add(normalizedReferenceLabel(definition.label));
+		for (let line = index; line <= definition.endLine; line++) {
+			definitionLines.add(line);
+		}
+		index = definition.endLine;
+	}
+
+	return { labels, definitionLines };
+}
+
+// A reference resolves against definitions anywhere in the document.
+function referenceLabels(body: string): Set<string> {
+	return referenceAnalysis(body).labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
-	const visible: string[] = [];
-	let titleContinuationContext: string | null = null;
-	for (const line of text.split("\n")) {
-		const container = containerLine(line);
-		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
-		) {
-			visible.push("");
-			titleContinuationContext = null;
-			continue;
-		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			visible.push("");
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		visible.push(line);
-		titleContinuationContext = null;
-	}
-	return visible.join("\n");
-}
-
-// A block that carries nothing but link reference definitions renders as
-// nothing at all, so it states no claim to ground.
-function isReferenceDefinitionBlock(text: string): boolean {
-	return withoutReferenceDefinitions(text).trim().length === 0;
+	const analysis = referenceAnalysis(text);
+	return visibleMarkdownLines(text)
+		.map((line, index) => (analysis.definitionLines.has(index) ? "" : line))
+		.join("\n");
 }
 
 function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
@@ -1024,7 +1278,7 @@ function sourceTags(text: string, labels: Set<string>): string[] {
 
 function normalizedAssumption(text: string): string {
 	return text
-		.replace(/^\s*(?:[-*+]|\d+\.)\s+/, "")
+		.replace(/^\s*(?:[-*+]|\d{1,9}[.)])\s+/, "")
 		.replace(SOURCE_TAG_RE, "")
 		.replace(/\s+/g, " ")
 		.trim()
@@ -1046,17 +1300,17 @@ function inspectDeliverable(
 		};
 	}
 
-	const parsed = claimBlocks(body);
+	const references = referenceAnalysis(body);
+	const parsed = claimBlocks(body, references.definitionLines);
 	if (!parsed.hasAssumptionsSection) {
 		findings.push(
 			`${basename(path)}: missing ## ${ASSUMPTIONS_HEADING}`,
 		);
 	}
 
-	const labels = referenceLabels(body);
+	const labels = references.labels;
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
-		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
 		const tags = sourceTags(block.text, labels);
 

--- a/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
@@ -389,6 +389,7 @@ function parseSourceUniverse(
 	}
 
 	const lines = visibleMarkdownLines(body);
+	const labels = referenceLabels(body);
 	const authority = loadRecordAuthority(stageDir);
 	findings.push(...authority.findings);
 	const registered = new Set<string>();
@@ -493,7 +494,7 @@ function parseSourceUniverse(
 	const acceptedAssumptions = new Set(
 		confirmation
 			.filter((line) => isListItem(line))
-			.filter((line) => sourceTags(line).includes("assumption"))
+			.filter((line) => sourceTags(line, labels).includes("assumption"))
 			.map(normalizedAssumption)
 			.filter((entry) => entry.length > 0),
 	);
@@ -726,6 +727,44 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+function referenceDefinitionLabel(line: string): string | null {
+	const start = line.search(/\S/);
+	if (start < 0 || start > 3 || line[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(line, start, "[", "]");
+	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
+	return line.slice(start + 1, labelEnd);
+}
+
+// CommonMark matches link labels case-insensitively with runs of whitespace
+// collapsed to a single space.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+// The labels a document defines. A reference link resolves against the whole
+// document, so this is collected once per file and handed to every block.
+function referenceLabels(body: string): Set<string> {
+	const labels = new Set<string>();
+	let mayContinueDefinition = false;
+	for (const line of visibleMarkdownLines(body)) {
+		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const label = referenceDefinitionLabel(line);
+		if (label === null) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const normalized = normalizedReferenceLabel(label);
+		if (normalized.length > 0) labels.add(normalized);
+		mayContinueDefinition = true;
+	}
+	return labels;
+}
+
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
 	let mayContinueDefinition = false;
@@ -736,14 +775,10 @@ function withoutReferenceDefinitions(text: string): string {
 			continue;
 		}
 
-		const start = line.search(/\S/);
-		if (start >= 0 && start <= 3 && line[start] === "[") {
-			const labelEnd = matchingDelimiter(line, start, "[", "]");
-			if (labelEnd >= 0 && line[labelEnd + 1] === ":") {
-				visible.push("");
-				mayContinueDefinition = true;
-				continue;
-			}
+		if (referenceDefinitionLabel(line) !== null) {
+			visible.push("");
+			mayContinueDefinition = true;
+			continue;
 		}
 
 		visible.push(line);
@@ -752,7 +787,13 @@ function withoutReferenceDefinitions(text: string): string {
 	return visible.join("\n");
 }
 
-function visibleMarkdownLinkText(text: string): string {
+// A block that carries nothing but link reference definitions renders as
+// nothing at all, so it states no claim to ground.
+function isReferenceDefinitionBlock(text: string): boolean {
+	return withoutReferenceDefinitions(text).trim().length === 0;
+}
+
+function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
 	let visible = "";
 	for (let index = 0; index < text.length; index++) {
 		const image =
@@ -772,6 +813,7 @@ function visibleMarkdownLinkText(text: string): string {
 			continue;
 		}
 
+		const label = text.slice(labelStart + 1, labelEnd);
 		let syntaxEnd = labelEnd;
 		if (text[labelEnd + 1] === "(") {
 			const destinationEnd = matchingDelimiter(text, labelEnd + 1, "(", ")");
@@ -786,8 +828,18 @@ function visibleMarkdownLinkText(text: string): string {
 				visible += text[index];
 				continue;
 			}
+			// Full `[text][label]` and collapsed `[label][]` references. An empty
+			// second pair points back at the first, and neither is a link unless
+			// the document defines the label it names.
+			const reference = text.slice(labelEnd + 2, referenceEnd);
+			const named = reference.trim().length > 0 ? reference : label;
+			if (!labels.has(normalizedReferenceLabel(named))) {
+				visible += text[index];
+				continue;
+			}
 			syntaxEnd = referenceEnd;
-		} else if (!image) {
+		} else if (!labels.has(normalizedReferenceLabel(label))) {
+			// Shortcut `[label]` reference: also a link only once defined.
 			visible += text[index];
 			continue;
 		}
@@ -798,10 +850,11 @@ function visibleMarkdownLinkText(text: string): string {
 	return visible;
 }
 
-function sourceTags(text: string): string[] {
+function sourceTags(text: string, labels: Set<string>): string[] {
 	const withoutInlineCode = text.replace(/(`+)([\s\S]*?)\1/g, "");
 	const visibleText = visibleMarkdownLinkText(
 		withoutReferenceDefinitions(visibleHtmlText(withoutInlineCode)),
+		labels,
 	);
 	return [...visibleText.matchAll(SOURCE_TAG_RE)].map((match) => match[1]);
 }
@@ -837,10 +890,12 @@ function inspectDeliverable(
 		);
 	}
 
+	const labels = referenceLabels(body);
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
+		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
-		const tags = sourceTags(block.text);
+		const tags = sourceTags(block.text, labels);
 
 		if (block.inAssumptions) {
 			if (isNoneBlock(block.text)) continue;

--- a/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-claim-sources.ts
@@ -550,7 +550,7 @@ function claimBlocks(body: string): {
 	let pending: string[] = [];
 
 	const flush = (): void => {
-		const text = pending.join("\n").trim();
+		const text = pending.join("\n").trimEnd();
 		if (text.length > 0) {
 			blocks.push({
 				section,
@@ -593,10 +593,10 @@ function claimBlocks(body: string): {
 		}
 		if (isListItem(line)) {
 			flush();
-			pending.push(line.trim());
+			pending.push(line);
 			continue;
 		}
-		pending.push(line.trim());
+		pending.push(line);
 	}
 	flush();
 
@@ -740,14 +740,30 @@ function visibleHtmlText(text: string): string {
 // the marker only comes off for a run of one to four — and four spaces of
 // remaining indentation is an indented code block too, which the caller's
 // column test rejects.
-function withoutContainerMarkers(line: string): string {
+interface ContainerLine {
+	text: string;
+	context: string;
+}
+
+function containerLine(line: string): ContainerLine {
 	let stripped = line;
+	const context: string[] = [];
 	for (;;) {
-		const next = stripped
-			.replace(/^ {0,3}(?:> ?)+/, "")
-			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
-		if (next === stripped) return stripped;
-		stripped = next;
+		const quote = /^ {0,3}> ?/.exec(stripped);
+		if (quote) {
+			stripped = stripped.slice(quote[0].length);
+			context.push("quote");
+			continue;
+		}
+		const list = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(
+			stripped,
+		);
+		if (list) {
+			stripped = stripped.slice(list[0].length);
+			context.push("list");
+			continue;
+		}
+		return { text: stripped, context: context.join("/") };
 	}
 }
 
@@ -770,8 +786,9 @@ function referenceDestinationEnd(text: string, start: number): number {
 	let depth = 0;
 	let index = start;
 	for (; index < text.length; index++) {
-		// Space and the ASCII control range both end a bare destination.
-		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		// Space and every ASCII control character end a bare destination.
+		const codePoint = text.codePointAt(index) ?? 0;
+		if (codePoint <= 0x20 || codePoint === 0x7f) break;
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
@@ -786,15 +803,34 @@ function referenceDestinationEnd(text: string, start: number): number {
 // Shape alone does not make a definition: `[label]: some prose` renders as the
 // visible sentence it is. Requiring a well-formed destination keeps a line the
 // reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Where this still diverges from
-// CommonMark it must diverge toward inspecting more, never less — so a
-// destination deferred to the next line reads as prose here rather than as a
-// definition that could skip a block.
-function referenceDefinitionLabel(line: string): string | null {
-	const text = withoutContainerMarkers(line);
+// from exempting its block from inspection. Multiline destinations are
+// collected separately for document-wide reference resolution, but stay as
+// prose here: when block removal cannot afford the complete grammar it must
+// inspect more, never less.
+interface ReferenceDefinition {
+	label: string;
+	context: string;
+	mayContinueTitle: boolean;
+}
+
+function referenceLabelEnd(text: string, start: number): number {
+	for (let index = start + 1; index < text.length; index++) {
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "[") return -1;
+		if (text[index] === "]") {
+			const label = text.slice(start + 1, index);
+			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+		}
+	}
+	return -1;
+}
+
+function referenceDefinition(line: string): ReferenceDefinition | null {
+	const container = containerLine(line);
+	const text = container.text;
 	const start = text.search(/\S/);
 	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	const labelEnd = referenceLabelEnd(text, start);
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
 	const rest = text.slice(labelEnd + 2);
@@ -802,10 +838,20 @@ function referenceDefinitionLabel(line: string): string | null {
 	if (destinationStart < 0) return null;
 	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
 	if (destinationEnd < 0) return null;
-	const trailing = rest.slice(destinationEnd).trim();
-	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+	const rawTrailing = rest.slice(destinationEnd);
+	const trailing = rawTrailing.trim();
+	if (
+		trailing.length > 0 &&
+		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+	) {
+		return null;
+	}
 
-	return text.slice(start + 1, labelEnd);
+	return {
+		label: text.slice(start + 1, labelEnd),
+		context: container.context,
+		mayContinueTitle: trailing.length === 0,
+	};
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace
@@ -818,44 +864,88 @@ function normalizedReferenceLabel(label: string): string {
 // document, so this is collected once per file and handed to every block.
 function referenceLabels(body: string): Set<string> {
 	const labels = new Set<string>();
-	let mayContinueDefinition = false;
-	for (const line of visibleMarkdownLines(body)) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
-			mayContinueDefinition = false;
+	const lines = visibleMarkdownLines(body);
+	let titleContinuationContext: string | null = null;
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
+			titleContinuationContext = null;
 			continue;
 		}
 
-		const label = referenceDefinitionLabel(line);
-		if (label === null) {
-			mayContinueDefinition = false;
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
+			labels.add(normalizedReferenceLabel(definition.label));
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
-		const normalized = normalizedReferenceLabel(label);
-		if (normalized.length > 0) labels.add(normalized);
-		mayContinueDefinition = true;
+		titleContinuationContext = null;
+		const text = container.text;
+		const start = text.search(/\S/);
+		if (start < 0 || start > 3 || text[start] !== "[") continue;
+		const labelEnd = referenceLabelEnd(text, start);
+		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
+		if (text.slice(labelEnd + 2).trim().length > 0) continue;
+
+		const next = lines[index + 1];
+		if (next === undefined) continue;
+		const nextContainer = containerLine(next);
+		if (nextContainer.context !== container.context) continue;
+		const destinationStart = nextContainer.text.search(/\S/);
+		if (destinationStart < 0 || destinationStart > 3) continue;
+		const destinationEnd = referenceDestinationEnd(
+			nextContainer.text,
+			destinationStart,
+		);
+		if (destinationEnd < 0) continue;
+		const rawTrailing = nextContainer.text.slice(destinationEnd);
+		const trailing = rawTrailing.trim();
+		if (
+			trailing.length > 0 &&
+			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		) {
+			continue;
+		}
+		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
+		index++;
 	}
 	return labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
-	let mayContinueDefinition = false;
+	let titleContinuationContext: string | null = null;
 	for (const line of text.split("\n")) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
 			visible.push("");
-			mayContinueDefinition = false;
+			titleContinuationContext = null;
 			continue;
 		}
 
-		if (referenceDefinitionLabel(line) !== null) {
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
 			visible.push("");
-			mayContinueDefinition = true;
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
 		visible.push(line);
-		mayContinueDefinition = false;
+		titleContinuationContext = null;
 	}
 	return visible.join("\n");
 }

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.57";
+export const AIDLC_VERSION = "2.5.58";

--- a/dist/codex/.codex/sensors/aidlc-claim-sources.md
+++ b/dist/codex/.codex/sensors/aidlc-claim-sources.md
@@ -45,6 +45,12 @@ The sensor excludes scaffolding, fenced code, HTML comments, and reviewer-added
 stage's adversarial reviewer judges whether the cited source actually supports
 the claim.
 
+A tag counts when the rendered document shows it as literal text. Bracket pairs
+resolve as Markdown links only against a link reference definition the document
+carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
+`[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
+nothing.
+
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing missing sections, untagged

--- a/dist/codex/.codex/sensors/aidlc-claim-sources.md
+++ b/dist/codex/.codex/sensors/aidlc-claim-sources.md
@@ -49,7 +49,15 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing.
+nothing. A definition is recognised by a well-formed destination, inside a
+block quote or list item as well as at the top level; a line that merely looks
+like one, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim.
+
+Where this reading cannot afford full CommonMark, the divergence must land as a
+false failure and never as a false pass: the sensor may ask for a citation the
+document did not owe, but it must not let unsourced or invisible-tag content
+through.
 
 ## Failure mode
 

--- a/dist/codex/.codex/sensors/aidlc-claim-sources.md
+++ b/dist/codex/.codex/sensors/aidlc-claim-sources.md
@@ -49,10 +49,13 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing. A definition is recognised by a well-formed destination, inside a
-block quote or list item as well as at the top level; a line that merely looks
-like one, such as `[note]: some prose`, is the visible sentence it renders as
-and is inspected like any other claim.
+nothing. A definition requires a non-empty CommonMark label, a well-formed
+destination, and a correctly separated optional title, inside a block quote or
+list item as well as at the top level. Multiline destinations still resolve
+references across the whole document. A line that merely looks like a
+definition, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim; neither an inline title nor a different
+container can hide the following line as title continuation.
 
 Where this reading cannot afford full CommonMark, the divergence must land as a
 false failure and never as a false pass: the sensor may ask for a citation the

--- a/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
@@ -56,6 +56,9 @@ const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
 const REFERENCE_TITLE_RE =
 	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+// The same title, when it trails the destination on the definition's own line.
+const REFERENCE_TITLE_BODY_RE =
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -727,12 +730,35 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+// A definition keeps its meaning inside a block quote or a list item, so the
+// container markers come off before the line is tested.
+function withoutContainerMarkers(line: string): string {
+	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
+	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
+	return stripped;
+}
+
+// Shape alone does not make a definition: `[label]: some prose` renders as the
+// visible sentence it is. Requiring a well-formed destination keeps a line the
+// reader can see out of the definition set, which is what stops such a line
+// from exempting its block from inspection. Where this still diverges from
+// CommonMark it must diverge toward inspecting more, never less — so a
+// destination deferred to the next line reads as prose here rather than as a
+// definition that could skip a block.
 function referenceDefinitionLabel(line: string): string | null {
-	const start = line.search(/\S/);
-	if (start < 0 || start > 3 || line[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(line, start, "[", "]");
-	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
-	return line.slice(start + 1, labelEnd);
+	const text = withoutContainerMarkers(line);
+	const start = text.search(/\S/);
+	if (start < 0 || start > 3 || text[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+
+	const rest = text.slice(labelEnd + 2).trim();
+	const destination = /^\S+/.exec(rest);
+	if (!destination) return null;
+	const trailing = rest.slice(destination[0].length).trim();
+	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+
+	return text.slice(start + 1, labelEnd);
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace

--- a/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
@@ -54,11 +54,13 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
+// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
+// line as prose, so accepting it here would let the line exempt its block.
 const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
 // The same title, when it trails the destination on the definition's own line.
 const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -730,12 +732,55 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
-// A definition keeps its meaning inside a block quote or a list item, so the
-// container markers come off before the line is tested.
+// A definition keeps its meaning inside a block quote or a list item, and the
+// two nest in either order and to any depth. Taking one of each off would read
+// `> - [Q1]: url` and miss the equally valid `- > [Q1]: url`, so the markers
+// come off until the line stops changing. Five or more spaces after a list
+// marker start an indented code block inside the item rather than content, so
+// the marker only comes off for a run of one to four — and four spaces of
+// remaining indentation is an indented code block too, which the caller's
+// column test rejects.
 function withoutContainerMarkers(line: string): string {
-	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
-	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
-	return stripped;
+	let stripped = line;
+	for (;;) {
+		const next = stripped
+			.replace(/^ {0,3}(?:> ?)+/, "")
+			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
+		if (next === stripped) return stripped;
+		stripped = next;
+	}
+}
+
+// CommonMark's link-destination grammar, which is what separates a definition
+// from a line that merely looks like one. A destination is either an
+// angle-bracket run that has to close on the same line and hold no unescaped
+// `<`, or a bare run that ends at the first space or control character and
+// keeps its parentheses balanced. Returns the index just past the destination,
+// or -1 when the text does not carry one.
+function referenceDestinationEnd(text: string, start: number): number {
+	if (text[start] === "<") {
+		for (let index = start + 1; index < text.length; index++) {
+			if (isEscaped(text, index)) continue;
+			if (text[index] === ">") return index + 1;
+			if (text[index] === "<") return -1;
+		}
+		return -1;
+	}
+
+	let depth = 0;
+	let index = start;
+	for (; index < text.length; index++) {
+		// Space and the ASCII control range both end a bare destination.
+		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "(") {
+			depth++;
+		} else if (text[index] === ")") {
+			depth--;
+			if (depth < 0) return -1;
+		}
+	}
+	return depth === 0 && index > start ? index : -1;
 }
 
 // Shape alone does not make a definition: `[label]: some prose` renders as the
@@ -752,10 +797,12 @@ function referenceDefinitionLabel(line: string): string | null {
 	const labelEnd = matchingDelimiter(text, start, "[", "]");
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
-	const rest = text.slice(labelEnd + 2).trim();
-	const destination = /^\S+/.exec(rest);
-	if (!destination) return null;
-	const trailing = rest.slice(destination[0].length).trim();
+	const rest = text.slice(labelEnd + 2);
+	const destinationStart = rest.search(/\S/);
+	if (destinationStart < 0) return null;
+	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
+	if (destinationEnd < 0) return null;
+	const trailing = rest.slice(destinationEnd).trim();
 	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
 
 	return text.slice(start + 1, labelEnd);

--- a/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
@@ -54,13 +54,6 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
-// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
-// line as prose, so accepting it here would let the line exempt its block.
-const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
-// The same title, when it trails the destination on the definition's own line.
-const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -524,18 +517,23 @@ function isTableLine(line: string): boolean {
 }
 
 function isListItem(line: string): boolean {
-	return /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+	return /^\s*(?:[-*+]|\d{1,9}[.)])\s+/.test(line);
 }
 
 function isNoneBlock(text: string): boolean {
 	return /^None\.?$/i.test(text.trim());
 }
 
-function claimBlocks(body: string): {
+function claimBlocks(
+	body: string,
+	definitionLines: ReadonlySet<number> = new Set(),
+): {
 	blocks: ClaimBlock[];
 	hasAssumptionsSection: boolean;
 } {
-	const lines = visibleMarkdownLines(body);
+	const lines = visibleMarkdownLines(body).map((line, index) =>
+		definitionLines.has(index) ? "" : line,
+	);
 	const tableHeaders = new Set<number>();
 	for (let index = 1; index < lines.length; index++) {
 		if (isTableSeparator(lines[index]) && isTableLine(lines[index - 1])) {
@@ -576,8 +574,13 @@ function claimBlocks(body: string): {
 			continue;
 		}
 		if (skipReview) continue;
-		if (line.trim().length === 0 || /^\s*---+\s*$/.test(line)) {
+		if (line.trim().length === 0 || isThematicBreak(line)) {
 			flush();
+			continue;
+		}
+		if (isHtmlBlockStart(line)) {
+			flush();
+			pending.push(line);
 			continue;
 		}
 		if (isTableLine(line)) {
@@ -792,6 +795,7 @@ function referenceDestinationEnd(text: string, start: number): number {
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
+			if (depth > 32) return -1;
 		} else if (text[index] === ")") {
 			depth--;
 			if (depth < 0) return -1;
@@ -800,160 +804,410 @@ function referenceDestinationEnd(text: string, start: number): number {
 	return depth === 0 && index > start ? index : -1;
 }
 
-// Shape alone does not make a definition: `[label]: some prose` renders as the
-// visible sentence it is. Requiring a well-formed destination keeps a line the
-// reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Multiline destinations are
-// collected separately for document-wide reference resolution, but stay as
-// prose here: when block removal cannot afford the complete grammar it must
-// inspect more, never less.
 interface ReferenceDefinition {
 	label: string;
-	context: string;
-	mayContinueTitle: boolean;
+	endLine: number;
 }
 
-function referenceLabelEnd(text: string, start: number): number {
-	for (let index = start + 1; index < text.length; index++) {
-		if (isEscaped(text, index)) continue;
-		if (text[index] === "[") return -1;
-		if (text[index] === "]") {
-			const label = text.slice(start + 1, index);
-			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+interface ReferenceAnalysis {
+	labels: Set<string>;
+	definitionLines: Set<number>;
+}
+
+interface ActiveListContainer {
+	beforeQuotes: number;
+	contentIndent: number;
+	listContext: string;
+}
+
+function contextParts(context: string): string[] {
+	return context.length > 0 ? context.split("/") : [];
+}
+
+function textColumns(text: string): number {
+	let column = 0;
+	for (const char of text) {
+		if (char === "\t") {
+			column += 4 - (column % 4);
+		} else {
+			column++;
 		}
 	}
-	return -1;
+	return column;
 }
 
-function referenceDefinition(line: string): ReferenceDefinition | null {
-	const container = containerLine(line);
-	const text = container.text;
-	const start = text.search(/\S/);
-	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = referenceLabelEnd(text, start);
-	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+function firstContent(text: string): { index: number; column: number } | null {
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		if (text[index] === " ") {
+			column++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			continue;
+		}
+		return { index, column };
+	}
+	return null;
+}
 
-	const rest = text.slice(labelEnd + 2);
-	const destinationStart = rest.search(/\S/);
-	if (destinationStart < 0) return null;
-	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
-	if (destinationEnd < 0) return null;
-	const rawTrailing = rest.slice(destinationEnd);
-	const trailing = rawTrailing.trim();
+function stripIndentColumns(text: string, required: number): string | null {
+	let column = 0;
+	let index = 0;
+	while (column < required && index < text.length) {
+		if (text[index] === " ") {
+			column++;
+			index++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			index++;
+			continue;
+		}
+		return null;
+	}
+	if (column < required) return null;
+	return `${" ".repeat(column - required)}${text.slice(index)}`;
+}
+
+function stripLeadingQuotes(
+	line: string,
+	count: number,
+): { text: string; contexts: string[] } | null {
+	let text = line;
+	const contexts: string[] = [];
+	for (let index = 0; index < count; index++) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) return null;
+		text = text.slice(quote[0].length);
+		contexts.push("quote");
+	}
+	return { text, contexts };
+}
+
+function explicitListContainer(
+	line: string,
+	listItem: number,
+): { line: ContainerLine; active: ActiveListContainer } | null {
+	let text = line;
+	const before: string[] = [];
+	for (;;) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) break;
+		text = text.slice(quote[0].length);
+		before.push("quote");
+	}
+
+	const marker =
+		/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(text);
+	if (!marker) return null;
+	const after = containerLine(text.slice(marker[0].length));
+	const listContext = `list#${listItem}`;
+	return {
+		line: {
+			text: after.text,
+			context: [...before, listContext, ...contextParts(after.context)].join(
+				"/",
+			),
+		},
+		active: {
+			beforeQuotes: before.length,
+			contentIndent: textColumns(marker[0]),
+			listContext,
+		},
+	};
+}
+
+// Container markers on the definition's first line are not repeated on its
+// continuation lines. Preserve the active list item's exact quote/list nesting,
+// indentation columns, and identity so continuations work through block quotes
+// and tabs but never cross into a sibling item.
+function documentContainerLines(lines: string[]): ContainerLine[] {
+	const result: ContainerLine[] = [];
+	let activeList: ActiveListContainer | null = null;
+	let listItem = 0;
+
+	for (const line of lines) {
+		const explicitList = explicitListContainer(line, listItem + 1);
+		if (explicitList) {
+			listItem++;
+			activeList = explicitList.active;
+			result.push(explicitList.line);
+			continue;
+		}
+
+		if (line.trim().length === 0) {
+			result.push({ text: line, context: activeList?.listContext ?? "" });
+			continue;
+		}
+
+		if (activeList) {
+			const quoted = stripLeadingQuotes(line, activeList.beforeQuotes);
+			if (quoted && /^[ \t]*$/.test(quoted.text)) {
+				result.push({
+					text: "",
+					context: [...quoted.contexts, activeList.listContext].join("/"),
+				});
+				continue;
+			}
+			const continuation = quoted
+				? stripIndentColumns(quoted.text, activeList.contentIndent)
+				: null;
+			if (quoted && continuation !== null) {
+				const after = containerLine(continuation);
+				result.push({
+					text: after.text,
+					context: [
+						...quoted.contexts,
+						activeList.listContext,
+						...contextParts(after.context),
+					].join("/"),
+				});
+				continue;
+			}
+		}
+
+		activeList = null;
+		result.push(containerLine(line));
+	}
+
+	return result;
+}
+
+const HTML_BLOCK_TAGS =
+	"address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul";
+const HTML_BLOCK_RE = new RegExp(
+	`^(?:<(?:script|pre|style|textarea)(?:[ \\t>]|$)|<!--|<\\?|<![A-Z]|<!\\[CDATA\\[|<\\/?(?:${HTML_BLOCK_TAGS})(?:[ \\t\\n\\f\\r\\/>]|$))`,
+	"i",
+);
+
+function isThematicBreak(line: string): boolean {
+	const content = firstContent(line);
+	if (content === null || content.column > 3) return false;
+	return /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
+		line.slice(content.index),
+	);
+}
+
+function isHtmlBlockStart(line: string): boolean {
+	const content = firstContent(line);
+	return (
+		content !== null &&
+		content.column <= 3 &&
+		HTML_BLOCK_RE.test(line.slice(content.index))
+	);
+}
+
+function interruptsReferenceContinuation(text: string): boolean {
+	const content = firstContent(text);
+	if (!content) return true;
+	// Once a reference definition has started, CommonMark accepts indented lazy
+	// continuation lines. At that point four columns are content, not a fresh
+	// indented-code block, and block-start tests do not interrupt the definition.
+	if (content.column > 3) return false;
+	const rest = text.slice(content.index);
+	return (
+		/^#{1,6}(?:[ \t]+|$)/.test(rest) ||
+		isThematicBreak(text) ||
+		/^(?:=+|-+)[ \t]*$/.test(rest) ||
+		HTML_BLOCK_RE.test(rest)
+	);
+}
+
+function canContinueReference(
+	lines: ContainerLine[],
+	index: number,
+	context: string,
+): boolean {
+	const line = lines[index];
+	if (!line) return false;
+	const sameOrLazilyElidedContext =
+		line.context === context ||
+			(line.context === "" && context !== "") ||
+			(line.context !== "" && context.startsWith(`${line.context}/`));
+	return (
+		sameOrLazilyElidedContext &&
+		!interruptsReferenceContinuation(line.text)
+	);
+}
+
+function referenceTitleEnd(
+	lines: ContainerLine[],
+	startLine: number,
+	start: number,
+): number | null {
+	const context = lines[startLine].context;
+	const opening = lines[startLine].text[start];
+	if (opening !== '"' && opening !== "'" && opening !== "(") return null;
+	const closing = opening === "(" ? ")" : opening;
+	let lineIndex = startLine;
+	let cursor = start + 1;
+
+	for (;;) {
+		const text = lines[lineIndex].text;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) continue;
+			if (opening === "(" && text[cursor] === "(") return null;
+			if (text[cursor] !== closing) continue;
+			return /^[ \t]*$/.test(text.slice(cursor + 1)) ? lineIndex : null;
+		}
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		lineIndex++;
+		cursor = 0;
+	}
+}
+
+// Parse one complete CommonMark link-reference definition. Lines are consumed
+// only after the label, destination, and optional title are certainly valid;
+// malformed candidates remain visible prose and are inspected fail-closed.
+function referenceDefinitionAt(
+	lines: ContainerLine[],
+	startLine: number,
+): ReferenceDefinition | null {
+	const context = lines[startLine].context;
+	let lineIndex = startLine;
+	let text = lines[lineIndex].text;
+	const first = firstContent(text);
+	if (!first || first.column > 3 || text[first.index] !== "[") return null;
+	const start = first.index;
+
+	let cursor = start + 1;
+	let label = "";
+	for (;;) {
+		let closed = false;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) {
+				label += text[cursor];
+				continue;
+			}
+			if (text[cursor] === "[") return null;
+			if (text[cursor] === "]") {
+				closed = true;
+				break;
+			}
+			label += text[cursor];
+		}
+		if (closed) break;
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		label += "\n";
+		lineIndex++;
+		text = next.text;
+		cursor = 0;
+	}
+
 	if (
-		trailing.length > 0 &&
-		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		text[cursor + 1] !== ":" ||
+		!/[^ \t\n\r]/.test(label) ||
+		Array.from(label).length > 999
 	) {
 		return null;
 	}
 
-	return {
-		label: text.slice(start + 1, labelEnd),
-		context: container.context,
-		mayContinueTitle: trailing.length === 0,
-	};
-}
-
-// CommonMark matches link labels case-insensitively with runs of whitespace
-// collapsed to a single space.
-function normalizedReferenceLabel(label: string): string {
-	return label.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-// The labels a document defines. A reference link resolves against the whole
-// document, so this is collected once per file and handed to every block.
-function referenceLabels(body: string): Set<string> {
-	const labels = new Set<string>();
-	const lines = visibleMarkdownLines(body);
-	let titleContinuationContext: string | null = null;
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index];
-		const container = containerLine(line);
+	let destinationLine = lineIndex;
+	let destinationOffset = cursor + 2;
+	let destinationText = text.slice(destinationOffset);
+	let destination = firstContent(destinationText);
+	if (!destination) {
+		const next = lines[destinationLine + 1];
 		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
+			!next ||
+			!canContinueReference(lines, destinationLine + 1, context)
 		) {
-			titleContinuationContext = null;
-			continue;
+			return null;
 		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			labels.add(normalizedReferenceLabel(definition.label));
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		titleContinuationContext = null;
-		const text = container.text;
-		const start = text.search(/\S/);
-		if (start < 0 || start > 3 || text[start] !== "[") continue;
-		const labelEnd = referenceLabelEnd(text, start);
-		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
-		if (text.slice(labelEnd + 2).trim().length > 0) continue;
-
-		const next = lines[index + 1];
-		if (next === undefined) continue;
-		const nextContainer = containerLine(next);
-		if (nextContainer.context !== container.context) continue;
-		const destinationStart = nextContainer.text.search(/\S/);
-		if (destinationStart < 0 || destinationStart > 3) continue;
-		const destinationEnd = referenceDestinationEnd(
-			nextContainer.text,
-			destinationStart,
-		);
-		if (destinationEnd < 0) continue;
-		const rawTrailing = nextContainer.text.slice(destinationEnd);
-		const trailing = rawTrailing.trim();
-		if (
-			trailing.length > 0 &&
-			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
-		) {
-			continue;
-		}
-		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
-		index++;
+		destinationLine++;
+		destinationOffset = 0;
+		destinationText = next.text;
+		destination = firstContent(destinationText);
+		if (!destination) return null;
 	}
-	return labels;
+	const destinationStart = destination.index;
+
+	const destinationEnd = referenceDestinationEnd(
+		destinationText,
+		destinationStart,
+	);
+	if (destinationEnd < 0) return null;
+
+	const rawTrailing = destinationText.slice(destinationEnd);
+	if (/[^ \t]/.test(rawTrailing)) {
+		if (!/^[ \t]+/.test(rawTrailing)) return null;
+		const trailing = firstContent(rawTrailing);
+		if (!trailing) return null;
+		const titleStart =
+			destinationOffset + destinationEnd + trailing.index;
+		const titleEnd = referenceTitleEnd(lines, destinationLine, titleStart);
+		return titleEnd === null ? null : { label, endLine: titleEnd };
+	}
+
+	const possibleTitle = lines[destinationLine + 1];
+	if (
+		possibleTitle &&
+		canContinueReference(lines, destinationLine + 1, context)
+	) {
+		const title = firstContent(possibleTitle.text);
+		if (
+			title &&
+			['"', "'", "("].includes(possibleTitle.text[title.index])
+		) {
+			const titleEnd = referenceTitleEnd(
+				lines,
+				destinationLine + 1,
+				title.index,
+			);
+			if (titleEnd !== null) return { label, endLine: titleEnd };
+		}
+	}
+
+	return { label, endLine: destinationLine };
+}
+
+// CommonMark label matching uses Unicode case folding after whitespace
+// normalization. The lower-then-upper sequence matches markdown-it and folds
+// variants such as `ss`, `ß`, and `ẞ` to the same key.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase().toUpperCase();
+}
+
+function referenceAnalysis(body: string): ReferenceAnalysis {
+	const visibleLines = visibleMarkdownLines(body);
+	const lines = documentContainerLines(visibleLines);
+	const labels = new Set<string>();
+	const definitionLines = new Set<number>();
+
+	for (let index = 0; index < lines.length; index++) {
+		const definition = referenceDefinitionAt(lines, index);
+		if (!definition) continue;
+		labels.add(normalizedReferenceLabel(definition.label));
+		for (let line = index; line <= definition.endLine; line++) {
+			definitionLines.add(line);
+		}
+		index = definition.endLine;
+	}
+
+	return { labels, definitionLines };
+}
+
+// A reference resolves against definitions anywhere in the document.
+function referenceLabels(body: string): Set<string> {
+	return referenceAnalysis(body).labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
-	const visible: string[] = [];
-	let titleContinuationContext: string | null = null;
-	for (const line of text.split("\n")) {
-		const container = containerLine(line);
-		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
-		) {
-			visible.push("");
-			titleContinuationContext = null;
-			continue;
-		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			visible.push("");
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		visible.push(line);
-		titleContinuationContext = null;
-	}
-	return visible.join("\n");
-}
-
-// A block that carries nothing but link reference definitions renders as
-// nothing at all, so it states no claim to ground.
-function isReferenceDefinitionBlock(text: string): boolean {
-	return withoutReferenceDefinitions(text).trim().length === 0;
+	const analysis = referenceAnalysis(text);
+	return visibleMarkdownLines(text)
+		.map((line, index) => (analysis.definitionLines.has(index) ? "" : line))
+		.join("\n");
 }
 
 function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
@@ -1024,7 +1278,7 @@ function sourceTags(text: string, labels: Set<string>): string[] {
 
 function normalizedAssumption(text: string): string {
 	return text
-		.replace(/^\s*(?:[-*+]|\d+\.)\s+/, "")
+		.replace(/^\s*(?:[-*+]|\d{1,9}[.)])\s+/, "")
 		.replace(SOURCE_TAG_RE, "")
 		.replace(/\s+/g, " ")
 		.trim()
@@ -1046,17 +1300,17 @@ function inspectDeliverable(
 		};
 	}
 
-	const parsed = claimBlocks(body);
+	const references = referenceAnalysis(body);
+	const parsed = claimBlocks(body, references.definitionLines);
 	if (!parsed.hasAssumptionsSection) {
 		findings.push(
 			`${basename(path)}: missing ## ${ASSUMPTIONS_HEADING}`,
 		);
 	}
 
-	const labels = referenceLabels(body);
+	const labels = references.labels;
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
-		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
 		const tags = sourceTags(block.text, labels);
 

--- a/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
@@ -389,6 +389,7 @@ function parseSourceUniverse(
 	}
 
 	const lines = visibleMarkdownLines(body);
+	const labels = referenceLabels(body);
 	const authority = loadRecordAuthority(stageDir);
 	findings.push(...authority.findings);
 	const registered = new Set<string>();
@@ -493,7 +494,7 @@ function parseSourceUniverse(
 	const acceptedAssumptions = new Set(
 		confirmation
 			.filter((line) => isListItem(line))
-			.filter((line) => sourceTags(line).includes("assumption"))
+			.filter((line) => sourceTags(line, labels).includes("assumption"))
 			.map(normalizedAssumption)
 			.filter((entry) => entry.length > 0),
 	);
@@ -726,6 +727,44 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+function referenceDefinitionLabel(line: string): string | null {
+	const start = line.search(/\S/);
+	if (start < 0 || start > 3 || line[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(line, start, "[", "]");
+	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
+	return line.slice(start + 1, labelEnd);
+}
+
+// CommonMark matches link labels case-insensitively with runs of whitespace
+// collapsed to a single space.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+// The labels a document defines. A reference link resolves against the whole
+// document, so this is collected once per file and handed to every block.
+function referenceLabels(body: string): Set<string> {
+	const labels = new Set<string>();
+	let mayContinueDefinition = false;
+	for (const line of visibleMarkdownLines(body)) {
+		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const label = referenceDefinitionLabel(line);
+		if (label === null) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const normalized = normalizedReferenceLabel(label);
+		if (normalized.length > 0) labels.add(normalized);
+		mayContinueDefinition = true;
+	}
+	return labels;
+}
+
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
 	let mayContinueDefinition = false;
@@ -736,14 +775,10 @@ function withoutReferenceDefinitions(text: string): string {
 			continue;
 		}
 
-		const start = line.search(/\S/);
-		if (start >= 0 && start <= 3 && line[start] === "[") {
-			const labelEnd = matchingDelimiter(line, start, "[", "]");
-			if (labelEnd >= 0 && line[labelEnd + 1] === ":") {
-				visible.push("");
-				mayContinueDefinition = true;
-				continue;
-			}
+		if (referenceDefinitionLabel(line) !== null) {
+			visible.push("");
+			mayContinueDefinition = true;
+			continue;
 		}
 
 		visible.push(line);
@@ -752,7 +787,13 @@ function withoutReferenceDefinitions(text: string): string {
 	return visible.join("\n");
 }
 
-function visibleMarkdownLinkText(text: string): string {
+// A block that carries nothing but link reference definitions renders as
+// nothing at all, so it states no claim to ground.
+function isReferenceDefinitionBlock(text: string): boolean {
+	return withoutReferenceDefinitions(text).trim().length === 0;
+}
+
+function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
 	let visible = "";
 	for (let index = 0; index < text.length; index++) {
 		const image =
@@ -772,6 +813,7 @@ function visibleMarkdownLinkText(text: string): string {
 			continue;
 		}
 
+		const label = text.slice(labelStart + 1, labelEnd);
 		let syntaxEnd = labelEnd;
 		if (text[labelEnd + 1] === "(") {
 			const destinationEnd = matchingDelimiter(text, labelEnd + 1, "(", ")");
@@ -786,8 +828,18 @@ function visibleMarkdownLinkText(text: string): string {
 				visible += text[index];
 				continue;
 			}
+			// Full `[text][label]` and collapsed `[label][]` references. An empty
+			// second pair points back at the first, and neither is a link unless
+			// the document defines the label it names.
+			const reference = text.slice(labelEnd + 2, referenceEnd);
+			const named = reference.trim().length > 0 ? reference : label;
+			if (!labels.has(normalizedReferenceLabel(named))) {
+				visible += text[index];
+				continue;
+			}
 			syntaxEnd = referenceEnd;
-		} else if (!image) {
+		} else if (!labels.has(normalizedReferenceLabel(label))) {
+			// Shortcut `[label]` reference: also a link only once defined.
 			visible += text[index];
 			continue;
 		}
@@ -798,10 +850,11 @@ function visibleMarkdownLinkText(text: string): string {
 	return visible;
 }
 
-function sourceTags(text: string): string[] {
+function sourceTags(text: string, labels: Set<string>): string[] {
 	const withoutInlineCode = text.replace(/(`+)([\s\S]*?)\1/g, "");
 	const visibleText = visibleMarkdownLinkText(
 		withoutReferenceDefinitions(visibleHtmlText(withoutInlineCode)),
+		labels,
 	);
 	return [...visibleText.matchAll(SOURCE_TAG_RE)].map((match) => match[1]);
 }
@@ -837,10 +890,12 @@ function inspectDeliverable(
 		);
 	}
 
+	const labels = referenceLabels(body);
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
+		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
-		const tags = sourceTags(block.text);
+		const tags = sourceTags(block.text, labels);
 
 		if (block.inAssumptions) {
 			if (isNoneBlock(block.text)) continue;

--- a/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-claim-sources.ts
@@ -550,7 +550,7 @@ function claimBlocks(body: string): {
 	let pending: string[] = [];
 
 	const flush = (): void => {
-		const text = pending.join("\n").trim();
+		const text = pending.join("\n").trimEnd();
 		if (text.length > 0) {
 			blocks.push({
 				section,
@@ -593,10 +593,10 @@ function claimBlocks(body: string): {
 		}
 		if (isListItem(line)) {
 			flush();
-			pending.push(line.trim());
+			pending.push(line);
 			continue;
 		}
-		pending.push(line.trim());
+		pending.push(line);
 	}
 	flush();
 
@@ -740,14 +740,30 @@ function visibleHtmlText(text: string): string {
 // the marker only comes off for a run of one to four — and four spaces of
 // remaining indentation is an indented code block too, which the caller's
 // column test rejects.
-function withoutContainerMarkers(line: string): string {
+interface ContainerLine {
+	text: string;
+	context: string;
+}
+
+function containerLine(line: string): ContainerLine {
 	let stripped = line;
+	const context: string[] = [];
 	for (;;) {
-		const next = stripped
-			.replace(/^ {0,3}(?:> ?)+/, "")
-			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
-		if (next === stripped) return stripped;
-		stripped = next;
+		const quote = /^ {0,3}> ?/.exec(stripped);
+		if (quote) {
+			stripped = stripped.slice(quote[0].length);
+			context.push("quote");
+			continue;
+		}
+		const list = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(
+			stripped,
+		);
+		if (list) {
+			stripped = stripped.slice(list[0].length);
+			context.push("list");
+			continue;
+		}
+		return { text: stripped, context: context.join("/") };
 	}
 }
 
@@ -770,8 +786,9 @@ function referenceDestinationEnd(text: string, start: number): number {
 	let depth = 0;
 	let index = start;
 	for (; index < text.length; index++) {
-		// Space and the ASCII control range both end a bare destination.
-		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		// Space and every ASCII control character end a bare destination.
+		const codePoint = text.codePointAt(index) ?? 0;
+		if (codePoint <= 0x20 || codePoint === 0x7f) break;
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
@@ -786,15 +803,34 @@ function referenceDestinationEnd(text: string, start: number): number {
 // Shape alone does not make a definition: `[label]: some prose` renders as the
 // visible sentence it is. Requiring a well-formed destination keeps a line the
 // reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Where this still diverges from
-// CommonMark it must diverge toward inspecting more, never less — so a
-// destination deferred to the next line reads as prose here rather than as a
-// definition that could skip a block.
-function referenceDefinitionLabel(line: string): string | null {
-	const text = withoutContainerMarkers(line);
+// from exempting its block from inspection. Multiline destinations are
+// collected separately for document-wide reference resolution, but stay as
+// prose here: when block removal cannot afford the complete grammar it must
+// inspect more, never less.
+interface ReferenceDefinition {
+	label: string;
+	context: string;
+	mayContinueTitle: boolean;
+}
+
+function referenceLabelEnd(text: string, start: number): number {
+	for (let index = start + 1; index < text.length; index++) {
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "[") return -1;
+		if (text[index] === "]") {
+			const label = text.slice(start + 1, index);
+			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+		}
+	}
+	return -1;
+}
+
+function referenceDefinition(line: string): ReferenceDefinition | null {
+	const container = containerLine(line);
+	const text = container.text;
 	const start = text.search(/\S/);
 	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	const labelEnd = referenceLabelEnd(text, start);
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
 	const rest = text.slice(labelEnd + 2);
@@ -802,10 +838,20 @@ function referenceDefinitionLabel(line: string): string | null {
 	if (destinationStart < 0) return null;
 	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
 	if (destinationEnd < 0) return null;
-	const trailing = rest.slice(destinationEnd).trim();
-	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+	const rawTrailing = rest.slice(destinationEnd);
+	const trailing = rawTrailing.trim();
+	if (
+		trailing.length > 0 &&
+		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+	) {
+		return null;
+	}
 
-	return text.slice(start + 1, labelEnd);
+	return {
+		label: text.slice(start + 1, labelEnd),
+		context: container.context,
+		mayContinueTitle: trailing.length === 0,
+	};
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace
@@ -818,44 +864,88 @@ function normalizedReferenceLabel(label: string): string {
 // document, so this is collected once per file and handed to every block.
 function referenceLabels(body: string): Set<string> {
 	const labels = new Set<string>();
-	let mayContinueDefinition = false;
-	for (const line of visibleMarkdownLines(body)) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
-			mayContinueDefinition = false;
+	const lines = visibleMarkdownLines(body);
+	let titleContinuationContext: string | null = null;
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
+			titleContinuationContext = null;
 			continue;
 		}
 
-		const label = referenceDefinitionLabel(line);
-		if (label === null) {
-			mayContinueDefinition = false;
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
+			labels.add(normalizedReferenceLabel(definition.label));
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
-		const normalized = normalizedReferenceLabel(label);
-		if (normalized.length > 0) labels.add(normalized);
-		mayContinueDefinition = true;
+		titleContinuationContext = null;
+		const text = container.text;
+		const start = text.search(/\S/);
+		if (start < 0 || start > 3 || text[start] !== "[") continue;
+		const labelEnd = referenceLabelEnd(text, start);
+		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
+		if (text.slice(labelEnd + 2).trim().length > 0) continue;
+
+		const next = lines[index + 1];
+		if (next === undefined) continue;
+		const nextContainer = containerLine(next);
+		if (nextContainer.context !== container.context) continue;
+		const destinationStart = nextContainer.text.search(/\S/);
+		if (destinationStart < 0 || destinationStart > 3) continue;
+		const destinationEnd = referenceDestinationEnd(
+			nextContainer.text,
+			destinationStart,
+		);
+		if (destinationEnd < 0) continue;
+		const rawTrailing = nextContainer.text.slice(destinationEnd);
+		const trailing = rawTrailing.trim();
+		if (
+			trailing.length > 0 &&
+			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		) {
+			continue;
+		}
+		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
+		index++;
 	}
 	return labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
-	let mayContinueDefinition = false;
+	let titleContinuationContext: string | null = null;
 	for (const line of text.split("\n")) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
 			visible.push("");
-			mayContinueDefinition = false;
+			titleContinuationContext = null;
 			continue;
 		}
 
-		if (referenceDefinitionLabel(line) !== null) {
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
 			visible.push("");
-			mayContinueDefinition = true;
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
 		visible.push(line);
-		mayContinueDefinition = false;
+		titleContinuationContext = null;
 	}
 	return visible.join("\n");
 }

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.57";
+export const AIDLC_VERSION = "2.5.58";

--- a/dist/kiro-ide/.kiro/sensors/aidlc-claim-sources.md
+++ b/dist/kiro-ide/.kiro/sensors/aidlc-claim-sources.md
@@ -45,6 +45,12 @@ The sensor excludes scaffolding, fenced code, HTML comments, and reviewer-added
 stage's adversarial reviewer judges whether the cited source actually supports
 the claim.
 
+A tag counts when the rendered document shows it as literal text. Bracket pairs
+resolve as Markdown links only against a link reference definition the document
+carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
+`[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
+nothing.
+
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing missing sections, untagged

--- a/dist/kiro-ide/.kiro/sensors/aidlc-claim-sources.md
+++ b/dist/kiro-ide/.kiro/sensors/aidlc-claim-sources.md
@@ -49,7 +49,15 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing.
+nothing. A definition is recognised by a well-formed destination, inside a
+block quote or list item as well as at the top level; a line that merely looks
+like one, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim.
+
+Where this reading cannot afford full CommonMark, the divergence must land as a
+false failure and never as a false pass: the sensor may ask for a citation the
+document did not owe, but it must not let unsourced or invisible-tag content
+through.
 
 ## Failure mode
 

--- a/dist/kiro-ide/.kiro/sensors/aidlc-claim-sources.md
+++ b/dist/kiro-ide/.kiro/sensors/aidlc-claim-sources.md
@@ -49,10 +49,13 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing. A definition is recognised by a well-formed destination, inside a
-block quote or list item as well as at the top level; a line that merely looks
-like one, such as `[note]: some prose`, is the visible sentence it renders as
-and is inspected like any other claim.
+nothing. A definition requires a non-empty CommonMark label, a well-formed
+destination, and a correctly separated optional title, inside a block quote or
+list item as well as at the top level. Multiline destinations still resolve
+references across the whole document. A line that merely looks like a
+definition, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim; neither an inline title nor a different
+container can hide the following line as title continuation.
 
 Where this reading cannot afford full CommonMark, the divergence must land as a
 false failure and never as a false pass: the sensor may ask for a citation the

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -56,6 +56,9 @@ const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
 const REFERENCE_TITLE_RE =
 	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+// The same title, when it trails the destination on the definition's own line.
+const REFERENCE_TITLE_BODY_RE =
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -727,12 +730,35 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+// A definition keeps its meaning inside a block quote or a list item, so the
+// container markers come off before the line is tested.
+function withoutContainerMarkers(line: string): string {
+	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
+	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
+	return stripped;
+}
+
+// Shape alone does not make a definition: `[label]: some prose` renders as the
+// visible sentence it is. Requiring a well-formed destination keeps a line the
+// reader can see out of the definition set, which is what stops such a line
+// from exempting its block from inspection. Where this still diverges from
+// CommonMark it must diverge toward inspecting more, never less — so a
+// destination deferred to the next line reads as prose here rather than as a
+// definition that could skip a block.
 function referenceDefinitionLabel(line: string): string | null {
-	const start = line.search(/\S/);
-	if (start < 0 || start > 3 || line[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(line, start, "[", "]");
-	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
-	return line.slice(start + 1, labelEnd);
+	const text = withoutContainerMarkers(line);
+	const start = text.search(/\S/);
+	if (start < 0 || start > 3 || text[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+
+	const rest = text.slice(labelEnd + 2).trim();
+	const destination = /^\S+/.exec(rest);
+	if (!destination) return null;
+	const trailing = rest.slice(destination[0].length).trim();
+	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+
+	return text.slice(start + 1, labelEnd);
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -54,11 +54,13 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
+// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
+// line as prose, so accepting it here would let the line exempt its block.
 const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
 // The same title, when it trails the destination on the definition's own line.
 const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -730,12 +732,55 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
-// A definition keeps its meaning inside a block quote or a list item, so the
-// container markers come off before the line is tested.
+// A definition keeps its meaning inside a block quote or a list item, and the
+// two nest in either order and to any depth. Taking one of each off would read
+// `> - [Q1]: url` and miss the equally valid `- > [Q1]: url`, so the markers
+// come off until the line stops changing. Five or more spaces after a list
+// marker start an indented code block inside the item rather than content, so
+// the marker only comes off for a run of one to four — and four spaces of
+// remaining indentation is an indented code block too, which the caller's
+// column test rejects.
 function withoutContainerMarkers(line: string): string {
-	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
-	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
-	return stripped;
+	let stripped = line;
+	for (;;) {
+		const next = stripped
+			.replace(/^ {0,3}(?:> ?)+/, "")
+			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
+		if (next === stripped) return stripped;
+		stripped = next;
+	}
+}
+
+// CommonMark's link-destination grammar, which is what separates a definition
+// from a line that merely looks like one. A destination is either an
+// angle-bracket run that has to close on the same line and hold no unescaped
+// `<`, or a bare run that ends at the first space or control character and
+// keeps its parentheses balanced. Returns the index just past the destination,
+// or -1 when the text does not carry one.
+function referenceDestinationEnd(text: string, start: number): number {
+	if (text[start] === "<") {
+		for (let index = start + 1; index < text.length; index++) {
+			if (isEscaped(text, index)) continue;
+			if (text[index] === ">") return index + 1;
+			if (text[index] === "<") return -1;
+		}
+		return -1;
+	}
+
+	let depth = 0;
+	let index = start;
+	for (; index < text.length; index++) {
+		// Space and the ASCII control range both end a bare destination.
+		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "(") {
+			depth++;
+		} else if (text[index] === ")") {
+			depth--;
+			if (depth < 0) return -1;
+		}
+	}
+	return depth === 0 && index > start ? index : -1;
 }
 
 // Shape alone does not make a definition: `[label]: some prose` renders as the
@@ -752,10 +797,12 @@ function referenceDefinitionLabel(line: string): string | null {
 	const labelEnd = matchingDelimiter(text, start, "[", "]");
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
-	const rest = text.slice(labelEnd + 2).trim();
-	const destination = /^\S+/.exec(rest);
-	if (!destination) return null;
-	const trailing = rest.slice(destination[0].length).trim();
+	const rest = text.slice(labelEnd + 2);
+	const destinationStart = rest.search(/\S/);
+	if (destinationStart < 0) return null;
+	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
+	if (destinationEnd < 0) return null;
+	const trailing = rest.slice(destinationEnd).trim();
 	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
 
 	return text.slice(start + 1, labelEnd);

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -54,13 +54,6 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
-// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
-// line as prose, so accepting it here would let the line exempt its block.
-const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
-// The same title, when it trails the destination on the definition's own line.
-const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -524,18 +517,23 @@ function isTableLine(line: string): boolean {
 }
 
 function isListItem(line: string): boolean {
-	return /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+	return /^\s*(?:[-*+]|\d{1,9}[.)])\s+/.test(line);
 }
 
 function isNoneBlock(text: string): boolean {
 	return /^None\.?$/i.test(text.trim());
 }
 
-function claimBlocks(body: string): {
+function claimBlocks(
+	body: string,
+	definitionLines: ReadonlySet<number> = new Set(),
+): {
 	blocks: ClaimBlock[];
 	hasAssumptionsSection: boolean;
 } {
-	const lines = visibleMarkdownLines(body);
+	const lines = visibleMarkdownLines(body).map((line, index) =>
+		definitionLines.has(index) ? "" : line,
+	);
 	const tableHeaders = new Set<number>();
 	for (let index = 1; index < lines.length; index++) {
 		if (isTableSeparator(lines[index]) && isTableLine(lines[index - 1])) {
@@ -576,8 +574,13 @@ function claimBlocks(body: string): {
 			continue;
 		}
 		if (skipReview) continue;
-		if (line.trim().length === 0 || /^\s*---+\s*$/.test(line)) {
+		if (line.trim().length === 0 || isThematicBreak(line)) {
 			flush();
+			continue;
+		}
+		if (isHtmlBlockStart(line)) {
+			flush();
+			pending.push(line);
 			continue;
 		}
 		if (isTableLine(line)) {
@@ -792,6 +795,7 @@ function referenceDestinationEnd(text: string, start: number): number {
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
+			if (depth > 32) return -1;
 		} else if (text[index] === ")") {
 			depth--;
 			if (depth < 0) return -1;
@@ -800,160 +804,410 @@ function referenceDestinationEnd(text: string, start: number): number {
 	return depth === 0 && index > start ? index : -1;
 }
 
-// Shape alone does not make a definition: `[label]: some prose` renders as the
-// visible sentence it is. Requiring a well-formed destination keeps a line the
-// reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Multiline destinations are
-// collected separately for document-wide reference resolution, but stay as
-// prose here: when block removal cannot afford the complete grammar it must
-// inspect more, never less.
 interface ReferenceDefinition {
 	label: string;
-	context: string;
-	mayContinueTitle: boolean;
+	endLine: number;
 }
 
-function referenceLabelEnd(text: string, start: number): number {
-	for (let index = start + 1; index < text.length; index++) {
-		if (isEscaped(text, index)) continue;
-		if (text[index] === "[") return -1;
-		if (text[index] === "]") {
-			const label = text.slice(start + 1, index);
-			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+interface ReferenceAnalysis {
+	labels: Set<string>;
+	definitionLines: Set<number>;
+}
+
+interface ActiveListContainer {
+	beforeQuotes: number;
+	contentIndent: number;
+	listContext: string;
+}
+
+function contextParts(context: string): string[] {
+	return context.length > 0 ? context.split("/") : [];
+}
+
+function textColumns(text: string): number {
+	let column = 0;
+	for (const char of text) {
+		if (char === "\t") {
+			column += 4 - (column % 4);
+		} else {
+			column++;
 		}
 	}
-	return -1;
+	return column;
 }
 
-function referenceDefinition(line: string): ReferenceDefinition | null {
-	const container = containerLine(line);
-	const text = container.text;
-	const start = text.search(/\S/);
-	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = referenceLabelEnd(text, start);
-	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+function firstContent(text: string): { index: number; column: number } | null {
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		if (text[index] === " ") {
+			column++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			continue;
+		}
+		return { index, column };
+	}
+	return null;
+}
 
-	const rest = text.slice(labelEnd + 2);
-	const destinationStart = rest.search(/\S/);
-	if (destinationStart < 0) return null;
-	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
-	if (destinationEnd < 0) return null;
-	const rawTrailing = rest.slice(destinationEnd);
-	const trailing = rawTrailing.trim();
+function stripIndentColumns(text: string, required: number): string | null {
+	let column = 0;
+	let index = 0;
+	while (column < required && index < text.length) {
+		if (text[index] === " ") {
+			column++;
+			index++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			index++;
+			continue;
+		}
+		return null;
+	}
+	if (column < required) return null;
+	return `${" ".repeat(column - required)}${text.slice(index)}`;
+}
+
+function stripLeadingQuotes(
+	line: string,
+	count: number,
+): { text: string; contexts: string[] } | null {
+	let text = line;
+	const contexts: string[] = [];
+	for (let index = 0; index < count; index++) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) return null;
+		text = text.slice(quote[0].length);
+		contexts.push("quote");
+	}
+	return { text, contexts };
+}
+
+function explicitListContainer(
+	line: string,
+	listItem: number,
+): { line: ContainerLine; active: ActiveListContainer } | null {
+	let text = line;
+	const before: string[] = [];
+	for (;;) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) break;
+		text = text.slice(quote[0].length);
+		before.push("quote");
+	}
+
+	const marker =
+		/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(text);
+	if (!marker) return null;
+	const after = containerLine(text.slice(marker[0].length));
+	const listContext = `list#${listItem}`;
+	return {
+		line: {
+			text: after.text,
+			context: [...before, listContext, ...contextParts(after.context)].join(
+				"/",
+			),
+		},
+		active: {
+			beforeQuotes: before.length,
+			contentIndent: textColumns(marker[0]),
+			listContext,
+		},
+	};
+}
+
+// Container markers on the definition's first line are not repeated on its
+// continuation lines. Preserve the active list item's exact quote/list nesting,
+// indentation columns, and identity so continuations work through block quotes
+// and tabs but never cross into a sibling item.
+function documentContainerLines(lines: string[]): ContainerLine[] {
+	const result: ContainerLine[] = [];
+	let activeList: ActiveListContainer | null = null;
+	let listItem = 0;
+
+	for (const line of lines) {
+		const explicitList = explicitListContainer(line, listItem + 1);
+		if (explicitList) {
+			listItem++;
+			activeList = explicitList.active;
+			result.push(explicitList.line);
+			continue;
+		}
+
+		if (line.trim().length === 0) {
+			result.push({ text: line, context: activeList?.listContext ?? "" });
+			continue;
+		}
+
+		if (activeList) {
+			const quoted = stripLeadingQuotes(line, activeList.beforeQuotes);
+			if (quoted && /^[ \t]*$/.test(quoted.text)) {
+				result.push({
+					text: "",
+					context: [...quoted.contexts, activeList.listContext].join("/"),
+				});
+				continue;
+			}
+			const continuation = quoted
+				? stripIndentColumns(quoted.text, activeList.contentIndent)
+				: null;
+			if (quoted && continuation !== null) {
+				const after = containerLine(continuation);
+				result.push({
+					text: after.text,
+					context: [
+						...quoted.contexts,
+						activeList.listContext,
+						...contextParts(after.context),
+					].join("/"),
+				});
+				continue;
+			}
+		}
+
+		activeList = null;
+		result.push(containerLine(line));
+	}
+
+	return result;
+}
+
+const HTML_BLOCK_TAGS =
+	"address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul";
+const HTML_BLOCK_RE = new RegExp(
+	`^(?:<(?:script|pre|style|textarea)(?:[ \\t>]|$)|<!--|<\\?|<![A-Z]|<!\\[CDATA\\[|<\\/?(?:${HTML_BLOCK_TAGS})(?:[ \\t\\n\\f\\r\\/>]|$))`,
+	"i",
+);
+
+function isThematicBreak(line: string): boolean {
+	const content = firstContent(line);
+	if (content === null || content.column > 3) return false;
+	return /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
+		line.slice(content.index),
+	);
+}
+
+function isHtmlBlockStart(line: string): boolean {
+	const content = firstContent(line);
+	return (
+		content !== null &&
+		content.column <= 3 &&
+		HTML_BLOCK_RE.test(line.slice(content.index))
+	);
+}
+
+function interruptsReferenceContinuation(text: string): boolean {
+	const content = firstContent(text);
+	if (!content) return true;
+	// Once a reference definition has started, CommonMark accepts indented lazy
+	// continuation lines. At that point four columns are content, not a fresh
+	// indented-code block, and block-start tests do not interrupt the definition.
+	if (content.column > 3) return false;
+	const rest = text.slice(content.index);
+	return (
+		/^#{1,6}(?:[ \t]+|$)/.test(rest) ||
+		isThematicBreak(text) ||
+		/^(?:=+|-+)[ \t]*$/.test(rest) ||
+		HTML_BLOCK_RE.test(rest)
+	);
+}
+
+function canContinueReference(
+	lines: ContainerLine[],
+	index: number,
+	context: string,
+): boolean {
+	const line = lines[index];
+	if (!line) return false;
+	const sameOrLazilyElidedContext =
+		line.context === context ||
+			(line.context === "" && context !== "") ||
+			(line.context !== "" && context.startsWith(`${line.context}/`));
+	return (
+		sameOrLazilyElidedContext &&
+		!interruptsReferenceContinuation(line.text)
+	);
+}
+
+function referenceTitleEnd(
+	lines: ContainerLine[],
+	startLine: number,
+	start: number,
+): number | null {
+	const context = lines[startLine].context;
+	const opening = lines[startLine].text[start];
+	if (opening !== '"' && opening !== "'" && opening !== "(") return null;
+	const closing = opening === "(" ? ")" : opening;
+	let lineIndex = startLine;
+	let cursor = start + 1;
+
+	for (;;) {
+		const text = lines[lineIndex].text;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) continue;
+			if (opening === "(" && text[cursor] === "(") return null;
+			if (text[cursor] !== closing) continue;
+			return /^[ \t]*$/.test(text.slice(cursor + 1)) ? lineIndex : null;
+		}
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		lineIndex++;
+		cursor = 0;
+	}
+}
+
+// Parse one complete CommonMark link-reference definition. Lines are consumed
+// only after the label, destination, and optional title are certainly valid;
+// malformed candidates remain visible prose and are inspected fail-closed.
+function referenceDefinitionAt(
+	lines: ContainerLine[],
+	startLine: number,
+): ReferenceDefinition | null {
+	const context = lines[startLine].context;
+	let lineIndex = startLine;
+	let text = lines[lineIndex].text;
+	const first = firstContent(text);
+	if (!first || first.column > 3 || text[first.index] !== "[") return null;
+	const start = first.index;
+
+	let cursor = start + 1;
+	let label = "";
+	for (;;) {
+		let closed = false;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) {
+				label += text[cursor];
+				continue;
+			}
+			if (text[cursor] === "[") return null;
+			if (text[cursor] === "]") {
+				closed = true;
+				break;
+			}
+			label += text[cursor];
+		}
+		if (closed) break;
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		label += "\n";
+		lineIndex++;
+		text = next.text;
+		cursor = 0;
+	}
+
 	if (
-		trailing.length > 0 &&
-		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		text[cursor + 1] !== ":" ||
+		!/[^ \t\n\r]/.test(label) ||
+		Array.from(label).length > 999
 	) {
 		return null;
 	}
 
-	return {
-		label: text.slice(start + 1, labelEnd),
-		context: container.context,
-		mayContinueTitle: trailing.length === 0,
-	};
-}
-
-// CommonMark matches link labels case-insensitively with runs of whitespace
-// collapsed to a single space.
-function normalizedReferenceLabel(label: string): string {
-	return label.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-// The labels a document defines. A reference link resolves against the whole
-// document, so this is collected once per file and handed to every block.
-function referenceLabels(body: string): Set<string> {
-	const labels = new Set<string>();
-	const lines = visibleMarkdownLines(body);
-	let titleContinuationContext: string | null = null;
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index];
-		const container = containerLine(line);
+	let destinationLine = lineIndex;
+	let destinationOffset = cursor + 2;
+	let destinationText = text.slice(destinationOffset);
+	let destination = firstContent(destinationText);
+	if (!destination) {
+		const next = lines[destinationLine + 1];
 		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
+			!next ||
+			!canContinueReference(lines, destinationLine + 1, context)
 		) {
-			titleContinuationContext = null;
-			continue;
+			return null;
 		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			labels.add(normalizedReferenceLabel(definition.label));
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		titleContinuationContext = null;
-		const text = container.text;
-		const start = text.search(/\S/);
-		if (start < 0 || start > 3 || text[start] !== "[") continue;
-		const labelEnd = referenceLabelEnd(text, start);
-		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
-		if (text.slice(labelEnd + 2).trim().length > 0) continue;
-
-		const next = lines[index + 1];
-		if (next === undefined) continue;
-		const nextContainer = containerLine(next);
-		if (nextContainer.context !== container.context) continue;
-		const destinationStart = nextContainer.text.search(/\S/);
-		if (destinationStart < 0 || destinationStart > 3) continue;
-		const destinationEnd = referenceDestinationEnd(
-			nextContainer.text,
-			destinationStart,
-		);
-		if (destinationEnd < 0) continue;
-		const rawTrailing = nextContainer.text.slice(destinationEnd);
-		const trailing = rawTrailing.trim();
-		if (
-			trailing.length > 0 &&
-			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
-		) {
-			continue;
-		}
-		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
-		index++;
+		destinationLine++;
+		destinationOffset = 0;
+		destinationText = next.text;
+		destination = firstContent(destinationText);
+		if (!destination) return null;
 	}
-	return labels;
+	const destinationStart = destination.index;
+
+	const destinationEnd = referenceDestinationEnd(
+		destinationText,
+		destinationStart,
+	);
+	if (destinationEnd < 0) return null;
+
+	const rawTrailing = destinationText.slice(destinationEnd);
+	if (/[^ \t]/.test(rawTrailing)) {
+		if (!/^[ \t]+/.test(rawTrailing)) return null;
+		const trailing = firstContent(rawTrailing);
+		if (!trailing) return null;
+		const titleStart =
+			destinationOffset + destinationEnd + trailing.index;
+		const titleEnd = referenceTitleEnd(lines, destinationLine, titleStart);
+		return titleEnd === null ? null : { label, endLine: titleEnd };
+	}
+
+	const possibleTitle = lines[destinationLine + 1];
+	if (
+		possibleTitle &&
+		canContinueReference(lines, destinationLine + 1, context)
+	) {
+		const title = firstContent(possibleTitle.text);
+		if (
+			title &&
+			['"', "'", "("].includes(possibleTitle.text[title.index])
+		) {
+			const titleEnd = referenceTitleEnd(
+				lines,
+				destinationLine + 1,
+				title.index,
+			);
+			if (titleEnd !== null) return { label, endLine: titleEnd };
+		}
+	}
+
+	return { label, endLine: destinationLine };
+}
+
+// CommonMark label matching uses Unicode case folding after whitespace
+// normalization. The lower-then-upper sequence matches markdown-it and folds
+// variants such as `ss`, `ß`, and `ẞ` to the same key.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase().toUpperCase();
+}
+
+function referenceAnalysis(body: string): ReferenceAnalysis {
+	const visibleLines = visibleMarkdownLines(body);
+	const lines = documentContainerLines(visibleLines);
+	const labels = new Set<string>();
+	const definitionLines = new Set<number>();
+
+	for (let index = 0; index < lines.length; index++) {
+		const definition = referenceDefinitionAt(lines, index);
+		if (!definition) continue;
+		labels.add(normalizedReferenceLabel(definition.label));
+		for (let line = index; line <= definition.endLine; line++) {
+			definitionLines.add(line);
+		}
+		index = definition.endLine;
+	}
+
+	return { labels, definitionLines };
+}
+
+// A reference resolves against definitions anywhere in the document.
+function referenceLabels(body: string): Set<string> {
+	return referenceAnalysis(body).labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
-	const visible: string[] = [];
-	let titleContinuationContext: string | null = null;
-	for (const line of text.split("\n")) {
-		const container = containerLine(line);
-		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
-		) {
-			visible.push("");
-			titleContinuationContext = null;
-			continue;
-		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			visible.push("");
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		visible.push(line);
-		titleContinuationContext = null;
-	}
-	return visible.join("\n");
-}
-
-// A block that carries nothing but link reference definitions renders as
-// nothing at all, so it states no claim to ground.
-function isReferenceDefinitionBlock(text: string): boolean {
-	return withoutReferenceDefinitions(text).trim().length === 0;
+	const analysis = referenceAnalysis(text);
+	return visibleMarkdownLines(text)
+		.map((line, index) => (analysis.definitionLines.has(index) ? "" : line))
+		.join("\n");
 }
 
 function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
@@ -1024,7 +1278,7 @@ function sourceTags(text: string, labels: Set<string>): string[] {
 
 function normalizedAssumption(text: string): string {
 	return text
-		.replace(/^\s*(?:[-*+]|\d+\.)\s+/, "")
+		.replace(/^\s*(?:[-*+]|\d{1,9}[.)])\s+/, "")
 		.replace(SOURCE_TAG_RE, "")
 		.replace(/\s+/g, " ")
 		.trim()
@@ -1046,17 +1300,17 @@ function inspectDeliverable(
 		};
 	}
 
-	const parsed = claimBlocks(body);
+	const references = referenceAnalysis(body);
+	const parsed = claimBlocks(body, references.definitionLines);
 	if (!parsed.hasAssumptionsSection) {
 		findings.push(
 			`${basename(path)}: missing ## ${ASSUMPTIONS_HEADING}`,
 		);
 	}
 
-	const labels = referenceLabels(body);
+	const labels = references.labels;
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
-		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
 		const tags = sourceTags(block.text, labels);
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -389,6 +389,7 @@ function parseSourceUniverse(
 	}
 
 	const lines = visibleMarkdownLines(body);
+	const labels = referenceLabels(body);
 	const authority = loadRecordAuthority(stageDir);
 	findings.push(...authority.findings);
 	const registered = new Set<string>();
@@ -493,7 +494,7 @@ function parseSourceUniverse(
 	const acceptedAssumptions = new Set(
 		confirmation
 			.filter((line) => isListItem(line))
-			.filter((line) => sourceTags(line).includes("assumption"))
+			.filter((line) => sourceTags(line, labels).includes("assumption"))
 			.map(normalizedAssumption)
 			.filter((entry) => entry.length > 0),
 	);
@@ -726,6 +727,44 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+function referenceDefinitionLabel(line: string): string | null {
+	const start = line.search(/\S/);
+	if (start < 0 || start > 3 || line[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(line, start, "[", "]");
+	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
+	return line.slice(start + 1, labelEnd);
+}
+
+// CommonMark matches link labels case-insensitively with runs of whitespace
+// collapsed to a single space.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+// The labels a document defines. A reference link resolves against the whole
+// document, so this is collected once per file and handed to every block.
+function referenceLabels(body: string): Set<string> {
+	const labels = new Set<string>();
+	let mayContinueDefinition = false;
+	for (const line of visibleMarkdownLines(body)) {
+		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const label = referenceDefinitionLabel(line);
+		if (label === null) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const normalized = normalizedReferenceLabel(label);
+		if (normalized.length > 0) labels.add(normalized);
+		mayContinueDefinition = true;
+	}
+	return labels;
+}
+
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
 	let mayContinueDefinition = false;
@@ -736,14 +775,10 @@ function withoutReferenceDefinitions(text: string): string {
 			continue;
 		}
 
-		const start = line.search(/\S/);
-		if (start >= 0 && start <= 3 && line[start] === "[") {
-			const labelEnd = matchingDelimiter(line, start, "[", "]");
-			if (labelEnd >= 0 && line[labelEnd + 1] === ":") {
-				visible.push("");
-				mayContinueDefinition = true;
-				continue;
-			}
+		if (referenceDefinitionLabel(line) !== null) {
+			visible.push("");
+			mayContinueDefinition = true;
+			continue;
 		}
 
 		visible.push(line);
@@ -752,7 +787,13 @@ function withoutReferenceDefinitions(text: string): string {
 	return visible.join("\n");
 }
 
-function visibleMarkdownLinkText(text: string): string {
+// A block that carries nothing but link reference definitions renders as
+// nothing at all, so it states no claim to ground.
+function isReferenceDefinitionBlock(text: string): boolean {
+	return withoutReferenceDefinitions(text).trim().length === 0;
+}
+
+function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
 	let visible = "";
 	for (let index = 0; index < text.length; index++) {
 		const image =
@@ -772,6 +813,7 @@ function visibleMarkdownLinkText(text: string): string {
 			continue;
 		}
 
+		const label = text.slice(labelStart + 1, labelEnd);
 		let syntaxEnd = labelEnd;
 		if (text[labelEnd + 1] === "(") {
 			const destinationEnd = matchingDelimiter(text, labelEnd + 1, "(", ")");
@@ -786,8 +828,18 @@ function visibleMarkdownLinkText(text: string): string {
 				visible += text[index];
 				continue;
 			}
+			// Full `[text][label]` and collapsed `[label][]` references. An empty
+			// second pair points back at the first, and neither is a link unless
+			// the document defines the label it names.
+			const reference = text.slice(labelEnd + 2, referenceEnd);
+			const named = reference.trim().length > 0 ? reference : label;
+			if (!labels.has(normalizedReferenceLabel(named))) {
+				visible += text[index];
+				continue;
+			}
 			syntaxEnd = referenceEnd;
-		} else if (!image) {
+		} else if (!labels.has(normalizedReferenceLabel(label))) {
+			// Shortcut `[label]` reference: also a link only once defined.
 			visible += text[index];
 			continue;
 		}
@@ -798,10 +850,11 @@ function visibleMarkdownLinkText(text: string): string {
 	return visible;
 }
 
-function sourceTags(text: string): string[] {
+function sourceTags(text: string, labels: Set<string>): string[] {
 	const withoutInlineCode = text.replace(/(`+)([\s\S]*?)\1/g, "");
 	const visibleText = visibleMarkdownLinkText(
 		withoutReferenceDefinitions(visibleHtmlText(withoutInlineCode)),
+		labels,
 	);
 	return [...visibleText.matchAll(SOURCE_TAG_RE)].map((match) => match[1]);
 }
@@ -837,10 +890,12 @@ function inspectDeliverable(
 		);
 	}
 
+	const labels = referenceLabels(body);
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
+		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
-		const tags = sourceTags(block.text);
+		const tags = sourceTags(block.text, labels);
 
 		if (block.inAssumptions) {
 			if (isNoneBlock(block.text)) continue;

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -550,7 +550,7 @@ function claimBlocks(body: string): {
 	let pending: string[] = [];
 
 	const flush = (): void => {
-		const text = pending.join("\n").trim();
+		const text = pending.join("\n").trimEnd();
 		if (text.length > 0) {
 			blocks.push({
 				section,
@@ -593,10 +593,10 @@ function claimBlocks(body: string): {
 		}
 		if (isListItem(line)) {
 			flush();
-			pending.push(line.trim());
+			pending.push(line);
 			continue;
 		}
-		pending.push(line.trim());
+		pending.push(line);
 	}
 	flush();
 
@@ -740,14 +740,30 @@ function visibleHtmlText(text: string): string {
 // the marker only comes off for a run of one to four — and four spaces of
 // remaining indentation is an indented code block too, which the caller's
 // column test rejects.
-function withoutContainerMarkers(line: string): string {
+interface ContainerLine {
+	text: string;
+	context: string;
+}
+
+function containerLine(line: string): ContainerLine {
 	let stripped = line;
+	const context: string[] = [];
 	for (;;) {
-		const next = stripped
-			.replace(/^ {0,3}(?:> ?)+/, "")
-			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
-		if (next === stripped) return stripped;
-		stripped = next;
+		const quote = /^ {0,3}> ?/.exec(stripped);
+		if (quote) {
+			stripped = stripped.slice(quote[0].length);
+			context.push("quote");
+			continue;
+		}
+		const list = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(
+			stripped,
+		);
+		if (list) {
+			stripped = stripped.slice(list[0].length);
+			context.push("list");
+			continue;
+		}
+		return { text: stripped, context: context.join("/") };
 	}
 }
 
@@ -770,8 +786,9 @@ function referenceDestinationEnd(text: string, start: number): number {
 	let depth = 0;
 	let index = start;
 	for (; index < text.length; index++) {
-		// Space and the ASCII control range both end a bare destination.
-		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		// Space and every ASCII control character end a bare destination.
+		const codePoint = text.codePointAt(index) ?? 0;
+		if (codePoint <= 0x20 || codePoint === 0x7f) break;
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
@@ -786,15 +803,34 @@ function referenceDestinationEnd(text: string, start: number): number {
 // Shape alone does not make a definition: `[label]: some prose` renders as the
 // visible sentence it is. Requiring a well-formed destination keeps a line the
 // reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Where this still diverges from
-// CommonMark it must diverge toward inspecting more, never less — so a
-// destination deferred to the next line reads as prose here rather than as a
-// definition that could skip a block.
-function referenceDefinitionLabel(line: string): string | null {
-	const text = withoutContainerMarkers(line);
+// from exempting its block from inspection. Multiline destinations are
+// collected separately for document-wide reference resolution, but stay as
+// prose here: when block removal cannot afford the complete grammar it must
+// inspect more, never less.
+interface ReferenceDefinition {
+	label: string;
+	context: string;
+	mayContinueTitle: boolean;
+}
+
+function referenceLabelEnd(text: string, start: number): number {
+	for (let index = start + 1; index < text.length; index++) {
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "[") return -1;
+		if (text[index] === "]") {
+			const label = text.slice(start + 1, index);
+			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+		}
+	}
+	return -1;
+}
+
+function referenceDefinition(line: string): ReferenceDefinition | null {
+	const container = containerLine(line);
+	const text = container.text;
 	const start = text.search(/\S/);
 	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	const labelEnd = referenceLabelEnd(text, start);
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
 	const rest = text.slice(labelEnd + 2);
@@ -802,10 +838,20 @@ function referenceDefinitionLabel(line: string): string | null {
 	if (destinationStart < 0) return null;
 	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
 	if (destinationEnd < 0) return null;
-	const trailing = rest.slice(destinationEnd).trim();
-	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+	const rawTrailing = rest.slice(destinationEnd);
+	const trailing = rawTrailing.trim();
+	if (
+		trailing.length > 0 &&
+		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+	) {
+		return null;
+	}
 
-	return text.slice(start + 1, labelEnd);
+	return {
+		label: text.slice(start + 1, labelEnd),
+		context: container.context,
+		mayContinueTitle: trailing.length === 0,
+	};
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace
@@ -818,44 +864,88 @@ function normalizedReferenceLabel(label: string): string {
 // document, so this is collected once per file and handed to every block.
 function referenceLabels(body: string): Set<string> {
 	const labels = new Set<string>();
-	let mayContinueDefinition = false;
-	for (const line of visibleMarkdownLines(body)) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
-			mayContinueDefinition = false;
+	const lines = visibleMarkdownLines(body);
+	let titleContinuationContext: string | null = null;
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
+			titleContinuationContext = null;
 			continue;
 		}
 
-		const label = referenceDefinitionLabel(line);
-		if (label === null) {
-			mayContinueDefinition = false;
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
+			labels.add(normalizedReferenceLabel(definition.label));
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
-		const normalized = normalizedReferenceLabel(label);
-		if (normalized.length > 0) labels.add(normalized);
-		mayContinueDefinition = true;
+		titleContinuationContext = null;
+		const text = container.text;
+		const start = text.search(/\S/);
+		if (start < 0 || start > 3 || text[start] !== "[") continue;
+		const labelEnd = referenceLabelEnd(text, start);
+		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
+		if (text.slice(labelEnd + 2).trim().length > 0) continue;
+
+		const next = lines[index + 1];
+		if (next === undefined) continue;
+		const nextContainer = containerLine(next);
+		if (nextContainer.context !== container.context) continue;
+		const destinationStart = nextContainer.text.search(/\S/);
+		if (destinationStart < 0 || destinationStart > 3) continue;
+		const destinationEnd = referenceDestinationEnd(
+			nextContainer.text,
+			destinationStart,
+		);
+		if (destinationEnd < 0) continue;
+		const rawTrailing = nextContainer.text.slice(destinationEnd);
+		const trailing = rawTrailing.trim();
+		if (
+			trailing.length > 0 &&
+			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		) {
+			continue;
+		}
+		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
+		index++;
 	}
 	return labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
-	let mayContinueDefinition = false;
+	let titleContinuationContext: string | null = null;
 	for (const line of text.split("\n")) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
 			visible.push("");
-			mayContinueDefinition = false;
+			titleContinuationContext = null;
 			continue;
 		}
 
-		if (referenceDefinitionLabel(line) !== null) {
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
 			visible.push("");
-			mayContinueDefinition = true;
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
 		visible.push(line);
-		mayContinueDefinition = false;
+		titleContinuationContext = null;
 	}
 	return visible.join("\n");
 }

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.57";
+export const AIDLC_VERSION = "2.5.58";

--- a/dist/kiro/.kiro/sensors/aidlc-claim-sources.md
+++ b/dist/kiro/.kiro/sensors/aidlc-claim-sources.md
@@ -45,6 +45,12 @@ The sensor excludes scaffolding, fenced code, HTML comments, and reviewer-added
 stage's adversarial reviewer judges whether the cited source actually supports
 the claim.
 
+A tag counts when the rendered document shows it as literal text. Bracket pairs
+resolve as Markdown links only against a link reference definition the document
+carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
+`[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
+nothing.
+
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing missing sections, untagged

--- a/dist/kiro/.kiro/sensors/aidlc-claim-sources.md
+++ b/dist/kiro/.kiro/sensors/aidlc-claim-sources.md
@@ -49,7 +49,15 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing.
+nothing. A definition is recognised by a well-formed destination, inside a
+block quote or list item as well as at the top level; a line that merely looks
+like one, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim.
+
+Where this reading cannot afford full CommonMark, the divergence must land as a
+false failure and never as a false pass: the sensor may ask for a citation the
+document did not owe, but it must not let unsourced or invisible-tag content
+through.
 
 ## Failure mode
 

--- a/dist/kiro/.kiro/sensors/aidlc-claim-sources.md
+++ b/dist/kiro/.kiro/sensors/aidlc-claim-sources.md
@@ -49,10 +49,13 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing. A definition is recognised by a well-formed destination, inside a
-block quote or list item as well as at the top level; a line that merely looks
-like one, such as `[note]: some prose`, is the visible sentence it renders as
-and is inspected like any other claim.
+nothing. A definition requires a non-empty CommonMark label, a well-formed
+destination, and a correctly separated optional title, inside a block quote or
+list item as well as at the top level. Multiline destinations still resolve
+references across the whole document. A line that merely looks like a
+definition, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim; neither an inline title nor a different
+container can hide the following line as title continuation.
 
 Where this reading cannot afford full CommonMark, the divergence must land as a
 false failure and never as a false pass: the sensor may ask for a citation the

--- a/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -56,6 +56,9 @@ const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
 const REFERENCE_TITLE_RE =
 	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+// The same title, when it trails the destination on the definition's own line.
+const REFERENCE_TITLE_BODY_RE =
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -727,12 +730,35 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+// A definition keeps its meaning inside a block quote or a list item, so the
+// container markers come off before the line is tested.
+function withoutContainerMarkers(line: string): string {
+	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
+	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
+	return stripped;
+}
+
+// Shape alone does not make a definition: `[label]: some prose` renders as the
+// visible sentence it is. Requiring a well-formed destination keeps a line the
+// reader can see out of the definition set, which is what stops such a line
+// from exempting its block from inspection. Where this still diverges from
+// CommonMark it must diverge toward inspecting more, never less — so a
+// destination deferred to the next line reads as prose here rather than as a
+// definition that could skip a block.
 function referenceDefinitionLabel(line: string): string | null {
-	const start = line.search(/\S/);
-	if (start < 0 || start > 3 || line[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(line, start, "[", "]");
-	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
-	return line.slice(start + 1, labelEnd);
+	const text = withoutContainerMarkers(line);
+	const start = text.search(/\S/);
+	if (start < 0 || start > 3 || text[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+
+	const rest = text.slice(labelEnd + 2).trim();
+	const destination = /^\S+/.exec(rest);
+	if (!destination) return null;
+	const trailing = rest.slice(destination[0].length).trim();
+	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+
+	return text.slice(start + 1, labelEnd);
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace

--- a/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -54,11 +54,13 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
+// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
+// line as prose, so accepting it here would let the line exempt its block.
 const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
 // The same title, when it trails the destination on the definition's own line.
 const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -730,12 +732,55 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
-// A definition keeps its meaning inside a block quote or a list item, so the
-// container markers come off before the line is tested.
+// A definition keeps its meaning inside a block quote or a list item, and the
+// two nest in either order and to any depth. Taking one of each off would read
+// `> - [Q1]: url` and miss the equally valid `- > [Q1]: url`, so the markers
+// come off until the line stops changing. Five or more spaces after a list
+// marker start an indented code block inside the item rather than content, so
+// the marker only comes off for a run of one to four — and four spaces of
+// remaining indentation is an indented code block too, which the caller's
+// column test rejects.
 function withoutContainerMarkers(line: string): string {
-	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
-	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
-	return stripped;
+	let stripped = line;
+	for (;;) {
+		const next = stripped
+			.replace(/^ {0,3}(?:> ?)+/, "")
+			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
+		if (next === stripped) return stripped;
+		stripped = next;
+	}
+}
+
+// CommonMark's link-destination grammar, which is what separates a definition
+// from a line that merely looks like one. A destination is either an
+// angle-bracket run that has to close on the same line and hold no unescaped
+// `<`, or a bare run that ends at the first space or control character and
+// keeps its parentheses balanced. Returns the index just past the destination,
+// or -1 when the text does not carry one.
+function referenceDestinationEnd(text: string, start: number): number {
+	if (text[start] === "<") {
+		for (let index = start + 1; index < text.length; index++) {
+			if (isEscaped(text, index)) continue;
+			if (text[index] === ">") return index + 1;
+			if (text[index] === "<") return -1;
+		}
+		return -1;
+	}
+
+	let depth = 0;
+	let index = start;
+	for (; index < text.length; index++) {
+		// Space and the ASCII control range both end a bare destination.
+		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "(") {
+			depth++;
+		} else if (text[index] === ")") {
+			depth--;
+			if (depth < 0) return -1;
+		}
+	}
+	return depth === 0 && index > start ? index : -1;
 }
 
 // Shape alone does not make a definition: `[label]: some prose` renders as the
@@ -752,10 +797,12 @@ function referenceDefinitionLabel(line: string): string | null {
 	const labelEnd = matchingDelimiter(text, start, "[", "]");
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
-	const rest = text.slice(labelEnd + 2).trim();
-	const destination = /^\S+/.exec(rest);
-	if (!destination) return null;
-	const trailing = rest.slice(destination[0].length).trim();
+	const rest = text.slice(labelEnd + 2);
+	const destinationStart = rest.search(/\S/);
+	if (destinationStart < 0) return null;
+	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
+	if (destinationEnd < 0) return null;
+	const trailing = rest.slice(destinationEnd).trim();
 	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
 
 	return text.slice(start + 1, labelEnd);

--- a/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -54,13 +54,6 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
-// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
-// line as prose, so accepting it here would let the line exempt its block.
-const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
-// The same title, when it trails the destination on the definition's own line.
-const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -524,18 +517,23 @@ function isTableLine(line: string): boolean {
 }
 
 function isListItem(line: string): boolean {
-	return /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+	return /^\s*(?:[-*+]|\d{1,9}[.)])\s+/.test(line);
 }
 
 function isNoneBlock(text: string): boolean {
 	return /^None\.?$/i.test(text.trim());
 }
 
-function claimBlocks(body: string): {
+function claimBlocks(
+	body: string,
+	definitionLines: ReadonlySet<number> = new Set(),
+): {
 	blocks: ClaimBlock[];
 	hasAssumptionsSection: boolean;
 } {
-	const lines = visibleMarkdownLines(body);
+	const lines = visibleMarkdownLines(body).map((line, index) =>
+		definitionLines.has(index) ? "" : line,
+	);
 	const tableHeaders = new Set<number>();
 	for (let index = 1; index < lines.length; index++) {
 		if (isTableSeparator(lines[index]) && isTableLine(lines[index - 1])) {
@@ -576,8 +574,13 @@ function claimBlocks(body: string): {
 			continue;
 		}
 		if (skipReview) continue;
-		if (line.trim().length === 0 || /^\s*---+\s*$/.test(line)) {
+		if (line.trim().length === 0 || isThematicBreak(line)) {
 			flush();
+			continue;
+		}
+		if (isHtmlBlockStart(line)) {
+			flush();
+			pending.push(line);
 			continue;
 		}
 		if (isTableLine(line)) {
@@ -792,6 +795,7 @@ function referenceDestinationEnd(text: string, start: number): number {
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
+			if (depth > 32) return -1;
 		} else if (text[index] === ")") {
 			depth--;
 			if (depth < 0) return -1;
@@ -800,160 +804,410 @@ function referenceDestinationEnd(text: string, start: number): number {
 	return depth === 0 && index > start ? index : -1;
 }
 
-// Shape alone does not make a definition: `[label]: some prose` renders as the
-// visible sentence it is. Requiring a well-formed destination keeps a line the
-// reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Multiline destinations are
-// collected separately for document-wide reference resolution, but stay as
-// prose here: when block removal cannot afford the complete grammar it must
-// inspect more, never less.
 interface ReferenceDefinition {
 	label: string;
-	context: string;
-	mayContinueTitle: boolean;
+	endLine: number;
 }
 
-function referenceLabelEnd(text: string, start: number): number {
-	for (let index = start + 1; index < text.length; index++) {
-		if (isEscaped(text, index)) continue;
-		if (text[index] === "[") return -1;
-		if (text[index] === "]") {
-			const label = text.slice(start + 1, index);
-			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+interface ReferenceAnalysis {
+	labels: Set<string>;
+	definitionLines: Set<number>;
+}
+
+interface ActiveListContainer {
+	beforeQuotes: number;
+	contentIndent: number;
+	listContext: string;
+}
+
+function contextParts(context: string): string[] {
+	return context.length > 0 ? context.split("/") : [];
+}
+
+function textColumns(text: string): number {
+	let column = 0;
+	for (const char of text) {
+		if (char === "\t") {
+			column += 4 - (column % 4);
+		} else {
+			column++;
 		}
 	}
-	return -1;
+	return column;
 }
 
-function referenceDefinition(line: string): ReferenceDefinition | null {
-	const container = containerLine(line);
-	const text = container.text;
-	const start = text.search(/\S/);
-	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = referenceLabelEnd(text, start);
-	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+function firstContent(text: string): { index: number; column: number } | null {
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		if (text[index] === " ") {
+			column++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			continue;
+		}
+		return { index, column };
+	}
+	return null;
+}
 
-	const rest = text.slice(labelEnd + 2);
-	const destinationStart = rest.search(/\S/);
-	if (destinationStart < 0) return null;
-	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
-	if (destinationEnd < 0) return null;
-	const rawTrailing = rest.slice(destinationEnd);
-	const trailing = rawTrailing.trim();
+function stripIndentColumns(text: string, required: number): string | null {
+	let column = 0;
+	let index = 0;
+	while (column < required && index < text.length) {
+		if (text[index] === " ") {
+			column++;
+			index++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			index++;
+			continue;
+		}
+		return null;
+	}
+	if (column < required) return null;
+	return `${" ".repeat(column - required)}${text.slice(index)}`;
+}
+
+function stripLeadingQuotes(
+	line: string,
+	count: number,
+): { text: string; contexts: string[] } | null {
+	let text = line;
+	const contexts: string[] = [];
+	for (let index = 0; index < count; index++) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) return null;
+		text = text.slice(quote[0].length);
+		contexts.push("quote");
+	}
+	return { text, contexts };
+}
+
+function explicitListContainer(
+	line: string,
+	listItem: number,
+): { line: ContainerLine; active: ActiveListContainer } | null {
+	let text = line;
+	const before: string[] = [];
+	for (;;) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) break;
+		text = text.slice(quote[0].length);
+		before.push("quote");
+	}
+
+	const marker =
+		/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(text);
+	if (!marker) return null;
+	const after = containerLine(text.slice(marker[0].length));
+	const listContext = `list#${listItem}`;
+	return {
+		line: {
+			text: after.text,
+			context: [...before, listContext, ...contextParts(after.context)].join(
+				"/",
+			),
+		},
+		active: {
+			beforeQuotes: before.length,
+			contentIndent: textColumns(marker[0]),
+			listContext,
+		},
+	};
+}
+
+// Container markers on the definition's first line are not repeated on its
+// continuation lines. Preserve the active list item's exact quote/list nesting,
+// indentation columns, and identity so continuations work through block quotes
+// and tabs but never cross into a sibling item.
+function documentContainerLines(lines: string[]): ContainerLine[] {
+	const result: ContainerLine[] = [];
+	let activeList: ActiveListContainer | null = null;
+	let listItem = 0;
+
+	for (const line of lines) {
+		const explicitList = explicitListContainer(line, listItem + 1);
+		if (explicitList) {
+			listItem++;
+			activeList = explicitList.active;
+			result.push(explicitList.line);
+			continue;
+		}
+
+		if (line.trim().length === 0) {
+			result.push({ text: line, context: activeList?.listContext ?? "" });
+			continue;
+		}
+
+		if (activeList) {
+			const quoted = stripLeadingQuotes(line, activeList.beforeQuotes);
+			if (quoted && /^[ \t]*$/.test(quoted.text)) {
+				result.push({
+					text: "",
+					context: [...quoted.contexts, activeList.listContext].join("/"),
+				});
+				continue;
+			}
+			const continuation = quoted
+				? stripIndentColumns(quoted.text, activeList.contentIndent)
+				: null;
+			if (quoted && continuation !== null) {
+				const after = containerLine(continuation);
+				result.push({
+					text: after.text,
+					context: [
+						...quoted.contexts,
+						activeList.listContext,
+						...contextParts(after.context),
+					].join("/"),
+				});
+				continue;
+			}
+		}
+
+		activeList = null;
+		result.push(containerLine(line));
+	}
+
+	return result;
+}
+
+const HTML_BLOCK_TAGS =
+	"address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul";
+const HTML_BLOCK_RE = new RegExp(
+	`^(?:<(?:script|pre|style|textarea)(?:[ \\t>]|$)|<!--|<\\?|<![A-Z]|<!\\[CDATA\\[|<\\/?(?:${HTML_BLOCK_TAGS})(?:[ \\t\\n\\f\\r\\/>]|$))`,
+	"i",
+);
+
+function isThematicBreak(line: string): boolean {
+	const content = firstContent(line);
+	if (content === null || content.column > 3) return false;
+	return /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
+		line.slice(content.index),
+	);
+}
+
+function isHtmlBlockStart(line: string): boolean {
+	const content = firstContent(line);
+	return (
+		content !== null &&
+		content.column <= 3 &&
+		HTML_BLOCK_RE.test(line.slice(content.index))
+	);
+}
+
+function interruptsReferenceContinuation(text: string): boolean {
+	const content = firstContent(text);
+	if (!content) return true;
+	// Once a reference definition has started, CommonMark accepts indented lazy
+	// continuation lines. At that point four columns are content, not a fresh
+	// indented-code block, and block-start tests do not interrupt the definition.
+	if (content.column > 3) return false;
+	const rest = text.slice(content.index);
+	return (
+		/^#{1,6}(?:[ \t]+|$)/.test(rest) ||
+		isThematicBreak(text) ||
+		/^(?:=+|-+)[ \t]*$/.test(rest) ||
+		HTML_BLOCK_RE.test(rest)
+	);
+}
+
+function canContinueReference(
+	lines: ContainerLine[],
+	index: number,
+	context: string,
+): boolean {
+	const line = lines[index];
+	if (!line) return false;
+	const sameOrLazilyElidedContext =
+		line.context === context ||
+			(line.context === "" && context !== "") ||
+			(line.context !== "" && context.startsWith(`${line.context}/`));
+	return (
+		sameOrLazilyElidedContext &&
+		!interruptsReferenceContinuation(line.text)
+	);
+}
+
+function referenceTitleEnd(
+	lines: ContainerLine[],
+	startLine: number,
+	start: number,
+): number | null {
+	const context = lines[startLine].context;
+	const opening = lines[startLine].text[start];
+	if (opening !== '"' && opening !== "'" && opening !== "(") return null;
+	const closing = opening === "(" ? ")" : opening;
+	let lineIndex = startLine;
+	let cursor = start + 1;
+
+	for (;;) {
+		const text = lines[lineIndex].text;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) continue;
+			if (opening === "(" && text[cursor] === "(") return null;
+			if (text[cursor] !== closing) continue;
+			return /^[ \t]*$/.test(text.slice(cursor + 1)) ? lineIndex : null;
+		}
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		lineIndex++;
+		cursor = 0;
+	}
+}
+
+// Parse one complete CommonMark link-reference definition. Lines are consumed
+// only after the label, destination, and optional title are certainly valid;
+// malformed candidates remain visible prose and are inspected fail-closed.
+function referenceDefinitionAt(
+	lines: ContainerLine[],
+	startLine: number,
+): ReferenceDefinition | null {
+	const context = lines[startLine].context;
+	let lineIndex = startLine;
+	let text = lines[lineIndex].text;
+	const first = firstContent(text);
+	if (!first || first.column > 3 || text[first.index] !== "[") return null;
+	const start = first.index;
+
+	let cursor = start + 1;
+	let label = "";
+	for (;;) {
+		let closed = false;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) {
+				label += text[cursor];
+				continue;
+			}
+			if (text[cursor] === "[") return null;
+			if (text[cursor] === "]") {
+				closed = true;
+				break;
+			}
+			label += text[cursor];
+		}
+		if (closed) break;
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		label += "\n";
+		lineIndex++;
+		text = next.text;
+		cursor = 0;
+	}
+
 	if (
-		trailing.length > 0 &&
-		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		text[cursor + 1] !== ":" ||
+		!/[^ \t\n\r]/.test(label) ||
+		Array.from(label).length > 999
 	) {
 		return null;
 	}
 
-	return {
-		label: text.slice(start + 1, labelEnd),
-		context: container.context,
-		mayContinueTitle: trailing.length === 0,
-	};
-}
-
-// CommonMark matches link labels case-insensitively with runs of whitespace
-// collapsed to a single space.
-function normalizedReferenceLabel(label: string): string {
-	return label.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-// The labels a document defines. A reference link resolves against the whole
-// document, so this is collected once per file and handed to every block.
-function referenceLabels(body: string): Set<string> {
-	const labels = new Set<string>();
-	const lines = visibleMarkdownLines(body);
-	let titleContinuationContext: string | null = null;
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index];
-		const container = containerLine(line);
+	let destinationLine = lineIndex;
+	let destinationOffset = cursor + 2;
+	let destinationText = text.slice(destinationOffset);
+	let destination = firstContent(destinationText);
+	if (!destination) {
+		const next = lines[destinationLine + 1];
 		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
+			!next ||
+			!canContinueReference(lines, destinationLine + 1, context)
 		) {
-			titleContinuationContext = null;
-			continue;
+			return null;
 		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			labels.add(normalizedReferenceLabel(definition.label));
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		titleContinuationContext = null;
-		const text = container.text;
-		const start = text.search(/\S/);
-		if (start < 0 || start > 3 || text[start] !== "[") continue;
-		const labelEnd = referenceLabelEnd(text, start);
-		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
-		if (text.slice(labelEnd + 2).trim().length > 0) continue;
-
-		const next = lines[index + 1];
-		if (next === undefined) continue;
-		const nextContainer = containerLine(next);
-		if (nextContainer.context !== container.context) continue;
-		const destinationStart = nextContainer.text.search(/\S/);
-		if (destinationStart < 0 || destinationStart > 3) continue;
-		const destinationEnd = referenceDestinationEnd(
-			nextContainer.text,
-			destinationStart,
-		);
-		if (destinationEnd < 0) continue;
-		const rawTrailing = nextContainer.text.slice(destinationEnd);
-		const trailing = rawTrailing.trim();
-		if (
-			trailing.length > 0 &&
-			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
-		) {
-			continue;
-		}
-		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
-		index++;
+		destinationLine++;
+		destinationOffset = 0;
+		destinationText = next.text;
+		destination = firstContent(destinationText);
+		if (!destination) return null;
 	}
-	return labels;
+	const destinationStart = destination.index;
+
+	const destinationEnd = referenceDestinationEnd(
+		destinationText,
+		destinationStart,
+	);
+	if (destinationEnd < 0) return null;
+
+	const rawTrailing = destinationText.slice(destinationEnd);
+	if (/[^ \t]/.test(rawTrailing)) {
+		if (!/^[ \t]+/.test(rawTrailing)) return null;
+		const trailing = firstContent(rawTrailing);
+		if (!trailing) return null;
+		const titleStart =
+			destinationOffset + destinationEnd + trailing.index;
+		const titleEnd = referenceTitleEnd(lines, destinationLine, titleStart);
+		return titleEnd === null ? null : { label, endLine: titleEnd };
+	}
+
+	const possibleTitle = lines[destinationLine + 1];
+	if (
+		possibleTitle &&
+		canContinueReference(lines, destinationLine + 1, context)
+	) {
+		const title = firstContent(possibleTitle.text);
+		if (
+			title &&
+			['"', "'", "("].includes(possibleTitle.text[title.index])
+		) {
+			const titleEnd = referenceTitleEnd(
+				lines,
+				destinationLine + 1,
+				title.index,
+			);
+			if (titleEnd !== null) return { label, endLine: titleEnd };
+		}
+	}
+
+	return { label, endLine: destinationLine };
+}
+
+// CommonMark label matching uses Unicode case folding after whitespace
+// normalization. The lower-then-upper sequence matches markdown-it and folds
+// variants such as `ss`, `ß`, and `ẞ` to the same key.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase().toUpperCase();
+}
+
+function referenceAnalysis(body: string): ReferenceAnalysis {
+	const visibleLines = visibleMarkdownLines(body);
+	const lines = documentContainerLines(visibleLines);
+	const labels = new Set<string>();
+	const definitionLines = new Set<number>();
+
+	for (let index = 0; index < lines.length; index++) {
+		const definition = referenceDefinitionAt(lines, index);
+		if (!definition) continue;
+		labels.add(normalizedReferenceLabel(definition.label));
+		for (let line = index; line <= definition.endLine; line++) {
+			definitionLines.add(line);
+		}
+		index = definition.endLine;
+	}
+
+	return { labels, definitionLines };
+}
+
+// A reference resolves against definitions anywhere in the document.
+function referenceLabels(body: string): Set<string> {
+	return referenceAnalysis(body).labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
-	const visible: string[] = [];
-	let titleContinuationContext: string | null = null;
-	for (const line of text.split("\n")) {
-		const container = containerLine(line);
-		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
-		) {
-			visible.push("");
-			titleContinuationContext = null;
-			continue;
-		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			visible.push("");
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		visible.push(line);
-		titleContinuationContext = null;
-	}
-	return visible.join("\n");
-}
-
-// A block that carries nothing but link reference definitions renders as
-// nothing at all, so it states no claim to ground.
-function isReferenceDefinitionBlock(text: string): boolean {
-	return withoutReferenceDefinitions(text).trim().length === 0;
+	const analysis = referenceAnalysis(text);
+	return visibleMarkdownLines(text)
+		.map((line, index) => (analysis.definitionLines.has(index) ? "" : line))
+		.join("\n");
 }
 
 function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
@@ -1024,7 +1278,7 @@ function sourceTags(text: string, labels: Set<string>): string[] {
 
 function normalizedAssumption(text: string): string {
 	return text
-		.replace(/^\s*(?:[-*+]|\d+\.)\s+/, "")
+		.replace(/^\s*(?:[-*+]|\d{1,9}[.)])\s+/, "")
 		.replace(SOURCE_TAG_RE, "")
 		.replace(/\s+/g, " ")
 		.trim()
@@ -1046,17 +1300,17 @@ function inspectDeliverable(
 		};
 	}
 
-	const parsed = claimBlocks(body);
+	const references = referenceAnalysis(body);
+	const parsed = claimBlocks(body, references.definitionLines);
 	if (!parsed.hasAssumptionsSection) {
 		findings.push(
 			`${basename(path)}: missing ## ${ASSUMPTIONS_HEADING}`,
 		);
 	}
 
-	const labels = referenceLabels(body);
+	const labels = references.labels;
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
-		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
 		const tags = sourceTags(block.text, labels);
 

--- a/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -389,6 +389,7 @@ function parseSourceUniverse(
 	}
 
 	const lines = visibleMarkdownLines(body);
+	const labels = referenceLabels(body);
 	const authority = loadRecordAuthority(stageDir);
 	findings.push(...authority.findings);
 	const registered = new Set<string>();
@@ -493,7 +494,7 @@ function parseSourceUniverse(
 	const acceptedAssumptions = new Set(
 		confirmation
 			.filter((line) => isListItem(line))
-			.filter((line) => sourceTags(line).includes("assumption"))
+			.filter((line) => sourceTags(line, labels).includes("assumption"))
 			.map(normalizedAssumption)
 			.filter((entry) => entry.length > 0),
 	);
@@ -726,6 +727,44 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+function referenceDefinitionLabel(line: string): string | null {
+	const start = line.search(/\S/);
+	if (start < 0 || start > 3 || line[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(line, start, "[", "]");
+	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
+	return line.slice(start + 1, labelEnd);
+}
+
+// CommonMark matches link labels case-insensitively with runs of whitespace
+// collapsed to a single space.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+// The labels a document defines. A reference link resolves against the whole
+// document, so this is collected once per file and handed to every block.
+function referenceLabels(body: string): Set<string> {
+	const labels = new Set<string>();
+	let mayContinueDefinition = false;
+	for (const line of visibleMarkdownLines(body)) {
+		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const label = referenceDefinitionLabel(line);
+		if (label === null) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const normalized = normalizedReferenceLabel(label);
+		if (normalized.length > 0) labels.add(normalized);
+		mayContinueDefinition = true;
+	}
+	return labels;
+}
+
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
 	let mayContinueDefinition = false;
@@ -736,14 +775,10 @@ function withoutReferenceDefinitions(text: string): string {
 			continue;
 		}
 
-		const start = line.search(/\S/);
-		if (start >= 0 && start <= 3 && line[start] === "[") {
-			const labelEnd = matchingDelimiter(line, start, "[", "]");
-			if (labelEnd >= 0 && line[labelEnd + 1] === ":") {
-				visible.push("");
-				mayContinueDefinition = true;
-				continue;
-			}
+		if (referenceDefinitionLabel(line) !== null) {
+			visible.push("");
+			mayContinueDefinition = true;
+			continue;
 		}
 
 		visible.push(line);
@@ -752,7 +787,13 @@ function withoutReferenceDefinitions(text: string): string {
 	return visible.join("\n");
 }
 
-function visibleMarkdownLinkText(text: string): string {
+// A block that carries nothing but link reference definitions renders as
+// nothing at all, so it states no claim to ground.
+function isReferenceDefinitionBlock(text: string): boolean {
+	return withoutReferenceDefinitions(text).trim().length === 0;
+}
+
+function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
 	let visible = "";
 	for (let index = 0; index < text.length; index++) {
 		const image =
@@ -772,6 +813,7 @@ function visibleMarkdownLinkText(text: string): string {
 			continue;
 		}
 
+		const label = text.slice(labelStart + 1, labelEnd);
 		let syntaxEnd = labelEnd;
 		if (text[labelEnd + 1] === "(") {
 			const destinationEnd = matchingDelimiter(text, labelEnd + 1, "(", ")");
@@ -786,8 +828,18 @@ function visibleMarkdownLinkText(text: string): string {
 				visible += text[index];
 				continue;
 			}
+			// Full `[text][label]` and collapsed `[label][]` references. An empty
+			// second pair points back at the first, and neither is a link unless
+			// the document defines the label it names.
+			const reference = text.slice(labelEnd + 2, referenceEnd);
+			const named = reference.trim().length > 0 ? reference : label;
+			if (!labels.has(normalizedReferenceLabel(named))) {
+				visible += text[index];
+				continue;
+			}
 			syntaxEnd = referenceEnd;
-		} else if (!image) {
+		} else if (!labels.has(normalizedReferenceLabel(label))) {
+			// Shortcut `[label]` reference: also a link only once defined.
 			visible += text[index];
 			continue;
 		}
@@ -798,10 +850,11 @@ function visibleMarkdownLinkText(text: string): string {
 	return visible;
 }
 
-function sourceTags(text: string): string[] {
+function sourceTags(text: string, labels: Set<string>): string[] {
 	const withoutInlineCode = text.replace(/(`+)([\s\S]*?)\1/g, "");
 	const visibleText = visibleMarkdownLinkText(
 		withoutReferenceDefinitions(visibleHtmlText(withoutInlineCode)),
+		labels,
 	);
 	return [...visibleText.matchAll(SOURCE_TAG_RE)].map((match) => match[1]);
 }
@@ -837,10 +890,12 @@ function inspectDeliverable(
 		);
 	}
 
+	const labels = referenceLabels(body);
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
+		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
-		const tags = sourceTags(block.text);
+		const tags = sourceTags(block.text, labels);
 
 		if (block.inAssumptions) {
 			if (isNoneBlock(block.text)) continue;

--- a/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-claim-sources.ts
@@ -550,7 +550,7 @@ function claimBlocks(body: string): {
 	let pending: string[] = [];
 
 	const flush = (): void => {
-		const text = pending.join("\n").trim();
+		const text = pending.join("\n").trimEnd();
 		if (text.length > 0) {
 			blocks.push({
 				section,
@@ -593,10 +593,10 @@ function claimBlocks(body: string): {
 		}
 		if (isListItem(line)) {
 			flush();
-			pending.push(line.trim());
+			pending.push(line);
 			continue;
 		}
-		pending.push(line.trim());
+		pending.push(line);
 	}
 	flush();
 
@@ -740,14 +740,30 @@ function visibleHtmlText(text: string): string {
 // the marker only comes off for a run of one to four — and four spaces of
 // remaining indentation is an indented code block too, which the caller's
 // column test rejects.
-function withoutContainerMarkers(line: string): string {
+interface ContainerLine {
+	text: string;
+	context: string;
+}
+
+function containerLine(line: string): ContainerLine {
 	let stripped = line;
+	const context: string[] = [];
 	for (;;) {
-		const next = stripped
-			.replace(/^ {0,3}(?:> ?)+/, "")
-			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
-		if (next === stripped) return stripped;
-		stripped = next;
+		const quote = /^ {0,3}> ?/.exec(stripped);
+		if (quote) {
+			stripped = stripped.slice(quote[0].length);
+			context.push("quote");
+			continue;
+		}
+		const list = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(
+			stripped,
+		);
+		if (list) {
+			stripped = stripped.slice(list[0].length);
+			context.push("list");
+			continue;
+		}
+		return { text: stripped, context: context.join("/") };
 	}
 }
 
@@ -770,8 +786,9 @@ function referenceDestinationEnd(text: string, start: number): number {
 	let depth = 0;
 	let index = start;
 	for (; index < text.length; index++) {
-		// Space and the ASCII control range both end a bare destination.
-		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		// Space and every ASCII control character end a bare destination.
+		const codePoint = text.codePointAt(index) ?? 0;
+		if (codePoint <= 0x20 || codePoint === 0x7f) break;
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
@@ -786,15 +803,34 @@ function referenceDestinationEnd(text: string, start: number): number {
 // Shape alone does not make a definition: `[label]: some prose` renders as the
 // visible sentence it is. Requiring a well-formed destination keeps a line the
 // reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Where this still diverges from
-// CommonMark it must diverge toward inspecting more, never less — so a
-// destination deferred to the next line reads as prose here rather than as a
-// definition that could skip a block.
-function referenceDefinitionLabel(line: string): string | null {
-	const text = withoutContainerMarkers(line);
+// from exempting its block from inspection. Multiline destinations are
+// collected separately for document-wide reference resolution, but stay as
+// prose here: when block removal cannot afford the complete grammar it must
+// inspect more, never less.
+interface ReferenceDefinition {
+	label: string;
+	context: string;
+	mayContinueTitle: boolean;
+}
+
+function referenceLabelEnd(text: string, start: number): number {
+	for (let index = start + 1; index < text.length; index++) {
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "[") return -1;
+		if (text[index] === "]") {
+			const label = text.slice(start + 1, index);
+			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+		}
+	}
+	return -1;
+}
+
+function referenceDefinition(line: string): ReferenceDefinition | null {
+	const container = containerLine(line);
+	const text = container.text;
 	const start = text.search(/\S/);
 	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	const labelEnd = referenceLabelEnd(text, start);
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
 	const rest = text.slice(labelEnd + 2);
@@ -802,10 +838,20 @@ function referenceDefinitionLabel(line: string): string | null {
 	if (destinationStart < 0) return null;
 	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
 	if (destinationEnd < 0) return null;
-	const trailing = rest.slice(destinationEnd).trim();
-	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+	const rawTrailing = rest.slice(destinationEnd);
+	const trailing = rawTrailing.trim();
+	if (
+		trailing.length > 0 &&
+		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+	) {
+		return null;
+	}
 
-	return text.slice(start + 1, labelEnd);
+	return {
+		label: text.slice(start + 1, labelEnd),
+		context: container.context,
+		mayContinueTitle: trailing.length === 0,
+	};
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace
@@ -818,44 +864,88 @@ function normalizedReferenceLabel(label: string): string {
 // document, so this is collected once per file and handed to every block.
 function referenceLabels(body: string): Set<string> {
 	const labels = new Set<string>();
-	let mayContinueDefinition = false;
-	for (const line of visibleMarkdownLines(body)) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
-			mayContinueDefinition = false;
+	const lines = visibleMarkdownLines(body);
+	let titleContinuationContext: string | null = null;
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
+			titleContinuationContext = null;
 			continue;
 		}
 
-		const label = referenceDefinitionLabel(line);
-		if (label === null) {
-			mayContinueDefinition = false;
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
+			labels.add(normalizedReferenceLabel(definition.label));
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
-		const normalized = normalizedReferenceLabel(label);
-		if (normalized.length > 0) labels.add(normalized);
-		mayContinueDefinition = true;
+		titleContinuationContext = null;
+		const text = container.text;
+		const start = text.search(/\S/);
+		if (start < 0 || start > 3 || text[start] !== "[") continue;
+		const labelEnd = referenceLabelEnd(text, start);
+		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
+		if (text.slice(labelEnd + 2).trim().length > 0) continue;
+
+		const next = lines[index + 1];
+		if (next === undefined) continue;
+		const nextContainer = containerLine(next);
+		if (nextContainer.context !== container.context) continue;
+		const destinationStart = nextContainer.text.search(/\S/);
+		if (destinationStart < 0 || destinationStart > 3) continue;
+		const destinationEnd = referenceDestinationEnd(
+			nextContainer.text,
+			destinationStart,
+		);
+		if (destinationEnd < 0) continue;
+		const rawTrailing = nextContainer.text.slice(destinationEnd);
+		const trailing = rawTrailing.trim();
+		if (
+			trailing.length > 0 &&
+			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		) {
+			continue;
+		}
+		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
+		index++;
 	}
 	return labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
-	let mayContinueDefinition = false;
+	let titleContinuationContext: string | null = null;
 	for (const line of text.split("\n")) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
 			visible.push("");
-			mayContinueDefinition = false;
+			titleContinuationContext = null;
 			continue;
 		}
 
-		if (referenceDefinitionLabel(line) !== null) {
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
 			visible.push("");
-			mayContinueDefinition = true;
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
 		visible.push(line);
-		mayContinueDefinition = false;
+		titleContinuationContext = null;
 	}
 	return visible.join("\n");
 }

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.57";
+export const AIDLC_VERSION = "2.5.58";

--- a/dist/opencode/.aidlc/sensors/aidlc-claim-sources.md
+++ b/dist/opencode/.aidlc/sensors/aidlc-claim-sources.md
@@ -45,6 +45,12 @@ The sensor excludes scaffolding, fenced code, HTML comments, and reviewer-added
 stage's adversarial reviewer judges whether the cited source actually supports
 the claim.
 
+A tag counts when the rendered document shows it as literal text. Bracket pairs
+resolve as Markdown links only against a link reference definition the document
+carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
+`[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
+nothing.
+
 ## Failure mode
 
 Emits `SENSOR_FAILED` and writes detail listing missing sections, untagged

--- a/dist/opencode/.aidlc/sensors/aidlc-claim-sources.md
+++ b/dist/opencode/.aidlc/sensors/aidlc-claim-sources.md
@@ -49,7 +49,15 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing.
+nothing. A definition is recognised by a well-formed destination, inside a
+block quote or list item as well as at the top level; a line that merely looks
+like one, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim.
+
+Where this reading cannot afford full CommonMark, the divergence must land as a
+false failure and never as a false pass: the sensor may ask for a citation the
+document did not owe, but it must not let unsourced or invisible-tag content
+through.
 
 ## Failure mode
 

--- a/dist/opencode/.aidlc/sensors/aidlc-claim-sources.md
+++ b/dist/opencode/.aidlc/sensors/aidlc-claim-sources.md
@@ -49,10 +49,13 @@ A tag counts when the rendered document shows it as literal text. Bracket pairs
 resolve as Markdown links only against a link reference definition the document
 carries, so adjacent tags such as `[Q1][Q2]` remain two visible tags, while
 `[Q1]` in a document that also defines `[Q1]: <url>` is a link and grounds
-nothing. A definition is recognised by a well-formed destination, inside a
-block quote or list item as well as at the top level; a line that merely looks
-like one, such as `[note]: some prose`, is the visible sentence it renders as
-and is inspected like any other claim.
+nothing. A definition requires a non-empty CommonMark label, a well-formed
+destination, and a correctly separated optional title, inside a block quote or
+list item as well as at the top level. Multiline destinations still resolve
+references across the whole document. A line that merely looks like a
+definition, such as `[note]: some prose`, is the visible sentence it renders as
+and is inspected like any other claim; neither an inline title nor a different
+container can hide the following line as title continuation.
 
 Where this reading cannot afford full CommonMark, the divergence must land as a
 false failure and never as a false pass: the sensor may ask for a citation the

--- a/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
@@ -56,6 +56,9 @@ const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
 const REFERENCE_TITLE_RE =
 	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+// The same title, when it trails the destination on the definition's own line.
+const REFERENCE_TITLE_BODY_RE =
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -727,12 +730,35 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+// A definition keeps its meaning inside a block quote or a list item, so the
+// container markers come off before the line is tested.
+function withoutContainerMarkers(line: string): string {
+	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
+	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
+	return stripped;
+}
+
+// Shape alone does not make a definition: `[label]: some prose` renders as the
+// visible sentence it is. Requiring a well-formed destination keeps a line the
+// reader can see out of the definition set, which is what stops such a line
+// from exempting its block from inspection. Where this still diverges from
+// CommonMark it must diverge toward inspecting more, never less — so a
+// destination deferred to the next line reads as prose here rather than as a
+// definition that could skip a block.
 function referenceDefinitionLabel(line: string): string | null {
-	const start = line.search(/\S/);
-	if (start < 0 || start > 3 || line[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(line, start, "[", "]");
-	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
-	return line.slice(start + 1, labelEnd);
+	const text = withoutContainerMarkers(line);
+	const start = text.search(/\S/);
+	if (start < 0 || start > 3 || text[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+
+	const rest = text.slice(labelEnd + 2).trim();
+	const destination = /^\S+/.exec(rest);
+	if (!destination) return null;
+	const trailing = rest.slice(destination[0].length).trim();
+	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+
+	return text.slice(start + 1, labelEnd);
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace

--- a/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
@@ -54,11 +54,13 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
+// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
+// line as prose, so accepting it here would let the line exempt its block.
 const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))[ \t]*$/;
+	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
 // The same title, when it trails the destination on the definition's own line.
 const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/;
+	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -730,12 +732,55 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
-// A definition keeps its meaning inside a block quote or a list item, so the
-// container markers come off before the line is tested.
+// A definition keeps its meaning inside a block quote or a list item, and the
+// two nest in either order and to any depth. Taking one of each off would read
+// `> - [Q1]: url` and miss the equally valid `- > [Q1]: url`, so the markers
+// come off until the line stops changing. Five or more spaces after a list
+// marker start an indented code block inside the item rather than content, so
+// the marker only comes off for a run of one to four — and four spaces of
+// remaining indentation is an indented code block too, which the caller's
+// column test rejects.
 function withoutContainerMarkers(line: string): string {
-	let stripped = line.replace(/^ {0,3}(?:> ?)+/, "");
-	stripped = stripped.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])[ \t]+/, "");
-	return stripped;
+	let stripped = line;
+	for (;;) {
+		const next = stripped
+			.replace(/^ {0,3}(?:> ?)+/, "")
+			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
+		if (next === stripped) return stripped;
+		stripped = next;
+	}
+}
+
+// CommonMark's link-destination grammar, which is what separates a definition
+// from a line that merely looks like one. A destination is either an
+// angle-bracket run that has to close on the same line and hold no unescaped
+// `<`, or a bare run that ends at the first space or control character and
+// keeps its parentheses balanced. Returns the index just past the destination,
+// or -1 when the text does not carry one.
+function referenceDestinationEnd(text: string, start: number): number {
+	if (text[start] === "<") {
+		for (let index = start + 1; index < text.length; index++) {
+			if (isEscaped(text, index)) continue;
+			if (text[index] === ">") return index + 1;
+			if (text[index] === "<") return -1;
+		}
+		return -1;
+	}
+
+	let depth = 0;
+	let index = start;
+	for (; index < text.length; index++) {
+		// Space and the ASCII control range both end a bare destination.
+		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "(") {
+			depth++;
+		} else if (text[index] === ")") {
+			depth--;
+			if (depth < 0) return -1;
+		}
+	}
+	return depth === 0 && index > start ? index : -1;
 }
 
 // Shape alone does not make a definition: `[label]: some prose` renders as the
@@ -752,10 +797,12 @@ function referenceDefinitionLabel(line: string): string | null {
 	const labelEnd = matchingDelimiter(text, start, "[", "]");
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
-	const rest = text.slice(labelEnd + 2).trim();
-	const destination = /^\S+/.exec(rest);
-	if (!destination) return null;
-	const trailing = rest.slice(destination[0].length).trim();
+	const rest = text.slice(labelEnd + 2);
+	const destinationStart = rest.search(/\S/);
+	if (destinationStart < 0) return null;
+	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
+	if (destinationEnd < 0) return null;
+	const trailing = rest.slice(destinationEnd).trim();
 	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
 
 	return text.slice(start + 1, labelEnd);

--- a/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
@@ -54,13 +54,6 @@ const SOURCE_TAG_RE =
 	/\[(desc|scope|assumption|Q\d+|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]/g;
 const SOURCE_ENTRY_RE =
 	/^ {0,3}[-*+]\s+\[(desc|scope|memory:[A-Za-z0-9][A-Za-z0-9._-]*)\]\s+(.+?)\s*$/;
-// A parenthesised title may not hold an unescaped `(` — CommonMark reads such a
-// line as prose, so accepting it here would let the line exempt its block.
-const REFERENCE_TITLE_RE =
-	/^ {0,3}(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))[ \t]*$/;
-// The same title, when it trails the destination on the definition's own line.
-const REFERENCE_TITLE_BODY_RE =
-	/^(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^()\\])*\))$/;
 
 function parseFlags(argv: string[]): Flags {
 	const flags: Flags = {};
@@ -524,18 +517,23 @@ function isTableLine(line: string): boolean {
 }
 
 function isListItem(line: string): boolean {
-	return /^\s*(?:[-*+]|\d+\.)\s+/.test(line);
+	return /^\s*(?:[-*+]|\d{1,9}[.)])\s+/.test(line);
 }
 
 function isNoneBlock(text: string): boolean {
 	return /^None\.?$/i.test(text.trim());
 }
 
-function claimBlocks(body: string): {
+function claimBlocks(
+	body: string,
+	definitionLines: ReadonlySet<number> = new Set(),
+): {
 	blocks: ClaimBlock[];
 	hasAssumptionsSection: boolean;
 } {
-	const lines = visibleMarkdownLines(body);
+	const lines = visibleMarkdownLines(body).map((line, index) =>
+		definitionLines.has(index) ? "" : line,
+	);
 	const tableHeaders = new Set<number>();
 	for (let index = 1; index < lines.length; index++) {
 		if (isTableSeparator(lines[index]) && isTableLine(lines[index - 1])) {
@@ -576,8 +574,13 @@ function claimBlocks(body: string): {
 			continue;
 		}
 		if (skipReview) continue;
-		if (line.trim().length === 0 || /^\s*---+\s*$/.test(line)) {
+		if (line.trim().length === 0 || isThematicBreak(line)) {
 			flush();
+			continue;
+		}
+		if (isHtmlBlockStart(line)) {
+			flush();
+			pending.push(line);
 			continue;
 		}
 		if (isTableLine(line)) {
@@ -792,6 +795,7 @@ function referenceDestinationEnd(text: string, start: number): number {
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
+			if (depth > 32) return -1;
 		} else if (text[index] === ")") {
 			depth--;
 			if (depth < 0) return -1;
@@ -800,160 +804,410 @@ function referenceDestinationEnd(text: string, start: number): number {
 	return depth === 0 && index > start ? index : -1;
 }
 
-// Shape alone does not make a definition: `[label]: some prose` renders as the
-// visible sentence it is. Requiring a well-formed destination keeps a line the
-// reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Multiline destinations are
-// collected separately for document-wide reference resolution, but stay as
-// prose here: when block removal cannot afford the complete grammar it must
-// inspect more, never less.
 interface ReferenceDefinition {
 	label: string;
-	context: string;
-	mayContinueTitle: boolean;
+	endLine: number;
 }
 
-function referenceLabelEnd(text: string, start: number): number {
-	for (let index = start + 1; index < text.length; index++) {
-		if (isEscaped(text, index)) continue;
-		if (text[index] === "[") return -1;
-		if (text[index] === "]") {
-			const label = text.slice(start + 1, index);
-			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+interface ReferenceAnalysis {
+	labels: Set<string>;
+	definitionLines: Set<number>;
+}
+
+interface ActiveListContainer {
+	beforeQuotes: number;
+	contentIndent: number;
+	listContext: string;
+}
+
+function contextParts(context: string): string[] {
+	return context.length > 0 ? context.split("/") : [];
+}
+
+function textColumns(text: string): number {
+	let column = 0;
+	for (const char of text) {
+		if (char === "\t") {
+			column += 4 - (column % 4);
+		} else {
+			column++;
 		}
 	}
-	return -1;
+	return column;
 }
 
-function referenceDefinition(line: string): ReferenceDefinition | null {
-	const container = containerLine(line);
-	const text = container.text;
-	const start = text.search(/\S/);
-	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = referenceLabelEnd(text, start);
-	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
+function firstContent(text: string): { index: number; column: number } | null {
+	let column = 0;
+	for (let index = 0; index < text.length; index++) {
+		if (text[index] === " ") {
+			column++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			continue;
+		}
+		return { index, column };
+	}
+	return null;
+}
 
-	const rest = text.slice(labelEnd + 2);
-	const destinationStart = rest.search(/\S/);
-	if (destinationStart < 0) return null;
-	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
-	if (destinationEnd < 0) return null;
-	const rawTrailing = rest.slice(destinationEnd);
-	const trailing = rawTrailing.trim();
+function stripIndentColumns(text: string, required: number): string | null {
+	let column = 0;
+	let index = 0;
+	while (column < required && index < text.length) {
+		if (text[index] === " ") {
+			column++;
+			index++;
+			continue;
+		}
+		if (text[index] === "\t") {
+			column += 4 - (column % 4);
+			index++;
+			continue;
+		}
+		return null;
+	}
+	if (column < required) return null;
+	return `${" ".repeat(column - required)}${text.slice(index)}`;
+}
+
+function stripLeadingQuotes(
+	line: string,
+	count: number,
+): { text: string; contexts: string[] } | null {
+	let text = line;
+	const contexts: string[] = [];
+	for (let index = 0; index < count; index++) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) return null;
+		text = text.slice(quote[0].length);
+		contexts.push("quote");
+	}
+	return { text, contexts };
+}
+
+function explicitListContainer(
+	line: string,
+	listItem: number,
+): { line: ContainerLine; active: ActiveListContainer } | null {
+	let text = line;
+	const before: string[] = [];
+	for (;;) {
+		const quote = /^ {0,3}> ?/.exec(text);
+		if (!quote) break;
+		text = text.slice(quote[0].length);
+		before.push("quote");
+	}
+
+	const marker =
+		/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(text);
+	if (!marker) return null;
+	const after = containerLine(text.slice(marker[0].length));
+	const listContext = `list#${listItem}`;
+	return {
+		line: {
+			text: after.text,
+			context: [...before, listContext, ...contextParts(after.context)].join(
+				"/",
+			),
+		},
+		active: {
+			beforeQuotes: before.length,
+			contentIndent: textColumns(marker[0]),
+			listContext,
+		},
+	};
+}
+
+// Container markers on the definition's first line are not repeated on its
+// continuation lines. Preserve the active list item's exact quote/list nesting,
+// indentation columns, and identity so continuations work through block quotes
+// and tabs but never cross into a sibling item.
+function documentContainerLines(lines: string[]): ContainerLine[] {
+	const result: ContainerLine[] = [];
+	let activeList: ActiveListContainer | null = null;
+	let listItem = 0;
+
+	for (const line of lines) {
+		const explicitList = explicitListContainer(line, listItem + 1);
+		if (explicitList) {
+			listItem++;
+			activeList = explicitList.active;
+			result.push(explicitList.line);
+			continue;
+		}
+
+		if (line.trim().length === 0) {
+			result.push({ text: line, context: activeList?.listContext ?? "" });
+			continue;
+		}
+
+		if (activeList) {
+			const quoted = stripLeadingQuotes(line, activeList.beforeQuotes);
+			if (quoted && /^[ \t]*$/.test(quoted.text)) {
+				result.push({
+					text: "",
+					context: [...quoted.contexts, activeList.listContext].join("/"),
+				});
+				continue;
+			}
+			const continuation = quoted
+				? stripIndentColumns(quoted.text, activeList.contentIndent)
+				: null;
+			if (quoted && continuation !== null) {
+				const after = containerLine(continuation);
+				result.push({
+					text: after.text,
+					context: [
+						...quoted.contexts,
+						activeList.listContext,
+						...contextParts(after.context),
+					].join("/"),
+				});
+				continue;
+			}
+		}
+
+		activeList = null;
+		result.push(containerLine(line));
+	}
+
+	return result;
+}
+
+const HTML_BLOCK_TAGS =
+	"address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul";
+const HTML_BLOCK_RE = new RegExp(
+	`^(?:<(?:script|pre|style|textarea)(?:[ \\t>]|$)|<!--|<\\?|<![A-Z]|<!\\[CDATA\\[|<\\/?(?:${HTML_BLOCK_TAGS})(?:[ \\t\\n\\f\\r\\/>]|$))`,
+	"i",
+);
+
+function isThematicBreak(line: string): boolean {
+	const content = firstContent(line);
+	if (content === null || content.column > 3) return false;
+	return /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
+		line.slice(content.index),
+	);
+}
+
+function isHtmlBlockStart(line: string): boolean {
+	const content = firstContent(line);
+	return (
+		content !== null &&
+		content.column <= 3 &&
+		HTML_BLOCK_RE.test(line.slice(content.index))
+	);
+}
+
+function interruptsReferenceContinuation(text: string): boolean {
+	const content = firstContent(text);
+	if (!content) return true;
+	// Once a reference definition has started, CommonMark accepts indented lazy
+	// continuation lines. At that point four columns are content, not a fresh
+	// indented-code block, and block-start tests do not interrupt the definition.
+	if (content.column > 3) return false;
+	const rest = text.slice(content.index);
+	return (
+		/^#{1,6}(?:[ \t]+|$)/.test(rest) ||
+		isThematicBreak(text) ||
+		/^(?:=+|-+)[ \t]*$/.test(rest) ||
+		HTML_BLOCK_RE.test(rest)
+	);
+}
+
+function canContinueReference(
+	lines: ContainerLine[],
+	index: number,
+	context: string,
+): boolean {
+	const line = lines[index];
+	if (!line) return false;
+	const sameOrLazilyElidedContext =
+		line.context === context ||
+			(line.context === "" && context !== "") ||
+			(line.context !== "" && context.startsWith(`${line.context}/`));
+	return (
+		sameOrLazilyElidedContext &&
+		!interruptsReferenceContinuation(line.text)
+	);
+}
+
+function referenceTitleEnd(
+	lines: ContainerLine[],
+	startLine: number,
+	start: number,
+): number | null {
+	const context = lines[startLine].context;
+	const opening = lines[startLine].text[start];
+	if (opening !== '"' && opening !== "'" && opening !== "(") return null;
+	const closing = opening === "(" ? ")" : opening;
+	let lineIndex = startLine;
+	let cursor = start + 1;
+
+	for (;;) {
+		const text = lines[lineIndex].text;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) continue;
+			if (opening === "(" && text[cursor] === "(") return null;
+			if (text[cursor] !== closing) continue;
+			return /^[ \t]*$/.test(text.slice(cursor + 1)) ? lineIndex : null;
+		}
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		lineIndex++;
+		cursor = 0;
+	}
+}
+
+// Parse one complete CommonMark link-reference definition. Lines are consumed
+// only after the label, destination, and optional title are certainly valid;
+// malformed candidates remain visible prose and are inspected fail-closed.
+function referenceDefinitionAt(
+	lines: ContainerLine[],
+	startLine: number,
+): ReferenceDefinition | null {
+	const context = lines[startLine].context;
+	let lineIndex = startLine;
+	let text = lines[lineIndex].text;
+	const first = firstContent(text);
+	if (!first || first.column > 3 || text[first.index] !== "[") return null;
+	const start = first.index;
+
+	let cursor = start + 1;
+	let label = "";
+	for (;;) {
+		let closed = false;
+		for (; cursor < text.length; cursor++) {
+			if (isEscaped(text, cursor)) {
+				label += text[cursor];
+				continue;
+			}
+			if (text[cursor] === "[") return null;
+			if (text[cursor] === "]") {
+				closed = true;
+				break;
+			}
+			label += text[cursor];
+		}
+		if (closed) break;
+
+		const next = lines[lineIndex + 1];
+		if (!next || !canContinueReference(lines, lineIndex + 1, context)) {
+			return null;
+		}
+		label += "\n";
+		lineIndex++;
+		text = next.text;
+		cursor = 0;
+	}
+
 	if (
-		trailing.length > 0 &&
-		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		text[cursor + 1] !== ":" ||
+		!/[^ \t\n\r]/.test(label) ||
+		Array.from(label).length > 999
 	) {
 		return null;
 	}
 
-	return {
-		label: text.slice(start + 1, labelEnd),
-		context: container.context,
-		mayContinueTitle: trailing.length === 0,
-	};
-}
-
-// CommonMark matches link labels case-insensitively with runs of whitespace
-// collapsed to a single space.
-function normalizedReferenceLabel(label: string): string {
-	return label.trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-// The labels a document defines. A reference link resolves against the whole
-// document, so this is collected once per file and handed to every block.
-function referenceLabels(body: string): Set<string> {
-	const labels = new Set<string>();
-	const lines = visibleMarkdownLines(body);
-	let titleContinuationContext: string | null = null;
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index];
-		const container = containerLine(line);
+	let destinationLine = lineIndex;
+	let destinationOffset = cursor + 2;
+	let destinationText = text.slice(destinationOffset);
+	let destination = firstContent(destinationText);
+	if (!destination) {
+		const next = lines[destinationLine + 1];
 		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
+			!next ||
+			!canContinueReference(lines, destinationLine + 1, context)
 		) {
-			titleContinuationContext = null;
-			continue;
+			return null;
 		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			labels.add(normalizedReferenceLabel(definition.label));
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		titleContinuationContext = null;
-		const text = container.text;
-		const start = text.search(/\S/);
-		if (start < 0 || start > 3 || text[start] !== "[") continue;
-		const labelEnd = referenceLabelEnd(text, start);
-		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
-		if (text.slice(labelEnd + 2).trim().length > 0) continue;
-
-		const next = lines[index + 1];
-		if (next === undefined) continue;
-		const nextContainer = containerLine(next);
-		if (nextContainer.context !== container.context) continue;
-		const destinationStart = nextContainer.text.search(/\S/);
-		if (destinationStart < 0 || destinationStart > 3) continue;
-		const destinationEnd = referenceDestinationEnd(
-			nextContainer.text,
-			destinationStart,
-		);
-		if (destinationEnd < 0) continue;
-		const rawTrailing = nextContainer.text.slice(destinationEnd);
-		const trailing = rawTrailing.trim();
-		if (
-			trailing.length > 0 &&
-			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
-		) {
-			continue;
-		}
-		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
-		index++;
+		destinationLine++;
+		destinationOffset = 0;
+		destinationText = next.text;
+		destination = firstContent(destinationText);
+		if (!destination) return null;
 	}
-	return labels;
+	const destinationStart = destination.index;
+
+	const destinationEnd = referenceDestinationEnd(
+		destinationText,
+		destinationStart,
+	);
+	if (destinationEnd < 0) return null;
+
+	const rawTrailing = destinationText.slice(destinationEnd);
+	if (/[^ \t]/.test(rawTrailing)) {
+		if (!/^[ \t]+/.test(rawTrailing)) return null;
+		const trailing = firstContent(rawTrailing);
+		if (!trailing) return null;
+		const titleStart =
+			destinationOffset + destinationEnd + trailing.index;
+		const titleEnd = referenceTitleEnd(lines, destinationLine, titleStart);
+		return titleEnd === null ? null : { label, endLine: titleEnd };
+	}
+
+	const possibleTitle = lines[destinationLine + 1];
+	if (
+		possibleTitle &&
+		canContinueReference(lines, destinationLine + 1, context)
+	) {
+		const title = firstContent(possibleTitle.text);
+		if (
+			title &&
+			['"', "'", "("].includes(possibleTitle.text[title.index])
+		) {
+			const titleEnd = referenceTitleEnd(
+				lines,
+				destinationLine + 1,
+				title.index,
+			);
+			if (titleEnd !== null) return { label, endLine: titleEnd };
+		}
+	}
+
+	return { label, endLine: destinationLine };
+}
+
+// CommonMark label matching uses Unicode case folding after whitespace
+// normalization. The lower-then-upper sequence matches markdown-it and folds
+// variants such as `ss`, `ß`, and `ẞ` to the same key.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase().toUpperCase();
+}
+
+function referenceAnalysis(body: string): ReferenceAnalysis {
+	const visibleLines = visibleMarkdownLines(body);
+	const lines = documentContainerLines(visibleLines);
+	const labels = new Set<string>();
+	const definitionLines = new Set<number>();
+
+	for (let index = 0; index < lines.length; index++) {
+		const definition = referenceDefinitionAt(lines, index);
+		if (!definition) continue;
+		labels.add(normalizedReferenceLabel(definition.label));
+		for (let line = index; line <= definition.endLine; line++) {
+			definitionLines.add(line);
+		}
+		index = definition.endLine;
+	}
+
+	return { labels, definitionLines };
+}
+
+// A reference resolves against definitions anywhere in the document.
+function referenceLabels(body: string): Set<string> {
+	return referenceAnalysis(body).labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
-	const visible: string[] = [];
-	let titleContinuationContext: string | null = null;
-	for (const line of text.split("\n")) {
-		const container = containerLine(line);
-		if (
-			titleContinuationContext !== null &&
-			container.context === titleContinuationContext &&
-			REFERENCE_TITLE_RE.test(container.text)
-		) {
-			visible.push("");
-			titleContinuationContext = null;
-			continue;
-		}
-
-		const definition = referenceDefinition(line);
-		if (definition !== null) {
-			visible.push("");
-			titleContinuationContext = definition.mayContinueTitle
-				? definition.context
-				: null;
-			continue;
-		}
-
-		visible.push(line);
-		titleContinuationContext = null;
-	}
-	return visible.join("\n");
-}
-
-// A block that carries nothing but link reference definitions renders as
-// nothing at all, so it states no claim to ground.
-function isReferenceDefinitionBlock(text: string): boolean {
-	return withoutReferenceDefinitions(text).trim().length === 0;
+	const analysis = referenceAnalysis(text);
+	return visibleMarkdownLines(text)
+		.map((line, index) => (analysis.definitionLines.has(index) ? "" : line))
+		.join("\n");
 }
 
 function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
@@ -1024,7 +1278,7 @@ function sourceTags(text: string, labels: Set<string>): string[] {
 
 function normalizedAssumption(text: string): string {
 	return text
-		.replace(/^\s*(?:[-*+]|\d+\.)\s+/, "")
+		.replace(/^\s*(?:[-*+]|\d{1,9}[.)])\s+/, "")
 		.replace(SOURCE_TAG_RE, "")
 		.replace(/\s+/g, " ")
 		.trim()
@@ -1046,17 +1300,17 @@ function inspectDeliverable(
 		};
 	}
 
-	const parsed = claimBlocks(body);
+	const references = referenceAnalysis(body);
+	const parsed = claimBlocks(body, references.definitionLines);
 	if (!parsed.hasAssumptionsSection) {
 		findings.push(
 			`${basename(path)}: missing ## ${ASSUMPTIONS_HEADING}`,
 		);
 	}
 
-	const labels = referenceLabels(body);
+	const labels = references.labels;
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
-		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
 		const tags = sourceTags(block.text, labels);
 

--- a/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
@@ -389,6 +389,7 @@ function parseSourceUniverse(
 	}
 
 	const lines = visibleMarkdownLines(body);
+	const labels = referenceLabels(body);
 	const authority = loadRecordAuthority(stageDir);
 	findings.push(...authority.findings);
 	const registered = new Set<string>();
@@ -493,7 +494,7 @@ function parseSourceUniverse(
 	const acceptedAssumptions = new Set(
 		confirmation
 			.filter((line) => isListItem(line))
-			.filter((line) => sourceTags(line).includes("assumption"))
+			.filter((line) => sourceTags(line, labels).includes("assumption"))
 			.map(normalizedAssumption)
 			.filter((entry) => entry.length > 0),
 	);
@@ -726,6 +727,44 @@ function visibleHtmlText(text: string): string {
 	return visible;
 }
 
+function referenceDefinitionLabel(line: string): string | null {
+	const start = line.search(/\S/);
+	if (start < 0 || start > 3 || line[start] !== "[") return null;
+	const labelEnd = matchingDelimiter(line, start, "[", "]");
+	if (labelEnd < 0 || line[labelEnd + 1] !== ":") return null;
+	return line.slice(start + 1, labelEnd);
+}
+
+// CommonMark matches link labels case-insensitively with runs of whitespace
+// collapsed to a single space.
+function normalizedReferenceLabel(label: string): string {
+	return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+// The labels a document defines. A reference link resolves against the whole
+// document, so this is collected once per file and handed to every block.
+function referenceLabels(body: string): Set<string> {
+	const labels = new Set<string>();
+	let mayContinueDefinition = false;
+	for (const line of visibleMarkdownLines(body)) {
+		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const label = referenceDefinitionLabel(line);
+		if (label === null) {
+			mayContinueDefinition = false;
+			continue;
+		}
+
+		const normalized = normalizedReferenceLabel(label);
+		if (normalized.length > 0) labels.add(normalized);
+		mayContinueDefinition = true;
+	}
+	return labels;
+}
+
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
 	let mayContinueDefinition = false;
@@ -736,14 +775,10 @@ function withoutReferenceDefinitions(text: string): string {
 			continue;
 		}
 
-		const start = line.search(/\S/);
-		if (start >= 0 && start <= 3 && line[start] === "[") {
-			const labelEnd = matchingDelimiter(line, start, "[", "]");
-			if (labelEnd >= 0 && line[labelEnd + 1] === ":") {
-				visible.push("");
-				mayContinueDefinition = true;
-				continue;
-			}
+		if (referenceDefinitionLabel(line) !== null) {
+			visible.push("");
+			mayContinueDefinition = true;
+			continue;
 		}
 
 		visible.push(line);
@@ -752,7 +787,13 @@ function withoutReferenceDefinitions(text: string): string {
 	return visible.join("\n");
 }
 
-function visibleMarkdownLinkText(text: string): string {
+// A block that carries nothing but link reference definitions renders as
+// nothing at all, so it states no claim to ground.
+function isReferenceDefinitionBlock(text: string): boolean {
+	return withoutReferenceDefinitions(text).trim().length === 0;
+}
+
+function visibleMarkdownLinkText(text: string, labels: Set<string>): string {
 	let visible = "";
 	for (let index = 0; index < text.length; index++) {
 		const image =
@@ -772,6 +813,7 @@ function visibleMarkdownLinkText(text: string): string {
 			continue;
 		}
 
+		const label = text.slice(labelStart + 1, labelEnd);
 		let syntaxEnd = labelEnd;
 		if (text[labelEnd + 1] === "(") {
 			const destinationEnd = matchingDelimiter(text, labelEnd + 1, "(", ")");
@@ -786,8 +828,18 @@ function visibleMarkdownLinkText(text: string): string {
 				visible += text[index];
 				continue;
 			}
+			// Full `[text][label]` and collapsed `[label][]` references. An empty
+			// second pair points back at the first, and neither is a link unless
+			// the document defines the label it names.
+			const reference = text.slice(labelEnd + 2, referenceEnd);
+			const named = reference.trim().length > 0 ? reference : label;
+			if (!labels.has(normalizedReferenceLabel(named))) {
+				visible += text[index];
+				continue;
+			}
 			syntaxEnd = referenceEnd;
-		} else if (!image) {
+		} else if (!labels.has(normalizedReferenceLabel(label))) {
+			// Shortcut `[label]` reference: also a link only once defined.
 			visible += text[index];
 			continue;
 		}
@@ -798,10 +850,11 @@ function visibleMarkdownLinkText(text: string): string {
 	return visible;
 }
 
-function sourceTags(text: string): string[] {
+function sourceTags(text: string, labels: Set<string>): string[] {
 	const withoutInlineCode = text.replace(/(`+)([\s\S]*?)\1/g, "");
 	const visibleText = visibleMarkdownLinkText(
 		withoutReferenceDefinitions(visibleHtmlText(withoutInlineCode)),
+		labels,
 	);
 	return [...visibleText.matchAll(SOURCE_TAG_RE)].map((match) => match[1]);
 }
@@ -837,10 +890,12 @@ function inspectDeliverable(
 		);
 	}
 
+	const labels = referenceLabels(body);
 	let hasAssumptions = false;
 	for (const block of parsed.blocks) {
+		if (isReferenceDefinitionBlock(block.text)) continue;
 		const location = `${basename(path)}${block.section ? ` ## ${block.section}` : ""}`;
-		const tags = sourceTags(block.text);
+		const tags = sourceTags(block.text, labels);
 
 		if (block.inAssumptions) {
 			if (isNoneBlock(block.text)) continue;

--- a/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor-claim-sources.ts
@@ -550,7 +550,7 @@ function claimBlocks(body: string): {
 	let pending: string[] = [];
 
 	const flush = (): void => {
-		const text = pending.join("\n").trim();
+		const text = pending.join("\n").trimEnd();
 		if (text.length > 0) {
 			blocks.push({
 				section,
@@ -593,10 +593,10 @@ function claimBlocks(body: string): {
 		}
 		if (isListItem(line)) {
 			flush();
-			pending.push(line.trim());
+			pending.push(line);
 			continue;
 		}
-		pending.push(line.trim());
+		pending.push(line);
 	}
 	flush();
 
@@ -740,14 +740,30 @@ function visibleHtmlText(text: string): string {
 // the marker only comes off for a run of one to four — and four spaces of
 // remaining indentation is an indented code block too, which the caller's
 // column test rejects.
-function withoutContainerMarkers(line: string): string {
+interface ContainerLine {
+	text: string;
+	context: string;
+}
+
+function containerLine(line: string): ContainerLine {
 	let stripped = line;
+	const context: string[] = [];
 	for (;;) {
-		const next = stripped
-			.replace(/^ {0,3}(?:> ?)+/, "")
-			.replace(/^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/, "");
-		if (next === stripped) return stripped;
-		stripped = next;
+		const quote = /^ {0,3}> ?/.exec(stripped);
+		if (quote) {
+			stripped = stripped.slice(quote[0].length);
+			context.push("quote");
+			continue;
+		}
+		const list = /^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:\t| {1,4}(?! ))/.exec(
+			stripped,
+		);
+		if (list) {
+			stripped = stripped.slice(list[0].length);
+			context.push("list");
+			continue;
+		}
+		return { text: stripped, context: context.join("/") };
 	}
 }
 
@@ -770,8 +786,9 @@ function referenceDestinationEnd(text: string, start: number): number {
 	let depth = 0;
 	let index = start;
 	for (; index < text.length; index++) {
-		// Space and the ASCII control range both end a bare destination.
-		if ((text.codePointAt(index) ?? 0) <= 0x20) break;
+		// Space and every ASCII control character end a bare destination.
+		const codePoint = text.codePointAt(index) ?? 0;
+		if (codePoint <= 0x20 || codePoint === 0x7f) break;
 		if (isEscaped(text, index)) continue;
 		if (text[index] === "(") {
 			depth++;
@@ -786,15 +803,34 @@ function referenceDestinationEnd(text: string, start: number): number {
 // Shape alone does not make a definition: `[label]: some prose` renders as the
 // visible sentence it is. Requiring a well-formed destination keeps a line the
 // reader can see out of the definition set, which is what stops such a line
-// from exempting its block from inspection. Where this still diverges from
-// CommonMark it must diverge toward inspecting more, never less — so a
-// destination deferred to the next line reads as prose here rather than as a
-// definition that could skip a block.
-function referenceDefinitionLabel(line: string): string | null {
-	const text = withoutContainerMarkers(line);
+// from exempting its block from inspection. Multiline destinations are
+// collected separately for document-wide reference resolution, but stay as
+// prose here: when block removal cannot afford the complete grammar it must
+// inspect more, never less.
+interface ReferenceDefinition {
+	label: string;
+	context: string;
+	mayContinueTitle: boolean;
+}
+
+function referenceLabelEnd(text: string, start: number): number {
+	for (let index = start + 1; index < text.length; index++) {
+		if (isEscaped(text, index)) continue;
+		if (text[index] === "[") return -1;
+		if (text[index] === "]") {
+			const label = text.slice(start + 1, index);
+			return label.trim().length > 0 && label.length <= 999 ? index : -1;
+		}
+	}
+	return -1;
+}
+
+function referenceDefinition(line: string): ReferenceDefinition | null {
+	const container = containerLine(line);
+	const text = container.text;
 	const start = text.search(/\S/);
 	if (start < 0 || start > 3 || text[start] !== "[") return null;
-	const labelEnd = matchingDelimiter(text, start, "[", "]");
+	const labelEnd = referenceLabelEnd(text, start);
 	if (labelEnd < 0 || text[labelEnd + 1] !== ":") return null;
 
 	const rest = text.slice(labelEnd + 2);
@@ -802,10 +838,20 @@ function referenceDefinitionLabel(line: string): string | null {
 	if (destinationStart < 0) return null;
 	const destinationEnd = referenceDestinationEnd(rest, destinationStart);
 	if (destinationEnd < 0) return null;
-	const trailing = rest.slice(destinationEnd).trim();
-	if (trailing.length > 0 && !REFERENCE_TITLE_BODY_RE.test(trailing)) return null;
+	const rawTrailing = rest.slice(destinationEnd);
+	const trailing = rawTrailing.trim();
+	if (
+		trailing.length > 0 &&
+		(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+	) {
+		return null;
+	}
 
-	return text.slice(start + 1, labelEnd);
+	return {
+		label: text.slice(start + 1, labelEnd),
+		context: container.context,
+		mayContinueTitle: trailing.length === 0,
+	};
 }
 
 // CommonMark matches link labels case-insensitively with runs of whitespace
@@ -818,44 +864,88 @@ function normalizedReferenceLabel(label: string): string {
 // document, so this is collected once per file and handed to every block.
 function referenceLabels(body: string): Set<string> {
 	const labels = new Set<string>();
-	let mayContinueDefinition = false;
-	for (const line of visibleMarkdownLines(body)) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
-			mayContinueDefinition = false;
+	const lines = visibleMarkdownLines(body);
+	let titleContinuationContext: string | null = null;
+	for (let index = 0; index < lines.length; index++) {
+		const line = lines[index];
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
+			titleContinuationContext = null;
 			continue;
 		}
 
-		const label = referenceDefinitionLabel(line);
-		if (label === null) {
-			mayContinueDefinition = false;
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
+			labels.add(normalizedReferenceLabel(definition.label));
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
-		const normalized = normalizedReferenceLabel(label);
-		if (normalized.length > 0) labels.add(normalized);
-		mayContinueDefinition = true;
+		titleContinuationContext = null;
+		const text = container.text;
+		const start = text.search(/\S/);
+		if (start < 0 || start > 3 || text[start] !== "[") continue;
+		const labelEnd = referenceLabelEnd(text, start);
+		if (labelEnd < 0 || text[labelEnd + 1] !== ":") continue;
+		if (text.slice(labelEnd + 2).trim().length > 0) continue;
+
+		const next = lines[index + 1];
+		if (next === undefined) continue;
+		const nextContainer = containerLine(next);
+		if (nextContainer.context !== container.context) continue;
+		const destinationStart = nextContainer.text.search(/\S/);
+		if (destinationStart < 0 || destinationStart > 3) continue;
+		const destinationEnd = referenceDestinationEnd(
+			nextContainer.text,
+			destinationStart,
+		);
+		if (destinationEnd < 0) continue;
+		const rawTrailing = nextContainer.text.slice(destinationEnd);
+		const trailing = rawTrailing.trim();
+		if (
+			trailing.length > 0 &&
+			(!/^[ \t]+/.test(rawTrailing) || !REFERENCE_TITLE_BODY_RE.test(trailing))
+		) {
+			continue;
+		}
+		labels.add(normalizedReferenceLabel(text.slice(start + 1, labelEnd)));
+		index++;
 	}
 	return labels;
 }
 
 function withoutReferenceDefinitions(text: string): string {
 	const visible: string[] = [];
-	let mayContinueDefinition = false;
+	let titleContinuationContext: string | null = null;
 	for (const line of text.split("\n")) {
-		if (mayContinueDefinition && REFERENCE_TITLE_RE.test(line)) {
+		const container = containerLine(line);
+		if (
+			titleContinuationContext !== null &&
+			container.context === titleContinuationContext &&
+			REFERENCE_TITLE_RE.test(container.text)
+		) {
 			visible.push("");
-			mayContinueDefinition = false;
+			titleContinuationContext = null;
 			continue;
 		}
 
-		if (referenceDefinitionLabel(line) !== null) {
+		const definition = referenceDefinition(line);
+		if (definition !== null) {
 			visible.push("");
-			mayContinueDefinition = true;
+			titleContinuationContext = definition.mayContinueTitle
+				? definition.context
+				: null;
 			continue;
 		}
 
 		visible.push(line);
-		mayContinueDefinition = false;
+		titleContinuationContext = null;
 	}
 	return visible.join("\n");
 }

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.57";
+export const AIDLC_VERSION = "2.5.58";

--- a/tests/unit/t247-claim-sources-sensor.test.ts
+++ b/tests/unit/t247-claim-sources-sensor.test.ts
@@ -544,25 +544,40 @@ describe("t247 claim-sources sensor", () => {
   // both directions. A line that only looks like a definition is prose the
   // reader sees, and a real definition stays real inside a container. Getting
   // either wrong lets unsourced or invisible-tag content through silently.
-  test("a definition-shaped line with an invalid destination is inspected as prose", () => {
-    const dir = makeStageDir();
-    replaceInFile(
-      dir,
-      "intent-statement.md",
-      "## Assumptions & Open Questions",
-      "[evidence]: this is an unsupported assertion\n\n## Assumptions & Open Questions",
-    );
+  for (const [label, line] of [
+    ["trailing prose", "[evidence]: this is an unsupported assertion"],
+    ["an unclosed angle-bracket destination", "[evidence]: <broken"],
+    ["an unbalanced bare destination", "[evidence]: /foo(bar"],
+    ["a bare destination closing a group it never opened", "[evidence]: /foo)bar"],
+    ["an unescaped angle bracket in the destination", "[evidence]: <a<b>"],
+    ["an unescaped parenthesis in the title", "[evidence]: /url (ti(tle)"],
+    [
+      "an indented code block after a list marker",
+      "-     [evidence]: https://example.invalid",
+    ],
+  ] as const) {
+    test(`a definition-shaped line with ${label} is inspected as prose`, () => {
+      const dir = makeStageDir();
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "## Assumptions & Open Questions",
+        `${line}\n\n## Assumptions & Open Questions`,
+      );
 
-    const result = run(dir);
-    expect(result.pass).toBe(false);
-    expect(result.findings.join("\n")).toContain(
-      "claim block has no source tag",
-    );
-  });
+      const result = run(dir);
+      expect(result.pass).toBe(false);
+      expect(result.findings.join("\n")).toContain(
+        "claim block has no source tag",
+      );
+    });
+  }
 
   for (const [label, definition] of [
     ["a block quote", "> [Q1]: https://example.invalid"],
     ["a list item", "- [Q1]: https://example.invalid"],
+    ["a block quote inside a list item", "- > [Q1]: https://example.invalid"],
+    ["a list item inside a block quote", "> - [Q1]: https://example.invalid"],
   ] as const) {
     test(`a definition inside ${label} still turns its reference into a link`, () => {
       const dir = makeStageDir();

--- a/tests/unit/t247-claim-sources-sensor.test.ts
+++ b/tests/unit/t247-claim-sources-sensor.test.ts
@@ -484,4 +484,73 @@ describe("t247 claim-sources sensor", () => {
     expect(result.pass).toBe(true);
     expect(result.findings).toEqual([]);
   });
+
+  // A reference link resolves only against a link reference definition that the
+  // document actually carries. Without one, CommonMark renders the brackets as
+  // literal text, so the tags stay visible and still ground the claim.
+  for (const [label, replacement] of [
+    ["two adjacent tags", "[desc][Q1]"],
+    ["three adjacent tags", "[desc][Q1][Q2]"],
+    ["a collapsed reference", "[desc][]"],
+    ["an adjacent pair inside a longer run", "[desc] [Q1][Q2] [Q3]"],
+  ] as const) {
+    test(`${label} without a matching definition still grounds a claim`, () => {
+      const dir = makeStageDir();
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+        `The initiative provides a local command that echoes supplied text. ${replacement}`,
+      );
+
+      const result = run(dir);
+      expect(result.pass).toBe(true);
+      expect(result.findings).toEqual([]);
+    });
+  }
+
+  // The mirror of the rule above: once the document defines the label, the
+  // brackets really are a link, the reader sees link text rather than a tag,
+  // and the claim is no longer grounded by it.
+  for (const [label, replacement, definition] of [
+    ["a full reference", "[desc][evidence]", "[evidence]: https://example.invalid"],
+    ["a collapsed reference", "[desc][]", "[desc]: https://example.invalid"],
+    ["a shortcut reference", "[desc]", "[desc]: https://example.invalid"],
+  ] as const) {
+    test(`${label} with a matching definition does not ground a claim`, () => {
+      const dir = makeStageDir();
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+        `The initiative provides a local command that echoes supplied text. ${replacement}`,
+      );
+      const statementPath = join(dir, "intent-statement.md");
+      writeFileSync(
+        statementPath,
+        `${readFileSync(statementPath, "utf-8")}\n${definition}\n`,
+        "utf-8",
+      );
+
+      const result = run(dir);
+      expect(result.pass).toBe(false);
+      expect(result.findings.join("\n")).toContain(
+        "claim block has no source tag",
+      );
+    });
+  }
+
+  test("a link reference definition is not itself a claim block", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Assumptions & Open Questions",
+      "[evidence]: https://example.invalid\n\n## Assumptions & Open Questions",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(true);
+    expect(result.findings).toEqual([]);
+  });
 });

--- a/tests/unit/t247-claim-sources-sensor.test.ts
+++ b/tests/unit/t247-claim-sources-sensor.test.ts
@@ -555,7 +555,6 @@ describe("t247 claim-sources sensor", () => {
     ["an unescaped angle bracket in the destination", "[evidence]: <a<b>"],
     ["an inline title without separating whitespace", '[evidence]: <url>"title"'],
     ["a DEL control character in the destination", "[evidence]: foo\u007fbar"],
-    ["top-level indentation that makes it code", "    [evidence]: /url"],
     ["an unescaped parenthesis in the title", "[evidence]: /url (ti(tle)"],
     [
       "an indented code block after a list marker",
@@ -578,6 +577,38 @@ describe("t247 claim-sources sensor", () => {
       );
     });
   }
+
+  test("a four-space-indented top-level definition is inspected as code", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "    [evidence]: /url",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("a tab-indented top-level definition is inspected as code", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "\t[evidence]: /url",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
 
   test("an inline title leaves the following quoted assertion visible", () => {
     const dir = makeStageDir();
@@ -615,6 +646,347 @@ describe("t247 claim-sources sensor", () => {
     expect(result.findings.join("\n")).toContain(
       "claim block has no source tag",
     );
+  });
+
+  test("a multiline destination inherits its parent list-item context", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "This is an unsupported assertion. [desc][Q1]",
+    );
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Review",
+      "## Review\n- [Q1]:\n  /url",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("a reference title may span physical lines", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "This is an unsupported assertion. [desc][Q1]",
+    );
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Review",
+      '## Review\n[Q1]: /url "title\ncontinued"',
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("reference-label length counts Unicode code points", () => {
+    const dir = makeStageDir();
+    const astralLabel = String.fromCodePoint(0x1f600).repeat(500);
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      `This is an unsupported assertion. [Q1][${astralLabel}]`,
+    );
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Review",
+      `## Review\n[${astralLabel}]: /url`,
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("a bare destination nested 33 levels is inspected as prose", () => {
+    const dir = makeStageDir();
+    const destination = `a${"(".repeat(33)}b${")".repeat(33)}`;
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      `[evidence]: ${destination}`,
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("ordered-list items ending in a parenthesis are separate claims", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      '1) [evidence]: /url\n2) "This is an unsupported assertion."',
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("an indented definition inherits its parent list-item context", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "- [desc]\n\n    [Q1]: /url\n\nThis is an unsupported assertion. [desc][Q1]",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("a multiline reference label resolves after whitespace normalization", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "This is an unsupported assertion. [desc][foo bar]",
+    );
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Review",
+      "## Review\n[foo\nbar]: /url",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("reference labels use Unicode full case folding", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "[ss]: /url\n\nThis is an unsupported assertion. [desc][\u1e9e]",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  for (const [label, definition] of [
+    ["a list nested in a block quote", "> - [Q1]:\n>   /url"],
+    ["a block quote nested in a list", "- > [Q1]:\n  > /url"],
+    ["a tab-indented list continuation", "- [Q1]:\n\t/url"],
+  ] as const) {
+    test(`a multiline destination preserves ${label}`, () => {
+      const dir = makeStageDir();
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+        "This is an unsupported assertion. [desc][Q1]",
+      );
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "## Review",
+        `## Review\n${definition}`,
+      );
+
+      const result = run(dir);
+      expect(result.pass).toBe(false);
+      expect(result.findings.join("\n")).toContain(
+        "claim block has no source tag",
+      );
+    });
+  }
+
+  test("a multiline label cannot cross an ATX heading", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "[Q1\n## Unsupported assertion]: /url",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("a multiline title cannot cross a thematic break", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      '[Q1]: /url "title\n---\nThis is an unsupported assertion."',
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("an HTML block interrupts a malformed multiline title", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      '[Q1]: /url "title\n<div>\nThis is an unsupported assertion."',
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("an asterisk thematic break interrupts a malformed multiline title", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      '[Q1]: /url "title\n***\nThis is an unsupported assertion."',
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  for (const [label, definition, reference] of [
+    ["destination", "[Q1]:\n    /url", "[desc][Q1]"],
+    ["label", "[foo\n    bar]: /url", "[desc][foo bar]"],
+  ] as const) {
+    test(`a multiline reference ${label} permits lazy indentation`, () => {
+      const dir = makeStageDir();
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+        `This is an unsupported assertion. ${reference}`,
+      );
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "## Review",
+        `## Review\n${definition}`,
+      );
+
+      const result = run(dir);
+      expect(result.pass).toBe(false);
+      expect(result.findings.join("\n")).toContain(
+        "claim block has no source tag",
+      );
+    });
+  }
+
+  test("an outer block-quote blank preserves the active list item", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "This is an unsupported assertion. [desc][Q1]",
+    );
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Review",
+      "## Review\n> - [desc]\n>\n>     [Q1]: /url",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  for (const [label, definition] of [
+    ["a nested list", "- - [Q1]:\n    /url"],
+    ["a nested list inside a block quote", "> - - [Q1]:\n>     /url"],
+    ["a nested list around a block quote", "- > - [Q1]:\n  >   /url"],
+    ["an elided list marker", "- [Q1]:\n/url"],
+    ["an elided block-quote marker", "> [Q1]:\n/url"],
+    ["elided quote and list markers", "> - [Q1]:\n    /url"],
+  ] as const) {
+    test(`a multiline destination preserves ${label}`, () => {
+      const dir = makeStageDir();
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+        "This is an unsupported assertion. [desc][Q1]",
+      );
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "## Review",
+        `## Review\n${definition}`,
+      );
+
+      const result = run(dir);
+      expect(result.pass).toBe(false);
+      expect(result.findings.join("\n")).toContain(
+        "claim block has no source tag",
+      );
+    });
+  }
+
+  test("a bare destination nested 32 levels remains a definition", () => {
+    const dir = makeStageDir();
+    const destination = `a${"(".repeat(32)}b${")".repeat(32)}`;
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Assumptions & Open Questions",
+      `[evidence]: ${destination}\n\n## Assumptions & Open Questions`,
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(true);
+    expect(result.findings).toEqual([]);
   });
 
   for (const [label, definition] of [

--- a/tests/unit/t247-claim-sources-sensor.test.ts
+++ b/tests/unit/t247-claim-sources-sensor.test.ts
@@ -540,6 +540,53 @@ describe("t247 claim-sources sensor", () => {
     });
   }
 
+  // Definition detection has to agree with CommonMark's definition grammar in
+  // both directions. A line that only looks like a definition is prose the
+  // reader sees, and a real definition stays real inside a container. Getting
+  // either wrong lets unsourced or invisible-tag content through silently.
+  test("a definition-shaped line with an invalid destination is inspected as prose", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Assumptions & Open Questions",
+      "[evidence]: this is an unsupported assertion\n\n## Assumptions & Open Questions",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  for (const [label, definition] of [
+    ["a block quote", "> [Q1]: https://example.invalid"],
+    ["a list item", "- [Q1]: https://example.invalid"],
+  ] as const) {
+    test(`a definition inside ${label} still turns its reference into a link`, () => {
+      const dir = makeStageDir();
+      replaceInFile(
+        dir,
+        "intent-statement.md",
+        "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+        "The initiative provides a local command that echoes supplied text. [desc][Q1]",
+      );
+      const statementPath = join(dir, "intent-statement.md");
+      writeFileSync(
+        statementPath,
+        `${readFileSync(statementPath, "utf-8")}\n${definition}\n`,
+        "utf-8",
+      );
+
+      const result = run(dir);
+      expect(result.pass).toBe(false);
+      expect(result.findings.join("\n")).toContain(
+        "claim block has no source tag",
+      );
+    });
+  }
+
   test("a link reference definition is not itself a claim block", () => {
     const dir = makeStageDir();
     replaceInFile(

--- a/tests/unit/t247-claim-sources-sensor.test.ts
+++ b/tests/unit/t247-claim-sources-sensor.test.ts
@@ -545,11 +545,17 @@ describe("t247 claim-sources sensor", () => {
   // reader sees, and a real definition stays real inside a container. Getting
   // either wrong lets unsourced or invisible-tag content through silently.
   for (const [label, line] of [
+    ["an empty label", "[]: /url"],
+    ["a whitespace-only label", "[   ]: /url"],
+    ["an unescaped bracket in the label", "[a[b]]: /url"],
     ["trailing prose", "[evidence]: this is an unsupported assertion"],
     ["an unclosed angle-bracket destination", "[evidence]: <broken"],
     ["an unbalanced bare destination", "[evidence]: /foo(bar"],
     ["a bare destination closing a group it never opened", "[evidence]: /foo)bar"],
     ["an unescaped angle bracket in the destination", "[evidence]: <a<b>"],
+    ["an inline title without separating whitespace", '[evidence]: <url>"title"'],
+    ["a DEL control character in the destination", "[evidence]: foo\u007fbar"],
+    ["top-level indentation that makes it code", "    [evidence]: /url"],
     ["an unescaped parenthesis in the title", "[evidence]: /url (ti(tle)"],
     [
       "an indented code block after a list marker",
@@ -572,6 +578,44 @@ describe("t247 claim-sources sensor", () => {
       );
     });
   }
+
+  test("an inline title leaves the following quoted assertion visible", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Assumptions & Open Questions",
+      '[evidence]: /url "title"\n"This is an unsupported assertion."\n\n## Assumptions & Open Questions',
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
+
+  test("a multiline definition resolves shortcut references document-wide", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "The initiative provides a local command that echoes supplied text. [desc] [Q1]",
+      "The initiative provides a local command that echoes supplied text. [desc]",
+    );
+    replaceInFile(
+      dir,
+      "intent-statement.md",
+      "## Review",
+      "## Review\n[desc]:\n/url",
+    );
+
+    const result = run(dir);
+    expect(result.pass).toBe(false);
+    expect(result.findings.join("\n")).toContain(
+      "claim block has no source tag",
+    );
+  });
 
   for (const [label, definition] of [
     ["a block quote", "> [Q1]: https://example.invalid"],


### PR DESCRIPTION
> **This description covers the change as opened.** Two review rounds have landed since, both
> reported here in the thread: definition detection now follows CommonMark's destination, title
> and container grammar, checked against a reference implementation over a generated sweep.

Closes #665.

## The report

`claim-sources` reported `claim block has no source tag` for claims that carry two tags with no separator — `[Q1][Q2]` — while the same claim passed with a space between them. @wowzoo's write-up already named the mechanism, and it holds: `visibleMarkdownLinkText` treats any `[a][b]` as a reference link and consumes the pair before `SOURCE_TAG_RE` ever sees it.

I reproduced it against the shipped sensor before changing anything, using `tests/fixtures/intent-grounding/passing` and a one-token mutation:

| claim text | before | after |
| --- | --- | --- |
| `[desc] [Q1]` (baseline) | `pass=true`, 0 findings | `pass=true`, 0 findings |
| `[desc][Q1]` | `pass=false`, *claim block has no source tag* | `pass=true`, 0 findings |

## Two things the report does not cover

Probing around the case turned up that the bug is **parity-dependent**, and that it has a mirror.

`[desc][Q1][Q2]` — three adjacent tags — passes today. Only the first pair is consumed, so the third tag survives and grounds the claim. The failure needs an even run; a document can carry adjacent tags in one paragraph and be fine, then fail in the next. That is worth a pinned test either way, so this PR adds one.

The mirror is the more interesting half. A shortcut `[Q1]` in a document that *also* defines `[Q1]: <url>` really is a link — the reader sees link text, not a tag — and the sensor accepts it as grounding. So the sensor was consuming brackets that CommonMark leaves as text, and keeping brackets that CommonMark turns into a link. Both are the same missing question: **is this label defined?**

I checked the contract against a reference CommonMark implementation rather than reasoning from the spec alone (markdown-it in `commonmark` mode):

| input | CommonMark | sensor before |
| --- | --- | --- |
| `[Q1][Q2]`, no definition | literal text | consumed |
| `[Q1][Q2]` + `[Q2]: url` | link | consumed ✓ |
| `[Q1][]`, no definition | literal text | consumed |
| `[Q1]`, no definition | literal text | kept ✓ |
| `[Q1]` + `[Q1]: url` | link | kept |

## The change

Reference resolution now consults the labels the document actually defines. Full `[a][b]`, collapsed `[a][]`, and shortcut `[a]` are each a link only when the named label is defined; otherwise the brackets stay literal and the tags remain visible. Labels are collected **per document**, because that is a reference definition's scope, and handed to the per-block and per-line callers — a block cannot see a definition that sits three paragraphs below it.

One consequence fell out of the same rule and is included: a paragraph holding only link reference definitions renders as nothing, so it is no longer treated as a claim block owing a tag. Before this, adding a normal reference-style link to a deliverable produced a finding against the definition line itself.

## Why not the fix the issue suggests

@wowzoo proposed exempting bracket groups whose content matches `SOURCE_TAG_RE` from reference-link handling, on the reasoning that a source tag is never a link label. That disambiguates the reported case correctly, and I want to be clear that it would work for it. I went a different way for two reasons.

The premise does not hold in general: in a document that defines `[Q1]: <url>`, `[Q1]` *is* a link label, and the reader sees a link. A content-based exemption would keep that reading a tag — the mirror described above — so the sensor would still disagree with the rendered document, just in the other direction. Resolving against the definitions the document carries answers both halves with the same rule, and it is CommonMark's own rule rather than a sensor-local exception list.

The issue's other suggestion — collect tags before link-syntax stripping — would drop protections `t247` currently pins: tags hidden in a link destination, in image alt metadata, in a reference title, or in an HTML attribute must *not* ground a claim, and each of those depends on the stripping running first.

On the third option you raised — declaring adjacent tags invalid and saying so in the stage prose — I took the opposite branch, because CommonMark already renders `[Q1][Q2]` as two visible tags and nothing in the prose asks the conductor to separate them. Pinning citation style would make the author responsible for a distinction the rendered document does not make. Your measurement carried weight here: 5 of 8 findings false in a single `poc` run, invisible to an author looking at a file that plainly shows the tags.

## Decisions I made, and would happily revisit

**Scope beyond the reported case.** I fixed the shortcut mirror rather than only the reported pair. The two are one rule and one code path, and leaving the mirror in place would mean the sensor keeps accepting a tag that renders as a link. If you would rather keep this PR to exactly the reported symptom, removing the shortcut branch is a two-line change and I will do it.

**What counts as a definition.** The sensor already recognises a definition by line shape (`withoutReferenceDefinitions` + `REFERENCE_TITLE_RE`), which is more permissive than CommonMark — CommonMark requires the definition to start its own block, so a `[label]: url` sitting on the second line of a paragraph is a lazy continuation and *not* a definition. I deliberately reused the sensor's existing notion instead of introducing a stricter one, so that label collection and definition removal cannot disagree with each other, and because tightening definition detection is a second behaviour change with its own risk. The residual gap is conservative in the direction that matters: the sensor may consider a label defined where CommonMark would not, and consume a pair it could have kept. `t247`'s existing *Markdown reference metadata* case depends on this reading, and still passes. Happy to take the stricter rule as a follow-up if you want it.

**Version slot.** Now **2.5.37**: 2.5.31 merged while this sat (#671), and 2.5.34–2.5.36 are claimed by open PRs. I read each open PR's actual `AIDLC_VERSION` diff rather than its title, since several titles trail their own bump. Glad to move it if you are sequencing differently.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- `t247` grew 26 → 34 tests at the time this was opened (**45 today**, after two review rounds): four cases pinning that undefined adjacent, triple-adjacent, collapsed, and mixed-run tags all ground a claim; three pinning that a defined full, collapsed, or shortcut reference grounds nothing; one pinning that a definition-only paragraph is not a claim block. Four of the eight fail on `v2` before the change.
- `bun scripts/package.ts` + `bun scripts/package.ts --check` → green for all 5 harnesses.
- `bun run check` (typecheck + biome) → clean, 543 files.
- `t68` (version/CHANGELOG/badge sync at 2.5.37), `gen-coverage-registry`, and `t247` → 74 tests, 0 failures. The coverage registry was regenerated with `bun tests/gen-coverage-registry.ts`, not hand-edited.
- Regression across everything that reaches the sensor: `t247`, `t227`, `t230`, `t234`, `t86`, `t68`, `gen-coverage-registry` → 171 tests, 1742 assertions, 0 failures; `t92` and `t93` (integration) → 60 tests, 223 assertions, 0 failures.
- **What I could not run:** the full `tests/unit/` tier does not complete on my Windows machine — I stopped it after ~30 minutes with no output, which matches the platform-specific failures I have hit on this repo before and is not specific to this change. The targeted runs above are the evidence I actually have; a Linux run of the full tier would be worth having before merge.
- The sensor's manifest documents the rule the tests pin, so a reader hitting this does not have to infer it from behaviour.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).

