### PR TITLE
fix(kiro): project disallowedTools out of the Kiro-native agent surface (2.6.60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.57] - 2026-08-23
+
+Kiro CLI and IDE agent Markdown no longer carries the unsupported Claude-only `disallowedTools` key; nested delegation remains blocked by Kiro's native agent tool configuration. **Upgrade:** refresh your `dist/kiro/` or `dist/kiro-ide/` shell, and re-run compose for installed Kiro plugins so their agent personas receive the same projection.
+
+* Kiro packaging validates that the authored denial is exactly `disallowedTools: Task`, then omits that inert line from all 14 projected agent personas on both Kiro distributions.
+* Kiro plugin composition strips the supported `Task` denial from composed personas and drop-logs any agent that declares a different, unenforceable `disallowedTools` value.
+
 ## [2.6.56] - 2026-08-23
 
 Kiro CLI agent-v1 hooks retain the literal selectors required by the host's canonical-name/alias glob semantics, while the adapter now normalizes selected payloads before shared guards and observers run. **Upgrade:** re-copy `dist/kiro/` into the project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [2.6.57] - 2026-08-23
+## [2.6.60] - 2026-08-23
 
-Kiro CLI and IDE agent Markdown no longer carries the unsupported Claude-only `disallowedTools` key; nested delegation remains blocked by Kiro's native agent tool configuration. **Upgrade:** refresh your `dist/kiro/` or `dist/kiro-ide/` shell, and re-run compose for installed Kiro plugins so their agent personas receive the same projection.
+Kiro CLI and IDE agent Markdown no longer carries the unsupported Claude-only `disallowedTools` key; nested delegation remains blocked by Kiro's native agent tool configuration. **Upgrade:** refresh your `dist/kiro/` or `dist/kiro-ide/` shell, and re-run compose for installed Kiro plugins. An unchanged same-plugin persona is migrated automatically; if doctor reports an already-composed unsupported value, fix the plugin source, remove the named installed persona, and re-run compose.
 
-* Kiro packaging validates that the authored denial is exactly `disallowedTools: Task`, then omits that inert line from all 14 projected agent personas on both Kiro distributions.
-* Kiro plugin composition strips the supported `Task` denial from composed personas and drop-logs any agent that declares a different, unenforceable `disallowedTools` value.
+* Kiro packaging requires exactly one authored `disallowedTools: Task` denial, then omits that inert line from all 14 projected agent personas on both Kiro distributions.
+* Kiro plugin composition strips the supported `Task` denial from new personas, migrates exact unchanged same-plugin legacy copies without clobbering edits, and drop-logs duplicate, unsupported, or already-composed invalid values with recovery guidance.
 
 ## [2.6.56] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.57-blue)
