### PR TITLE
fix(cursor): emit preToolUse allow JSON under failClosed (2.5.66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.69] - 2026-08-13
+
+Cursor IDE no longer blocks every tool call on a fail-closed PreToolUse hook that allowed with empty stdout. The Cursor adapter now emits `{"permission":"allow"}` on both allow returns, matching Cursor's required permission JSON; deny JSON and `failClosed: true` are unchanged. Cursor CLI already treated silence as allow, so CLI-only verification missed this. **Upgrade:** refresh `dist/cursor/` and rerun `bun dist/cursor/install.ts <project>`.
+
+* Cursor `preToolUse` (`guards`) allow paths write `{"permission":"allow"}` before exit 0. Empty stdout is invalid JSON; with `failClosed: true` the IDE denied the call (`Hook "bun .cursor/hooks/aidlc-cursor-adapter.ts guards" returned no output`).
+* Unit coverage in t276 asserts allow stdout is that JSON, and still deny JSON on block or malformed input.
+* No command or flag changes.
+
 ## [2.5.68] - 2026-08-13
 
 Codex balanced and templated agents now use a supported model on Amazon Bedrock. **Upgrade:** re-copy `dist/codex/` into the project.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.68-blue)
+![version](https://img.shields.io/badge/version-2.5.69-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
@@ -9,9 +9,11 @@
 // shares the hooks.json surface) are near-isomorphic to Claude Code's with
 // these load-bearing differences:
 //   1. Event names are camelCase (sessionStart, preToolUse, ...) and each
-//      event has its OWN stdout output schema — a PreToolUse deny is
-//      {"permission":"deny","agent_message"} JSON, NOT exit 2 + stderr
-//      (exit 2 does block, but the reason channel is the JSON field);
+//      event has its OWN stdout output schema — PreToolUse must emit
+//      {"permission":"allow"|"deny"} JSON (deny may add agent_message),
+//      NOT Claude's exit 2 + stderr (exit 2 does block, but the reason
+//      channel is the JSON field; empty allow stdout is invalid JSON, so
+//      failClosed IDE denies while the CLI treats silence as allow);
 //      sessionStart context is {"additional_context"} (snake_case), and stop
 //      cannot block at all — only {"followup_message"} (advisory nudge).
 //   2. The shell tool is named "Shell" (tool_input.command, like Bash).
@@ -689,6 +691,12 @@ export async function run(
     return true;
   }
 
+  // Cursor IDE failClosed preToolUse treats empty stdout as invalid JSON and
+  // blocks. Cursor CLI treats the same silence as allow. Always emit allow JSON.
+  function writeAllow(): void {
+    process.stdout.write(`${JSON.stringify({ permission: "allow" })}\n`);
+  }
+
   // --- Targets ------------------------------------------------------------------
 
   switch (target) {
@@ -798,6 +806,7 @@ export async function run(
       // it feeds the identity ledger. Block contract conversion: core exit 2 + stderr becomes
       // Cursor's {"permission":"deny","agent_message"} stdout JSON
       // (live-verified: the deny blocks the call and relays the reason).
+      // Allow paths write {"permission":"allow"} — required under failClosed.
       if (toolName === "Task") {
         const parentAgent = activeSubagent();
         if (parentAgent) {
@@ -816,6 +825,7 @@ export async function run(
         }
         const sub = cursor.tool_input?.subagent_type;
         if (typeof sub === "string" && sub.length > 0) recordSpawn(sub);
+        writeAllow();
         return 0;
       }
       const agent = attributed();
@@ -871,6 +881,7 @@ export async function run(
       for (const guard of guards) {
         if (blockedByGuard(guard.file, guard.input)) return 0;
       }
+      writeAllow();
       return 0;
     }
 

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.68";
+export const AIDLC_VERSION = "2.5.69";

--- a/docs/guide/harnesses/cursor.md
+++ b/docs/guide/harnesses/cursor.md
@@ -86,10 +86,11 @@ projection directly (no `emit.ts`, no split dot-dir). The distribution is:
   state-transition, reviewer read-scope, review-freeze, and plan-approval
   guards before a tool runs, audit +
   sensors on write/edit, failed-Task attribution cleanup, stage-graph rebuilds on
-  shell, and state validation before compaction. The **PreToolUse guards block**
-  via Cursor's `{"permission":"deny","agent_message":...}` stdout channel and
-  register `failClosed: true`; malformed input, a missing guard, or a crashing
-  guard denies the operation. Cursor names its shell tool `Shell`; the adapter
+  shell, and state validation before compaction. The **PreToolUse guards**
+  answer on Cursor's `{"permission":"allow"|"deny"}` stdout channel (`deny`
+  may add `agent_message`) and register `failClosed: true`. Empty stdout is
+  invalid JSON, so the IDE blocks the call; malformed input, a missing guard,
+  or a crashing guard also denies the operation. Cursor names its shell tool `Shell`; the adapter
   maps it to the core hooks' `Bash`. Cursor's
     first-class `Delete` tool (unique to this harness - everywhere else deletion
     goes through the shell) is presented to the reviewer-scope guard as a write so a

--- a/harness/cursor/hooks/aidlc-cursor-adapter.ts
+++ b/harness/cursor/hooks/aidlc-cursor-adapter.ts
@@ -9,9 +9,11 @@
 // shares the hooks.json surface) are near-isomorphic to Claude Code's with
 // these load-bearing differences:
 //   1. Event names are camelCase (sessionStart, preToolUse, ...) and each
-//      event has its OWN stdout output schema — a PreToolUse deny is
-//      {"permission":"deny","agent_message"} JSON, NOT exit 2 + stderr
-//      (exit 2 does block, but the reason channel is the JSON field);
+//      event has its OWN stdout output schema — PreToolUse must emit
+//      {"permission":"allow"|"deny"} JSON (deny may add agent_message),
+//      NOT Claude's exit 2 + stderr (exit 2 does block, but the reason
+//      channel is the JSON field; empty allow stdout is invalid JSON, so
+//      failClosed IDE denies while the CLI treats silence as allow);
 //      sessionStart context is {"additional_context"} (snake_case), and stop
 //      cannot block at all — only {"followup_message"} (advisory nudge).
 //   2. The shell tool is named "Shell" (tool_input.command, like Bash).
@@ -689,6 +691,12 @@ export async function run(
     return true;
   }
 
+  // Cursor IDE failClosed preToolUse treats empty stdout as invalid JSON and
+  // blocks. Cursor CLI treats the same silence as allow. Always emit allow JSON.
+  function writeAllow(): void {
+    process.stdout.write(`${JSON.stringify({ permission: "allow" })}\n`);
+  }
+
   // --- Targets ------------------------------------------------------------------
 
   switch (target) {
@@ -798,6 +806,7 @@ export async function run(
       // it feeds the identity ledger. Block contract conversion: core exit 2 + stderr becomes
       // Cursor's {"permission":"deny","agent_message"} stdout JSON
       // (live-verified: the deny blocks the call and relays the reason).
+      // Allow paths write {"permission":"allow"} — required under failClosed.
       if (toolName === "Task") {
         const parentAgent = activeSubagent();
         if (parentAgent) {
@@ -816,6 +825,7 @@ export async function run(
         }
         const sub = cursor.tool_input?.subagent_type;
         if (typeof sub === "string" && sub.length > 0) recordSpawn(sub);
+        writeAllow();
         return 0;
       }
       const agent = attributed();
@@ -871,6 +881,7 @@ export async function run(
       for (const guard of guards) {
         if (blockedByGuard(guard.file, guard.input)) return 0;
       }
+      writeAllow();
       return 0;
     }
 

--- a/tests/unit/t276-cursor-adapter.test.ts
+++ b/tests/unit/t276-cursor-adapter.test.ts
@@ -15,6 +15,8 @@
 //   - guards (preToolUse): Shell maps to Bash for the core guards; a core
 //     exit-2 block converts to {"permission":"deny","agent_message"} stdout
 //     JSON (exit 0) - Cursor's deny channel, NOT the Claude exit-2 contract.
+//     Allow paths emit {"permission":"allow"} (failClosed IDE treats empty
+//     stdout as invalid JSON and blocks; CLI treated the same silence as allow).
 //   - Task spawn/completion maintains the subagent-identity ledger, so a
 //     guard event from another conversation_id gets agent_type attributed
 //     (the reviewer-scope bound's identity source on this harness).
@@ -23,7 +25,8 @@
 //     Cursor's final live Task; beforeSubmitPrompt mints HUMAN_TURN.
 //   - stop: a core {"decision":"block","reason"} converts to
 //     {"followup_message"} (advisory nudge - Cursor stop cannot block).
-//   - malformed stdin fails open (exit 0, no output).
+//   - malformed stdin denies guards and remains advisory (empty stdout)
+//     on every other target.
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
@@ -138,6 +141,17 @@ function runAdapter(
   return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", code: r.status ?? 0 };
 }
 
+/** Cursor failClosed preToolUse requires permission JSON on allow, not silence. */
+function expectAllowJson(
+  r: { code: number; stdout: string },
+  label?: string,
+): void {
+  expect(r.code, label).toBe(0);
+  expect(JSON.parse(r.stdout) as { permission?: string }, label).toEqual({
+    permission: "allow",
+  });
+}
+
 function registerTaskParent(projectDir: string): void {
   const conversation = PAYLOADS.preToolUseTask.conversation_id;
   if (typeof conversation !== "string") {
@@ -235,12 +249,11 @@ describe("t276 cursor adapter payload conversion", () => {
     expect(out.agent_message ?? "").toContain("aidlc-orchestrate");
   });
 
-  test("4: guards allow an ordinary shell command silently", () => {
+  test("4: guards allow an ordinary shell command with permission-allow JSON", () => {
     const proj = installedProject();
     seedStateFile(proj, "state-construction.md");
     const r = runAdapter(proj, "guards", payload("preToolUseShell", proj));
-    expect(r.code).toBe(0);
-    expect(r.stdout.trim()).toBe("");
+    expectAllowJson(r);
   });
 
   test("5: Task attribution binds unknown conversations only; registered mains are never conflated", () => {
@@ -273,7 +286,7 @@ describe("t276 cursor adapter payload conversion", () => {
     );
     // Spawn: the MAIN conversation's Task call records the ledger entry.
     const spawn = runAdapter(proj, "guards", payload("preToolUseTask", proj));
-    expect(spawn.code).toBe(0);
+    expectAllowJson(spawn);
     expect(ledgerFilesFor(proj)).toHaveLength(1);
     // The registered independent conversation must not inherit the reviewer
     // identity (the review round-1 conflation repro).
@@ -287,7 +300,7 @@ describe("t276 cursor adapter payload conversion", () => {
       }),
     );
     expect(unrelated.code).toBe(0);
-    expect(unrelated.stdout.trim()).toBe("");
+    expectAllowJson(unrelated);
     // The reviewer's own Read (fresh conversation_id, no sessionStart, no
     // identity fields — the live subagent shape) is scope-enforced.
     const sibling = runAdapter(
@@ -325,7 +338,7 @@ describe("t276 cursor adapter payload conversion", () => {
       }),
     );
     expect(afterDispatch.code).toBe(0);
-    expect(afterDispatch.stdout.trim()).toBe("");
+    expectAllowJson(afterDispatch);
   });
 
   test("6: postToolUse Write lands an audit row; Task lands SUBAGENT_COMPLETED; mint lands HUMAN_TURN", () => {
@@ -498,7 +511,7 @@ describe("t276 cursor adapter payload conversion", () => {
       conversation_id: "parent-conversation-b",
       session_id: "parent-conversation-b",
     });
-    expect(parentB.stdout.trim()).toBe("");
+    expectAllowJson(parentB);
     // An unknown conversation (the live subagent shape) is attributed while
     // both records name the same agent...
     expect(JSON.parse(siblingRead({}).stdout).permission).toBe("deny");
@@ -696,7 +709,7 @@ describe("t276 cursor adapter payload conversion", () => {
       }),
     );
     expect(own.code).toBe(0);
-    expect(own.stdout.trim()).toBe("");
+    expectAllowJson(own);
   });
 
   test("17: Delete keeps its real name for the state-transition guard", () => {
@@ -889,7 +902,7 @@ describe("t276 cursor adapter payload conversion", () => {
         },
       }),
     );
-    expect(harmless.stdout).toBe("");
+    expectAllowJson(harmless);
 
     const ready = projectWithReadyReview();
     const protectedWrite = runAdapter(
@@ -1111,7 +1124,7 @@ describe("t276 cursor adapter payload conversion", () => {
         tool_input: { command: "printf '%s\\n' '$HOME'" },
       }),
     );
-    expect(literalDollar.stdout.trim()).toBe("");
+    expectAllowJson(literalDollar);
 
     for (const command of [
       "rg node README.md",
@@ -1127,7 +1140,7 @@ describe("t276 cursor adapter payload conversion", () => {
           tool_input: { command },
         }),
       );
-      expect(harmlessArgument.stdout.trim(), command).toBe("");
+      expectAllowJson(harmlessArgument, command);
     }
 
     // Simulate corruption outside the delegated tool path. The active dispatch
@@ -1270,6 +1283,6 @@ describe("t276 cursor adapter payload conversion", () => {
       }),
     );
     expect(resumed.code).toBe(0);
-    expect(resumed.stdout.trim()).toBe("");
+    expectAllowJson(resumed);
   });
 });

--- a/tests/unit/t276-cursor-adapter.test.ts
+++ b/tests/unit/t276-cursor-adapter.test.ts
@@ -375,7 +375,7 @@ describe("t276 cursor adapter payload conversion", () => {
     clearLedger(proj);
 
     const parent = runAdapter(proj, "guards", payload("preToolUseTask", proj));
-    expect(parent.code).toBe(0);
+    expectAllowJson(parent);
     const [ledger] = ledgerFilesFor(proj);
     const before = readFileSync(ledger, "utf-8");
 
@@ -728,7 +728,7 @@ describe("t276 cursor adapter payload conversion", () => {
         tool_input: { file_path: join(proj, "obsolete.md") },
       }),
     );
-    expect(r.code).toBe(0);
+    expectAllowJson(r);
     const forwarded = JSON.parse(readFileSync(captureFile, "utf-8")) as {
       tool_name?: string;
     };
@@ -776,7 +776,7 @@ describe("t276 cursor adapter payload conversion", () => {
         tool_input: { file_path: join(proj, "README.md") },
       }),
     );
-    expect(r.code).toBe(0);
+    expectAllowJson(r);
     expect(Date.now() - statSync(record).mtimeMs).toBeLessThan(60 * 1000);
   });
 
@@ -809,7 +809,7 @@ describe("t276 cursor adapter payload conversion", () => {
         },
       }),
     );
