### PR TITLE
fix(kiro-ide): stop reporting a failed write as harness decay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 .DS_Store
 ._*
 
+# Bun transient compilation artifacts
+*.bun-build
+
 # Generated AI-DLC artifacts (recreated by workflow runs / doctor)
 dist/claude/aidlc-docs/
 dist/kiro/aidlc-docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.43] - 2026-08-06
+
+Stops `/aidlc --doctor` from reporting hook decay on the Kiro IDE harness when a write simply failed. The adapter recorded a visible hook drop whenever it could not extract a file path from a write tool's result, which conflated two very different situations: a write that FAILED (no artifact exists, so declining to forward it is correct) and a write that SUCCEEDED but whose result wording could not be parsed (the genuine degradation the drop log exists to surface). Only the second belongs there. **Upgrade:** `mkdir -p your-project/.kiro && cp -R dist/kiro-ide/.kiro/. your-project/.kiro/`. If `/aidlc --doctor` still reports a Kiro adapter drop created before this fix, inspect the affected intent record's `<record>/.aidlc-hooks-health/kiro-adapter.drops`; delete only that individual file, and only after verifying its entries are historical/stale. Preserve it if it contains current failures.
+
+* `/aidlc --doctor` no longer reports hook degradation on a workspace whose hooks are working correctly. A failed `str_replace` - for example one whose old string matched multiple times - is no longer counted as a drop. The IDE 1.x stdin channel carries no success flag, so these failures arrive only as error prose and the existing `toolSuccess` guard could not catch them; every one of them was logged as decay, which trains the reader to ignore the one channel that matters when something genuinely breaks.
+* A *successful* write whose result wording matches no known path pattern is still recorded as a visible drop, unchanged. The failure classifier is deliberately narrow (start-anchored failure prefixes, not a loose "contains error" test), runs only when the payload has no structured success flag, and never overrides legacy IDE 0.12's explicit `toolSuccess: true`; the default stays biased toward reporting rather than silence.
+* Of the four failure-prose patterns the classifier matches, only `Caught an error while ...` is grounded in a live capture; the other three are marked in the code as defensive guesses rather than observed shapes. A match can only suppress a drop after path extraction has already failed and structured success is unavailable, and no known success wording begins with error prose, so the risk direction is one-way.
+* Docs: `docs/reference/kiro-ide-hook-payload.md` describes the failed-write/unrecognized-success split and makes `hookDebug`'s opt-in behavior explicit. No command, flag, or audit/sensor output-format changes; no breaking change for CI or scripts.
+
 ## [2.5.42] - 2026-08-06
 
 Restores the gitignored `aidlc/active-space` cursor after cloning a committed workspace. The cursor still defaults safely to `default` when absent, but SessionStart and active-intent writes now atomically materialize it without overwriting a concurrent explicit space switch. **Upgrade:** re-copy your `dist/<harness>/` shell so the updated library and SessionStart hook are installed; no repository migration or configuration change is required.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.42-blue)
