### PR TITLE
fix: make consumes_absent respect produces_kinds when flagging a real gap (2.5.68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.5.68] - 2026-08-12
+
+`consumes_absent`'s `expected` flag now respects a producer's own `produces_kinds` gate, so a kind-tagged unit that correctly never produces a given artifact no longer gets a false "real gap" alarm on the next stage's directive. Fixes #736. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
+
+* `splitConsumesByPresence` now takes `unitKind` (mirroring `resolveProduces`'s existing parameter) and checks the producing stage's `produces_kinds` gate before computing `expected`.
+* An untagged unit, or a stage with no `produces_kinds` map, sees byte-for-byte identical behaviour — this is a strict narrowing of the true case, not a behaviour change for anything that isn't kind-gated.
+* No command or flag changes; no breaking change for CI or scripts.
+
 ## [2.5.64] - 2026-08-11
 
 Composed-workflow routing is now deterministic from proposal through execution, and the affected test-runner and live-journey paths fail closed. Stock matches present exactly the grid that will run, incomplete model-produced grids cannot match a stock scope, in-flight recomposition preserves the running plan, isolated stages no longer wait on nonexistent questions, and mid-flow new work carries one typed continuation contract with a named scope. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.5.64-blue)
+![version](https://img.shields.io/badge/version-2.5.68-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
+++ b/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -1506,10 +1506,22 @@ function resolveConsumes(
 //     check against; everything stays in `consumes`, exactly as before.
 //   - a path still carrying the {unit-name} placeholder → existence is
 //     unknowable pre-Bolt; it stays in `consumes`.
+//
+// "A producer is on the path" is necessary but not sufficient — a producer
+// on path can still legitimately not produce THIS artifact for THIS unit's
+// kind, via that producer's own produces_kinds gate (mirrors resolveProduces's
+// existing unitKind filtering below). Without this, a kind-excluded artifact
+// (e.g. a `ui`-kind unit correctly never producing an artifact a stage's own
+// produces_kinds map scopes to `[service, spec, library]`) is flagged
+// `expected: false` — a false "real gap" alarm, since the producing stage
+// itself did run. `unitKind` defaults to null (an untagged unit, or a
+// non-per-unit stage), which keeps prior behaviour exactly:
+// filterProducesByKind is a no-op when unitKind is null.
 function splitConsumesByPresence(
   consumes: ResolvedConsume[],
   scope: string,
   codekbCtx?: CodekbCtx,
+  unitKind: string | null = null,
 ): { present: string[]; absent: Array<{ path: string; expected: boolean }> } {
   if (!codekbCtx) return { present: consumes.map((c) => c.path), absent: [] };
   const onPath = new Set(subgraphForScope(scope).map((s) => s.slug));
@@ -1527,7 +1539,11 @@ function splitConsumesByPresence(
     }
     if (!c.required) continue; // optional + missing → not an input, not a gap
     const producers = producersOf(c.artifact);
-    const producerOnPath = producers.some((p) => onPath.has(p.slug));
+    const producerOnPath = producers.some(
+      (p) =>
+        onPath.has(p.slug) &&
+        filterProducesByKind(p.produces_kinds, [c.artifact], unitKind).length > 0,
+    );
     absent.push({ path: c.path, expected: !producerOnPath });
   }
   return { present, absent };
@@ -1861,7 +1877,7 @@ function buildRunStageDirective(
   const resolvedConsumes = resolveConsumes(
     node.consumes ?? [], node, projectType, unit, recordPrefix, codekbCtx,
   );
-  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx);
+  const { present, absent } = splitConsumesByPresence(resolvedConsumes, scope, codekbCtx, unitKind);
   const inlineContext = inlineContextRoster(node, codekbCtx);
   const ruleEntries = codekbCtx
     ? rulesContentEntries(node, codekbCtx.projectDir, codekbCtx.space)

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.5.64";
+export const AIDLC_VERSION = "2.5.68";

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -769,6 +769,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t275-cursor-packaging.test.ts",
     "unit/t276-cursor-adapter.test.ts",
     "unit/t277-validate-grid-nearest-stock.test.ts",
+    "unit/t279-consumes-absent-kind-gate.test.ts",
     "integration/t102.test.ts",
     "integration/t104.test.ts",
     "integration/t105.test.ts",

--- a/tests/unit/t279-consumes-absent-kind-gate.test.ts
+++ b/tests/unit/t279-consumes-absent-kind-gate.test.ts
@@ -1,0 +1,165 @@
+// covers: subcommand:aidlc-orchestrate:next
+//
+// t279 - consumes_absent's `expected` flag now respects a producer's own
+// produces_kinds gate. Regression test for the defect reported in #736.
+//
+// Mechanism: cli. splitConsumesByPresence is unexported, so the contract is
+// exercised behaviourally through the JSON run-stage directive the spawned
+// engine emits - the same boundary t186/t208 (per-unit iteration/kind
+// pruning) drive.
+//
+// THE DEFECT: splitConsumesByPresence() computed each consumes_absent entry's
+// `expected` flag purely from whether a PRODUCING STAGE is on the active
+// scope's path - it never checked the current unit's `kind` against that
+// producer's own produces_kinds gate. Its sibling function, resolveProduces(),
+// already does exactly this filtering on the produces side. Result: a `ui`-kind
+// unit that correctly never produces `business-rules.md` (functional-design's
+// own produces_kinds gates it to [service, spec, library], excluding `ui`) was
+// flagged `expected: false` ("a real gap") on nfr-requirements' own directive,
+// because functional-design itself did run - the checker never looked one
+// level deeper at whether THIS artifact was legitimately excluded for THIS
+// unit's kind.
+//
+// THE FIX: splitConsumesByPresence now takes unitKind (mirroring
+// resolveProduces's existing parameter) and additionally checks the
+// producer's own produces_kinds gate via filterProducesByKind before
+// computing `expected`.
+//
+// Fixture discipline mirrors t208: a fresh temp project per case, a clean
+// single-row Construction state pivoted directly to nfr-requirements (the
+// real consumer in the bug report), and a kind-aware bolt_dag runtime graph.
+// No functional-design artifact is ever written for the ui-kind case - the
+// absence is the point.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  AIDLC_SRC,
+  cleanupTestProject,
+  createTestProject,
+  resetAidlcEnv,
+  runOrchestrateNext,
+  seedAidlcMemory,
+  seedBoltDag,
+  seededStateFile,
+} from "../harness/fixtures.ts";
+
+resetAidlcEnv();
+
+const ORCH = join(AIDLC_SRC, "tools", "aidlc-orchestrate.ts");
+
+interface Directive {
+  stage?: string;
+  unit?: string;
+  consumes_absent?: Array<{ path: string; expected: boolean }>;
+  [k: string]: unknown;
+}
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length) cleanupTestProject(tempDirs.pop());
+});
+
+function constructionState(current: string): string {
+  return `# AI-DLC State Tracking
+
+## Project Information
+- **Project**: consumes_absent kind-gate test
+- **Project Type**: Greenfield
+- **Scope**: feature
+- **State Version**: 7
+- **Skeleton Stance**: on
+## Scope Configuration
+- **Stages to Execute**: all
+- **Stages to Skip**: none
+- **Depth**: Standard
+- **Test Strategy**: Standard
+
+## Stage Progress
+
+### CONSTRUCTION PHASE
+- [x] functional-design — EXECUTE
+- [-] nfr-requirements — EXECUTE
+- [ ] nfr-design — EXECUTE
+- [ ] infrastructure-design — EXECUTE
+- [ ] code-generation — EXECUTE
+- [ ] build-and-test — EXECUTE
+
+### INCEPTION PHASE
+- [x] application-design — EXECUTE
+
+## Current Status
+- **Lifecycle Phase**: CONSTRUCTION
+- **Current Stage**: ${current}
+- **Status**: Running
+`;
+}
+
+function seedProject(current: string): string {
+  const proj = createTestProject();
+  tempDirs.push(proj);
+  seedAidlcMemory(proj);
+  writeFileSync(seededStateFile(proj), constructionState(current));
+  return proj;
+}
+
+function runNext(proj: string): Directive {
+  const e = { ...process.env };
+  delete e.AWS_AIDLC_DEFAULT_SCOPE;
+  const r = runOrchestrateNext(ORCH, proj, [], { env: e });
+  if (r.directive === null) {
+    throw new Error(`runNext no JSON. status=${r.status}\n${r.stdout}\n${r.stderr}`);
+  }
+  return r.directive as Directive;
+}
+
+function businessRulesAbsentEntry(d: Directive): { path: string; expected: boolean } | undefined {
+  return d.consumes_absent?.find((e) => e.path.endsWith("/business-rules.md"));
+}
+
+describe("t279 consumes_absent respects produces_kinds (#736)", () => {
+  // 1: a ui-kind unit at nfr-requirements — business-rules.md is genuinely,
+  // legitimately never produced (functional-design's own produces_kinds gates
+  // it to [service, spec, library]). expected MUST be true — not a real gap.
+  test("1: a ui-kind unit's absent business-rules is expected:true, not a false alarm", () => {
+    const proj = seedProject("nfr-requirements");
+    seedBoltDag(proj, [{ name: "web", kind: "ui" }]);
+    const d = runNext(proj);
+    expect(d.stage).toBe("nfr-requirements");
+    expect(d.unit).toBe("web");
+    const entry = businessRulesAbsentEntry(d);
+    expect(entry).toBeDefined();
+    expect(entry!.expected).toBe(true);
+  }, 30000);
+
+  // 2: REGRESSION ANCHOR — a service-kind unit at the same stage, same
+  // missing file. business-rules IS in scope for [service, spec, library], so
+  // its absence is a genuine gap: expected must stay false, byte-identical to
+  // pre-fix behaviour. Proves the fix is a strict narrowing, not a blanket
+  // "always true" change.
+  test("2: a service-kind unit's absent business-rules is still expected:false (real gap)", () => {
+    const proj = seedProject("nfr-requirements");
+    seedBoltDag(proj, [{ name: "api", kind: "service" }]);
+    const d = runNext(proj);
+    expect(d.stage).toBe("nfr-requirements");
+    expect(d.unit).toBe("api");
+    const entry = businessRulesAbsentEntry(d);
+    expect(entry).toBeDefined();
+    expect(entry!.expected).toBe(false);
+  }, 30000);
+
+  // 3: REGRESSION ANCHOR — an UNTAGGED unit (no kind at all) at the same
+  // stage. unitKind is null, so filterProducesByKind is a no-op: behaviour
+  // must be byte-identical to today's (expected:false, a real gap).
+  test("3: an untagged unit's absent business-rules is still expected:false (unchanged)", () => {
+    const proj = seedProject("nfr-requirements");
+    seedBoltDag(proj, [{ name: "svc" }]);
+    const d = runNext(proj);
+    expect(d.stage).toBe("nfr-requirements");
+    expect(d.unit).toBe("svc");
+    const entry = businessRulesAbsentEntry(d);
+    expect(entry).toBeDefined();
+    expect(entry!.expected).toBe(false);
+  }, 30000);
+});


