### PR TITLE
fix(evaluator): PTY driver deadlock + multi-select gate handling

### DIFF
--- a/evaluator/packages/cli-harness/src/cli_harness/adapters/_pty_terminal.py
+++ b/evaluator/packages/cli-harness/src/cli_harness/adapters/_pty_terminal.py
@@ -203,11 +203,27 @@ class PtyTerminal:
         return bool(_MENU_CARET_RE.search(screen) and _SELECT_FOOTER_RE.search(screen))
 
     def answer_gate_default(self) -> None:
-        """Accept the highlighted (default/Recommended) option on a single-select gate.
+        """Answer the painted gate, mirroring tui-drive.ts's per-widget key model.
 
-        Mirrors tui-drive's single-select behavior: the engine highlights the
-        Recommended option by default, so a bare Enter selects it.
+        - Submit review screen: Enter commits the whole form.
+        - Multi-select option (numbered line with a checkbox): Enter TOGGLES
+          instead of selecting (the t73 toggle-forever hang), so Space toggles
+          the Recommended option ON, then Right advances a multi-tab form or
+          Enter commits a lone multi-select question.
+        - Single-select: bare Enter accepts the highlighted Recommended option.
         """
+        screen = self.screen_text()
+        if "Submit answers" in screen:
+            self.send_key("Enter")
+            return
+        if re.search(r"\d+\.\s*\[[ xX✔]\]", screen):
+            self.send_key("Space")
+            time.sleep(0.15)
+            if "←" in screen and "→" in screen:
+                self.send_key("Right")
+            else:
+                self.send_key("Enter")
+            return
         self.send_key("Enter")
 
     def drive_until(
@@ -228,6 +244,7 @@ class PtyTerminal:
         not success).
         """
         deadline = time.monotonic() + timeout
+        last_menu_screen = ""
         while time.monotonic() < deadline:
             if is_done():
                 return True
@@ -236,10 +253,19 @@ class PtyTerminal:
                 return is_done()
             advanced = False
             if self.screen_has_menu():
-                if on_idle is not None:
-                    on_idle(self)
-                else:
-                    self.answer_gate_default()
+                # Only answer when the menu screen has actually changed since the
+                # last answer; a stale identical screen means the TUI hasn't
+                # processed the previous keystroke yet. Always drain after
+                # answering — sending keys in a tight loop without pumping the
+                # PTY output fills both pipe buffers and deadlocks writer/reader.
+                screen_now = self.screen_text()
+                if screen_now != last_menu_screen:
+                    if on_idle is not None:
+                        on_idle(self)
+                    else:
+                        self.answer_gate_default()
+                    last_menu_screen = screen_now
+                self._drain(timeout=2.0)
                 advanced = True
             elif idle_pattern is not None and self.wait_for(
                 idle_pattern, timeout=idle_timeout, stable_ms=800


### PR DESCRIPTION
## Summary

Two fixes to the cli-harness PTY driver (`_pty_terminal.py`), both hit while producing the first scored v2 evaluation run (#684). Root cause for both: the evaluator was written against v2 ~2.1.x when `--test-run` auto-approved gates; v2 removed that bypass in 2.1.4 (#448), so every gate — including multi-select widgets — now surfaces to the driver.

### 1. `drive_until()` pipe deadlock

When a menu stayed painted (any widget Enter doesn't dismiss), the loop re-sent Enter every iteration **without draining PTY output**. The TUI's output filled the kernel pipe buffer, the TUI blocked writing, the driver blocked on `write(2)` sending the next keystroke, and the pair froze permanently — confirmed twice via process sampling (`sample` showed both sides parked in `write`), costing multi-hour runs each time.

Fix: answer a given menu screen once — re-answer only when the rendered screen changes — and always `_drain()` after answering.

### 2. Multi-select gates spun forever

`answer_gate_default()` only knew single-select menus (bare Enter accepts the highlighted option). On a multi-select widget — e.g. the v2 Learnings ritual — **Enter toggles the checkbox instead of selecting**, so the driver toggled `[ ]`↔`[✔]` indefinitely (observed for 19h). This is exactly the failure the repo's own e2e driver documents as the t73 hang ("the loop toggled `[ ]`↔`[✔]` forever", `tests/harness/tui-drive.ts`).

Fix: port tui-drive.ts's per-widget key model to the Python driver —
- checkbox option lines (`1. [ ]`) → **Space** toggles the Recommended option, then **Right** advances a multi-tab form / **Enter** commits a lone question
- `Submit answers` review screen → plain **Enter**
- anything else → single-select, bare Enter (unchanged)

## Validation

- 51/51 cli-harness tests pass; `ruff check` + `ruff format --check` clean.
- Proven in anger: with these two fixes the claude-cli adapter drove a complete 21-stage v2/mvp workflow end-to-end (three `/aidlc --resume` sessions), producing the scored results on #684 — 88/88 contract tests, 293 generated tests at 100% coverage.

## Known gaps NOT addressed here (follow-ups)

Found in the same exercise, needing owner decisions rather than mechanical fixes:
1. **2h adapter timeout** (`timeout_seconds: 7200`, `adapter.py`) is far too small for v2/mvp (~7.5h observed). Suggest raising it and/or teaching the adapter to chain `/aidlc --resume` sessions (which worked flawlessly when driven manually).
2. **`find_aidlc_docs()` doesn't know v2's layout** (`aidlc/spaces/<space>/intents/<intent>/`), so a completed run still reports "no aidlc-docs" — we extracted docs manually for #684.
3. **Stage-5 scorer needs an explicit `--region`** (NoRegionError otherwise); should default from config or the dist's pinned region.
4. **No token-usage capture** in the CLI adapters — `run-metrics.yaml` reports zero. Stopgap documented on #684: sum `AWS/Bedrock` CloudWatch metrics over the run window from `run-meta.yaml`.

Refs #684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
