### PR TITLE
docs: refresh the v2 roadmap through 2.6.18

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,7 +60,7 @@ Two strategic pillars shape how the North Star reaches users and evolves:
 | 3 | Adaptiveness | Shipped | 2.2.0 composer, entropy-scored composition (#595), deterministic ARS (#644), unit-major Code Generation (#705), Classic/Express scopes and conditional protocol modules (#767) | Boundary changes remain human-approved by design |
 | 4 | Verifier as adversary | Shipped | 2.4.0 adversarial evidence contract (#566), completion-path enforcement (#569), reviewer-class cost dial (#718), turn/recovery backstops (#613, #758) | Blocking sensor severity is an adjacent follow-up (#431) |
 | 5 | Cyclic flows | Partial | Within-stage review/revision loops, bounded recovery mechanics, and explicit human-authorized forward/backward/redo stage jumps | Stage-triggered governed cross-stage feedback loops remain unbuilt; #616 is a narrower Build & Test loop-back |
-| 6 | Traceability | Partial | Artefact graph, upstream coverage, claim provenance (#647, #686), shared CodeKB safeguards (#670), domain/contract boundaries (#711), fingerprinted Testing Posture plan approval (#772) | Progressive in-place enrichment, stale-result propagation (#716), source-bound receipts (#646), per-stage enforcement (#401), cross-unit discovery |
+| 6 | Traceability | Partial | Artefact graph, upstream coverage, per-stage enforcement (#401), claim provenance (#647, #686), shared CodeKB safeguards (#670), domain/contract boundaries (#711), fingerprinted Testing Posture plan approval (#772) | Progressive in-place enrichment, stale-result propagation (#716), source-bound receipts (#646), cross-unit discovery |
 | 7 | Org repository | Shipped | 2.1.0 spaces/intents/org-KB, declared multi-repo manifest and sync (#674), clone-safe active-space cursor (#709), DocumentKB indexing and citations (#731) | Additional retrieval lifecycle and auditable supplemental-knowledge selection remain active extensions (#694, #714) |
 
 <!-- markdownlint-enable MD013 -->
@@ -91,6 +91,7 @@ Two strategic pillars shape how the North Star reaches users and evolves:
 | 2.5.60 | GitHub Copilot harness for Copilot CLI and VS Code agent mode | 1, 2 | #657 |
 | 2.5.63 | Cursor harness | 1, 2 | #661 |
 | 2.5.67 | Batch-parallel per-unit waves and foreground reviewers | 1, 4 | #617 |
+| 2.5.71 - 2.5.75 | Per-stage traceability enforcement, design-stage code boundaries, test-instruction ownership and first-class observability artifacts | 4, 6 | #401-#404 |
 | 2.6.1 - 2.6.2 | Domain/contract design restructuring, consolidated infrastructure design and follow-up guards | 1, 6 | #711, #751 |
 | 2.6.8 - 2.6.9 | Reviewer turn backstop and bounded stale-receipt recovery | 4 | #613, #758 |
 | 2.6.12 - 2.6.14 | Copilot continuation stability, gate authorship enforcement and audit timestamp normalization | 1, 4 | #749, #750, #759 |
@@ -122,7 +123,6 @@ frequently; each linked pull request is authoritative.
 | [#754](https://github.com/awslabs/aidlc-workflows/pull/754) | Reconcile planned Bolt terminology with the current Construction walk | Construction semantics |
 | [#788](https://github.com/awslabs/aidlc-workflows/pull/788) | Kiro agent-v1 hook matcher and adapter hardening | Harness reliability |
 | [#526](https://github.com/awslabs/aidlc-workflows/pull/526) | Product discovery in Ideation | Product discovery |
-| [#401](https://github.com/awslabs/aidlc-workflows/pull/401) | Per-stage traceability enforcement sensor | Traceability |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -133,9 +133,9 @@ but do not yet have committed release versions.
 
 ### Traceability and progressive enrichment
 
-- Enforce per-stage upstream traceability
-  ([#401](https://github.com/awslabs/aidlc-workflows/pull/401)), bind review
-  evidence to source state
+- Per-stage upstream traceability enforcement shipped in
+  [#401](https://github.com/awslabs/aidlc-workflows/pull/401). Bind review evidence
+  to source state
   ([#646](https://github.com/awslabs/aidlc-workflows/pull/646)), and propagate
   stale stage results
   ([#716](https://github.com/awslabs/aidlc-workflows/pull/716)).
@@ -162,7 +162,8 @@ but do not yet have committed release versions.
 ### Plugins and marketplace
 
 - The plugin mechanism, content projection, selection and plugin-contributed
-  scopes are shipped; the plugin test kit and authoring tiers shipped in #792.
+  scopes are shipped; the plugin test kit and authoring tiers shipped in
+  [#792](https://github.com/awslabs/aidlc-workflows/pull/792).
 - Remote discovery, trust, a first-party marketplace and a graduation path are
   proposed in [#723](https://github.com/awslabs/aidlc-workflows/issues/723).
   Product discovery
@@ -199,9 +200,9 @@ but do not yet have committed release versions.
 - [#722](https://github.com/awslabs/aidlc-workflows/issues/722) covers binary
   packaging, installers, release automation, rollback and post-install setup;
   its milestones 1-3 implementation is under review in
-  [#756](https://github.com/awslabs/aidlc-workflows/pull/756).
-  [#399](https://github.com/awslabs/aidlc-workflows/issues/399) tracks the hard
-  Bun dependency of the copy channel.
+  [#756](https://github.com/awslabs/aidlc-workflows/pull/756). The earlier Bun
+  dependency tracker [#399](https://github.com/awslabs/aidlc-workflows/issues/399)
+  is closed as superseded by #722.
 - [#636](https://github.com/awslabs/aidlc-workflows/issues/636) tracks a
   first-class upgrade contract. The earlier implementation PR
   [#535](https://github.com/awslabs/aidlc-workflows/pull/535) closed without
@@ -218,8 +219,10 @@ but do not yet have committed release versions.
 - Cursor support shipped in
   [#661](https://github.com/awslabs/aidlc-workflows/pull/661). A unified Kiro
   distribution is under review in
-  [#775](https://github.com/awslabs/aidlc-workflows/pull/775), while matcher and
-  adapter reliability continues in
+  [#775](https://github.com/awslabs/aidlc-workflows/pull/775); the existing
+  `dist/kiro-ide/` compatibility gap remains tracked separately in
+  [#555](https://github.com/awslabs/aidlc-workflows/issues/555), while matcher
+  and adapter reliability continues in
   [#788](https://github.com/awslabs/aidlc-workflows/pull/788).
 - Antigravity setup is proposed in
   [#690](https://github.com/awslabs/aidlc-workflows/issues/690).
@@ -227,9 +230,11 @@ but do not yet have committed release versions.
 ### Evaluation and operations
 
 - [#684](https://github.com/awslabs/aidlc-workflows/issues/684) proposes
-  repeatable benchmarks for measuring AI-DLC outcomes;
-  [#223](https://github.com/awslabs/aidlc-workflows/issues/223) tracks automated
-  harness evaluation, initially for Claude Code and Kiro.
+  repeatable benchmarks for measuring AI-DLC outcomes. Evaluator work is active
+  in [#753](https://github.com/awslabs/aidlc-workflows/pull/753); the earlier
+  harness-evaluation tracker
+  [#223](https://github.com/awslabs/aidlc-workflows/issues/223) closed as not
+  planned for v1.
 - Operations-phase steering remains a requested direction
   ([#221](https://github.com/awslabs/aidlc-workflows/issues/221),
   [#473](https://github.com/awslabs/aidlc-workflows/issues/473)), not an active
@@ -242,9 +247,9 @@ but do not yet have committed release versions.
 - Sensor failures are advisory; blocking severity remains open in #431.
 - General cross-stage cycles and progressive in-place artefact enrichment remain
   North Star gaps.
-- Kiro's remaining gaps are now concentrated in hook registration/payload drift,
-  plugin projection and argument forwarding (#763, #764, #776, #778, #779,
-  #783, #784).
+- Kiro's remaining gaps include the legacy `dist/kiro-ide/` compatibility issue
+  (#555), plus hook registration/payload drift, plugin projection and argument
+  forwarding (#763, #764, #776, #778, #779, #783, #784). The unified Kiro work
+  in #775 is a separate distribution and does not yet retire that legacy gap.
 - Several older community PRs remain open and need rebasing or disposition:
-  #401-#404, #526 and #553. PRs #432, #535, #552, #653 and #712 closed without
-  merging.
+  #526 and #553. PRs #432, #535, #552, #653 and #712 closed without merging.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,15 +1,17 @@
 # AI-DLC Workflows 2.0 - Roadmap
 
-Status as of 2026-08-10.
+Status as of 2026-08-20.
 
-- The current v2 version is **2.5.62** (`origin/v2` tip `18bcc468`). Version
+- The current v2 version is **2.6.18** (`origin/v2` tip `fbb1460c`). Version
   numbers describe the committed framework tree;
   they are not GitHub Releases.
 - AI-DLC Workflows 2.0 is **GA**. The README announcement landed in #627 after
   the reviewer-as-verifier and three-role ensemble milestones shipped.
 - Release publication is not yet aligned with the v2 branch: GitHub still marks
-  `v1.0.1` as Latest, tracked by #635. Packaging and release distribution are
-  being reconsidered in #722.
+  `v1.0.1` as Latest, tracked by #635. The native distribution implementation
+  for #722 is under review in #756; no public v2 native release exists yet.
+- PR validation now includes the deterministic integration and end-to-end tiers
+  in addition to smoke, unit, packaging, typecheck and lint (#791).
 
 The version numbers below describe where work landed on the v2 branch. Future
 themes and open pull requests are directional, not committed release promises.
@@ -53,13 +55,13 @@ Two strategic pillars shape how the North Star reaches users and evolves:
 
 | # | Goal | Status | Delivered by | Remaining work |
 | --- | --- | --- | --- | --- |
-| 1 | Real-world ensemble | Shipped | 2.5.0 independent collaborators and selectable topologies (#568); enforced reviewer receipts (#569) | Native live-team transports and parallel per-unit waves remain enhancements (#617) |
-| 2 | Customization | Shipped, with follow-ups | 2.3.0 plugin seam, 2.3.5 content projection/selection (#550), deterministic rule delivery (#658), plugin scopes (#664) | Stage-specific rules, `when:` evaluation, remote discovery and marketplace (#723) |
-| 3 | Adaptiveness | Shipped | 2.2.0 composer, entropy-scored composition (#595), deterministic ARS (#644), unit-major Code Generation (#705) | Boundary changes remain human-approved by design |
-| 4 | Verifier as adversary | Shipped | 2.4.0 adversarial evidence contract (#566), completion-path enforcement (#569), reviewer-class cost dial (#718) | Blocking sensor severity is an adjacent follow-up (#431) |
+| 1 | Real-world ensemble | Shipped | 2.5.0 independent collaborators and selectable topologies (#568); enforced reviewer receipts (#569); batch-parallel per-unit waves (#617) | Harness-native live-team transports and planned-Bolt/runtime alignment remain enhancements (#734) |
+| 2 | Customization | Shipped, with follow-ups | 2.3.0 plugin seam, 2.3.5 content projection/selection (#550), deterministic rule delivery (#658), plugin scopes (#664), reusable plugin test kit (#792) | Stage-specific rules, `when:` evaluation, remote discovery and marketplace (#723) |
+| 3 | Adaptiveness | Shipped | 2.2.0 composer, entropy-scored composition (#595), deterministic ARS (#644), unit-major Code Generation (#705), Classic/Express scopes and conditional protocol modules (#767) | Boundary changes remain human-approved by design |
+| 4 | Verifier as adversary | Shipped | 2.4.0 adversarial evidence contract (#566), completion-path enforcement (#569), reviewer-class cost dial (#718), turn/recovery backstops (#613, #758) | Blocking sensor severity is an adjacent follow-up (#431) |
 | 5 | Cyclic flows | Partial | Within-stage review/revision loops, bounded recovery mechanics, and explicit human-authorized forward/backward/redo stage jumps | Stage-triggered governed cross-stage feedback loops remain unbuilt; #616 is a narrower Build & Test loop-back |
-| 6 | Traceability | Partial | Artefact graph, upstream coverage, claim provenance (#647, #686), shared CodeKB safeguards (#670) | Progressive in-place enrichment, stale-result propagation (#716), source-bound receipts (#646), per-stage enforcement (#401), cross-unit discovery |
-| 7 | Org repository | Shipped | 2.1.0 spaces/intents/org-KB, declared multi-repo manifest and sync (#674), clone-safe active-space cursor (#709) | Document retrieval and auditable supplemental knowledge are active extensions (#694, #714, #731) |
+| 6 | Traceability | Partial | Artefact graph, upstream coverage, claim provenance (#647, #686), shared CodeKB safeguards (#670), domain/contract boundaries (#711), fingerprinted Testing Posture plan approval (#772) | Progressive in-place enrichment, stale-result propagation (#716), source-bound receipts (#646), per-stage enforcement (#401), cross-unit discovery |
+| 7 | Org repository | Shipped | 2.1.0 spaces/intents/org-KB, declared multi-repo manifest and sync (#674), clone-safe active-space cursor (#709), DocumentKB indexing and citations (#731) | Additional retrieval lifecycle and auditable supplemental-knowledge selection remain active extensions (#694, #714) |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -87,6 +89,15 @@ Two strategic pillars shape how the North Star reaches users and evolves:
 | 2.5.40, 2.5.53 | Per-stage token/cost accounting, opt-in metrics and usage-tracking kill switch | - | #673, #720 |
 | 2.5.56 | Code Generation joins the unit-major Construction walk | 3 | #705 |
 | 2.5.60 | GitHub Copilot harness for Copilot CLI and VS Code agent mode | 1, 2 | #657 |
+| 2.5.63 | Cursor harness | 1, 2 | #661 |
+| 2.5.67 | Batch-parallel per-unit waves and foreground reviewers | 1, 4 | #617 |
+| 2.6.1 - 2.6.2 | Domain/contract design restructuring, consolidated infrastructure design and follow-up guards | 1, 6 | #711, #751 |
+| 2.6.8 - 2.6.9 | Reviewer turn backstop and bounded stale-receipt recovery | 4 | #613, #758 |
+| 2.6.12 - 2.6.14 | Copilot continuation stability, gate authorship enforcement and audit timestamp normalization | 1, 4 | #749, #750, #759 |
+| 2.6.15 | DocumentKB S1 indexing and citation delivery | 7 | #731 |
+| 2.6.16 | Code Generation plans bound to the affirmed Testing Posture | 4, 6 | #772 |
+| 2.6.17 | Reusable plugin test kit and plugin-author testing tiers | 2 | #792 |
+| 2.6.18 | Classic and Express scopes, Classic implicit default and conditional protocol modules | 2, 3 | #767 |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -99,18 +110,19 @@ frequently; each linked pull request is authoritative.
 
 | PR | Work | Theme |
 | --- | --- | --- |
-| [#731](https://github.com/awslabs/aidlc-workflows/pull/731) | DocumentKB S1: index team documents for citation by agents | Knowledge and org repository |
+| [#756](https://github.com/awslabs/aidlc-workflows/pull/756) | Native distribution, six-command CLI, config policy and release hardening | Installation and releases |
+| [#775](https://github.com/awslabs/aidlc-workflows/pull/775) | Unified Kiro distribution aligned to the agent harness | Harness parity |
+| [#782](https://github.com/awslabs/aidlc-workflows/pull/782) | Product-discovery plugin (AI-PLC) | Plugins and product discovery |
+| [#797](https://github.com/awslabs/aidlc-workflows/pull/797) | Plugin-extensible doctor checks | Plugin ecosystem |
+| [#799](https://github.com/awslabs/aidlc-workflows/pull/799) | Adversarial AI pull-request review agent | CI and verification |
+| [#813](https://github.com/awslabs/aidlc-workflows/pull/813) | Per-unit attribution for Code Generation review receipts | Traceability and validity |
 | [#716](https://github.com/awslabs/aidlc-workflows/pull/716) | Project and propagate stale stage results | Traceability and validity |
-| [#661](https://github.com/awslabs/aidlc-workflows/pull/661) | Cursor harness | Harness expansion |
-| [#617](https://github.com/awslabs/aidlc-workflows/pull/617) | Batch-parallel per-unit waves and foreground reviewers | Ensemble and execution |
 | [#616](https://github.com/awslabs/aidlc-workflows/pull/616) | Bounded Build & Test to Code Generation loop-back | Cyclic flows |
 | [#646](https://github.com/awslabs/aidlc-workflows/pull/646) | Bind Code Generation review receipts to workspace source state | Traceability and validity |
-| [#653](https://github.com/awslabs/aidlc-workflows/pull/653) | Kiro IDE-native agent and settings surfaces | Harness parity |
+| [#754](https://github.com/awslabs/aidlc-workflows/pull/754) | Reconcile planned Bolt terminology with the current Construction walk | Construction semantics |
+| [#788](https://github.com/awslabs/aidlc-workflows/pull/788) | Kiro agent-v1 hook matcher and adapter hardening | Harness reliability |
 | [#526](https://github.com/awslabs/aidlc-workflows/pull/526) | Product discovery in Ideation | Product discovery |
 | [#401](https://github.com/awslabs/aidlc-workflows/pull/401) | Per-stage traceability enforcement sensor | Traceability |
-| [#402](https://github.com/awslabs/aidlc-workflows/pull/402) / [#403](https://github.com/awslabs/aidlc-workflows/pull/403) / [#404](https://github.com/awslabs/aidlc-workflows/pull/404) | Design/code boundaries, test ownership and observability consistency | Artefact quality |
-| [#712](https://github.com/awslabs/aidlc-workflows/pull/712) | Tutorial scope for a guided first run | Adoption |
-| [#730](https://github.com/awslabs/aidlc-workflows/pull/730) | Composed-workflow determinism and test-suite hardening | Reliability |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -127,9 +139,10 @@ but do not yet have committed release versions.
   ([#646](https://github.com/awslabs/aidlc-workflows/pull/646)), and propagate
   stale stage results
   ([#716](https://github.com/awslabs/aidlc-workflows/pull/716)).
-- Define per-unit attribution for Code Generation review receipts
-  ([#662](https://github.com/awslabs/aidlc-workflows/issues/662)) and a fresh v2
-  implementation for cross-unit discovery propagation
+- Per-unit attribution for Code Generation review receipts is active in
+  [#813](https://github.com/awslabs/aidlc-workflows/pull/813), addressing
+  [#662](https://github.com/awslabs/aidlc-workflows/issues/662). A fresh v2
+  implementation is still needed for cross-unit discovery propagation
   ([#299](https://github.com/awslabs/aidlc-workflows/issues/299)/[#300](https://github.com/awslabs/aidlc-workflows/pull/300)).
 - Preserve progressive enrichment as the North Star destination: downstream
   stages enrich upstream artefacts in place, with ADRs as a core design artefact.
@@ -149,19 +162,25 @@ but do not yet have committed release versions.
 ### Plugins and marketplace
 
 - The plugin mechanism, content projection, selection and plugin-contributed
-  scopes are shipped.
+  scopes are shipped; the plugin test kit and authoring tiers shipped in #792.
 - Remote discovery, trust, a first-party marketplace and a graduation path are
   proposed in [#723](https://github.com/awslabs/aidlc-workflows/issues/723).
   Product discovery
-  ([#652](https://github.com/awslabs/aidlc-workflows/issues/652)) and design
+  ([#652](https://github.com/awslabs/aidlc-workflows/issues/652),
+  [#782](https://github.com/awslabs/aidlc-workflows/pull/782)) and design
   ([#527](https://github.com/awslabs/aidlc-workflows/issues/527)) are candidates
   for first-party plugins.
+- Plugin-native diagnostics are active in
+  [#797](https://github.com/awslabs/aidlc-workflows/pull/797); external authoring
+  and test tooling is proposed in
+  [#793](https://github.com/awslabs/aidlc-workflows/issues/793).
 
 ### Knowledge and documents
 
-- [#714](https://github.com/awslabs/aidlc-workflows/issues/714) defines
-  DocumentKB and [#731](https://github.com/awslabs/aidlc-workflows/pull/731)
-  implements its first indexing slice.
+- [#731](https://github.com/awslabs/aidlc-workflows/pull/731) shipped
+  DocumentKB's first indexing and citation slice;
+  [#714](https://github.com/awslabs/aidlc-workflows/issues/714) remains the
+  broader retrieval lifecycle.
 - [#694](https://github.com/awslabs/aidlc-workflows/issues/694) proposes auditable
   supplemental-knowledge selection and delivery across stage topologies.
 
@@ -178,9 +197,11 @@ but do not yet have committed release versions.
 ### Installation, upgrades and releases
 
 - [#722](https://github.com/awslabs/aidlc-workflows/issues/722) covers binary
-  packaging, installers, npm, release automation, rollback and post-install
-  setup. [#399](https://github.com/awslabs/aidlc-workflows/issues/399) tracks the
-  hard Bun dependency.
+  packaging, installers, release automation, rollback and post-install setup;
+  its milestones 1-3 implementation is under review in
+  [#756](https://github.com/awslabs/aidlc-workflows/pull/756).
+  [#399](https://github.com/awslabs/aidlc-workflows/issues/399) tracks the hard
+  Bun dependency of the copy channel.
 - [#636](https://github.com/awslabs/aidlc-workflows/issues/636) tracks a
   first-class upgrade contract. The earlier implementation PR
   [#535](https://github.com/awslabs/aidlc-workflows/pull/535) closed without
@@ -192,13 +213,14 @@ but do not yet have committed release versions.
 ### Harness expansion and parity
 
 - GitHub Copilot support shipped in
-  [#657](https://github.com/awslabs/aidlc-workflows/pull/657); its RFC
-  [#472](https://github.com/awslabs/aidlc-workflows/issues/472) still needs
-  reconciliation.
-- Cursor support is open in
-  [#661](https://github.com/awslabs/aidlc-workflows/pull/661), and Kiro IDE-native
-  surfaces remain open in
-  [#653](https://github.com/awslabs/aidlc-workflows/pull/653).
+  [#657](https://github.com/awslabs/aidlc-workflows/pull/657), and its RFC
+  [#472](https://github.com/awslabs/aidlc-workflows/issues/472) is closed.
+- Cursor support shipped in
+  [#661](https://github.com/awslabs/aidlc-workflows/pull/661). A unified Kiro
+  distribution is under review in
+  [#775](https://github.com/awslabs/aidlc-workflows/pull/775), while matcher and
+  adapter reliability continues in
+  [#788](https://github.com/awslabs/aidlc-workflows/pull/788).
 - Antigravity setup is proposed in
   [#690](https://github.com/awslabs/aidlc-workflows/issues/690).
 
@@ -220,10 +242,9 @@ but do not yet have committed release versions.
 - Sensor failures are advisory; blocking severity remains open in #431.
 - General cross-stage cycles and progressive in-place artefact enrichment remain
   North Star gaps.
-- Kiro IDE issue #543 is closed, but #555/#653 still track native agent/settings
-  surfaces.
+- Kiro's remaining gaps are now concentrated in hook registration/payload drift,
+  plugin projection and argument forwarding (#763, #764, #776, #778, #779,
+  #783, #784).
 - Several older community PRs remain open and need rebasing or disposition:
-  #401-#404, #526 and #553. PRs #432, #535 and #552 closed without merging.
-- The Copilot RFC #472 and deterministic ARS issue #618 remain open despite their
-  implementations shipping in #657 and #644; their issue state should be
-  reconciled.
+  #401-#404, #526 and #553. PRs #432, #535, #552, #653 and #712 closed without
+  merging.


### PR DESCRIPTION
## Summary

Follow-up to #733 that refreshes the v2 roadmap from the 2026-08-10 snapshot through the current `2.6.18` tip.

## Changes

- update the status date, current version/commit, release-publication state, and deterministic CI coverage
- move Cursor, batch-parallel waves, domain/contract design, reviewer recovery, DocumentKB, Testing Posture, plugin testing, and Classic/Express scopes into Delivered
- remove merged and closed PRs from In flight
- add selected active work for native distribution, unified Kiro, plugins, AI review, traceability, Bolt semantics, and hook reliability
- refresh the traceability, plugin, knowledge, installation, harness, and known-gap themes
- preserve the distinction between merged delivery and directional open work; no future version is promised

## Validation

- `bun test tests/unit/t239-documentation-parity.test.ts` (9 tests, 146 assertions)
- `bun scripts/package.ts --check` (all seven harnesses in sync)
- `git diff --check`

This is a documentation-only update. It does not change framework behavior, version metadata, the changelog, or generated distributions.