-    expect(developer.code).toBe(0);
+    expectAllowJson(developer);
     expect(ledgerFilesFor(proj)).toHaveLength(1);
 
     // Cursor emits no postToolUse for the developer Task. The parent's next
@@ -823,7 +823,7 @@ describe("t276 cursor adapter payload conversion", () => {
         tool_use_id: "review-tool-use",
       }),
     );
-    expect(reviewer.code).toBe(0);
+    expectAllowJson(reviewer);
     expect(ledgerFilesFor(proj)).toHaveLength(1);
     expect(readAllAuditShards(proj)).toContain("SUBAGENT_COMPLETED");
     expect(readAllAuditShards(proj)).toContain("aidlc-developer-agent");


### PR DESCRIPTION
Fixes #743

# Summary

Cursor IDE blocks every tool call on the AI-DLC Cursor harness because
`preToolUse` is `failClosed: true` and the adapter allow path returns
exit 0 with empty stdout. Empty stdout is invalid JSON; the IDE denies.
Cursor CLI (`agent`) treats the same silence as allow, so #661's
CLI-only live verification missed this.

## Changes

- `harness/cursor/hooks/aidlc-cursor-adapter.ts` `guards`: write
  `{"permission":"allow"}` on both allow returns (Task spawn and
  post-guard loop). Deny JSON and `failClosed: true` are unchanged.