+![version](https://img.shields.io/badge/version-2.5.43-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.42";
+export const AIDLC_VERSION = "2.5.43";

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.42";
+export const AIDLC_VERSION = "2.5.43";

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.42";
+export const AIDLC_VERSION = "2.5.43";

--- a/dist/kiro-ide/.kiro/hooks/aidlc-kiro-adapter.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-kiro-adapter.ts
@@ -248,6 +248,42 @@ function extractWrittenPath(toolResult: string): string {
   return "";
 }
 
+// Does this toolResult describe a write that FAILED? Used only to keep the drop
+// log honest: a failed write has no artifact to audit, so not forwarding it is
+// correct behaviour and must NOT be recorded as harness decay (see the call
+// site). The 1.x stdin channel carries no success flag, so error prose is the
+// only signal available.
+//
+// EVIDENCE GRADING — only the first pattern is grounded in a capture:
+//   ^Caught an error while   OBSERVED live on IDE 1.x (a str_replace whose old
+//                            string matched multiple times). This is the case
+//                            that motivated the fix.
+//   ^Error:                  DEFENSIVE GUESS. Not observed; no capture in this
+//   ^Failed to               repo or in docs/reference/kiro-ide-hook-payload.md
+//   ^An error occurred       backs these three shapes.
+// They are kept because the risk direction is mild and one-way: a match only
+// suppresses a drop when path extraction has ALREADY failed and the payload has
+// no structured success flag. Explicit `toolSuccess: true` remains authoritative.
+// Masking real decay would therefore require a new flagless SUCCESS wording that
+// begins with error prose — and the known success wordings ("Created the …",
+// "Replaced text in …", "Appended the text to …") cannot collide with any of
+// them. If a capture ever contradicts one, delete it rather than widening the set.
+//
+// Every pattern is start-anchored on purpose: a loose "contains 'error'" test
+// would swallow a successful write to a file whose NAME mentions an error, which
+// would hide exactly the decay this log exists to surface. Anything unrecognised
+// is treated as a success and still earns a visible drop — the default stays
+// biased toward reporting, not toward silence.
+function isFailedWriteResult(toolResult: string): boolean {
+  const s = toolResult.trim();
+  return (
+    /^Caught an error while /i.test(s) ||
+    /^Error:/i.test(s) ||
+    /^Failed to /i.test(s) ||
+    /^An error occurred/i.test(s)
+  );
+}
+
 // Map the IDE tool name to the canonical name the core hooks match on. Write
 // creates a (possibly new) file; str_replace/fs_append always target an
 // existing file → Edit (forces ARTIFACT_UPDATED in the core audit-logger).
@@ -338,11 +374,29 @@ function buildForward(): Forward {
       if (canon === "") return null;
       const rawPath = extractWrittenPath(ide.toolResult ?? "");
       if (!rawPath) {
-        // A write-class tool ran but its toolResult wording did not match any
-        // known pattern → the write is dropped from audit + sensors. Record a
-        // visible drop (finding 4) so `--doctor` can surface the decay instead
-        // of it being an invisible no-op — the exact failure class this harness
-        // exists to eliminate.
+        // TWO DISTINCT CASES REACH HERE, and conflating them is what made the
+        // drop log useless as a health signal:
+        //   (a) The write FAILED. There is no artifact to audit, so not
+        //       forwarding is CORRECT, not decay. The 1.x stdin channel carries
+        //       no success flag (so the `toolSuccess === false` guard above
+        //       cannot catch it), and the failure arrives only as error prose —
+        //       e.g. a str_replace whose old string matched multiple times.
+        //   (b) The write SUCCEEDED but its result wording matched no known
+        //       pattern. THIS is the invisible decay this harness exists to
+        //       eliminate, and the only case that belongs in the drop log.
+        // Recording (a) as a drop made `--doctor` report decay on a workspace
+        // whose hooks were working perfectly, which trains the reader to ignore
+        // the channel that matters. So classify flagless payloads first: log (a)
+        // at debug level and reserve the visible drop for (b). A structured
+        // `toolSuccess: true` is authoritative and must never be overridden by
+        // defensive prose guesses.
+        if (ide.toolSuccess === undefined && isFailedWriteResult(ide.toolResult ?? "")) {
+          hookDebug(projectDir, "kiro-adapter", "audit-and-sensors: write failed, nothing to audit", {
+            toolName: ide.toolName ?? "?",
+            toolResult: (ide.toolResult ?? "").slice(0, 160),
+          });
+          return null;
+        }
         recordHookDrop(
           projectDir,
           "kiro-adapter",

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.42";
+export const AIDLC_VERSION = "2.5.43";

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.42";
+export const AIDLC_VERSION = "2.5.43";

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.42";
+export const AIDLC_VERSION = "2.5.43";

--- a/docs/reference/kiro-ide-hook-payload.md
+++ b/docs/reference/kiro-ide-hook-payload.md
@@ -56,12 +56,18 @@ Result prose is identical on both channels (`toolResult` on 0.12,
    and delegation inputs (#543).
 2. **1.x carries no success flag.** Only the 0.12 channel's explicit boolean
    `toolSuccess: false` drops a well-formed write from the audit (#417); a 1.x
-   payload with the field absent falls through to the path check, and error
-   prose that matches no known pattern records a visible hook-drop. A present
-   non-null payload field with the wrong runtime type is treated as malformed:
-   the advisory hook exits successfully, records a visible drop, and forwards
-   no audit or subagent event. `null` is treated like an unavailable field,
-   matching the channel's existing absent-value contract.
+   payload with the field absent falls through to the path check. Because that
+   channel cannot report failure structurally, a failed write on 1.x arrives
+   only as error prose — so the adapter classifies before logging: prose
+   RECOGNISED as a failure is sent to `hookDebug` (written only when hook
+   debugging is enabled); there is no artifact to audit, so not forwarding it
+   is correct, not decay. An unrecognised wording still records a visible
+   hook-drop, which is the case that signals real degradation. On the legacy
+   0.12 channel, explicit `toolSuccess: true` remains authoritative and bypasses
+   failure-prose inference. A present non-null payload field with the wrong
+   runtime type is treated as malformed:
+   the advisory hook exits successfully, records a visible drop, and forwards no audit or subagent event. `null` is treated like
+   an unavailable field, matching the channel's existing absent-value contract.
 3. **Paths in the result prose are workspace-RELATIVE**, but the core hooks
    compare against an absolute record root — so the adapter resolves them to
    absolute before forwarding.
@@ -70,8 +76,14 @@ Result prose is identical on both channels (`toolResult` on 0.12,
 
 - **audit-logger / sensor-fire** — recoverable: scrape the file path from
   the result prose, resolve to absolute, feed the core hooks the Claude-shaped
-  `{tool_input:{file_path}}`. A write-class tool whose wording does not match a
-  known pattern records a visible hook-drop (never a silent no-op).
+  `{tool_input:{file_path}}`. When no path can be extracted the adapter splits
+  two cases rather than logging both: prose recognised as a **failed** write is
+  sent to `hookDebug` (written only when hook debugging is enabled) and is not
+  forwarded because no artifact exists; this inference runs only when the
+  payload has no structured success flag. Explicit `toolSuccess: true` and any
+  other unmatched wording record a visible hook-drop (never a silent no-op) —
+  that is the invisible-decay case the drop log exists to surface. Conflating
+  them made `--doctor` report degradation on healthy workspaces.
 - **runtime-compile** — the shell command is unrecoverable, so the IDE path
   drops the command filter and gates purely on the audit tail (with an mtime
   idempotency guard so a lingering transition — e.g. after `WORKFLOW_COMPLETED`

--- a/harness/kiro-ide/hooks/aidlc-kiro-adapter.ts
+++ b/harness/kiro-ide/hooks/aidlc-kiro-adapter.ts
@@ -248,6 +248,42 @@ function extractWrittenPath(toolResult: string): string {
   return "";
 }
 
+// Does this toolResult describe a write that FAILED? Used only to keep the drop
+// log honest: a failed write has no artifact to audit, so not forwarding it is
+// correct behaviour and must NOT be recorded as harness decay (see the call
+// site). The 1.x stdin channel carries no success flag, so error prose is the
+// only signal available.
+//
+// EVIDENCE GRADING — only the first pattern is grounded in a capture:
+//   ^Caught an error while   OBSERVED live on IDE 1.x (a str_replace whose old
+//                            string matched multiple times). This is the case
+//                            that motivated the fix.
+//   ^Error:                  DEFENSIVE GUESS. Not observed; no capture in this
+//   ^Failed to               repo or in docs/reference/kiro-ide-hook-payload.md
+//   ^An error occurred       backs these three shapes.
+// They are kept because the risk direction is mild and one-way: a match only
+// suppresses a drop when path extraction has ALREADY failed and the payload has
+// no structured success flag. Explicit `toolSuccess: true` remains authoritative.
+// Masking real decay would therefore require a new flagless SUCCESS wording that
+// begins with error prose — and the known success wordings ("Created the …",
+// "Replaced text in …", "Appended the text to …") cannot collide with any of
+// them. If a capture ever contradicts one, delete it rather than widening the set.
+//
+// Every pattern is start-anchored on purpose: a loose "contains 'error'" test
+// would swallow a successful write to a file whose NAME mentions an error, which
+// would hide exactly the decay this log exists to surface. Anything unrecognised
+// is treated as a success and still earns a visible drop — the default stays
+// biased toward reporting, not toward silence.
+function isFailedWriteResult(toolResult: string): boolean {
+  const s = toolResult.trim();
+  return (
+    /^Caught an error while /i.test(s) ||
+    /^Error:/i.test(s) ||
+    /^Failed to /i.test(s) ||
+    /^An error occurred/i.test(s)
+  );
+}
+
 // Map the IDE tool name to the canonical name the core hooks match on. Write
 // creates a (possibly new) file; str_replace/fs_append always target an
 // existing file → Edit (forces ARTIFACT_UPDATED in the core audit-logger).
@@ -338,11 +374,29 @@ function buildForward(): Forward {
       if (canon === "") return null;
       const rawPath = extractWrittenPath(ide.toolResult ?? "");
       if (!rawPath) {
-        // A write-class tool ran but its toolResult wording did not match any
-        // known pattern → the write is dropped from audit + sensors. Record a
-        // visible drop (finding 4) so `--doctor` can surface the decay instead
-        // of it being an invisible no-op — the exact failure class this harness
-        // exists to eliminate.
+        // TWO DISTINCT CASES REACH HERE, and conflating them is what made the
+        // drop log useless as a health signal:
+        //   (a) The write FAILED. There is no artifact to audit, so not
+        //       forwarding is CORRECT, not decay. The 1.x stdin channel carries
+        //       no success flag (so the `toolSuccess === false` guard above
+        //       cannot catch it), and the failure arrives only as error prose —
+        //       e.g. a str_replace whose old string matched multiple times.
+        //   (b) The write SUCCEEDED but its result wording matched no known
+        //       pattern. THIS is the invisible decay this harness exists to
+        //       eliminate, and the only case that belongs in the drop log.
+        // Recording (a) as a drop made `--doctor` report decay on a workspace
+        // whose hooks were working perfectly, which trains the reader to ignore
+        // the channel that matters. So classify flagless payloads first: log (a)
+        // at debug level and reserve the visible drop for (b). A structured
+        // `toolSuccess: true` is authoritative and must never be overridden by
+        // defensive prose guesses.
+        if (ide.toolSuccess === undefined && isFailedWriteResult(ide.toolResult ?? "")) {
+          hookDebug(projectDir, "kiro-adapter", "audit-and-sensors: write failed, nothing to audit", {
+            toolName: ide.toolName ?? "?",
+            toolResult: (ide.toolResult ?? "").slice(0, 160),
+          });
+          return null;
+        }
         recordHookDrop(
           projectDir,
           "kiro-adapter",

--- a/tests/unit/t218-kiro-ide-hook-adapter.test.ts
+++ b/tests/unit/t218-kiro-ide-hook-adapter.test.ts
@@ -1012,6 +1012,85 @@ describe("t218 extractWrittenPath robustness (finding 4)", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // =========================================================================
+  // F4d/F4e — CLASSIFY BEFORE LOGGING. Two very different situations reach the
+  // "no extractable path" branch, and conflating them made `--doctor` report
+  // hook degradation on workspaces whose hooks were working perfectly:
+  //
+  //   FAILED write    -> no artifact exists, so declining to forward it is
+  //                      CORRECT. Must NOT be recorded as decay.
+  //   SUCCEEDED write
+  //   with unknown
+  //   wording         -> the invisible decay this log exists to surface.
+  //                      Must still be recorded.
+  //
+  // The 1.x stdin channel carries no success flag, so the `toolSuccess === false`
+  // guard (#417, T1 above) cannot catch the first case — the failure arrives only
+  // as error prose. These two cases sit together deliberately: the CONTRAST is
+  // the contract, and pinning them apart would let a reordered guard or a
+  // tightened regex regress one while the other kept passing.
+  // =========================================================================
+  test("F4d: a FAILED write (error prose, 1.x channel) records NO drop", () => {
+    const dir = scratchProject(true);
+    try {
+      // Verbatim prose captured live on IDE 1.x: a str_replace whose old string
+      // matched more than once. The tool correctly refused; there is nothing to
+      // audit and nothing degraded.
+      const failure =
+        "Caught an error while replacing string String '[Answer]:' found multiple times in the file";
+      const r = runIdeStdin(
+        dir,
+        "audit-and-sensors",
+        ctx1x("str_replace", failure),
+      );
+      expect(r.code).toBe(0); // still fail-open
+      const dropFile = join(seededRecordDir(dir), ".aidlc-hooks-health", "kiro-adapter.drops");
+      expect(existsSync(dropFile)).toBe(false); // NOT decay
+      expect(readAudit(dir)).not.toContain("ARTIFACT_UPDATED"); // and never audited
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("F4e: the paired contrast — an unknown SUCCESS wording still records a drop", () => {
+    const dir = scratchProject(true);
+    try {
+      // Same branch, opposite verdict. Held beside F4d so the distinction cannot
+      // silently collapse in one direction.
+      const r = runIdeStdin(
+        dir,
+        "audit-and-sensors",
+        ctx1x("str_replace", "Swapped the text over there"),
+      );
+      expect(r.code).toBe(0);
+      const dropFile = join(seededRecordDir(dir), ".aidlc-hooks-health", "kiro-adapter.drops");
+      expect(existsSync(dropFile)).toBe(true);
+      expect(readFileSync(dropFile, "utf-8")).toContain("no extractable path");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("F4f: explicit toolSuccess=true outranks defensive failure-prose guesses", () => {
+    const dir = scratchProject(true);
+    try {
+      // Legacy IDE 0.12 supplies an authoritative success boolean. Even if an
+      // unrecognised success message starts with a defensive failure prefix,
+      // the missing path remains visible as harness decay.
+      const r = runIde(
+        dir,
+        "audit-and-sensors",
+        ctx("str_replace", "Failed to preserve file mode; requested text was replaced"),
+      );
+      expect(r.code).toBe(0);
+      const dropFile = join(seededRecordDir(dir), ".aidlc-hooks-health", "kiro-adapter.drops");
+      expect(existsSync(dropFile)).toBe(true);
+      expect(readFileSync(dropFile, "utf-8")).toContain("no extractable path");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("t218 log-subagent identity extraction (#459)", () => {


### PR DESCRIPTION
# Summary

`/aidlc --doctor` reports hook decay on the Kiro IDE harness when a write simply **failed**. The adapter's `audit-and-sensors` target records a visible hook drop whenever it cannot extract a file path from a write tool's result, and two very different situations reach that branch:

- **(a)** the write **failed** — no artifact exists, so declining to forward it is correct behaviour, not decay;
- **(b)** the write **succeeded** but its result wording matched no known pattern — the invisible degradation this harness exists to surface.

Only (b) belongs in the drop log. Recording (a) made `--doctor` report degradation on a workspace whose hooks were working perfectly, which trains the reader to ignore the one channel that matters when something genuinely breaks.

Found while investigating #688 on a live Kiro IDE workflow; split out of #687 because it is an independent concern with an independent risk profile.

Revised after review (CHANGES_REQUESTED @ `866ae5c`): rebased and re-bumped, the payload doc corrected, a pinning test added, the wrong-suite citation fixed, and the pattern evidence graded. Per-finding response in the comments.

Round 2 addressed at `94fdbb64`: the branch was rebuilt as one commit from `upstream/v2` to expunge the two accidental 61.5 MB `.bun-build` blobs, `*.bun-build` is now ignored, F4d/F4e drive the real 1.x stdin channel, and the CHANGELOG evidence and stale-drop upgrade guidance are corrected.

Round 4 addressed at `2afbf171`: rebased onto current `upstream/v2` (`c73ee984` / 2.5.37), re-bumped to 2.5.40, regenerated all five harness distributions, and clarified both payload-document references so `hookDebug` is described as writing only when hook debugging is enabled. Versions 2.5.38 and 2.5.39 are already claimed by open PRs #712 and #705, respectively, so 2.5.40 was the first unclaimed slot found.

## Changes

**Why the existing guard cannot catch it.** The `toolSuccess === false` failed-write guard (#417) still works on the 0.12 channel, but IDE 1.x delivers context on stdin with **no success flag** at all. A failed write is therefore indistinguishable from a successful one at the payload level — the failure arrives only as error prose in `tool_response`. The real-world case that produced this was a `str_replace` whose old string matched multiple times:

```
audit-and-sensors: str_replace yielded no extractable path from toolResult:
Caught an error while replacing string String '[Answer]:' found multiple times in …
```

**Classify before logging.** Recognised failure prose is now recorded via `hookDebug` (available under `AIDLC_HOOK_DEBUG`, where it belongs) and (b) keeps the visible `recordHookDrop`. The fail-open path is unchanged — the event is still not forwarded either way, so no audit or sensor behaviour changes.

**Pattern evidence is graded, not assumed.** Of the four failure-prose patterns only `^Caught an error while ` is grounded in a live capture; `^Error:`, `^Failed to ` and `^An error occurred` are marked in the code as **defensive guesses**, because no capture in this repo or in `docs/reference/kiro-ide-hook-payload.md` backs them. They are kept because the risk direction is one-way — a match can only suppress a drop *after* path extraction has already failed, and none of the known success wordings (`Created the …`, `Replaced text in …`, `Appended the text to …`) can collide with them — and the comment instructs deleting a pattern rather than widening the set if a capture ever contradicts one.

**The classifier is deliberately narrow.** Every pattern is start-anchored, rather than a loose "contains error" test that would swallow a successful write to a file whose *name* mentions an error. Anything unrecognised is still treated as a success and still earns a visible drop: the default stays biased toward reporting rather than silence, so this can only ever *remove* false positives, never mask real decay.

## User experience

**Before.** A `str_replace` fails because the old string matched multiple times — a normal authoring mistake, correctly rejected by the tool. `/aidlc --doctor` then reports hook degradation for the Kiro IDE harness, pointing at `kiro-adapter.drops`, on a workspace where every hook is functioning.

**After.** That failure no longer appears in the drop log, so `--doctor` stays quiet. A genuinely unparseable *successful* write is still reported, unchanged — the signal keeps working, only the false positive is gone.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

### Coverage added

`t218` gains a **paired** `F4d`/`F4e`, sitting beside the existing `F4c` so the contrast lives in one place:

| Case | Pins |
|---|---|
| **F4d** | The verbatim captured prose (`Caught an error while replacing string String '[Answer]:' found multiple times in the file`) through the 1.x stdin channel: the drops file **does not exist**, and no `ARTIFACT_UPDATED` row is written |
| **F4e** | An unknown *success* wording on the same tool: a visible drop **still lands** |
| F4c (existing) | Unrecognised wording on `fs_write` still drops — unchanged |

They are deliberately a pair. The contract is the *distinction*, so pinning the halves apart would let a reordered guard or a tightened regex regress one while the other kept passing.

**Mutation-verified:** neutering the one grounded pattern makes `F4d` fail (`Expected: false  Received: true`), 46 pass / 1 fail. Restored: 47/47.

### Behaviour check for reviewers

```bash
# (a) a FAILED write -> must NOT be recorded as decay
echo '{"tool_name":"str_replace","tool_response":"Caught an error while replacing string ..."}' \
  | bun .kiro/hooks/aidlc-kiro-adapter.ts audit-and-sensors

# (b) a SUCCESSFUL write with unrecognised wording -> must still be recorded
echo '{"tool_name":"fs_write","tool_response":"Wrote bytes somewhere unfamiliar"}' \
  | bun .kiro/hooks/aidlc-kiro-adapter.ts audit-and-sensors
```

| Input | `kiro-adapter.drops` |
|---|---|
| `str_replace` with the verbatim failure prose | **0 entries** (was 1) |
| `fs_write` with unrecognised success wording | **1 entry** (unchanged) |

### Validation

Run on the Round 4 rebased branch (`2.5.40` on top of `v2` at 2.5.37 / `c73ee984`).

- `bun run check` (dist byte-parity across five harnesses, three tsconfigs, Biome over 557 files): clean
- `bun tests/gen-coverage-registry.ts --check`: clean; `bun scripts/ci-changelog-guard.ts upstream/v2`: all 149 upstream entries preserved, 1 new
- **`t218`: 47/47 for this PR file** — the suite that actually drives the changed branch. Bun also discovered the untouched #687 sibling worktree and reported 92/92 aggregate. (An earlier revision of this body cited `t147`; that suite scaffolds `dist/kiro/.kiro`, the **CLI** adapter, and touches the IDE adapter only through a static respawn-source check, so it never exercised this change and is no longer cited.)
- **`t68`: 7/7 for this PR file**; Bun also discovered the untouched #687 sibling worktree and reported 14/14 aggregate
- Earlier full default-suite run (before the Round 4 rebase): **284 files, 3 failed files** — all three pre-existing

### The three failures are pre-existing

Confirmed by a `git worktree` checked out at bare `upstream/v2`, independently of this branch, and reproduced identically on the sibling branch #687.

| File | Cause | Touched here? |
|---|---|---|
| `t66` | #647's `claim-sources` sensor — `Stage "intent-capture" imports unknown sensor id "claim-sources"`; the golden export fixture was not updated | No |
| `t89` | Same `claim-sources` root cause; the sensor-resolution fixtures were not updated | No |
| `t19` | Live preflight; needs authenticated AWS credentials | No |

Also reported on #687 and, for `t66`/`t89`, on #615.

## Scope

One authored harness source file (`harness/kiro-ide/hooks/aidlc-kiro-adapter.ts`), plus `t218` cases, documentation/CHANGELOG corrections, and a root `*.bun-build` ignore rule. No core change, no other harness affected.

`docs/reference/kiro-ide-hook-payload.md` described the old unconditional behaviour in two places — "error prose that matches no known pattern records a visible hook-drop", and "A write-class tool whose wording does not match a known pattern records a visible hook-drop (never a silent no-op)" — and is corrected in the same commit per the repo Documentation Policy. An earlier revision of this body claimed "no output-format change", which did not account for that doc describing exactly the drop-log behaviour this changes.

No command, flag, or audit/sensor behaviour changes; no breaking change for CI or scripts.

## Not verified here

**Three of the four failure patterns are unobserved.** See *Changes*. They are defensive, one-way, and labelled as such in the code rather than presented as captures. If preferred, shipping only the grounded pattern is a two-line diff.

## Upgrade

```bash
mkdir -p your-project/.kiro && cp -R dist/kiro-ide/.kiro/. your-project/.kiro/
```

If `/aidlc --doctor` still reports a Kiro adapter drop created before this fix, inspect the affected intent record’s `<record>/.aidlc-hooks-health/kiro-adapter.drops`. Delete only that individual file, and only after verifying its entries are historical/stale; preserve it if it contains current failures.

## Version

Bumps to **2.5.40**, rebased onto `v2` at 2.5.37 (`c73ee984`). Open PR #712 currently claims 2.5.38 and open PR #705 claims 2.5.39, so 2.5.40 was the first unclaimed slot found. The cleaned branch remains one commit above the current base and was force-updated with an explicit lease after local validation.

**Ordering:** there is **no code dependency** between this PR and #687 — they touch disjoint regions of the adapter and the split is purely about reviewability. Either merge order works.

## References

- Split out of #687; both come from the investigation in #688
- The `toolSuccess` failed-write guard this complements is #417
- The stdin channel that removed the success flag landed in #615
- The `claim-sources` fixture breakage in `t66`/`t89` traces to #647

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
