### PR TITLE
fix: diagnostic bundle reads read-only latch and turn counter from the path the Kiro seam writes (2.6.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.45] - 2026-08-21
+
+Diagnostic exports now read Kiro's turn-scoped markers from their canonical project-level location, so exported evidence accurately reflects the active latch and counter. **Upgrade:** refresh your `dist/<harness>/` shell to install the corrected diagnostic exporter; existing workflow state needs no migration.
+
+* The diagnostic bundle now reports the read-only latch and turn counter from `<project>/aidlc/`, the path the Kiro seam writes, instead of the record directory.
+
 ## [2.6.44] - 2026-08-21
 
 Codex structured `request_user_input` selections now mint the same `HUMAN_TURN` evidence as typed prompts, without treating empty, cancelled, timed-out, auto-resolved, error, or malformed responses as human judgment. **Upgrade:** refresh `dist/codex/`, then re-run `bun scripts/package.ts codex trust --project "/absolute/project/path"` and replace the existing hook trust tables before starting a fresh Codex session.
@@ -106,6 +112,7 @@ Bounded Build & Test → Code Generation failure loop-back. When Build and Test 
 * Single-stage runs (`/aidlc --stage build-and-test --single`) stop at classification because they have no main-workflow position to move; impact-estimated options appear in the isolated-run summary.
 * The stage-ritual exception is present in all seven shipped conductor SKILLs, including Cursor and GitHub Copilot, and generated distributions remain byte-aligned with their authored sources.
 * Deterministic integration coverage (`t304-loopback-review-receipt-replay`) proves the replayed Code Generation gate refuses stale per-Unit reviews after `STAGE_JUMPED` and succeeds only after fresh receipts are recorded.
+
 ## [2.6.18] - 2026-08-19
 
 Classic and Express are new scope options, and the implicit default scope is now Classic — a **declared behavior change**: invocations that name no scope and match no keyword now run the v1-style lifecycle without Ideation instead of the full-lifecycle Feature scope. Exactly two things control the implicit default: the `AWS_AIDLC_DEFAULT_SCOPE` env var (which overrides) and the framework's hard-coded `classic` fallback. Express has a deterministic requirements-to-conditional-deploy path, and conditional protocol modules reduce fixed context without dropping reviewer recovery behavior. **Upgrade:** refresh your `dist/<harness>/` shell; in-flight workflows keep their persisted scope and need no migration; set `AWS_AIDLC_DEFAULT_SCOPE=feature` (Claude: the `.claude/settings.json` `env` block, which now ships `classic`) to keep the previous full-lifecycle default.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.44-blue)
+![version](https://img.shields.io/badge/version-2.6.45-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-doctor-bundle.ts
+++ b/core/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/dist/claude/.claude/tools/aidlc-doctor-bundle.ts
+++ b/dist/claude/.claude/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/dist/codex/.codex/tools/aidlc-doctor-bundle.ts
+++ b/dist/codex/.codex/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/dist/copilot/.aidlc/tools/aidlc-doctor-bundle.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/dist/cursor/.cursor/tools/aidlc-doctor-bundle.ts
+++ b/dist/cursor/.cursor/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/dist/kiro-ide/.kiro/tools/aidlc-doctor-bundle.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/dist/kiro/.kiro/tools/aidlc-doctor-bundle.ts
+++ b/dist/kiro/.kiro/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/dist/opencode/.aidlc/tools/aidlc-doctor-bundle.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-doctor-bundle.ts
@@ -55,7 +55,6 @@ import {
   activeSpace,
   auditBlockField,
   auditShardDir,
-  docsRoot,
   harnessDir,
   hooksHealthDir,
   isoTimestamp,
@@ -1482,8 +1481,8 @@ function readMarkers(projectDir: string): NormalizedEvidence["markers"] {
     }
   }
   const stopDir = stopHookDir(projectDir);
-  const turnCounterPath = join(docsRoot(projectDir), ".aidlc-turn-counter");
-  const latchPath = join(docsRoot(projectDir), ".aidlc-readonly-latch");
+  const turnCounterPath = join(projectDir, "aidlc", ".aidlc-turn-counter");
+  const latchPath = join(projectDir, "aidlc", ".aidlc-readonly-latch");
   return {
     planExists,
     planParseable,

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.44";
+export const AIDLC_VERSION = "2.6.45";

--- a/tests/unit/t243-doctor-bundle.test.ts
+++ b/tests/unit/t243-doctor-bundle.test.ts
@@ -272,6 +272,31 @@ describe("t243 doctor --export diagnostic exporter (#575)", () => {
     expect(event.Source).toBeUndefined();
   }, 30000);
 
+  test("2c: normalized evidence reads Kiro turn markers from the project aidlc dir", () => {
+    const proj = freshProject();
+    const aidlcDir = join(proj, "aidlc");
+    mkdirSync(aidlcDir, { recursive: true });
+    writeFileSync(join(aidlcDir, ".aidlc-turn-counter"), "7\n", "utf-8");
+    writeFileSync(
+      join(aidlcDir, ".aidlc-readonly-latch"),
+      `${JSON.stringify({
+        turn: 7,
+        flag: "status",
+        source: "read-only-flag",
+        ts: Date.now(),
+      })}\n`,
+      "utf-8",
+    );
+
+    const { bundleDir } = runExport(proj);
+    expect(bundleDir).not.toBeNull();
+    const normalized = JSON.parse(
+      readFileSync(join(bundleDir!, "evidence", "normalized.json"), "utf-8"),
+    );
+    expect(normalized.markers.turnCounter).toBe("7");
+    expect(normalized.markers.readonlyLatch).toBe(true);
+  }, 30000);
+
   test("3: report.json exposes findings + timeline.stages and the gate-unresolved error", () => {
     const proj = freshProject();
     seedCanaryIntent(proj);


### PR DESCRIPTION
The doctor bundle read the turn counter and read-only latch from docsRoot() (the intent record dir) while the Kiro seam writes them at <project>/aidlc/, so evidence/normalized.json reported both markers absent whenever they existed. readMarkers now joins projectDir/aidlc like the engine done-guard and the adapter backstop, with a t243 regression test that seeds the writer-shaped files and asserts the exported markers. Closes #779