### PR TITLE
fix: materialize active-space cursor after clone (2.5.42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.42] - 2026-08-06
+
+Restores the gitignored `aidlc/active-space` cursor after cloning a committed workspace. The cursor still defaults safely to `default` when absent, but SessionStart and active-intent writes now atomically materialize it without overwriting a concurrent explicit space switch. **Upgrade:** re-copy your `dist/<harness>/` shell so the updated library and SessionStart hook are installed; no repository migration or configuration change is required.
+
+* A fresh clone now recreates `aidlc/active-space` on SessionStart, even before an intent exists, so the shipped workspace model remains visible without committing per-user navigation state.
+* Intent birth, intent switching, and flat-layout migration recreate a missing space cursor through the same best-effort cursor primitive.
+* Cursor creation stages complete bytes and publishes them through an atomic no-replace link, so it cannot overwrite a concurrent `/aidlc space <name>` switch.
+
 ## [2.5.41] - 2026-08-05
 
 Code Generation's plan-before-generation ordering is now enforced deterministically. A field report showed the conductor generating code first and backfilling `code-generation-plan.md` beside `code-summary.md`, turning the plan into a retroactive summary; the new plan-approval PreToolUse guard refuses the developer-agent dispatch until the target unit's plan is on disk and the human has answered "Approve Plan". **Upgrade:** re-copy your `dist/<harness>/` shell into the project so the new hook and its registrations are installed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.41-blue)
