### PR TITLE
fix(tests): isolate Claude SDK runtime state

### DIFF
--- a/docs/reference/09-testing.md
+++ b/docs/reference/09-testing.md
@@ -155,6 +155,12 @@ The stack defaults to **`c5.4xlarge`** — the proven size for the full `--all -
 
 Before running unfiltered live-capable levels (integration or e2e), the runner executes `tests/integration/t19.test.ts` as a gate. It drives a tiny real turn through the **Claude Agent SDK** (the same live path the integration tier uses) and asserts only on deterministic surfaces. If the preflight fails, deterministic files still run and Claude-dependent files are skipped with per-file `SKIP` entries.
 
+The SDK driver gives each `driveAidlc()` call an ephemeral `CLAUDE_CONFIG_DIR`
+and disables session persistence. Live tests therefore leave the user's
+`~/.claude.json` and Claude transcripts untouched, including when the home
+directory is read-only inside a command sandbox. A per-call
+`env.CLAUDE_CONFIG_DIR` remains available for focused calibration.
+
 | Assertion | Surface | On fail |
 |-----------|---------|---------|
 | AWS credentials valid | `aws sts get-caller-identity` exits 0 (PASS-by-skip when the `aws` CLI is absent) | bail — Bedrock needs IAM auth |

--- a/tests/harness/sdk-drive.ts
+++ b/tests/harness/sdk-drive.ts
@@ -34,7 +34,16 @@
 //   - state:  <projectDir>/aidlc-docs/aidlc-state.md   (aidlc-lib.ts:137)
 //   - audit:  <projectDir>/aidlc-docs/audit.md         (aidlc-lib.ts:141)
 
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { query } from "@anthropic-ai/claude-agent-sdk";
@@ -431,6 +440,14 @@ export async function driveAidlc(
   const permissionMode = opts.permissionMode ?? "bypassPermissions";
   const settingSources = opts.settingSources ?? ["project"];
   const sdkSettings = resolveDriveSdkSettings(projectDir, opts);
+  // settingSources does not relocate Claude's mutable runtime state. Keep live
+  // tests off the user's ~/.claude.json so they work with a read-only home.
+  const requestedConfigDir = opts.env?.CLAUDE_CONFIG_DIR?.trim();
+  const claudeConfigDir =
+    requestedConfigDir ||
+    mkdtempSync(join(process.env.TMPDIR || tmpdir(), "aidlc-sdk-claude-"));
+  const ephemeralConfigDir = requestedConfigDir ? undefined : claudeConfigDir;
+  sdkSettings.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
 
   const toolResults: CapturedToolResult[] = [];
   const askedQuestions: CapturedAskUserQuestion[] = [];
@@ -483,64 +500,66 @@ export async function driveAidlc(
         }, opts.timeoutMs)
       : undefined;
 
-  const run = query({
-    prompt,
-    options: {
-      cwd: projectDir,
-      permissionMode,
-      settingSources,
-      abortController,
-      ...(sdkSettings.model ? { model: sdkSettings.model } : {}),
-      ...(Object.keys(sdkSettings.env).length > 0 ? { env: sdkSettings.env } : {}),
-      canUseTool: async (toolName, input, permissionOptions) => {
-        // PreToolUse rewrites have already run when this callback receives the
-        // input. Retain it as a fallback, but allowed tools can bypass this
-        // callback; Agent/Task tool results carry their executed prompt.
-        permissionToolInputs.set(permissionOptions.toolUseID, input);
-        if (toolName === "AskUserQuestion") {
-          const questions =
-            (input as { questions?: AskUserQuestionItem[] }).questions ?? [];
-          const answers = buildAnswers(questions, answerScript, askMenuIndex);
-          askMenuIndex++;
-          const captured: CapturedAskUserQuestion = { questions, answers };
-          askedQuestions.push(captured);
-          writeSdkTrace(tracePath, "ask_user_question", {
-            questions: questions.map((q) => ({
-              header: q.header,
-              question: q.question,
-              options: q.options.map((o) => o.label),
-            })),
-            answers,
-          });
-          opts.onAskUserQuestion?.(captured);
-          if (askMenuIndex === stopAfterAskUserQuestionAt) {
-            // Record the INTENT to stop, but do NOT abort here. Aborting inside
-            // canUseTool tears down the SDK permission transport before this
-            // `{ behavior: "allow" }` response can be delivered, so the gate's
-            // tool_result comes back as "Tool permission stream closed before
-            // response received" (isError) instead of carrying the scripted
-            // answer's bytes. The actual stop happens in the tool_result handler
-            // below, keyed on stopAfterAskUserQuestionToolUseId — that fires
-            // AFTER the answer has crossed the boundary and been captured in the
-            // AskUserQuestion tool_result, which is the deterministic surface the
-            // calibration asserts on. (MR10's Windows wave introduced an eager
-            // abort here; the original design stopped only post-tool_result.)
-            writeSdkTrace(tracePath, "will_stop_after_ask_user_question", {
-              menuIndex: askMenuIndex,
-            });
-          }
-          return {
-            behavior: "allow",
-            updatedInput: { ...(input as object), answers },
-          };
-        }
-        // Everything else passes through unchanged (Bash/Write/Edit/Skill/...).
-        return { behavior: "allow", updatedInput: input };
-      },
-    },
-  });
-
   try {
+    const run = query({
+      prompt,
+      options: {
+        cwd: projectDir,
+        permissionMode,
+        settingSources,
+        abortController,
+        // Each drive is independent; avoid transcript writes racing cleanup.
+        persistSession: false,
+        ...(sdkSettings.model ? { model: sdkSettings.model } : {}),
+        ...(Object.keys(sdkSettings.env).length > 0 ? { env: sdkSettings.env } : {}),
+        canUseTool: async (toolName, input, permissionOptions) => {
+          // PreToolUse rewrites have already run when this callback receives the
+          // input. Retain it as a fallback, but allowed tools can bypass this
+          // callback; Agent/Task tool results carry their executed prompt.
+          permissionToolInputs.set(permissionOptions.toolUseID, input);
+          if (toolName === "AskUserQuestion") {
+            const questions =
+              (input as { questions?: AskUserQuestionItem[] }).questions ?? [];
+            const answers = buildAnswers(questions, answerScript, askMenuIndex);
+            askMenuIndex++;
+            const captured: CapturedAskUserQuestion = { questions, answers };
+            askedQuestions.push(captured);
+            writeSdkTrace(tracePath, "ask_user_question", {
+              questions: questions.map((q) => ({
+                header: q.header,
+                question: q.question,
+                options: q.options.map((o) => o.label),
+              })),
+              answers,
+            });
+            opts.onAskUserQuestion?.(captured);
+            if (askMenuIndex === stopAfterAskUserQuestionAt) {
+              // Record the INTENT to stop, but do NOT abort here. Aborting inside
+              // canUseTool tears down the SDK permission transport before this
+              // `{ behavior: "allow" }` response can be delivered, so the gate's
+              // tool_result comes back as "Tool permission stream closed before
+              // response received" (isError) instead of carrying the scripted
+              // answer's bytes. The actual stop happens in the tool_result handler
+              // below, keyed on stopAfterAskUserQuestionToolUseId — that fires
+              // AFTER the answer has crossed the boundary and been captured in the
+              // AskUserQuestion tool_result, which is the deterministic surface the
+              // calibration asserts on. (MR10's Windows wave introduced an eager
+              // abort here; the original design stopped only post-tool_result.)
+              writeSdkTrace(tracePath, "will_stop_after_ask_user_question", {
+                menuIndex: askMenuIndex,
+              });
+            }
+            return {
+              behavior: "allow",
+              updatedInput: { ...(input as object), answers },
+            };
+          }
+          // Everything else passes through unchanged (Bash/Write/Edit/Skill/...).
+          return { behavior: "allow", updatedInput: input };
+        },
+      },
+    });
+
     for await (const msg of run) {
       writeSdkTrace(tracePath, "message", { type: msg.type });
       if (msg.type === "assistant") {
@@ -684,6 +703,14 @@ export async function driveAidlc(
     }
   } finally {
     if (timer) clearTimeout(timer);
+    if (ephemeralConfigDir && process.env.AIDLC_KEEP_TEMP !== "1") {
+      rmSync(ephemeralConfigDir, {
+        recursive: true,
+        force: true,
+        maxRetries: process.platform === "win32" ? 10 : 0,
+        retryDelay: 50,
+      });
+    }
     writeSdkTrace(tracePath, "end", {
       timedOut,
       stoppedAfterAskUserQuestion,


### PR DESCRIPTION
## Summary

- give every `driveAidlc()` call an ephemeral `CLAUDE_CONFIG_DIR`
- disable unused SDK session persistence and retry transient Windows cleanup failures
- document why live SDK tests no longer touch the user's Claude state

## Problem

Claude Agent SDK journeys inherited the real `HOME` and attempted to update `~/.claude.json`. Under Codex `workspace-git`, that file is read-only, causing live integration failures with `EROFS`. Granting the file directly as a Codex writable root also crashes the Linux bubblewrap mount setup because writable roots are treated as directories.

## Validation

- `bun run check`
- `workspace-git`, integration filter `^t19`: all four former `EROFS` journeys passed; one unrelated live-model path divergence (`t193`) was rerun green-alone
- `workspace-git`, exact `t193-compose-report-journey.sdk.test.ts`: 1 pass / 0 fail
- `workspace-git`, unit filter `^t140` after rebase: 3 assertions pass
- zero `EROFS` / `.claude.json` hits and zero leaked `aidlc-sdk-claude-*` directories

Linux was live-tested. The implementation uses portable Node filesystem/path APIs and Windows cleanup retries, but macOS and Windows live gates were not run in this session.