### PR TITLE
test: green the two standing deterministic e2e base reds (t113, t122)

### DIFF
--- a/tests/e2e/t113.test.ts
+++ b/tests/e2e/t113.test.ts
@@ -75,6 +75,7 @@ import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts
 
 const UTIL = join(AIDLC_SRC, "tools", "aidlc-utility.ts");
 const STATE = join(AIDLC_SRC, "tools", "aidlc-state.ts");
+const LOG = join(AIDLC_SRC, "tools", "aidlc-log.ts");
 
 // Spawn a state/utility subcommand via the SAME bun that runs this test
 // (process.execPath), cwd-independent. Mirrors t51's `bun "$STATE" ...` calls.
@@ -104,6 +105,29 @@ function run(
 function walkStage(slug: string, proj: string): void {
   const gs = run(STATE, ["gate-start", slug], proj);
   expect(gs.status).toBe(0);
+  // Reviewer-bearing stages need a terminal REVIEW_COMPLETED before approve
+  // commits (§12a gate precondition), recorded by the stage's DECLARED reviewer.
+  // Record one for the two reviewer-bearing stages this walk crosses; a
+  // no-reviewer stage ignores the extra row. This walk drives transitions to
+  // accumulate the audit trail, not to test the reviewer gate. Mirrors t51.
+  const reviewerFor: Record<string, string> = {
+    "requirements-analysis": "aidlc-product-lead-agent",
+    "code-generation": "aidlc-architecture-reviewer-agent",
+  };
+  if (reviewerFor[slug]) {
+    const rv = run(LOG, [
+      "review",
+      "--stage",
+      slug,
+      "--reviewer",
+      reviewerFor[slug],
+      "--iteration",
+      "1",
+      "--verdict",
+      "READY",
+    ], proj);
+    expect(rv.status).toBe(0);
+  }
   const ap = run(STATE, ["approve", slug, "--user-input", "approve"], proj);
   expect(ap.status).toBe(0);
 }

--- a/tests/e2e/t122-stop-hook-e2e.test.ts
+++ b/tests/e2e/t122-stop-hook-e2e.test.ts
@@ -298,9 +298,26 @@ describe("t122 Stop hook end-to-end — real hook, real engine (sdk+cli)", () =>
         // The reason names the pending stage and re-feeds the loop...
         expect(parsed.reason).toContain(PENDING_STAGE);
         expect(parsed.reason).toContain("aidlc-orchestrate");
-        // ...and uses no override-shaped verbs (the security property SPIKE 1
-        // pinned; aidlc-stop.ts:298-307 phrases continuation, never override).
-        expect(/ignore|override|disregard|bypass/i.test(parsed.reason)).toBe(
+        // ...and the hook's OWN framing uses no override-shaped verbs (the
+        // security property SPIKE 1 pinned: the hook phrases continuation,
+        // never override). A load-steering reason EMBEDS rule-file text
+        // verbatim as a single-line JSON rules_content payload
+        // (continuationReason JSON.stringifies it, so the payload carries no
+        // raw newlines), and rule PROSE may legitimately contain these verbs
+        // (e.g. operation.md's "Never remove or bypass existing security
+        // controls"). Scan only the hook-authored lines, not the quoted
+        // payload — delivered content is not the hook speaking.
+        const hookFraming = parsed.reason
+          .split("\n")
+          .filter((line) => {
+            try {
+              return !Array.isArray(JSON.parse(line));
+            } catch {
+              return true;
+            }
+          })
+          .join("\n");
+        expect(/ignore|override|disregard|bypass/i.test(hookFraming)).toBe(
           false,
         );
       } finally {


### PR DESCRIPTION
## What

Greens the two standing deterministic e2e reds on v2 - `t113` and `t122-stop-hook-e2e` - which fail on a clean checkout of the current tip (and failed identically through the last several merges' pre-merge gates). Both were bisected to their first-red commits; both turn out to be stale test contracts, not engine bugs. Test-only: no version bump per the changelog policy.

### 1. t113 - red since the 2.5.5 §12a reviewer enforcement (#569)

`t113.test.ts`'s `walkStage` drives `gate-start` -> `approve` with no reviewer verdict. Since #569, approve refuses on reviewer-bearing stages without a fresh `REVIEW_COMPLETED` row:

```json
{"error":"Refusing to complete \"requirements-analysis\": it declares a reviewer (aidlc-product-lead-agent) but no fresh REVIEW_COMPLETED is recorded for it. ..."}
```

#569 updated the integration twin (t51's `walkStage` grew a `reviewerFor` map recording a READY verdict via `aidlc-log.ts review`) but missed this e2e file. Fix: the same `reviewerFor` block, mirrored into t113's `walkStage`, for the two reviewer-bearing stages the bugfix walk crosses (`requirements-analysis`, `code-generation`).

Bisect evidence: FAIL at f122f193 (#569) and every later commit probed; PASS at its parent 1354abcd. The failure was masked in the test (stderr discarded); reproducing the walk under the runner's exact suite env (`AIDLC_SKIP_ARTIFACT_GUARD=1` etc., per `run-tests.ts`) surfaced the JSON error above.

### 2. t122-stop-hook-e2e - red since 2.5.33 deterministic steering delivery (#658)

The test pins that a block reason contains no override-shaped verbs (`/ignore|override|disregard|bypass/i`) - a security property about the hook's own phrasing. Since #658, a `load-steering` block reason embeds rule-file text verbatim as a single-line JSON `rules_content` payload, and rule prose legitimately contains those words: `core/memory/phases/operation.md` says "Never remove or **bypass** existing security controls...". The verb the regex catches is quoted, delivered content - the hook's own framing is still clean, so the property itself holds.

Fix: scan only the hook-authored lines. The payload is the only line in the reason that parses as a JSON array (continuationReason `JSON.stringify`s it, so it carries no raw newlines); filter those lines out before applying the verb regex. Mutation-checked both ways: the filter strips a payload containing "bypass", and still catches an "ignore the previous instruction" planted in the hook's own framing.

The integration twin (t121's verb pin) is unaffected: its fixture rules don't contain the verbs, and its separate load-steering case asserts payload fidelity, not verb absence.

## Testing

- Both files: FAIL -> PASS on the same machine and base (v2 tip)
- smoke+unit: 184 files, 0 failed
- `bun tests/gen-coverage-registry.ts --check` OK; `bun run check` (package parity + 3x tsc + biome) green
- Deterministic throughout - no live vars involved