+![version](https://img.shields.io/badge/version-2.6.60-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.56-blue)
+![version](https://img.shields.io/badge/version-2.6.57-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/conductor.md
+++ b/core/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.57";
+export const AIDLC_VERSION = "2.6.60";

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.57";

--- a/dist/claude/.claude/aidlc-common/conductor.md
+++ b/dist/claude/.claude/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.60";

--- a/dist/codex/.codex/aidlc-common/conductor.md
+++ b/dist/codex/.codex/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.60";

--- a/dist/copilot/.aidlc/aidlc-common/conductor.md
+++ b/dist/copilot/.aidlc/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.60";

--- a/dist/cursor/.cursor/aidlc-common/conductor.md
+++ b/dist/cursor/.cursor/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.60";

--- a/dist/kiro-ide/.kiro/agents/aidlc-architect-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-architect-agent.md
@@ -8,7 +8,6 @@ description: >
   Solutions architect responsible for domain design, contract design, NFR patterns, and component decomposition.
   Leads Feasibility, Domain Design, Units Generation, Contract Design, Functional Design, NFR Requirements, and NFR Design stages,
   and serves as the dispatched final link of the Reverse Engineering pipeline.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-architecture-reviewer-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-architecture-reviewer-agent.md
@@ -3,7 +3,6 @@ name: aidlc-architecture-reviewer-agent
 display_name: Architecture Reviewer
 description: >
   Senior solutions architect who reviews technical design artifacts for soundness, implementability, and coherence. Finds broken cross-references, hidden dependencies, unachievable quality targets, and designs that won't survive contact with reality.
-disallowedTools: Task
 maxTurns: 60
 tools: ["read", "write", "shell"]
 ---

--- a/dist/kiro-ide/.kiro/agents/aidlc-aws-platform-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-aws-platform-agent.md
@@ -8,7 +8,6 @@ description: >
   AWS solutions architect responsible for infrastructure design, environment provisioning, and cloud-native architecture.
   Leads Infrastructure Design and Environment Provisioning stages.
   Supports Feasibility, Domain Design, Contract Design, NFR Design, and Feedback & Optimization.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-compliance-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-compliance-agent.md
@@ -7,7 +7,6 @@ examples:
 description: >
   GRC analyst and regulatory specialist responsible for compliance mapping, data classification, and risk assessment.
   Support-only agent for Feasibility & Constraint Analysis and cross-cutting compliance validation.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-composer-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-composer-agent.md
@@ -11,7 +11,6 @@ description: >
   indexed; only falls back to bounded workspace analysis when CodeKB is absent
   or not ready.
   Dispatched by the /aidlc orchestrator; never invoked directly by a stage.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-delivery-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-delivery-agent.md
@@ -8,7 +8,6 @@ description: >
   Engineering manager responsible for team formation, Bolt sequencing, and phase handoffs.
   Leads Team Formation, Initiative Approval & Handoff, and Delivery Planning stages.
   Supports Scope Definition and Units Generation.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-design-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-design-agent.md
@@ -8,7 +8,6 @@ description: >
   UX/UI designer responsible for wireframing, interaction design, accessibility, and design system compliance.
   Leads Rough Mockups and Refined Mockups stages. Supports Domain Design, and serves as a
   dispatched collaborator in the User Stories mob ensemble.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-developer-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-developer-agent.md
@@ -8,7 +8,6 @@ description: >
   Senior developer responsible for code generation, reverse engineering, and data modelling.
   Leads the Reverse Engineering code scan and Code Generation, and serves as a dispatched
   collaborator in the Practices Discovery hub-and-spoke and User Stories mob ensembles.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-devsecops-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-devsecops-agent.md
@@ -8,7 +8,6 @@ description: >
   Security engineer and DevSecOps specialist responsible for threat modelling, security requirements, secure design review,
   and security pipeline integration. Supports NFR Requirements, Infrastructure Design, Build and Test, and Environment
   Provisioning, and serves as a dispatched collaborator in the Practices Discovery hub-and-spoke ensemble.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-operations-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-operations-agent.md
@@ -8,7 +8,6 @@ description: >
   SRE and reliability engineer responsible for observability, incident response, and operational optimization.
   Leads Observability Setup, Incident Response, and Feedback & Optimization stages.
   Supports Performance Validation.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-pipeline-deploy-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-pipeline-deploy-agent.md
@@ -7,7 +7,6 @@ examples:
 description: >
   CI/CD engineer and release manager responsible for pipeline configuration, deployment strategy, and release execution.
   Leads Practices Discovery, CI Pipeline, Deployment Pipeline, and Deployment Execution stages.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-product-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-product-agent.md
@@ -7,7 +7,6 @@ examples:
 description: >
   Product manager and business analyst responsible for requirements, user stories, market research, and scope.
   Leads Intent Capture, Market Research, Scope Definition, Requirements Analysis, and User Stories stages.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/agents/aidlc-product-lead-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-product-lead-agent.md
@@ -3,7 +3,6 @@ name: aidlc-product-lead-agent
 display_name: Product Lead
 description: >
   Senior product leader who reviews requirements, user stories, and UX artifacts for completeness, business alignment, and testability. Does not produce — only reviews and challenges. Represents the customer's voice at the quality gate.
-disallowedTools: Task
 maxTurns: 60
 tools: ["read", "write", "shell"]
 ---

--- a/dist/kiro-ide/.kiro/agents/aidlc-quality-agent.md
+++ b/dist/kiro-ide/.kiro/agents/aidlc-quality-agent.md
@@ -8,7 +8,6 @@ description: >
   QA lead responsible for test strategy, test case design, quality gates, and performance validation.
   Leads Build and Test and Performance Validation stages. Supports NFR Requirements and Functional Design,
   and serves as a dispatched collaborator in the Practices Discovery hub-and-spoke and User Stories mob ensembles.
-disallowedTools: Task
 tools: ["read", "write", "shell"]
 ---
 

--- a/dist/kiro-ide/.kiro/aidlc-common/conductor.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.60";

--- a/dist/kiro/.kiro/agents/aidlc-architect-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-architect-agent.md
@@ -8,7 +8,6 @@ description: >
   Solutions architect responsible for domain design, contract design, NFR patterns, and component decomposition.
   Leads Feasibility, Domain Design, Units Generation, Contract Design, Functional Design, NFR Requirements, and NFR Design stages,
   and serves as the dispatched final link of the Reverse Engineering pipeline.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-architecture-reviewer-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-architecture-reviewer-agent.md
@@ -3,7 +3,6 @@ name: aidlc-architecture-reviewer-agent
 display_name: Architecture Reviewer
 description: >
   Senior solutions architect who reviews technical design artifacts for soundness, implementability, and coherence. Finds broken cross-references, hidden dependencies, unachievable quality targets, and designs that won't survive contact with reality.
-disallowedTools: Task
 maxTurns: 60
 ---
 

--- a/dist/kiro/.kiro/agents/aidlc-aws-platform-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-aws-platform-agent.md
@@ -8,7 +8,6 @@ description: >
   AWS solutions architect responsible for infrastructure design, environment provisioning, and cloud-native architecture.
   Leads Infrastructure Design and Environment Provisioning stages.
   Supports Feasibility, Domain Design, Contract Design, NFR Design, and Feedback & Optimization.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-compliance-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-compliance-agent.md
@@ -7,7 +7,6 @@ examples:
 description: >
   GRC analyst and regulatory specialist responsible for compliance mapping, data classification, and risk assessment.
   Support-only agent for Feasibility & Constraint Analysis and cross-cutting compliance validation.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-composer-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-composer-agent.md
@@ -11,7 +11,6 @@ description: >
   indexed; only falls back to bounded workspace analysis when CodeKB is absent
   or not ready.
   Dispatched by the /aidlc orchestrator; never invoked directly by a stage.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-delivery-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-delivery-agent.md
@@ -8,7 +8,6 @@ description: >
   Engineering manager responsible for team formation, Bolt sequencing, and phase handoffs.
   Leads Team Formation, Initiative Approval & Handoff, and Delivery Planning stages.
   Supports Scope Definition and Units Generation.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-design-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-design-agent.md
@@ -8,7 +8,6 @@ description: >
   UX/UI designer responsible for wireframing, interaction design, accessibility, and design system compliance.
   Leads Rough Mockups and Refined Mockups stages. Supports Domain Design, and serves as a
   dispatched collaborator in the User Stories mob ensemble.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-developer-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-developer-agent.md
@@ -8,7 +8,6 @@ description: >
   Senior developer responsible for code generation, reverse engineering, and data modelling.
   Leads the Reverse Engineering code scan and Code Generation, and serves as a dispatched
   collaborator in the Practices Discovery hub-and-spoke and User Stories mob ensembles.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-devsecops-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-devsecops-agent.md
@@ -8,7 +8,6 @@ description: >
   Security engineer and DevSecOps specialist responsible for threat modelling, security requirements, secure design review,
   and security pipeline integration. Supports NFR Requirements, Infrastructure Design, Build and Test, and Environment
   Provisioning, and serves as a dispatched collaborator in the Practices Discovery hub-and-spoke ensemble.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-operations-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-operations-agent.md
@@ -8,7 +8,6 @@ description: >
   SRE and reliability engineer responsible for observability, incident response, and operational optimization.
   Leads Observability Setup, Incident Response, and Feedback & Optimization stages.
   Supports Performance Validation.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-pipeline-deploy-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-pipeline-deploy-agent.md
@@ -7,7 +7,6 @@ examples:
 description: >
   CI/CD engineer and release manager responsible for pipeline configuration, deployment strategy, and release execution.
   Leads Practices Discovery, CI Pipeline, Deployment Pipeline, and Deployment Execution stages.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-product-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-product-agent.md
@@ -7,7 +7,6 @@ examples:
 description: >
   Product manager and business analyst responsible for requirements, user stories, market research, and scope.
   Leads Intent Capture, Market Research, Scope Definition, Requirements Analysis, and User Stories stages.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/agents/aidlc-product-lead-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-product-lead-agent.md
@@ -3,7 +3,6 @@ name: aidlc-product-lead-agent
 display_name: Product Lead
 description: >
   Senior product leader who reviews requirements, user stories, and UX artifacts for completeness, business alignment, and testability. Does not produce — only reviews and challenges. Represents the customer's voice at the quality gate.
-disallowedTools: Task
 maxTurns: 60
 ---
 

--- a/dist/kiro/.kiro/agents/aidlc-quality-agent.md
+++ b/dist/kiro/.kiro/agents/aidlc-quality-agent.md
@@ -8,7 +8,6 @@ description: >
   QA lead responsible for test strategy, test case design, quality gates, and performance validation.
   Leads Build and Test and Performance Validation stages. Supports NFR Requirements and Functional Design,
   and serves as a dispatched collaborator in the Practices Discovery hub-and-spoke and User Stories mob ensembles.
-disallowedTools: Task
 ---
 
 **IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**

--- a/dist/kiro/.kiro/aidlc-common/conductor.md
+++ b/dist/kiro/.kiro/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.60";

--- a/dist/opencode/.aidlc/aidlc-common/conductor.md
+++ b/dist/opencode/.aidlc/aidlc-common/conductor.md
@@ -17,10 +17,11 @@ it for the whole run.
 For an `inline` stage, load the lead agent's flat file (e.g.
 `agents/aidlc-architect-agent.md`) and adopt its voice for the stage body — you
 are speaking as that domain expert. Load knowledge per `stage-protocol.md` §5
-knowledge-loading order. For a `subagent` stage, the `Task` boundary loads the
-persona and enforces the agent's `disallowedTools`/`model` - pass
-context in the prompt (subagents cannot see conversation history), never inject
-the persona text yourself.
+knowledge-loading order. For a `subagent` stage, the harness's native dispatch
+boundary loads the persona and enforces its projected model/tool policy
+(`disallowedTools: Task` on Claude; delegate allowlists without `subagent` on
+Kiro). Pass context in the prompt (subagents cannot see conversation history);
+never inject the persona text yourself.
 
 For a multi-agent stage, load `stage-protocol-ensemble.md` when the directive
 names that module. It is the single contract for topology behavior,

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.56";
+export const AIDLC_VERSION = "2.6.60";

--- a/dist/plugins/test-pro/claude/hooks/compose.ts
+++ b/dist/plugins/test-pro/claude/hooks/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/claude/hooks/compose.ts
+++ b/dist/plugins/test-pro/claude/hooks/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/codex/hooks/compose.ts
+++ b/dist/plugins/test-pro/codex/hooks/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/codex/hooks/compose.ts
+++ b/dist/plugins/test-pro/codex/hooks/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/copilot/hooks/compose.ts
+++ b/dist/plugins/test-pro/copilot/hooks/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/copilot/hooks/compose.ts
+++ b/dist/plugins/test-pro/copilot/hooks/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/cursor/hooks/compose.ts
+++ b/dist/plugins/test-pro/cursor/hooks/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/cursor/hooks/compose.ts
+++ b/dist/plugins/test-pro/cursor/hooks/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/kiro-ide/hooks/compose.ts
+++ b/dist/plugins/test-pro/kiro-ide/hooks/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/kiro-ide/hooks/compose.ts
+++ b/dist/plugins/test-pro/kiro-ide/hooks/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/kiro/hooks/compose.ts
+++ b/dist/plugins/test-pro/kiro/hooks/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/kiro/hooks/compose.ts
+++ b/dist/plugins/test-pro/kiro/hooks/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/opencode/hooks/compose.ts
+++ b/dist/plugins/test-pro/opencode/hooks/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/dist/plugins/test-pro/opencode/hooks/compose.ts
+++ b/dist/plugins/test-pro/opencode/hooks/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/docs/guide/06-agents.md
+++ b/docs/guide/06-agents.md
@@ -231,16 +231,16 @@ This table shows which agents are active in which phases, and whether they serve
 
 ## Agent Tool Access
 
-Every agent inherits the **full session toolset** — all of Claude Code's built-in tools plus any MCP tools provisioned to the session. The one shipped restriction is `disallowedTools: Task` (only the conductor spawns subagents); none of the 14 agents declare a `tools:` allowlist. So the table below is not a set of per-agent grants — it records which tools each persona is *expected* to exercise in its work.
+On Claude Code, every agent inherits the **full session toolset** plus provisioned MCP tools, with `disallowedTools: Task` blocking nested delegation. Other harnesses use native tool policy for the same boundary; Kiro delegate allowlists omit `subagent`, and its projected agent Markdown does not carry the unsupported Claude key. The table below records which tools each persona is *expected* to exercise in its work, not a per-agent grant.
 
 | Tool | Expected to exercise it |
 |------|-------------|
 | Read, Edit, Write, Glob, Grep, AskUserQuestion | All 14 agents |
 | Bash | aidlc-aws-platform-agent, aidlc-devsecops-agent, aidlc-developer-agent, aidlc-quality-agent, aidlc-pipeline-deploy-agent, aidlc-operations-agent |
 | WebSearch | aidlc-product-agent, aidlc-design-agent, aidlc-compliance-agent |
-| Task | None (blocked on every agent via `disallowedTools: Task`) |
+| Task / native delegation tool | None (blocked by each harness's projected agent policy) |
 
-To genuinely narrow a persona, add an optional `tools:` allowlist to its frontmatter — but doing so drops inherited MCP access unless the fully-qualified `mcp__<server>__<tool>` ids are also listed. This implementation ships no such restrictions today.
+To narrow a Claude persona, add an optional `tools:` allowlist to its frontmatter — but doing so drops inherited MCP access unless the fully-qualified `mcp__<server>__<tool>` ids are also listed. Other harnesses use their native agent configuration.
 
 ### MCP servers are shared, not per-agent
 

--- a/docs/guide/13-customization.md
+++ b/docs/guide/13-customization.md
@@ -187,7 +187,7 @@ The scoped `Bash(bun "$CLAUDE_PROJECT_DIR/.claude/tools/"*)` entry sits ahead of
 ### How permissions work
 
 - **Project-wide ceiling**: The `settings.json` allow list is the maximum set of tools available
-- **Agents inherit the full session toolset** by default; the only shipped restriction is `disallowedTools: Task`, which blocks nested subagent spawning
+- **Claude Code agents inherit the full session toolset** by default; `disallowedTools: Task` blocks nested subagent spawning on this harness
 - **Optional per-agent narrowing**: An agent can be narrowed by adding a `tools:` allowlist to its frontmatter — omit it to inherit everything. Listing `tools:` drops inherited MCP tools unless the fully-qualified `mcp__<server>__<tool>` ids are also listed
 
 ### Expanding permissions

--- a/docs/harness-engineering/03-adding-an-agent.md
+++ b/docs/harness-engineering/03-adding-an-agent.md
@@ -82,7 +82,10 @@ delegated workers; the conductor (the live `/aidlc` session) performs the `Task`
 call when the engine's `run-stage` directive carries `mode: subagent`. Allowing
 `Task` would let an agent spawn its own subagents, cascading delegation chains
 the framework is built to prevent. Every shipped agent disallows `Task`, and so
-must yours.
+must yours. The Kiro projections remove this Claude-only frontmatter key and
+enforce the same no-nested-delegation boundary through Kiro's native agent tool
+configuration; any other `disallowedTools` value fails packaging or is
+drop-logged during plugin compose.
 
 **`tier` names the kind of work; the packager projects it into per-harness
 model/effort keys.** You never author raw `model:` or `effort:` in core agent

--- a/docs/reference/01-architecture.md
+++ b/docs/reference/01-architecture.md
@@ -55,7 +55,7 @@ graph LR
 
 **Rules** (`rules/`) -- Organization and project guardrails. Self-learning: human corrections become persistent behavioral rules. Only ~35 lines total -- kept minimal to avoid context bloat in non-AI-DLC conversations.
 
-**Agents** (`agents/*.md`) -- Fourteen flat agent files: 11 domain-expert personas, 2 review-only agents, and the adaptive-workflows composer. Each defines its role, responsibilities, collaboration pattern, tools, and knowledge loading order. All have `disallowedTools: Task` -- only the conductor delegates.
+**Agents** (`agents/*.md`) -- Fourteen flat agent files: 11 domain-expert personas, 2 review-only agents, and the adaptive-workflows composer. Each defines its role, responsibilities, collaboration pattern, tools, and knowledge loading order. Authored core personas carry `disallowedTools: Task`; the packager keeps that native denial where supported and projects the same no-nested-delegation boundary to each harness's tool policy. Kiro agent Markdown omits the unsupported key, while Kiro CLI agent JSON and Kiro IDE `tools:` grants exclude the `subagent` tool from delegates.
 
 **Knowledge** (`knowledge/`) -- Two-tier methodology reference:
 - `aidlc-shared/` -- Principles, verification, brownfield safeguards, **audit event taxonomy** (canonical event registry), state template

--- a/docs/reference/03-orchestrator.md
+++ b/docs/reference/03-orchestrator.md
@@ -431,7 +431,7 @@ Some stages involve multiple agents: a lead agent and one or more support agents
 1. Execute the lead agent's work first, producing primary artifacts.
 2. Bring in each support agent per the topology. On an `inline` stage the orchestrator reads every lead/support entry in `directive.inline_context_paths` and adopts those perspectives rather than dispatching them. On `mob`, it reads the lead-only roster and performs the lead work inline, while each support is a real dispatch. On `subagent` (hub-and-spoke) and `pipeline` (chain), the lead and supports are dispatched: mutually-blind spokes on subagent, ordered enrichment hops on pipeline, and parallel blind contributions plus a bounded objection round on mob (`stage-protocol-ensemble.md`). Every returned pipeline hop is recorded with `aidlc-log.ts link`; multi-repo chains include `--repo`, isolated runs include `--single`, and repo-scoped reuse rows suppress dispatch for reused stores.
 3. Synthesize all agent outputs into the final stage artifacts — dispatched support agents write contribution files (Contribution + Positions, `stage-protocol-ensemble.md` §11) that the lead integrates; the lead alone edits the `produces[]` artifacts (pipeline links advance them directly); unresolved mob judgment calls surface to the human mid-stage, and maintained dissent is quoted verbatim at the gate.
-4. Agents do NOT invoke each other -- only the orchestrator delegates. Enforced by `disallowedTools: Task` on all agent files.
+4. Agents do NOT invoke each other -- only the orchestrator delegates. Authored core and Claude personas enforce this with `disallowedTools: Task`; harness projections use their native tool policy instead where needed. Kiro omits that unsupported Markdown key and excludes the `subagent` tool from delegate JSON/frontmatter allowlists.
 
 Practices Discovery is the gate-ordering exception. Its hub-and-spoke work ends
 at an **Approve** / **Request Changes** gate; after Approve, the conductor runs
@@ -643,7 +643,7 @@ The following intentional differences from the upstream `aidlc-workflows/` refer
 | 14 | Minimal rules | Multiple rule files | Only guardrails (~35 lines) | Avoids context bloat in non-AI-DLC conversations |
 | 15 | Scope-to-stage mapping location | In rules | File-authored: `.claude/scopes/aidlc-<name>.md` (identity) + per-stage `scopes:` frontmatter (membership), transposed at compile into `scope-grid.json` (the runtime source the engine reads) | Scope is a file-authored primitive; no `scope-mapping.json`, no SKILL.md-resident routing |
 | 16 | Agent tool access | Scoped restrictions | Binary: full Bash or none | Claude Code doesn't support scoped tool restrictions |
-| 17 | No nested delegation | Agents can delegate | All agents have `disallowedTools: Task` | Prevents cascading subagent chains |
+| 17 | No nested delegation | Agents can delegate | Authored/Claude personas deny `Task`; other harnesses project the same boundary to native tool policy | Prevents cascading subagent chains |
 | 18 | Flat agent location | `.claude/agents/aidlc/*.md` | `.claude/agents/*.md` | Matches Claude Code standard discovery |
 | 19 | Agent memory | `memory: project` defined | Omitted | Not a supported Claude Code frontmatter field |
 | 20 | Design-agent support additions | 1.6, 2.5 only | Added as support to 2.4, 2.6 | UX-informed development |
@@ -746,7 +746,7 @@ Complete reference of all 33 stages with execution metadata. The welcome message
 
 **Mode key:**
 - `inline`: Runs in the orchestrator conversation. User can interact.
-- `subagent (<agent-name>)`: Delegated via Claude Code Task tool with `subagent_type` set to the named agent (e.g., `aidlc-developer-agent`). The subagent inherits the full session toolset unless narrowed by an optional `tools:` allowlist in the agent's frontmatter; `disallowedTools: Task` is the only shipped restriction.
+- `subagent (<agent-name>)`: On Claude Code, delegated via the Task tool with `subagent_type` set to the named agent (e.g., `aidlc-developer-agent`). The subagent inherits the full session toolset unless narrowed by an optional `tools:` allowlist; `disallowedTools: Task` blocks nested delegation. Other harnesses use their native dispatch and tool-policy surfaces; Kiro delegate allowlists omit `subagent`.
 
 ---
 

--- a/docs/reference/05-agent-system.md
+++ b/docs/reference/05-agent-system.md
@@ -8,11 +8,11 @@ For user-facing agent descriptions, see the [User Guide -- Agents](../guide/06-a
 
 ## Agent Structure
 
-Each agent is a flat `.md` file in `.claude/agents/` with YAML frontmatter followed by a markdown body. The conductor reads these files to frame its perspective during inline stage execution or to build context for subagent delegation.
+Each authored agent is a flat `.md` file in `core/agents/` with YAML frontmatter followed by a markdown body. The packager projects those personas into each harness's agent surface; the conductor reads the projected files to frame inline work or delegated execution.
 
 ### Frontmatter Contract
 
-Every agent file must include this YAML frontmatter:
+Every authored core agent file must include this YAML frontmatter:
 
 ```yaml
 ---
@@ -30,7 +30,7 @@ tier: judgment                      # judgment | balanced | templated (see Agent
 | `name` | Yes | Agent identifier, must match filename |
 | `description` | Yes | Brief role summary |
 | `tools` | No | Optional allowlist; omit to inherit the full session toolset. Listing it narrows the agent and drops inherited MCP tools unless `mcp__<server>__<tool>` ids are also listed |
-| `disallowedTools` | Yes | Must include `Task` -- only the conductor delegates |
+| `disallowedTools` | Yes in authored core | Must include `Task` -- only the conductor delegates. The packager removes or translates this Claude-dialect key when a harness uses a different native tool-policy surface |
 | `tier` | Yes | `judgment`, `balanced`, or `templated`. The AUTHORED dial: the packager projects it into each harness's native model/effort keys (see Agent Tiers below). Raw `model:`/`effort:` never appear in authored frontmatter -- they are projection OUTPUTS in `dist/<harness>/` |
 
 ### Markdown Body Sections
@@ -49,11 +49,11 @@ Below the frontmatter, the markdown body defines:
 
 ## Shared Configuration
 
-All 14 agents share a common configuration baseline. None declares a `tools:` allowlist, so every agent inherits the **full session toolset** — all of Claude Code's built-in tools plus any MCP tools provisioned to the session. The one shipped restriction is `disallowedTools: Task`.
+All 14 authored agents share a common configuration baseline. On Claude Code, none declares a `tools:` allowlist, so every agent inherits the **full session toolset** plus provisioned MCP tools, with `disallowedTools: Task` as the shipped denial. Other harnesses project that intent into native surfaces: Kiro agent Markdown omits `disallowedTools`, Kiro CLI delegate JSON omits `subagent` from `tools`, and Kiro IDE delegate `tools:` grants likewise exclude delegation.
 
-### The session toolset (inherited by every agent)
+### The Claude Code session toolset
 
-Every agent inherits the built-in Claude Code tools, including:
+Every Claude Code agent inherits the built-in tools, including:
 
 | Tool | Purpose |
 |------|---------|
@@ -68,11 +68,11 @@ Every agent inherits the built-in Claude Code tools, including:
 
 | Tool | Reason |
 |------|--------|
-| Task | Agents operate as delegated workers. Only the SKILL.md conductor performs the Task call. `disallowedTools: Task` avoids cascading subagent chains. |
+| Task | Agents operate as delegated workers. Only the SKILL.md conductor performs the Task call. Claude enforces `disallowedTools: Task`; other harnesses use their native deny/allowlist equivalent. |
 
 ### Tools each persona is expected to exercise
 
-Every agent *can* reach Bash and WebSearch by inheritance; the table records which personas the methodology **expects** to use them in their stage work, not a per-agent grant. To genuinely restrict a persona, add an optional `tools:` allowlist (which drops inherited MCP unless `mcp__<server>__<tool>` ids are also listed) — this implementation ships no such restrictions.
+On Claude Code, every agent *can* reach Bash and WebSearch by inheritance; the table records which personas the methodology **expects** to use them in their stage work, not a per-agent grant. To genuinely restrict a Claude persona, add an optional `tools:` allowlist (which drops inherited MCP unless `mcp__<server>__<tool>` ids are also listed).
 
 | Tool | Expected to exercise it |
 |------|---------------------|

--- a/docs/reference/06-hooks-and-tools.md
+++ b/docs/reference/06-hooks-and-tools.md
@@ -642,7 +642,7 @@ The `permissions.allow` array in `.claude/settings.json` pre-approves Claude Cod
 
 ### Agent Tool Restrictions
 
-Every agent inherits the full session toolset by default; the only shipped restriction is `disallowedTools: Task`. A persona can be narrowed by adding an optional `tools:` allowlist to its frontmatter (which drops inherited MCP tools unless the `mcp__<server>__<tool>` ids are also listed), but none of the 14 shipped agents do so. The table below records which agents the methodology *expects* to exercise Bash and WebSearch in their stage work.
+On Claude Code, every agent inherits the full session toolset by default; `disallowedTools: Task` is the shipped nested-delegation denial, and an optional `tools:` allowlist can narrow the persona (dropping inherited MCP tools unless their fully qualified ids are retained). Other harnesses project the same boundary to native policy: Kiro agent Markdown omits the unsupported key and delegate allowlists exclude `subagent`. The table below records which agents the methodology *expects* to exercise Bash and WebSearch in their stage work, not a cross-harness grant.
 
 | Claude Code Tool | Agents Expected to Exercise It |
 |------------------|---------------------------------|

--- a/docs/reference/18-plugin-mechanism.md
+++ b/docs/reference/18-plugin-mechanism.md
@@ -292,7 +292,10 @@ without clobbering core or another plugin; an identical file is an idempotent
 skip, and different content at the same destination is drop-logged. On
 OpenCode, compose also emits a native `.opencode/agents/` twin with
 `mode: subagent`, `permission.task: deny`, and OpenCode-valid model/memory
-frontmatter.
+frontmatter. On Kiro, compose removes the unsupported `disallowedTools: Task`
+line from the `.kiro/agents/` persona while Kiro's native agent tool
+configuration keeps nested delegation unavailable; a different
+`disallowedTools` value is drop-logged and the persona is not copied.
 
 On Kiro CLI/IDE, Codex, and OpenCode, a Markdown persona in the engine roster
 is available only for `mode: inline`. Native dispatch also requires a

--- a/docs/reference/18-plugin-mechanism.md
+++ b/docs/reference/18-plugin-mechanism.md
@@ -295,7 +295,11 @@ OpenCode, compose also emits a native `.opencode/agents/` twin with
 frontmatter. On Kiro, compose removes the unsupported `disallowedTools: Task`
 line from the `.kiro/agents/` persona while Kiro's native agent tool
 configuration keeps nested delegation unavailable; a different
-`disallowedTools` value is drop-logged and the persona is not copied.
+`disallowedTools` value is drop-logged and the persona is not copied. Re-compose
+also migrates an existing persona only when it is an exact, unchanged,
+same-plugin copy from the pre-projection composer; edited or foreign files retain
+no-clobber behavior. An already-composed unsupported value is left in place with
+a degraded diagnostic that names the file to remove before re-compose.
 
 On Kiro CLI/IDE, Codex, and OpenCode, a Markdown persona in the engine roster
 is available only for `mode: inline`. Native dispatch also requires a

--- a/docs/reference/agents/README.md
+++ b/docs/reference/agents/README.md
@@ -31,11 +31,11 @@ For design philosophy and rationale, see the
 
 ## Shared Configuration
 
-All 14 agents share a common configuration baseline defined in their frontmatter. None declares a `tools:` allowlist, so every agent inherits the **full session toolset** — all of Claude Code's built-in tools plus any MCP tools provisioned to the session. The one shipped restriction is `disallowedTools: Task`. The two review-only agents additionally carry `maxTurns: 60` - a hard turn backstop enforced natively where the harness has a lever: on Claude Code the frontmatter key is binding (the sub-agent is stopped mid-task, no final message), and on opencode the packager projects it to the native per-agent `steps: 60` (the runner grants one final text-only turn - a summary can return, but no tool call can write the review). Codex TOML personas carry the number as prose only (a TOML persona has no frontmatter, so the emit rewrites the citation), and Cursor, Copilot, and Kiro expose no per-agent cap key (the inert `maxTurns:` key still ships on the .md surfaces that tolerate unknown keys; the kiro agent JSONs never receive it). Section 12a's incomplete-attempt guard turns a review cut off at the cap into one retried dispatch and then a NOT-READY finding instead of a silently missing verdict - and the conductor deletes any pre-existing `## Review` section before every dispatch, so a stale verdict can never stand in for a missing one.
+All 14 authored agents share a common frontmatter baseline. On Claude Code, none declares a `tools:` allowlist, so every agent inherits the **full session toolset** plus provisioned MCP tools, with `disallowedTools: Task` as the nested-delegation denial. Other harnesses project that intent into native policy: Kiro agent Markdown omits the unsupported key, while Kiro CLI JSON and Kiro IDE `tools:` grants exclude `subagent` from delegates. The two review-only agents additionally carry `maxTurns: 60` - a hard turn backstop enforced natively where the harness has a lever: on Claude Code the frontmatter key is binding (the sub-agent is stopped mid-task, no final message), and on opencode the packager projects it to the native per-agent `steps: 60` (the runner grants one final text-only turn - a summary can return, but no tool call can write the review). Codex TOML personas carry the number as prose only (a TOML persona has no frontmatter, so the emit rewrites the citation), and Cursor, Copilot, and Kiro expose no per-agent cap key (the inert `maxTurns:` key still ships on the .md surfaces that tolerate unknown keys; the kiro agent JSONs never receive it). Section 12a's incomplete-attempt guard turns a review cut off at the cap into one retried dispatch and then a NOT-READY finding instead of a silently missing verdict - and the conductor deletes any pre-existing `## Review` section before every dispatch, so a stale verdict can never stand in for a missing one.
 
-### The session toolset (inherited by every agent)
+### The Claude Code session toolset
 
-Every agent inherits the built-in Claude Code tools, including:
+Every Claude Code agent inherits the built-in tools, including:
 
 | Claude Code Tool | Purpose |
 |------------------|---------|
@@ -50,11 +50,11 @@ Every agent inherits the built-in Claude Code tools, including:
 
 | Claude Code Tool | Reason |
 |------------------|--------|
-| Task | Agents operate as delegated workers. The conductor (the live `/aidlc` session) performs the `Task` call that runs an agent; agents themselves never spawn subagents. `disallowedTools: Task` avoids cascading subagent chains. |
+| Task | Agents operate as delegated workers. The conductor performs the `Task` call; Claude enforces `disallowedTools: Task`, while other harnesses use their native deny/allowlist equivalent. |
 
 ### Tools each persona is expected to exercise
 
-Every agent *can* reach Bash and WebSearch by inheritance; the table records which personas the methodology **expects** to use them, not a per-agent grant. To genuinely restrict a persona, add an optional `tools:` allowlist (which drops inherited MCP unless `mcp__<server>__<tool>` ids are also listed) — this implementation ships no such restrictions.
+On Claude Code, every agent *can* reach Bash and WebSearch by inheritance; the table records which personas the methodology **expects** to use them, not a per-agent grant. To genuinely restrict a Claude persona, add an optional `tools:` allowlist (which drops inherited MCP unless `mcp__<server>__<tool>` ids are also listed).
 
 | Claude Code Tool | Expected to exercise it |
 |------------------|---------------------|

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -186,6 +186,16 @@ function projectTierFrontmatter(
   const m = s.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${srcPath}: agent .md has no closed frontmatter block.`);
   const fm = m[1];
+  const disallowedMatch = fm.match(/^disallowedTools:\s*(.*?)\s*$/m);
+  if (
+    harness === "kiro" &&
+    disallowedMatch &&
+    !/^task$/i.test(disallowedMatch[1].trim())
+  ) {
+    throw new Error(
+      `${srcPath}: kiro projection cannot project disallowedTools: ${disallowedMatch[1]}.`,
+    );
+  }
   const proj = projectTier(tier, harness, TIER_CAP); // throws on unknown tier
   const lines: string[] = [];
   if (proj.model !== null) lines.push(`model: ${proj.model}`);
@@ -199,7 +209,10 @@ function projectTierFrontmatter(
   // sits - first, last, or mid-frontmatter.
   const newFm = fm
     .split(/\r?\n/)
-    .flatMap((line) => (/^tier:/.test(line) ? lines : [line]))
+    .flatMap((line) => {
+      if (harness === "kiro" && /^disallowedTools:/.test(line)) return [];
+      return /^tier:/.test(line) ? lines : [line];
+    })
     .join("\n");
   // Function replacement: a literal `$&`/`$'` in frontmatter must not be
   // interpreted as a replacement pattern.

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -186,14 +186,16 @@ function projectTierFrontmatter(
   const m = s.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${srcPath}: agent .md has no closed frontmatter block.`);
   const fm = m[1];
-  const disallowedMatch = fm.match(/^disallowedTools:\s*(.*?)\s*$/m);
+  const disallowedMatches = [
+    ...fm.matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ];
   if (
     harness === "kiro" &&
-    disallowedMatch &&
-    !/^task$/i.test(disallowedMatch[1].trim())
+    (disallowedMatches.length !== 1 ||
+      !/^task$/i.test(disallowedMatches[0][1].trim()))
   ) {
     throw new Error(
-      `${srcPath}: kiro projection cannot project disallowedTools: ${disallowedMatch[1]}.`,
+      `${srcPath}: kiro projection requires exactly one disallowedTools: Task line.`,
     );
   }
   const proj = projectTier(tier, harness, TIER_CAP); // throws on unknown tier

--- a/scripts/plugin-hooks-template/compose.ts
+++ b/scripts/plugin-hooks-template/compose.ts
@@ -611,6 +611,35 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function projectKiroNativeAgent({ file, content }: CopyContext): string {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const fm = m[1]
+    .split(/\r?\n/)
+    .filter((line) => !/^disallowedTools:/.test(line))
+    .join("\n");
+  return content.replace(m[0], () => `---\n${fm}\n---\n`);
+}
+
+function kiroNativeAgentPrecheck(): CopyPrecheck {
+  return (ctx) => {
+    if (!ctx.content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" has no closed frontmatter block; not copied to Kiro's agent roster`,
+      );
+      return false;
+    }
+    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
+    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
   const collision = installedNameCollisionPrecheck(dst, "agents");
   return (ctx) => {
@@ -1401,13 +1430,16 @@ try {
       "agents",
       combinePrechecks(
         kiroAgentPrechecks?.agent,
+        HARNESS_LEAF === ".kiro" ? kiroNativeAgentPrecheck() : undefined,
         installedNameCollisionPrecheck(agentsDir, "agents"),
       ),
       HARNESS_LEAF === ".aidlc"
         ? ({ content }) => projectOpencodeAgentMemory(content)
         : HARNESS_LEAF === ".cursor"
           ? projectCursorNativeAgent
-          : undefined,
+          : HARNESS_LEAF === ".kiro"
+            ? projectKiroNativeAgent
+            : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/scripts/plugin-hooks-template/compose.ts
+++ b/scripts/plugin-hooks-template/compose.ts
@@ -462,6 +462,10 @@ function walk(dir: string): string[] {
 type CopyContext = { file: string; rel: string; content: string };
 type CopyPrecheck = (ctx: CopyContext & { dest: string }) => boolean;
 type CopyTransform = (ctx: CopyContext) => string;
+type ExistingCopyAction = "compare" | "handled" | "written";
+type ExistingCopyHandler = (
+  ctx: CopyContext & { dest: string; installed: Buffer },
+) => ExistingCopyAction;
 
 function frontmatterName(content: string): string | null {
   return frontmatterScalar(content, "name");
@@ -611,9 +615,22 @@ function projectCursorNativeAgent({ file, content }: CopyContext): string {
   return content.replace(m[0], () => `---\n${fm}\n---\n`);
 }
 
+function disallowedToolsValues(content: string): string[] {
+  return [
+    ...frontmatter(content).matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+  ].map((match) => match[1].trim());
+}
+
 function projectKiroNativeAgent({ file, content }: CopyContext): string {
   const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!m) throw new Error(`${file}: plugin agent has no closed frontmatter block`);
+  const disallowed = disallowedToolsValues(content);
+  if (
+    disallowed.length > 1 ||
+    (disallowed.length === 1 && !/^Task$/i.test(disallowed[0]))
+  ) {
+    throw new Error(`${file}: Kiro cannot project this disallowedTools declaration`);
+  }
   const fm = m[1]
     .split(/\r?\n/)
     .filter((line) => !/^disallowedTools:/.test(line))
@@ -629,15 +646,56 @@ function kiroNativeAgentPrecheck(): CopyPrecheck {
       );
       return false;
     }
-    const disallowed = frontmatter(ctx.content).match(/^disallowedTools:\s*(.*?)\s*$/m);
-    if (disallowed && !/^\s*Task\s*$/i.test(disallowed[1])) {
+    const disallowed = disallowedToolsValues(ctx.content);
+    if (disallowed.length > 1) {
       recordDrop(
-        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[1]}" to Kiro; not copied`,
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" declares multiple disallowedTools lines; Kiro accepts at most one disallowedTools: Task line; not copied`,
+      );
+      return false;
+    }
+    if (disallowed.length === 1 && !/^Task$/i.test(disallowed[0])) {
+      recordDrop(
+        `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" cannot project disallowedTools "${disallowed[0]}" to Kiro; not copied`,
       );
       return false;
     }
     return true;
   };
+}
+
+function migrateExistingKiroAgent(
+  ctx: CopyContext & { dest: string; installed: Buffer },
+): ExistingCopyAction {
+  if (!ctx.file.endsWith(".md")) return "compare";
+  const installed = ctx.installed.toString("utf-8");
+  // This migration is deliberately narrower than ordinary plugin upgrades:
+  // only an unchanged pre-projection copy owned by this plugin is rewritten.
+  // User edits, core files, and another plugin's files stay under no-clobber.
+  if (
+    installed !== ctx.content ||
+    frontmatterScalar(ctx.content, "plugin") !== PLUGIN_NAME ||
+    frontmatterScalar(installed, "plugin") !== PLUGIN_NAME
+  ) {
+    return "compare";
+  }
+  const disallowed = disallowedToolsValues(ctx.content);
+  if (disallowed.length === 0) return "compare";
+  if (disallowed.length > 1) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with multiple disallowedTools lines; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  if (!/^Task$/i.test(disallowed[0])) {
+    const installedRel = relative(PROJECT_DIR, ctx.dest).replace(/\\/g, "/");
+    recordDrop(
+      `plugin "${PLUGIN_NAME}" agent file "${ctx.rel}" is already composed with unsupported disallowedTools "${disallowed[0]}"; fix the plugin source, remove "${installedRel}", and re-run compose`,
+    );
+    return "handled";
+  }
+  writeComposeFile(ctx.dest, projectKiroNativeAgent(ctx));
+  return "written";
 }
 
 function opencodeNativeAgentPrecheck(dst: string): CopyPrecheck {
@@ -1124,6 +1182,7 @@ function copyTreeNoClobber(
   kind: string,
   precheck?: CopyPrecheck,
   transform?: CopyTransform,
+  existingHandler?: ExistingCopyHandler,
 ): boolean {
   if (!existsSync(src)) return false;
   let wrote = false;
@@ -1139,6 +1198,19 @@ function copyTreeNoClobber(
       // content collision, not an identical idempotent re-copy. The installed
       // copy was written transformed, so transform before comparing; a source
       // the transform rejects cannot equal any installed copy.
+      const installed = readFileSync(dest);
+      const existingAction = existingHandler?.({
+        file,
+        rel,
+        dest,
+        content: buf.toString("utf-8"),
+        installed,
+      }) ?? "compare";
+      if (existingAction === "written") {
+        wrote = true;
+        continue;
+      }
+      if (existingAction === "handled") continue;
       let current: Buffer | null = buf;
       if (transform) {
         try {
@@ -1147,7 +1219,7 @@ function copyTreeNoClobber(
           current = null;
         }
       }
-      if (current === null || !readFileSync(dest).equals(current)) {
+      if (current === null || !installed.equals(current)) {
         recordDrop(`${kind} "${rel}" collides with an existing file (core or another plugin); not overwritten — rename it to a plugin-namespaced path`);
       }
       continue;
@@ -1440,6 +1512,7 @@ try {
           : HARNESS_LEAF === ".kiro"
             ? projectKiroNativeAgent
             : undefined,
+      HARNESS_LEAF === ".kiro" ? migrateExistingKiroAgent : undefined,
     ) || changed;
     if (IS_OPENCODE) {
       const rosterDir = nativeAgentsDir();

--- a/tests/integration/t188-plugin-compose.test.ts
+++ b/tests/integration/t188-plugin-compose.test.ts
@@ -1597,6 +1597,136 @@ describe("t188 plugin compose — emit + compose the contribution seam", () => {
     expect(unsupported.drops).toContain(
       'cannot project disallowedTools "WebSearch" to Kiro; not copied',
     );
+
+    const duplicateAgent = unsupportedAgent
+      .replaceAll("syn-kiro-unsupported", "syn-kiro-duplicate")
+      .replace(
+        "disallowedTools: WebSearch",
+        "disallowedTools: Task\ndisallowedTools: WebSearch",
+      );
+    const duplicate = composeSynthetic(
+      "syn-kiro-duplicate",
+      {
+        "agents/syn-kiro-duplicate-agent.md": duplicateAgent,
+      },
+      ".kiro",
+    );
+    expect(existsSync(join(
+      duplicate.proj,
+      ".kiro",
+      "agents",
+      "syn-kiro-duplicate-agent.md",
+    ))).toBe(false);
+    expect(duplicate.drops).toContain(
+      "declares multiple disallowedTools lines",
+    );
+  });
+
+  test("Kiro re-compose migrates only an exact same-plugin legacy persona", () => {
+    const agent = [
+      "---",
+      "name: syn-kiro-upgrade-agent",
+      "display_name: Synthetic Kiro Upgrade Agent",
+      "plugin: syn-kiro-upgrade",
+      "disallowedTools: Task",
+      "---",
+      "",
+      "# Synthetic Kiro Upgrade Agent",
+      "",
+    ].join("\n");
+    const rel = join("agents", "syn-kiro-upgrade-agent.md");
+    const migrated = composeSynthetic(
+      "syn-kiro-upgrade",
+      { "agents/syn-kiro-upgrade-agent.md": agent },
+      ".kiro",
+      (_proj, harnessDir) => {
+        mkdirSync(join(harnessDir, "agents"), { recursive: true });
+        writeFileSync(join(harnessDir, rel), agent);
+      },
+    );
+    const migratedBody = readFileSync(
+      join(migrated.proj, ".kiro", rel),
+      "utf-8",
+    );
+    expect(migratedBody).not.toMatch(/^disallowedTools:/m);
+    expect(migrated.drops).not.toContain("collides with an existing file");
+
+    const editedAgent = `${agent}\n<!-- user-owned edit -->\n`;
+    const edited = composeSynthetic(
+      "syn-kiro-upgrade",
+      { "agents/syn-kiro-upgrade-agent.md": agent },
+      ".kiro",
+      (_proj, harnessDir) => {
+        mkdirSync(join(harnessDir, "agents"), { recursive: true });
+        writeFileSync(join(harnessDir, rel), editedAgent);
+      },
+    );
+    const editedBody = readFileSync(join(edited.proj, ".kiro", rel), "utf-8");
+    expect(editedBody).toBe(editedAgent);
+    expect(edited.drops).toContain("collides with an existing file");
+
+    const unsupportedAgent = agent
+      .replaceAll("syn-kiro-upgrade", "syn-kiro-unsupported-upgrade")
+      .replace("disallowedTools: Task", "disallowedTools: WebSearch");
+    const unsupportedRel = join(
+      "agents",
+      "syn-kiro-unsupported-upgrade-agent.md",
+    );
+    const unsupported = composeSynthetic(
+      "syn-kiro-unsupported-upgrade",
+      {
+        "agents/syn-kiro-unsupported-upgrade-agent.md": unsupportedAgent,
+      },
+      ".kiro",
+      (_proj, harnessDir) => {
+        mkdirSync(join(harnessDir, "agents"), { recursive: true });
+        writeFileSync(join(harnessDir, unsupportedRel), unsupportedAgent);
+      },
+    );
+    expect(readFileSync(
+      join(unsupported.proj, ".kiro", unsupportedRel),
+      "utf-8",
+    )).toBe(unsupportedAgent);
+    expect(unsupported.drops).toContain(
+      'is already composed with unsupported disallowedTools "WebSearch"',
+    );
+    expect(unsupported.drops).toContain(
+      'remove ".kiro/agents/syn-kiro-unsupported-upgrade-agent.md", and re-run compose',
+    );
+    expect(unsupported.drops).not.toContain("collides with an existing file");
+
+    const duplicateAgent = agent
+      .replaceAll("syn-kiro-upgrade", "syn-kiro-duplicate-upgrade")
+      .replace(
+        "disallowedTools: Task",
+        "disallowedTools: Task\ndisallowedTools: WebSearch",
+      );
+    const duplicateRel = join(
+      "agents",
+      "syn-kiro-duplicate-upgrade-agent.md",
+    );
+    const duplicate = composeSynthetic(
+      "syn-kiro-duplicate-upgrade",
+      {
+        "agents/syn-kiro-duplicate-upgrade-agent.md": duplicateAgent,
+      },
+      ".kiro",
+      (_proj, harnessDir) => {
+        mkdirSync(join(harnessDir, "agents"), { recursive: true });
+        writeFileSync(join(harnessDir, duplicateRel), duplicateAgent);
+      },
+    );
+    expect(readFileSync(
+      join(duplicate.proj, ".kiro", duplicateRel),
+      "utf-8",
+    )).toBe(duplicateAgent);
+    expect(duplicate.drops).toContain(
+      "is already composed with multiple disallowedTools lines",
+    );
+    expect(duplicate.drops).toContain(
+      'remove ".kiro/agents/syn-kiro-duplicate-upgrade-agent.md", and re-run compose',
+    );
+    expect(duplicate.drops).not.toContain("collides with an existing file");
   });
 
   test("Kiro rejects an agent JSON that is missing conductor trust registration", () => {

--- a/tests/integration/t188-plugin-compose.test.ts
+++ b/tests/integration/t188-plugin-compose.test.ts
@@ -1526,6 +1526,7 @@ describe("t188 plugin compose — emit + compose the contribution seam", () => {
       "name: syn-kiro-collaborator-agent",
       "display_name: Synthetic Kiro Collaborator",
       "plugin: syn-kiro",
+      "disallowedTools: Task",
       "---",
       "",
       "# Synthetic Kiro Collaborator",
@@ -1554,6 +1555,12 @@ describe("t188 plugin compose — emit + compose the contribution seam", () => {
       "agents",
       "syn-kiro-collaborator-agent.md",
     ))).toBe(true);
+    expect(readFileSync(join(
+      proj,
+      ".kiro",
+      "agents",
+      "syn-kiro-collaborator-agent.md",
+    ), "utf-8")).not.toMatch(/^disallowedTools:/m);
     expect(drops).toContain('stage "syn-kiro-ensemble"');
     expect(drops).toContain('agent "syn-kiro-collaborator-agent"');
     expect(drops).toContain("agent-v1 JSON");
@@ -1562,6 +1569,34 @@ describe("t188 plugin compose — emit + compose the contribution seam", () => {
     // The lead is a CORE persona: its shipped agent-v1 JSON is its dispatch
     // surface, so it must never be named as undispatchable.
     expect(drops).not.toContain('agent "aidlc-product-agent"');
+
+    const unsupportedAgent = [
+      "---",
+      "name: syn-kiro-unsupported-agent",
+      "display_name: Synthetic Kiro Unsupported Agent",
+      "plugin: syn-kiro-unsupported",
+      "disallowedTools: WebSearch",
+      "---",
+      "",
+      "# Synthetic Kiro Unsupported Agent",
+      "",
+    ].join("\n");
+    const unsupported = composeSynthetic(
+      "syn-kiro-unsupported",
+      {
+        "agents/syn-kiro-unsupported-agent.md": unsupportedAgent,
+      },
+      ".kiro",
+    );
+    expect(existsSync(join(
+      unsupported.proj,
+      ".kiro",
+      "agents",
+      "syn-kiro-unsupported-agent.md",
+    ))).toBe(false);
+    expect(unsupported.drops).toContain(
+      'cannot project disallowedTools "WebSearch" to Kiro; not copied',
+    );
   });
 
   test("Kiro rejects an agent JSON that is missing conductor trust registration", () => {

--- a/tests/smoke/t148-kiro-file-structure.test.ts
+++ b/tests/smoke/t148-kiro-file-structure.test.ts
@@ -274,6 +274,33 @@ describe("t148 dist/kiro file structure", () => {
     }
   });
 
+  test("Kiro agent Markdown omits the Claude-only disallowedTools key", () => {
+    for (const harness of ["kiro", "kiro-ide"] as const) {
+      const agentsDir = join(REPO_ROOT, "dist", harness, ".kiro", "agents");
+      const files = readdirSync(agentsDir)
+        .filter((name) => name.endsWith("-agent.md"))
+        .sort();
+      expect(files.length).toBe(14);
+      for (const file of files) {
+        const projected = readFileSync(join(agentsDir, file), "utf-8");
+        const projectedFm =
+          projected.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? "";
+        expect(projectedFm, `dist/${harness} ${file}`).not.toMatch(
+          /^disallowedTools:/m,
+        );
+
+        const core = readFileSync(
+          join(REPO_ROOT, "core", "agents", file),
+          "utf-8",
+        );
+        const coreFm = core.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? "";
+        expect(coreFm, `core/agents/${file}`).toMatch(
+          /^disallowedTools:\s*Task\s*$/mi,
+        );
+      }
+    }
+  });
+
   test("IDE-native tools: frontmatter grant on delegation targets - kiro-ide ONLY", () => {
     // The Kiro IDE resolves a delegated subagent's tools from the agent .md
     // frontmatter, not from the agent-v1 JSON the CLI reads (field-proven:

--- a/tests/unit/t04-agent-frontmatter.test.ts
+++ b/tests/unit/t04-agent-frontmatter.test.ts
@@ -165,15 +165,17 @@ describe("t04 agent-persona frontmatter contract (migrated from t04-agent-frontm
   });
 
   // .sh L48-52: `grep -q "^disallowedTools:.*Task"`.
-  test("disallowedTools: contains Task (no nested subagents) [.sh test 4 x11]", () => {
+  test("disallowedTools: is exactly one Task denial (no nested subagents) [.sh test 4 x11]", () => {
     for (const agent of AGENTS) {
       const fm = frontmatter(agent);
-      const m = fm.match(/^disallowedTools:\s*(.+)$/m);
-      expect(m, `aidlc-${agent}-agent.md: no disallowedTools: line`).not.toBeNull();
-      // STRONGER: parse the value and assert Task is one of the listed tools,
-      // not merely that "Task" appears somewhere on the line.
-      const tools = (m?.[1] ?? "").split(",").map((t) => t.trim());
-      expect(tools).toContain("Task");
+      const matches = [
+        ...fm.matchAll(/^disallowedTools:\s*(.*?)\s*$/gm),
+      ];
+      expect(
+        matches,
+        `aidlc-${agent}-agent.md: expected exactly one disallowedTools: line`,
+      ).toHaveLength(1);
+      expect(matches[0][1].trim()).toBe("Task");
     }
   });
 


### PR DESCRIPTION
The Claude-only `disallowedTools: Task` frontmatter key shipped verbatim in all 28 Kiro CLI/IDE agent .md files, where it is an inert, unenforced denial. The packager now validates that the authored denial is exactly `Task` and drops the line for the kiro tier flavor (nested delegation stays blocked by Kiro's native tool allowlists, which omit `subagent` for delegates), mirroring the copilot/opencode precedent. Plugin compose applies the same projection: new personas are projected with drop-logging for unprojectable values, and re-running compose migrates an installed persona when it is an exact, unchanged, same-plugin pre-projection copy; edited or foreign files keep no-clobber collision behavior, and an already-composed unsupported value gets a specific remove-and-recompose diagnostic. Central architecture and agent references now distinguish the authored/Claude `disallowedTools: Task` enforcement from Kiro's native delegate allowlists. Guarded by t148 (projected surface) and t188 (compose projection and migration paths). Ships as 2.6.56. Closes #774