### PR DESCRIPTION
Fixes #736

# Summary

`consumes_absent`'s `expected` flag now checks a producer's own `produces_kinds` gate before flagging an absent artifact as a real gap, so a kind-tagged unit that correctly never produces a given artifact no longer gets a false "real gap" alarm on the next stage's directive.

## Changes

- `splitConsumesByPresence(consumes, scope, codekbCtx)` → `splitConsumesByPresence(consumes, scope, codekbCtx, unitKind)`, mirroring `resolveProduces`'s existing `unitKind` parameter.
- `producerOnPath`'s computation now also checks `filterProducesByKind(producer.produces_kinds, [artifact], unitKind).length > 0` — a producing stage being on the active scope's path is necessary but no longer sufficient; it must also actually be scoped to produce this specific artifact for this unit's kind.
- `buildRunStageDirective` (the one call site) already received `unitKind` as a parameter and already passed it to `resolveProduces` — it now passes it through to `splitConsumesByPresence` too.
- `filterProducesByKind` returns its input unchanged when `unitKind` is `null`, so an untagged unit or a stage with no `produces_kinds` map sees byte-for-byte identical behaviour — this is a strict narrowing of the true case, not a behaviour change for anything that isn't kind-gated.
- Regenerated `dist/` via `bun scripts/package.ts` (not hand-edited).
- Version `2.5.68` (README badge + CHANGELOG).

