### PR TITLE
docs: scope the Claude-only surfaces and add per-harness install dropdowns

### DIFF
--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -2,6 +2,14 @@
 
 This chapter walks you through installing this implementation, verifying your environment, and preparing for your first workflow.
 
+> **Note**: This chapter's walkthrough shows **Claude Code**. AI-DLC also runs
+> on Kiro CLI, Kiro IDE, Codex CLI, and opencode: the methodology is identical
+> on every harness, but prerequisites, configuration, and some surfaces (the
+> welcome banner, the statusline) are not. Step 1 of
+> [Installation](#installation) below has the copy commands for every harness;
+> everything else that differs lives in your harness's chapter under
+> [Running on other harnesses](harnesses/README.md).
+
 ---
 
 ## Prerequisites
@@ -134,12 +142,14 @@ Missing credentials are not blocking. A server you have no credentials for — n
 ## Installation
 
 AI-DLC installs by copying its distribution for your harness into your project.
-The steps below cover **Claude Code** (the `dist/claude/.claude/` tree). For the
-other distributions, see [Running on Kiro CLI](harnesses/kiro-cli.md),
-[Running on Kiro IDE](harnesses/kiro-ide.md), or
+Step 1 below has the copy commands for every harness; the rest of this chapter
+continues on **Claude Code** (the `dist/claude/` tree, which ships as a
+`.claude/` directory). On another harness, finish the install in its chapter
+instead - [Running on Kiro CLI](harnesses/kiro-cli.md),
+[Running on Kiro IDE](harnesses/kiro-ide.md),
 [Running on Codex CLI](harnesses/codex-cli.md), or
-[AI-DLC on opencode](harnesses/opencode.md). The Claude Code implementation
-ships as a `.claude/` directory that you copy into your project.
+[AI-DLC on opencode](harnesses/opencode.md) - each covers the prerequisites
+and post-copy steps that differ.
 
 The `cp` commands below run from a clone of this repository on the `v2`
 branch:
@@ -152,12 +162,76 @@ git checkout v2
 
 ### Step 1: Copy the implementation
 
+Expand your harness:
+
+<details open markdown="1">
+<summary><strong>Claude Code</strong></summary>
+
 ```bash
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/     # the workspace shell — a sibling of .claude/, not inside it
 ```
 
 The first line copies the engine — the orchestrator, stage files, agent personas, hooks, knowledge files, and default settings. The second copies the **workspace shell**: the pre-built `aidlc/spaces/default/memory/` method tree the engine reads. It ships as a **sibling** of `.claude/` (not inside it), so it must be copied separately — or copy the whole `dist/claude/` tree at once. `/aidlc --doctor` fails its "workspace shell ready" check if `aidlc/spaces/default/memory/` is missing.
+
+</details>
+
+<details markdown="1">
+<summary><strong>Kiro CLI</strong></summary>
+
+```bash
+mkdir -p your-project/.kiro your-project/aidlc
+cp -R dist/kiro/.kiro/. your-project/.kiro/
+cp -R dist/kiro/aidlc/. your-project/aidlc/    # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
+cp dist/kiro/AGENTS.md your-project/AGENTS.md  # merge if you already have one
+```
+
+Then continue in [Running AI-DLC on Kiro CLI](harnesses/kiro-cli.md): prerequisites (Kiro CLI ≥ 2.6, a paid plan for Opus 4.8) and the shipped default-agent setting.
+
+</details>
+
+<details markdown="1">
+<summary><strong>Kiro IDE</strong></summary>
+
+```bash
+mkdir -p your-project/.kiro your-project/aidlc
+cp -R dist/kiro-ide/.kiro/. your-project/.kiro/
+cp -R dist/kiro-ide/aidlc/. your-project/aidlc/     # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
+cp dist/kiro-ide/AGENTS.md your-project/AGENTS.md   # merge if you already have one
+```
+
+Then continue in [Running AI-DLC on Kiro IDE](harnesses/kiro-ide.md): prerequisites (Opus 4.8 as the chat model), the v2 hook files, and the PATH note for bun in non-interactive shells.
+
+</details>
+
+<details markdown="1">
+<summary><strong>Codex CLI</strong></summary>
+
+```bash
+cp -r dist/codex/.codex/  your-project/.codex/
+cp -r dist/codex/.agents/ your-project/.agents/
+cp -r dist/codex/aidlc/   your-project/aidlc/      # the workspace shell (spaces/default/memory) — a sibling of .codex/, not inside it
+cp dist/codex/AGENTS.md   your-project/AGENTS.md   # or merge into yours
+```
+
+Then continue in [AI-DLC on Codex CLI](harnesses/codex-cli.md): the project must be a **git repository**, and the install is not complete until the `.gitignore` entries and the hook trust pre-seed from that chapter are applied.
+
+</details>
+
+<details markdown="1">
+<summary><strong>opencode</strong></summary>
+
+```bash
+cp -r dist/opencode/.aidlc/    your-project/.aidlc/
+cp -r dist/opencode/.opencode/ your-project/.opencode/
+cp -r dist/opencode/aidlc/     your-project/aidlc/      # the workspace shell — a sibling of .aidlc/, not inside it
+cp dist/opencode/opencode.json your-project/opencode.json  # or merge into yours
+cp dist/opencode/AGENTS.md     your-project/AGENTS.md      # or merge into yours
+```
+
+Then continue in [AI-DLC on opencode](harnesses/opencode.md): the split `.aidlc/` + `.opencode/` layout, the load-bearing `opencode.json` blocks to keep when merging, and the `.gitignore` entries.
+
+</details>
 
 ### Step 2: Navigate to your project
 

--- a/docs/guide/02-your-first-workflow.md
+++ b/docs/guide/02-your-first-workflow.md
@@ -4,10 +4,10 @@ This chapter walks through a complete AI-DLC workflow run, explaining what you s
 
 > **Note**: The transcripts in this chapter show **Claude Code**. On Kiro CLI,
 > Kiro IDE, Codex CLI, and opencode the workflow - stages, agents, gates,
-> artifacts - is identical, but two Claude-Code-only surfaces do not appear:
-> there is **no welcome banner** and **no statusline** (use `/aidlc --status`
-> and the progress line at each gate instead), and on Codex CLI you invoke
-> `$aidlc` rather than `/aidlc`. Your harness's chapter under
+> artifacts - is identical, but the Claude-only welcome banner and custom
+> AI-DLC statusline do not appear. Use `/aidlc --status` on Kiro and opencode;
+> Codex uses `$aidlc --status` and its built-in `update_plan` progress display.
+> Your harness's chapter under
 > [Running on other harnesses](harnesses/README.md) lists every difference.
 
 ---
@@ -79,7 +79,7 @@ After Initialization, the workflow enters Ideation. Each stage from here on runs
 
 ### Stage 1.1: Intent Capture (aidlc-product-agent)
 
-On Claude Code, the status line at the bottom of your terminal updates (the other harnesses render no statusline - use `/aidlc --status`):
+On Claude Code, the custom AI-DLC status line at the bottom of your terminal updates (Kiro and opencode use `/aidlc --status`; Codex uses `$aidlc --status` and its built-in `update_plan` progress display):
 
 ```
 [AIDLC] IDEATION > Intent Capture [▓▓▓▓▓░░░░░] 4/7 -- product
@@ -261,7 +261,7 @@ aidlc/spaces/<space>/intents/<YYMMDD>-<label>/
 
 ## Status Line
 
-Throughout the workflow on Claude Code, the terminal status line shows your current position (no other harness renders this statusline - use `/aidlc --status` and the progress line at each gate; Codex CLI additionally tracks position via its `update_plan` tool):
+Throughout the workflow on Claude Code, the custom AI-DLC status line shows your current position (Kiro and opencode use `/aidlc --status` and the progress line at each gate; Codex uses `$aidlc --status` and its built-in `update_plan` progress display):
 
 ```
 [AIDLC] IDEATION > Intent Capture [▓▓▓▓▓░░░░░] 4/7 -- product

--- a/docs/guide/02-your-first-workflow.md
+++ b/docs/guide/02-your-first-workflow.md
@@ -2,6 +2,14 @@
 
 This chapter walks through a complete AI-DLC workflow run, explaining what you see at each step and what decisions you make. The example uses a `feature`-scoped workflow to build a REST API.
 
+> **Note**: The transcripts in this chapter show **Claude Code**. On Kiro CLI,
+> Kiro IDE, Codex CLI, and opencode the workflow - stages, agents, gates,
+> artifacts - is identical, but two Claude-Code-only surfaces do not appear:
+> there is **no welcome banner** and **no statusline** (use `/aidlc --status`
+> and the progress line at each gate instead), and on Codex CLI you invoke
+> `$aidlc` rather than `/aidlc`. Your harness's chapter under
+> [Running on other harnesses](harnesses/README.md) lists every difference.
+
 ---
 
 ## Starting the Workflow
@@ -10,7 +18,7 @@ This chapter walks through a complete AI-DLC workflow run, explaining what you s
 /aidlc Build a REST API for inventory management
 ```
 
-At session start, Claude Code renders the AI-DLC welcome message via the `companyAnnouncements` entry in `settings.json`. It explains how AI-DLC works, and shows the stage map and scope options.
+At session start, Claude Code renders the AI-DLC welcome message via the `companyAnnouncements` entry in `settings.json`. It explains how AI-DLC works, and shows the stage map and scope options. (`companyAnnouncements` is a Claude Code setting with no equivalent on the other harnesses - there, no banner appears and the workflow begins directly with the initialization below.)
 
 ```
 # Welcome to AI-DLC
@@ -71,7 +79,7 @@ After Initialization, the workflow enters Ideation. Each stage from here on runs
 
 ### Stage 1.1: Intent Capture (aidlc-product-agent)
 
-The status line at the bottom of your terminal updates:
+On Claude Code, the status line at the bottom of your terminal updates (the other harnesses render no statusline - use `/aidlc --status`):
 
 ```
 [AIDLC] IDEATION > Intent Capture [▓▓▓▓▓░░░░░] 4/7 -- product
@@ -253,7 +261,7 @@ aidlc/spaces/<space>/intents/<YYMMDD>-<label>/
 
 ## Status Line
 
-Throughout the workflow, the terminal status line shows your current position:
+Throughout the workflow on Claude Code, the terminal status line shows your current position (no other harness renders this statusline - use `/aidlc --status` and the progress line at each gate; Codex CLI additionally tracks position via its `update_plan` tool):
 
 ```
 [AIDLC] IDEATION > Intent Capture [▓▓▓▓▓░░░░░] 4/7 -- product

--- a/zensical.toml
+++ b/zensical.toml
@@ -171,6 +171,11 @@ admonition = {}
 
 [markdown_extensions."pymdownx.details"]
 
+# Renders markdown inside HTML blocks carrying markdown="1" (the per-harness
+# <details> dropdowns in the install docs). GitHub ignores the attribute and
+# renders the same blocks natively.
+[markdown_extensions.md_in_html]
+
 [markdown_extensions."pymdownx.superfences"]
 custom_fences = [
   { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },


### PR DESCRIPTION
Closes #683

## Problem

The Getting Started and Your First Workflow chapters showed the Claude Code experience without saying so. The `companyAnnouncements` welcome banner and the statusline exist only in the Claude distribution (`harness/claude/settings.json` - no other harness manifest ships a `settings.json`, and the Kiro/Codex/opencode chapters and shipped `AGENTS.md` files all document "no welcome message" / "no statusline"). A reader on Kiro CLI, Kiro IDE, Codex CLI, or opencode followed a walkthrough that promised output their harness never renders, then watched the workflow jump straight into the composer with no banner - the confusion reported in #683.

The issue's suggested fix (copy `settings.json` into every dist) would not work: `companyAnnouncements` is a Claude Code settings key with no render equivalent on the other harnesses, so the copy would be dead weight. This PR fixes the docs instead.

## Changes

**`docs/guide/01-getting-started.md`**
- A note at the top: the walkthrough shows Claude Code; the methodology is identical on every harness but prerequisites, configuration, and some surfaces (welcome banner, statusline) are not, with a pointer to the harness chapters.
- Installation Step 1 is now five per-harness `<details>` dropdowns (Claude Code expanded by default). Each holds that harness's copy commands verbatim from its chapter, and links onward for the harness-specific steps (Codex's git-repo requirement and hook-trust pre-seed, opencode's load-bearing `opencode.json` blocks, Kiro's prerequisites).

**`docs/guide/02-your-first-workflow.md`**
- A note at the top: transcripts show Claude Code; on the other harnesses there is no welcome banner and no statusline (use `/aidlc --status` and the progress line at each gate), and Codex CLI invokes `$aidlc`.
- The welcome-banner paragraph now states inline that `companyAnnouncements` is a Claude Code setting with no equivalent elsewhere - on other harnesses no banner appears and the workflow begins directly with initialization.
- Both statusline passages are scoped to Claude Code with the cross-harness fallback.

**`zensical.toml`**
- Enabled `md_in_html` so the dropdown bodies render as markdown on the docs site. GitHub renders the same `<details>` blocks natively and ignores the `markdown="1"` attribute.

## Verification

- Zensical build: same 14 pre-existing issues as the v2 baseline, zero new. All five dropdowns render with highlighted fences and resolved links in the built HTML.
- Enabling `md_in_html` changes nothing else: the built site is byte-identical before and after enabling it (full `diff -rq` of the two builds).
- `scripts/docs-rewrite-links.ts` (the deploy-time dead-link gate) passes on the edited docs: 16 rewrites, 0 missing targets.
- `--smoke --unit`: 181 files / 4457 assertions, 0 failures (includes the doc gates t174, t239, t246, t68, re-run green on the rebased head).

No version/CHANGELOG bump: docs-only per the changelog policy (same shape as #642).