- t276 asserts allow stdout is that JSON on captured guards allow
  paths; deny / malformed input still deny.
- `docs/guide/harnesses/cursor.md` documents the allow|deny JSON
  contract (empty stdout is an IDE deny).
- Regenerated `dist/` via `bun scripts/package.ts` (not hand-edited).
- Version `2.5.66` (README badge + CHANGELOG). `#731` already claimed
  `2.5.65`.

## User experience

**Before:** Cursor IDE: `Hook "bun .cursor/hooks/aidlc-cursor-adapter.ts guards" returned no output` on every tool. CLI: tools run.

**After:** IDE and CLI both allow when the guards allow. Deny still
blocks with `{"permission":"deny","agent_message":...}`.

**Upgrade:** refresh `dist/cursor/` and rerun
`bun dist/cursor/install.ts /path/to/project`.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- [x] `bun scripts/package.ts --check`
- [x] `bun test tests/unit/t276-cursor-adapter.test.ts`
- [x] `bun test tests/unit/t68-version-changelog-sync.test.ts`
- [x] `bun tests/run-tests.ts --smoke --unit` (t276/t68 green; t248 and
      t255 failed in isolation on this machine and are untouched by this
      diff)
- [x] Live Cursor IDE 3.15.6: installed `dist/cursor/` into
      `/tmp/aidlc-cursor-verify`; Read of `AGENTS.md` was allowed;
      `bun .cursor/tools/aidlc-state.ts approve` was denied by the
      state-transition guard

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of the
project license.