## User experience

**Before:** a `ui`-kind unit correctly never produces `business-rules.md` (`functional-design`'s own `produces_kinds` map scopes it to `[service, spec, library]`, excluding `ui`). The next stage that consumes `business-rules` as `required: true` (e.g. `nfr-requirements`) still flags it `expected: false` — "a real gap, surface it per the recovery protocol" — on its own `run-stage` directive, because `functional-design` itself did run. The conductor is pointed at a recovery protocol for an artifact that was never supposed to exist.

**After:** the same `ui`-kind unit's `consumes_absent` entry for `business-rules` reports `expected: true` — its absence is by design, not a gap. A `service`-kind (or untagged) unit's identical absence at the same stage is unaffected and still correctly reports `expected: false`, since `business-rules` genuinely is in scope for that kind.

**Upgrade:** re-copy your `dist/<harness>/` shell into the project.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

- [x] New regression test `tests/unit/t279-consumes-absent-kind-gate.test.ts`: (1) a `ui`-kind unit's absent `business-rules` is `expected: true`, not a false alarm — confirmed RED against the pre-fix `dist/`, then GREEN after regenerating; (2) a `service`-kind unit's identical absence stays `expected: false` (real gap, regression anchor); (3) an untagged unit's identical absence also stays `expected: false` (unchanged, regression anchor).
- [x] `bun test tests/unit/t113.test.ts tests/unit/t116-directive-path-resolution.test.ts tests/unit/t207-unit-kind-schema.test.ts tests/unit/t279-consumes-absent-kind-gate.test.ts tests/unit/gen-coverage-registry.test.ts tests/unit/t68-version-changelog-sync.test.ts` → 137 pass, 0 fail.
- [x] `bun run check` (`package.ts --check` + `typecheck` + `lint`) → clean (the only lint output is 3 pre-existing infos in an unrelated file, `t267-usage.test.ts`, unaffected by this branch).
- [x] `bun test tests/unit/t208-unit-kind-pruning.test.ts tests/unit/t236-ensemble-evidence-gate.test.ts` → confirmed the 21 failures in these two files reproduce identically on a pristine, unmodified `v2` checkout (unrelated environment-specific failures — missing question-flow/contribution-file fixtures, not this change) — not a regression from this branch.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