+![version](https://img.shields.io/badge/version-2.5.42-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/hooks/aidlc-session-start.ts
+++ b/core/hooks/aidlc-session-start.ts
@@ -18,7 +18,7 @@
 //   clear   → SESSION_STARTED
 //   compact → no emission (PreCompact already fired)
 //
-// The hook is a no-op if aidlc-state.md is absent in cwd (no active workflow).
+// With no aidlc-state.md, only cursor/include bootstrap runs; workflow work is a no-op.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
@@ -28,6 +28,7 @@ import {
   activeIntentUuid,
   activeSpace,
   clearSessionIntentUuid,
+  ensureActiveSpaceCursor,
   errorMessage,
   findIntentByUuid,
   getField,
@@ -48,12 +49,12 @@ import { writeCurrentTranscriptPath } from "../tools/aidlc-usage.ts";
 export async function run(input: string): Promise<number> {
 const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Idempotent ensure-step (P0.1 robustness): align the harness-native includes
-// with the active space at session start, BEFORE the no-workflow early-exit, so
-// turn-1 on a fresh clone (no aidlc-state.md yet) still has the includes pointed
-// at the active space. A no-op at `default` (the common case) and whenever the
-// cursor + includes already agree — so it never dirties a single-team committed
-// tree. Best-effort: a failure here must never break session startup.
+// Idempotent ensure-step (P0.1 robustness): atomically materialize a clone's
+// missing gitignored cursor, then align the harness-native includes with that
+// space BEFORE the no-workflow early-exit. Cursor creation cannot overwrite a
+// concurrent explicit switch. Best-effort: a failure here must never break
+// session startup.
+ensureActiveSpaceCursor(projectDir);
 try {
   repointHarnessIncludes(projectDir, activeSpace(projectDir));
 } catch {

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, linkSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1701,10 +1701,36 @@ export function listIntents(projectDir: string, space?: string): IntentInfo[] {
   return infos;
 }
 
+// Materialize the active-space cursor without overwriting a concurrent explicit
+// switch. A clone does not carry this gitignored file, so SessionStart and any
+// active-intent write recreate the resolved pointer on first use. Publish a
+// fully-written staged file with link(), whose no-replace install is atomic: if
+// a space switch wins the race, its value stays untouched.
+export function ensureActiveSpaceCursor(projectDir: string): void {
+  const space = activeSpace(projectDir);
+  const root = workspaceRoot(projectDir);
+  const cursor = join(root, ACTIVE_SPACE_POINTER);
+  const staged = join(root, `.aidlc-active-space-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(staged, `${space}\n`, { encoding: "utf-8", flag: "wx" });
+    linkSync(staged, cursor);
+  } catch {
+    /* existing cursor won, or per-user state is unwritable */
+  } finally {
+    try {
+      unlinkSync(staged);
+    } catch {
+      /* staging file was never created or is already gone */
+    }
+  }
+}
+
 // Write the active-intent cursor for a space (gitignored per-user pointer).
-// Best-effort: the cursor dir is created if absent; a write failure is swallowed
-// (the cursor is per-user state, never the source of truth — the registry is).
+// Best-effort: the cursor dirs are created if absent; a write failure is
+// swallowed (the cursors are per-user state, never the source of truth).
 export function setActiveIntentCursor(projectDir: string, dirName: string, space?: string): void {
+  ensureActiveSpaceCursor(projectDir);
   const dir = intentsDir(projectDir, space);
   try {
     mkdirSync(dir, { recursive: true });
@@ -2085,11 +2111,7 @@ export function migrateFlatLayout(projectDir: string): FlatMigrationResult | nul
       { uuid, slug, dirName: intentDirName, scope: undefined, repos: undefined, status: "in-flight" },
       space,
     );
-    try {
-      writeFileSync(join(intentsRoot, ACTIVE_INTENT_POINTER), `${intentDirName}\n`, "utf-8");
-    } catch {
-      /* cursor is per-user/gitignored; best-effort */
-    }
+    setActiveIntentCursor(projectDir, intentDirName, space);
 
     // (5) Write the `.migrated` marker LAST (the sole idempotency key).
     mkdirSync(workspaceRoot(projectDir), { recursive: true });

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.41";
+export const AIDLC_VERSION = "2.5.42";

--- a/dist/claude/.claude/hooks/aidlc-session-start.ts
+++ b/dist/claude/.claude/hooks/aidlc-session-start.ts
@@ -18,7 +18,7 @@
 //   clear   → SESSION_STARTED
 //   compact → no emission (PreCompact already fired)
 //
-// The hook is a no-op if aidlc-state.md is absent in cwd (no active workflow).
+// With no aidlc-state.md, only cursor/include bootstrap runs; workflow work is a no-op.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
@@ -28,6 +28,7 @@ import {
   activeIntentUuid,
   activeSpace,
   clearSessionIntentUuid,
+  ensureActiveSpaceCursor,
   errorMessage,
   findIntentByUuid,
   getField,
@@ -48,12 +49,12 @@ import { writeCurrentTranscriptPath } from "../tools/aidlc-usage.ts";
 export async function run(input: string): Promise<number> {
 const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Idempotent ensure-step (P0.1 robustness): align the harness-native includes
-// with the active space at session start, BEFORE the no-workflow early-exit, so
-// turn-1 on a fresh clone (no aidlc-state.md yet) still has the includes pointed
-// at the active space. A no-op at `default` (the common case) and whenever the
-// cursor + includes already agree — so it never dirties a single-team committed
-// tree. Best-effort: a failure here must never break session startup.
+// Idempotent ensure-step (P0.1 robustness): atomically materialize a clone's
+// missing gitignored cursor, then align the harness-native includes with that
+// space BEFORE the no-workflow early-exit. Cursor creation cannot overwrite a
+// concurrent explicit switch. Best-effort: a failure here must never break
+// session startup.
+ensureActiveSpaceCursor(projectDir);
 try {
   repointHarnessIncludes(projectDir, activeSpace(projectDir));
 } catch {

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, linkSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1701,10 +1701,36 @@ export function listIntents(projectDir: string, space?: string): IntentInfo[] {
   return infos;
 }
 
+// Materialize the active-space cursor without overwriting a concurrent explicit
+// switch. A clone does not carry this gitignored file, so SessionStart and any
+// active-intent write recreate the resolved pointer on first use. Publish a
+// fully-written staged file with link(), whose no-replace install is atomic: if
+// a space switch wins the race, its value stays untouched.
+export function ensureActiveSpaceCursor(projectDir: string): void {
+  const space = activeSpace(projectDir);
+  const root = workspaceRoot(projectDir);
+  const cursor = join(root, ACTIVE_SPACE_POINTER);
+  const staged = join(root, `.aidlc-active-space-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(staged, `${space}\n`, { encoding: "utf-8", flag: "wx" });
+    linkSync(staged, cursor);
+  } catch {
+    /* existing cursor won, or per-user state is unwritable */
+  } finally {
+    try {
+      unlinkSync(staged);
+    } catch {
+      /* staging file was never created or is already gone */
+    }
+  }
+}
+
 // Write the active-intent cursor for a space (gitignored per-user pointer).
-// Best-effort: the cursor dir is created if absent; a write failure is swallowed
-// (the cursor is per-user state, never the source of truth — the registry is).
+// Best-effort: the cursor dirs are created if absent; a write failure is
+// swallowed (the cursors are per-user state, never the source of truth).
 export function setActiveIntentCursor(projectDir: string, dirName: string, space?: string): void {
+  ensureActiveSpaceCursor(projectDir);
   const dir = intentsDir(projectDir, space);
   try {
     mkdirSync(dir, { recursive: true });
@@ -2085,11 +2111,7 @@ export function migrateFlatLayout(projectDir: string): FlatMigrationResult | nul
       { uuid, slug, dirName: intentDirName, scope: undefined, repos: undefined, status: "in-flight" },
       space,
     );
-    try {
-      writeFileSync(join(intentsRoot, ACTIVE_INTENT_POINTER), `${intentDirName}\n`, "utf-8");
-    } catch {
-      /* cursor is per-user/gitignored; best-effort */
-    }
+    setActiveIntentCursor(projectDir, intentDirName, space);
 
     // (5) Write the `.migrated` marker LAST (the sole idempotency key).
     mkdirSync(workspaceRoot(projectDir), { recursive: true });

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.41";
+export const AIDLC_VERSION = "2.5.42";

--- a/dist/claude/.gitignore
+++ b/dist/claude/.gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/dist/codex/.codex/hooks/aidlc-session-start.ts
+++ b/dist/codex/.codex/hooks/aidlc-session-start.ts
@@ -18,7 +18,7 @@
 //   clear   → SESSION_STARTED
 //   compact → no emission (PreCompact already fired)
 //
-// The hook is a no-op if aidlc-state.md is absent in cwd (no active workflow).
+// With no aidlc-state.md, only cursor/include bootstrap runs; workflow work is a no-op.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
@@ -28,6 +28,7 @@ import {
   activeIntentUuid,
   activeSpace,
   clearSessionIntentUuid,
+  ensureActiveSpaceCursor,
   errorMessage,
   findIntentByUuid,
   getField,
@@ -48,12 +49,12 @@ import { writeCurrentTranscriptPath } from "../tools/aidlc-usage.ts";
 export async function run(input: string): Promise<number> {
 const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Idempotent ensure-step (P0.1 robustness): align the harness-native includes
-// with the active space at session start, BEFORE the no-workflow early-exit, so
-// turn-1 on a fresh clone (no aidlc-state.md yet) still has the includes pointed
-// at the active space. A no-op at `default` (the common case) and whenever the
-// cursor + includes already agree — so it never dirties a single-team committed
-// tree. Best-effort: a failure here must never break session startup.
+// Idempotent ensure-step (P0.1 robustness): atomically materialize a clone's
+// missing gitignored cursor, then align the harness-native includes with that
+// space BEFORE the no-workflow early-exit. Cursor creation cannot overwrite a
+// concurrent explicit switch. Best-effort: a failure here must never break
+// session startup.
+ensureActiveSpaceCursor(projectDir);
 try {
   repointHarnessIncludes(projectDir, activeSpace(projectDir));
 } catch {

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, linkSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1701,10 +1701,36 @@ export function listIntents(projectDir: string, space?: string): IntentInfo[] {
   return infos;
 }
 
+// Materialize the active-space cursor without overwriting a concurrent explicit
+// switch. A clone does not carry this gitignored file, so SessionStart and any
+// active-intent write recreate the resolved pointer on first use. Publish a
+// fully-written staged file with link(), whose no-replace install is atomic: if
+// a space switch wins the race, its value stays untouched.
+export function ensureActiveSpaceCursor(projectDir: string): void {
+  const space = activeSpace(projectDir);
+  const root = workspaceRoot(projectDir);
+  const cursor = join(root, ACTIVE_SPACE_POINTER);
+  const staged = join(root, `.aidlc-active-space-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(staged, `${space}\n`, { encoding: "utf-8", flag: "wx" });
+    linkSync(staged, cursor);
+  } catch {
+    /* existing cursor won, or per-user state is unwritable */
+  } finally {
+    try {
+      unlinkSync(staged);
+    } catch {
+      /* staging file was never created or is already gone */
+    }
+  }
+}
+
 // Write the active-intent cursor for a space (gitignored per-user pointer).
-// Best-effort: the cursor dir is created if absent; a write failure is swallowed
-// (the cursor is per-user state, never the source of truth — the registry is).
+// Best-effort: the cursor dirs are created if absent; a write failure is
+// swallowed (the cursors are per-user state, never the source of truth).
 export function setActiveIntentCursor(projectDir: string, dirName: string, space?: string): void {
+  ensureActiveSpaceCursor(projectDir);
   const dir = intentsDir(projectDir, space);
   try {
     mkdirSync(dir, { recursive: true });
@@ -2085,11 +2111,7 @@ export function migrateFlatLayout(projectDir: string): FlatMigrationResult | nul
       { uuid, slug, dirName: intentDirName, scope: undefined, repos: undefined, status: "in-flight" },
       space,
     );
-    try {
-      writeFileSync(join(intentsRoot, ACTIVE_INTENT_POINTER), `${intentDirName}\n`, "utf-8");
-    } catch {
-      /* cursor is per-user/gitignored; best-effort */
-    }
+    setActiveIntentCursor(projectDir, intentDirName, space);
 
     // (5) Write the `.migrated` marker LAST (the sole idempotency key).
     mkdirSync(workspaceRoot(projectDir), { recursive: true });

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.41";
+export const AIDLC_VERSION = "2.5.42";

--- a/dist/codex/.gitignore
+++ b/dist/codex/.gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/dist/kiro-ide/.gitignore
+++ b/dist/kiro-ide/.gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-turn roll-forward guard (Kiro): a turn counter + a read-only/nav latch the
 # userPromptSubmit seam stamps and the engine done-guard / preToolUse backstop
 # read. Per-machine runtime, never shared truth. (Inert on Kiro IDE, which has no

--- a/dist/kiro-ide/.kiro/hooks/aidlc-session-start.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-session-start.ts
@@ -18,7 +18,7 @@
 //   clear   → SESSION_STARTED
 //   compact → no emission (PreCompact already fired)
 //
-// The hook is a no-op if aidlc-state.md is absent in cwd (no active workflow).
+// With no aidlc-state.md, only cursor/include bootstrap runs; workflow work is a no-op.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
@@ -28,6 +28,7 @@ import {
   activeIntentUuid,
   activeSpace,
   clearSessionIntentUuid,
+  ensureActiveSpaceCursor,
   errorMessage,
   findIntentByUuid,
   getField,
@@ -48,12 +49,12 @@ import { writeCurrentTranscriptPath } from "../tools/aidlc-usage.ts";
 export async function run(input: string): Promise<number> {
 const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Idempotent ensure-step (P0.1 robustness): align the harness-native includes
-// with the active space at session start, BEFORE the no-workflow early-exit, so
-// turn-1 on a fresh clone (no aidlc-state.md yet) still has the includes pointed
-// at the active space. A no-op at `default` (the common case) and whenever the
-// cursor + includes already agree — so it never dirties a single-team committed
-// tree. Best-effort: a failure here must never break session startup.
+// Idempotent ensure-step (P0.1 robustness): atomically materialize a clone's
+// missing gitignored cursor, then align the harness-native includes with that
+// space BEFORE the no-workflow early-exit. Cursor creation cannot overwrite a
+// concurrent explicit switch. Best-effort: a failure here must never break
+// session startup.
+ensureActiveSpaceCursor(projectDir);
 try {
   repointHarnessIncludes(projectDir, activeSpace(projectDir));
 } catch {

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, linkSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1701,10 +1701,36 @@ export function listIntents(projectDir: string, space?: string): IntentInfo[] {
   return infos;
 }
 
+// Materialize the active-space cursor without overwriting a concurrent explicit
+// switch. A clone does not carry this gitignored file, so SessionStart and any
+// active-intent write recreate the resolved pointer on first use. Publish a
+// fully-written staged file with link(), whose no-replace install is atomic: if
+// a space switch wins the race, its value stays untouched.
+export function ensureActiveSpaceCursor(projectDir: string): void {
+  const space = activeSpace(projectDir);
+  const root = workspaceRoot(projectDir);
+  const cursor = join(root, ACTIVE_SPACE_POINTER);
+  const staged = join(root, `.aidlc-active-space-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(staged, `${space}\n`, { encoding: "utf-8", flag: "wx" });
+    linkSync(staged, cursor);
+  } catch {
+    /* existing cursor won, or per-user state is unwritable */
+  } finally {
+    try {
+      unlinkSync(staged);
+    } catch {
+      /* staging file was never created or is already gone */
+    }
+  }
+}
+
 // Write the active-intent cursor for a space (gitignored per-user pointer).
-// Best-effort: the cursor dir is created if absent; a write failure is swallowed
-// (the cursor is per-user state, never the source of truth — the registry is).
+// Best-effort: the cursor dirs are created if absent; a write failure is
+// swallowed (the cursors are per-user state, never the source of truth).
 export function setActiveIntentCursor(projectDir: string, dirName: string, space?: string): void {
+  ensureActiveSpaceCursor(projectDir);
   const dir = intentsDir(projectDir, space);
   try {
     mkdirSync(dir, { recursive: true });
@@ -2085,11 +2111,7 @@ export function migrateFlatLayout(projectDir: string): FlatMigrationResult | nul
       { uuid, slug, dirName: intentDirName, scope: undefined, repos: undefined, status: "in-flight" },
       space,
     );
-    try {
-      writeFileSync(join(intentsRoot, ACTIVE_INTENT_POINTER), `${intentDirName}\n`, "utf-8");
-    } catch {
-      /* cursor is per-user/gitignored; best-effort */
-    }
+    setActiveIntentCursor(projectDir, intentDirName, space);
 
     // (5) Write the `.migrated` marker LAST (the sole idempotency key).
     mkdirSync(workspaceRoot(projectDir), { recursive: true });

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.41";
+export const AIDLC_VERSION = "2.5.42";

--- a/dist/kiro/.gitignore
+++ b/dist/kiro/.gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-turn roll-forward guard (Kiro): a turn counter + a read-only/nav latch the
 # userPromptSubmit seam stamps and the engine done-guard / preToolUse backstop
 # read. Per-machine runtime, never shared truth.

--- a/dist/kiro/.kiro/hooks/aidlc-session-start.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-session-start.ts
@@ -18,7 +18,7 @@
 //   clear   → SESSION_STARTED
 //   compact → no emission (PreCompact already fired)
 //
-// The hook is a no-op if aidlc-state.md is absent in cwd (no active workflow).
+// With no aidlc-state.md, only cursor/include bootstrap runs; workflow work is a no-op.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
@@ -28,6 +28,7 @@ import {
   activeIntentUuid,
   activeSpace,
   clearSessionIntentUuid,
+  ensureActiveSpaceCursor,
   errorMessage,
   findIntentByUuid,
   getField,
@@ -48,12 +49,12 @@ import { writeCurrentTranscriptPath } from "../tools/aidlc-usage.ts";
 export async function run(input: string): Promise<number> {
 const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Idempotent ensure-step (P0.1 robustness): align the harness-native includes
-// with the active space at session start, BEFORE the no-workflow early-exit, so
-// turn-1 on a fresh clone (no aidlc-state.md yet) still has the includes pointed
-// at the active space. A no-op at `default` (the common case) and whenever the
-// cursor + includes already agree — so it never dirties a single-team committed
-// tree. Best-effort: a failure here must never break session startup.
+// Idempotent ensure-step (P0.1 robustness): atomically materialize a clone's
+// missing gitignored cursor, then align the harness-native includes with that
+// space BEFORE the no-workflow early-exit. Cursor creation cannot overwrite a
+// concurrent explicit switch. Best-effort: a failure here must never break
+// session startup.
+ensureActiveSpaceCursor(projectDir);
 try {
   repointHarnessIncludes(projectDir, activeSpace(projectDir));
 } catch {

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, linkSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1701,10 +1701,36 @@ export function listIntents(projectDir: string, space?: string): IntentInfo[] {
   return infos;
 }
 
+// Materialize the active-space cursor without overwriting a concurrent explicit
+// switch. A clone does not carry this gitignored file, so SessionStart and any
+// active-intent write recreate the resolved pointer on first use. Publish a
+// fully-written staged file with link(), whose no-replace install is atomic: if
+// a space switch wins the race, its value stays untouched.
+export function ensureActiveSpaceCursor(projectDir: string): void {
+  const space = activeSpace(projectDir);
+  const root = workspaceRoot(projectDir);
+  const cursor = join(root, ACTIVE_SPACE_POINTER);
+  const staged = join(root, `.aidlc-active-space-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(staged, `${space}\n`, { encoding: "utf-8", flag: "wx" });
+    linkSync(staged, cursor);
+  } catch {
+    /* existing cursor won, or per-user state is unwritable */
+  } finally {
+    try {
+      unlinkSync(staged);
+    } catch {
+      /* staging file was never created or is already gone */
+    }
+  }
+}
+
 // Write the active-intent cursor for a space (gitignored per-user pointer).
-// Best-effort: the cursor dir is created if absent; a write failure is swallowed
-// (the cursor is per-user state, never the source of truth — the registry is).
+// Best-effort: the cursor dirs are created if absent; a write failure is
+// swallowed (the cursors are per-user state, never the source of truth).
 export function setActiveIntentCursor(projectDir: string, dirName: string, space?: string): void {
+  ensureActiveSpaceCursor(projectDir);
   const dir = intentsDir(projectDir, space);
   try {
     mkdirSync(dir, { recursive: true });
@@ -2085,11 +2111,7 @@ export function migrateFlatLayout(projectDir: string): FlatMigrationResult | nul
       { uuid, slug, dirName: intentDirName, scope: undefined, repos: undefined, status: "in-flight" },
       space,
     );
-    try {
-      writeFileSync(join(intentsRoot, ACTIVE_INTENT_POINTER), `${intentDirName}\n`, "utf-8");
-    } catch {
-      /* cursor is per-user/gitignored; best-effort */
-    }
+    setActiveIntentCursor(projectDir, intentDirName, space);
 
     // (5) Write the `.migrated` marker LAST (the sole idempotency key).
     mkdirSync(workspaceRoot(projectDir), { recursive: true });

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.41";
+export const AIDLC_VERSION = "2.5.42";

--- a/dist/opencode/.aidlc/hooks/aidlc-session-start.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-session-start.ts
@@ -18,7 +18,7 @@
 //   clear   → SESSION_STARTED
 //   compact → no emission (PreCompact already fired)
 //
-// The hook is a no-op if aidlc-state.md is absent in cwd (no active workflow).
+// With no aidlc-state.md, only cursor/include bootstrap runs; workflow work is a no-op.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
@@ -28,6 +28,7 @@ import {
   activeIntentUuid,
   activeSpace,
   clearSessionIntentUuid,
+  ensureActiveSpaceCursor,
   errorMessage,
   findIntentByUuid,
   getField,
@@ -48,12 +49,12 @@ import { writeCurrentTranscriptPath } from "../tools/aidlc-usage.ts";
 export async function run(input: string): Promise<number> {
 const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Idempotent ensure-step (P0.1 robustness): align the harness-native includes
-// with the active space at session start, BEFORE the no-workflow early-exit, so
-// turn-1 on a fresh clone (no aidlc-state.md yet) still has the includes pointed
-// at the active space. A no-op at `default` (the common case) and whenever the
-// cursor + includes already agree — so it never dirties a single-team committed
-// tree. Best-effort: a failure here must never break session startup.
+// Idempotent ensure-step (P0.1 robustness): atomically materialize a clone's
+// missing gitignored cursor, then align the harness-native includes with that
+// space BEFORE the no-workflow early-exit. Cursor creation cannot overwrite a
+// concurrent explicit switch. Best-effort: a failure here must never break
+// session startup.
+ensureActiveSpaceCursor(projectDir);
 try {
   repointHarnessIncludes(projectDir, activeSpace(projectDir));
 } catch {

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { accessSync, appendFileSync, closeSync, constants as fsConstants, cpSync, existsSync, linkSync, mkdirSync, openSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { hostname, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1701,10 +1701,36 @@ export function listIntents(projectDir: string, space?: string): IntentInfo[] {
   return infos;
 }
 
+// Materialize the active-space cursor without overwriting a concurrent explicit
+// switch. A clone does not carry this gitignored file, so SessionStart and any
+// active-intent write recreate the resolved pointer on first use. Publish a
+// fully-written staged file with link(), whose no-replace install is atomic: if
+// a space switch wins the race, its value stays untouched.
+export function ensureActiveSpaceCursor(projectDir: string): void {
+  const space = activeSpace(projectDir);
+  const root = workspaceRoot(projectDir);
+  const cursor = join(root, ACTIVE_SPACE_POINTER);
+  const staged = join(root, `.aidlc-active-space-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    mkdirSync(root, { recursive: true });
+    writeFileSync(staged, `${space}\n`, { encoding: "utf-8", flag: "wx" });
+    linkSync(staged, cursor);
+  } catch {
+    /* existing cursor won, or per-user state is unwritable */
+  } finally {
+    try {
+      unlinkSync(staged);
+    } catch {
+      /* staging file was never created or is already gone */
+    }
+  }
+}
+
 // Write the active-intent cursor for a space (gitignored per-user pointer).
-// Best-effort: the cursor dir is created if absent; a write failure is swallowed
-// (the cursor is per-user state, never the source of truth — the registry is).
+// Best-effort: the cursor dirs are created if absent; a write failure is
+// swallowed (the cursors are per-user state, never the source of truth).
 export function setActiveIntentCursor(projectDir: string, dirName: string, space?: string): void {
+  ensureActiveSpaceCursor(projectDir);
   const dir = intentsDir(projectDir, space);
   try {
     mkdirSync(dir, { recursive: true });
@@ -2085,11 +2111,7 @@ export function migrateFlatLayout(projectDir: string): FlatMigrationResult | nul
       { uuid, slug, dirName: intentDirName, scope: undefined, repos: undefined, status: "in-flight" },
       space,
     );
-    try {
-      writeFileSync(join(intentsRoot, ACTIVE_INTENT_POINTER), `${intentDirName}\n`, "utf-8");
-    } catch {
-      /* cursor is per-user/gitignored; best-effort */
-    }
+    setActiveIntentCursor(projectDir, intentDirName, space);
 
     // (5) Write the `.migrated` marker LAST (the sole idempotency key).
     mkdirSync(workspaceRoot(projectDir), { recursive: true });

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.41";
+export const AIDLC_VERSION = "2.5.42";

--- a/dist/opencode/.gitignore
+++ b/dist/opencode/.gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/docs/guide/03-spaces-and-intents.md
+++ b/docs/guide/03-spaces-and-intents.md
@@ -277,8 +277,8 @@ repo. Two kinds of file are deliberately **gitignored** instead:
 
 | Gitignored (per-user, machine-local) | Why |
 |---|---|
-| `aidlc/active-space`, `…/intents/active-intent` | Cursors — "where am I right now." Committing them would dirty the tree on every `/aidlc` and have teammates fight over the cursor on each switch. |
-| `…/intents/<id>/runtime-graph.json`, `.aidlc-*`, `aidlc/.aidlc-sessions/` | Derived, machine-local runtime state. |
+| `aidlc/active-space`, `…/intents/active-intent` | Cursors — "where am I right now." Committing them would turn per-user navigation into shared repository state and have teammates fight over intent births and cursor switches. |
+| `…/intents/<id>/runtime-graph.json`, `.aidlc-*`, `aidlc/.aidlc-sessions/`, `aidlc/.aidlc-active-space-*.tmp` | Derived, machine-local runtime state. |
 
 Everything else under a space — `memory/**`, `knowledge/**`, `codekb/**`,
 `intents.json`, each record's `aidlc-state.md`, `audit/` shards, and artifacts — is

--- a/harness/claude/dot-gitignore
+++ b/harness/claude/dot-gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/harness/codex/dot-gitignore
+++ b/harness/codex/dot-gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/harness/kiro-ide/dot-gitignore
+++ b/harness/kiro-ide/dot-gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-turn roll-forward guard (Kiro): a turn counter + a read-only/nav latch the
 # userPromptSubmit seam stamps and the engine done-guard / preToolUse backstop
 # read. Per-machine runtime, never shared truth. (Inert on Kiro IDE, which has no

--- a/harness/kiro/dot-gitignore
+++ b/harness/kiro/dot-gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-turn roll-forward guard (Kiro): a turn counter + a read-only/nav latch the
 # userPromptSubmit seam stamps and the engine done-guard / preToolUse backstop
 # read. Per-machine runtime, never shared truth.

--- a/harness/opencode/dot-gitignore
+++ b/harness/opencode/dot-gitignore
@@ -29,8 +29,8 @@ dist-ssr
 # method, registry, state, AUDIT (per-clone shards), artifacts — is committed.
 #
 # Per-user session cursors — ignored (two teammates legitimately point at
-# different spaces/intents at once; committing them would dirty the tree on
-# every /aidlc and have teammates fight over the cursor on each switch).
+# different spaces/intents at once; committing them would turn per-user
+# navigation into shared state and cause conflicts on births and switches).
 aidlc/active-space
 aidlc/spaces/*/intents/active-intent
 #
@@ -38,6 +38,8 @@ aidlc/spaces/*/intents/active-intent
 # The clone-id token names this clone's audit shard; it MUST stay machine-local
 # (gitignored) or every clone from a commit would share a shard and git-conflict.
 aidlc/.aidlc-clone-id
+# Atomic active-space create staging (normally unlinked immediately).
+aidlc/.aidlc-active-space-*.tmp
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -374,10 +374,11 @@ const MEMORY_SEED_DST = join("tools", "data", "memory-seed");
 // NOTE: it is GITIGNORED in the user's workspace (a per-user session cursor,
 // vision 5.1 - teammates legitimately point at different spaces at once), yet
 // dist must SHIP it as part of the shell. The two reconcile: the dist
-// .gitignore ignores aidlc/active-space for the END USER (their first /aidlc
-// cursor-write stays untracked), while OUR repo commits the shipped pointer
-// once (git add -f on the seed commit) - after which it is tracked and the
-// gitignore is moot for that path here, exactly like a shipped default .env.
+// .gitignore ignores aidlc/active-space for the END USER; a clone's first
+// SessionStart or active-intent write atomically recreates the missing pointer
+// and keeps it untracked. OUR repo commits the shipped pointer once (git add -f
+// on the seed commit) - after which the gitignore is moot for that path here,
+// exactly like a shipped default .env.
 const ACTIVE_SPACE_REL = join("aidlc", "active-space");
 const ACTIVE_SPACE_VALUE = "default\n";
 

--- a/tests/.coverage-ratchet.json
+++ b/tests/.coverage-ratchet.json
@@ -1,7 +1,7 @@
 {
   "note": "Committed baseline: covered-unit count per class. The --check ratchet fails CI if any class's covered count DROPS below these numbers without a reviewed deferred entry. Monotonic anti-regression: you can cover more, never silently less. Regenerate with: bun tests/gen-coverage-registry.ts",
   "coveredByClass": {
-    "function": 117,
+    "function": 118,
     "audit": 36,
     "scope": 9,
     "stage": 9,

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -20,9 +20,9 @@
     "render-surface": "tui"
   },
   "counts": {
-    "total": 504,
+    "total": 505,
     "enumeratedByClass": {
-      "function": 264,
+      "function": 265,
       "audit": 77,
       "scope": 9,
       "stage": 32,
@@ -31,7 +31,7 @@
       "render-surface": 7
     },
     "coveredByClass": {
-      "function": 117,
+      "function": 118,
       "audit": 36,
       "scope": 9,
       "stage": 9,
@@ -1441,6 +1441,18 @@
         },
         {
           "file": "tests/unit/t64.test.ts",
+          "mechanism": "none"
+        }
+      ],
+      "status": "covered"
+    },
+    {
+      "unitClass": "function",
+      "unitId": "function:ensureActiveSpaceCursor",
+      "minMechanism": "none",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t160-workspace-record-resolution.test.ts",
           "mechanism": "none"
         }
       ],

--- a/tests/integration/t165-intent-birth-p4.test.ts
+++ b/tests/integration/t165-intent-birth-p4.test.ts
@@ -129,6 +129,17 @@ describe("t164 auto-birth (intent-birth) on an empty workspace", () => {
     expect(shards).toContain("**Event**: WORKFLOW_STARTED");
   });
 
+  test("birth materializes the active-space cursor missing from a fresh clone", () => {
+    const cursor = join(proj, "aidlc", "active-space");
+    rmSync(cursor, { force: true });
+    expect(existsSync(cursor)).toBe(false);
+
+    const r = util(["intent-birth", "--scope", "poc"]);
+    expect(r.status).toBe(0);
+    expect(readFileSync(cursor, "utf-8")).toBe("default\n");
+    expect(activeIntent(proj)).not.toBeNull();
+  });
+
   test("birth slugs the freeform --arguments description (SLUG_RE-valid)", () => {
     const r = util(["intent-birth", "--scope", "feature", "--arguments", "Build the Auth Service!!"]);
     expect(r.status).toBe(0);
@@ -527,9 +538,12 @@ describe("t164 migration wiring (flat → per-intent on first birth)", () => {
       "utf-8",
     );
     writeFileSync(join(flat, "audit.md"), "# AI-DLC Audit Log\n", "utf-8");
+    const cursor = join(proj, "aidlc", "active-space");
+    rmSync(cursor, { force: true });
 
     const r = util(["intent-birth", "--scope", "feature"]);
     expect(r.status).toBe(0);
+    expect(readFileSync(cursor, "utf-8")).toBe("default\n");
 
     // Migration moved the flat state into a per-intent record (NOT a second
     // freshly-minted intent on top).

--- a/tests/unit/t10-hook-session-start.test.ts
+++ b/tests/unit/t10-hook-session-start.test.ts
@@ -79,9 +79,11 @@
 //     JSON on the corrupted fixture (graceful, not just non-crashing).
 //   - test 1 asserts EMPTY stdout (the additionalContext JSON is the only thing
 //     the hook writes), strictly stronger than the .sh's `-z` on merged output.
+//   - one additional regression pins cursor materialization before the no-state
+//     early exit; it has no legacy .sh counterpart.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   AIDLC_SRC,
@@ -185,6 +187,18 @@ describe("t10 session-start SessionStart hook (mechanism cli — spawned hook + 
     const r = fire(proj);
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("");
+  });
+
+  test("materializes a missing active-space cursor before the no-state early exit", () => {
+    const cursor = join(proj, "aidlc", "active-space");
+    rmSync(cursor, { force: true });
+    expect(existsSync(statePath(proj))).toBe(false);
+    expect(existsSync(cursor)).toBe(false);
+
+    const r = fire(proj);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(readFileSync(cursor, "utf-8")).toBe("default\n");
   });
 
   test("no heartbeat when no state file [.sh test 2]", () => {

--- a/tests/unit/t157-workspace-shell-seed.test.ts
+++ b/tests/unit/t157-workspace-shell-seed.test.ts
@@ -230,6 +230,9 @@ describe("t157 seeded workspace shell + re-rooted .gitignore (SEED)", () => {
       const lines = gi.split("\n").map((l) => l.trim());
       // The two session cursors (re-rooted under aidlc/).
       expect(lines, `${h}: ignores aidlc/active-space`).toContain("aidlc/active-space");
+      expect(lines, `${h}: ignores active-space create staging`).toContain(
+        "aidlc/.aidlc-active-space-*.tmp",
+      );
       expect(lines, `${h}: ignores active-intent`).toContain(
         "aidlc/spaces/*/intents/active-intent",
       );

--- a/tests/unit/t160-workspace-record-resolution.test.ts
+++ b/tests/unit/t160-workspace-record-resolution.test.ts
@@ -1,4 +1,4 @@
-// covers: function:activeSpace, function:activeIntent, function:recordDir, function:relativeRecordDir, function:stateFilePath, function:auditFilePath, function:uuidv7, function:slugify, function:migrateFlatLayout, function:knowledgeDir
+// covers: function:activeSpace, function:ensureActiveSpaceCursor, function:activeIntent, function:recordDir, function:relativeRecordDir, function:stateFilePath, function:auditFilePath, function:uuidv7, function:slugify, function:migrateFlatLayout, function:knowledgeDir
 //
 // t160 — P1 Step B re-root: the per-intent record-dir resolution + the flat
 // legacy fallback + the one-time crash-safe migration. Mechanism: in-process
@@ -23,6 +23,7 @@ import {
   auditFilePath,
   auditShardName,
   auditShards,
+  ensureActiveSpaceCursor,
   idSuffix,
   intentsDir,
   knowledgeDir,
@@ -115,6 +116,22 @@ describe("t160 selectors — space + intent resolution", () => {
     expect(activeSpace(proj)).toBe("default");
     seedShell(proj, "team-b");
     expect(activeSpace(proj)).toBe("team-b");
+  });
+
+  test("ensureActiveSpaceCursor creates the fallback only when the cursor is absent", () => {
+    const cursor = join(proj, "aidlc", "active-space");
+    rmSync(cursor, { force: true });
+    ensureActiveSpaceCursor(proj);
+    expect(readFileSync(cursor, "utf-8")).toBe("default\n");
+
+    writeFileSync(cursor, "team-b\n", "utf-8");
+    ensureActiveSpaceCursor(proj);
+    expect(readFileSync(cursor, "utf-8")).toBe("team-b\n");
+    expect(
+      readdirSync(join(proj, "aidlc")).filter((name) =>
+        name.startsWith(".aidlc-active-space-")
+      ),
+    ).toEqual([]);
   });
 
   test("knowledgeDir resolves the SPACE-level knowledge dir for the active (or explicit) space", () => {


### PR DESCRIPTION
## Summary

- recreate a missing gitignored `aidlc/active-space` cursor during SessionStart and active-intent writes
- publish the cursor atomically without replacing a concurrent explicit space switch
- ignore transient staging files, update the workspace documentation, regenerate every harness distribution, and bump the release metadata to 2.5.42

## Verification

- targeted unit + integration slice: 4 files, 83 assertions, PASS (`2026-08-06T00-58-08Z`)
- `bun run check` (package parity, all TypeScript configs, Biome over 570 files)

Fixes #706
