### PR TITLE
feat: engine-owned atomic single-use continuation cursor on every harness (2.6.51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.51] - 2026-08-21
+
+Steering continuation tokens are now single-use on every harness: Claude, Codex, Copilot, Cursor, Kiro CLI, Kiro IDE, and opencode share one engine-owned, crash-safe continuation cursor in the active-directive marker, closing the sessionless same-token replay carve-out accepted in PR #749 (issue #762). **Upgrade:** replace the whole `dist/<harness>/` shell in one quiescent swap (no AI-DLC command or hook running) - mixed old/new tool files are unsupported - then run a fresh `next`; a matching in-flight token instead migrates atomically. Rolling back to an older release restores its sessionless replay behavior until re-upgraded.
+
+* **Behavior change:** presenting the same continuation token twice now returns an error directive ("This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token.") instead of repeating the successor. Concurrent uses of one token have exactly one winner on every harness; recovery is always a fresh `next`.
+* `continue` keeps all native token validation, then compares the SHA-256 of the complete presented token with the persisted current token inside the active-directive transaction and atomically publishes the exact successor - or a tokenless `run-stage` - before stdout. New marker publications record the installed harness as `cursor_harness` (marker v2, optional on read); pre-upgrade markers migrate on the first matching `continue` or fresh `next`.
+* Fresh `next` must now commit its first directive before emitting on every harness. Publication failure or contention yields "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`." - replacing the previous Copilot-only wording and the non-Copilot fail-open delivery.
+* Missing, malformed, oversized, v1, cross-harness, and pre-state bare-space markers permit one natively validated recovery continuation under the same transaction; a mismatched token is stale, not a bootstrap opportunity.
+* The exactly-one-winner guarantee requires the marker and lock paths on one local filesystem (atomic rename, exclusive directory creation, coherent cross-process visibility); NFS/SMB/FUSE-style shares are unsupported, and sudden power-loss durability is outside the claim. See the new "Atomic continuation cursor" section in the Developer Reference for the crash/retry matrix, migration, rollback, and per-harness residual limits.
+
 ## [2.6.50] - 2026-08-21
 
 Approval checkpoints now reject replies that do not exactly match a currently offered decision, while change-request feedback travels separately from the selected choice. **Upgrade:** refresh your `dist/<harness>/` shell so the gate protocol, deterministic transition guards, and harness instructions stay aligned.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.50-blue)
+![version](https://img.shields.io/badge/version-2.6.51-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/dist/copilot/.aidlc/tools/aidlc-lib.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/dist/cursor/.cursor/tools/aidlc-lib.ts
+++ b/dist/cursor/.cursor/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
+++ b/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -2579,6 +2579,7 @@ interface ActiveDirectiveResume {
 export interface ActiveDirectiveMarker {
   version: 1 | 2; stage: string; unit?: string; state_sha256: string;
   revision?: number; project_sha256?: string; intent_uuid?: string | null; state_present?: boolean;
+  cursor_harness?: string;
   owner_session?: string; owner_epoch?: number; context_epoch?: number; kind?: ActiveDirectiveKind;
   part?: number; parts?: number; continue_token?: string; continue_token_sha256?: string;
   delivery?: "issued" | "delivered" | "consumed" | "superseded"; needs_rehydrate?: boolean;
@@ -2691,6 +2692,8 @@ function parseActiveDirectiveMarker(parsed: unknown): ActiveDirectiveMarker | nu
   if (
     parsed.version !== 2 || !/^[0-9a-f]{64}$/.test(String(parsed.project_sha256 ?? "")) ||
     (parsed.intent_uuid !== null && typeof parsed.intent_uuid !== "string") || typeof parsed.state_present !== "boolean" ||
+    ("cursor_harness" in parsed &&
+      (typeof parsed.cursor_harness !== "string" || !/^[a-z0-9][a-z0-9._-]*$/i.test(parsed.cursor_harness))) ||
     typeof parsed.owner_session !== "string" || parsed.owner_session.length === 0 ||
     !integer(parsed.revision) || !integer(parsed.owner_epoch) || !integer(parsed.context_epoch) ||
     !integer(parsed.event_sequence) || !integer(parsed.human_sequence) || !integer(parsed.engine_sequence) ||
@@ -2846,10 +2849,12 @@ function freshActiveDirectiveMarker(
   stage: string,
 ): ActiveDirectiveMarker {
   const context = activeDirectiveContext(target, stateContent);
+  const cursorHarness = installedHarnessName(target);
   const owner = `sessionless:${context.projectSha256.slice(0, 16)}`;
   return {
     version: 2, revision: 0, project_sha256: context.projectSha256,
     intent_uuid: context.intentUuid, state_present: context.statePresent, state_sha256: context.stateSha256,
+    ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
     owner_session: owner, owner_epoch: 0, context_epoch: 0, kind: "error", stage,
     delivery: "superseded", needs_rehydrate: true,
     active_attempt: {
@@ -2888,7 +2893,6 @@ export function writeActiveDirectiveMarker(
     commandKind?: CopilotCommandClaim["commandKind"];
     commandSha256?: string;
     resultSha256?: string;
-    requireCopilotCommit?: boolean;
   },
 ): ActiveDirectiveWriteResult {
   if (!/^[a-z][a-z0-9-]*$/.test(marker.stage)) {
@@ -2903,10 +2907,8 @@ export function writeActiveDirectiveMarker(
   return transactActiveDirective(projectDir, (current, target) => {
     const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
     const context = activeDirectiveContext(target, stateContent);
+    const cursorHarness = installedHarnessName(target);
     const copilotOwned = exactCopilotMarker(current, target, context);
-    if (invocation?.requireCopilotCommit && !copilotOwned) {
-      return { marker: current, result: "preserved" as const, preserve: true };
-    }
     const attempt = current?.version === 2 ? current.active_attempt : undefined;
     const matchingAttempt = copilotOwned && attempt?.status === "pending" && invocation?.attemptId !== undefined &&
       attempt.id === invocation.attemptId && attempt.command_kind === invocation.commandKind &&
@@ -2942,6 +2944,7 @@ export function writeActiveDirectiveMarker(
     const next: ActiveDirectiveMarker = {
       ...base,
       revision: nextRevision,
+      ...(cursorHarness ? { cursor_harness: cursorHarness } : {}),
       state_present: context.statePresent,
       state_sha256: marker.state_sha256,
       kind: marker.kind,
@@ -3021,13 +3024,11 @@ export function hasCurrentSharedResumeWait(projectDir: string): boolean {
   });
 }
 
-export interface CopilotContinuationSnapshot {
+export interface ContinuationCursorSnapshot {
   target: ActiveDirectiveTarget;
-  authority: "stateless" | "current" | "superseded";
   stateSha256: string;
   statePresent: boolean;
-  markerBytesSha256: string | null;
-  copilotInstalled: boolean;
+  cursorHarness: string | null;
 }
 
 function exactCopilotMarker(
@@ -3036,63 +3037,52 @@ function exactCopilotMarker(
   context: ReturnType<typeof activeDirectiveContext>,
 ): marker is ActiveDirectiveMarker & { version: 2 } {
   return installedHarnessName(target) === "copilot" && marker?.version === 2 &&
+    (marker.cursor_harness === undefined || marker.cursor_harness === "copilot") &&
     !marker.owner_session?.startsWith("sessionless:") &&
     marker.project_sha256 === context.projectSha256 && marker.intent_uuid === context.intentUuid &&
     marker.state_sha256 === context.stateSha256 && marker.state_present === context.statePresent;
 }
 
 function installedHarnessName(target: ActiveDirectiveTarget): string | null {
+  const explicit = process.env.AIDLC_HARNESS_NAME?.trim();
+  if (explicit && /^[a-z0-9][a-z0-9._-]*$/i.test(explicit)) return explicit;
   try {
     const parsed = JSON.parse(readFileSync(
       join(target.canonicalProjectDir, harnessDir(), "tools", "data", "harness.json"),
       "utf-8",
     )) as { name?: unknown };
     return typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : null;
-  } catch { return null; }
+  } catch {
+    const dir = harnessDir();
+    if (dir === ".aidlc") return "opencode";
+    if (dir === ".kiro") return "kiro";
+    return /^\.[a-z0-9][a-z0-9._-]*$/i.test(dir) ? dir.slice(1) : null;
+  }
 }
 
-export function copilotDirectiveCommitRequired(projectDir: string, stateSha256: string): boolean {
-  try {
-    const target = resolveActiveDirectiveTarget(projectDir);
-    const stateContent = existsSync(target.statePath) ? readFileSync(target.statePath, "utf-8") : null;
-    const context = activeDirectiveContext(target, stateContent);
-    return context.stateSha256 === stateSha256 &&
-      exactCopilotMarker(readActiveDirectiveMarkerRaw(target.markerPath), target, context);
-  } catch { return false; }
-}
-
-export function inspectCopilotContinuation(
+export function inspectContinuationCursor(
   projectDir: string,
   stateContent: string | null,
-  presentedToken: string,
-): CopilotContinuationSnapshot {
+): ContinuationCursorSnapshot {
   const target = resolveActiveDirectiveTarget(projectDir);
   const context = activeDirectiveContext(target, stateContent);
-  const markerSnapshot = readActiveDirectiveMarkerSnapshot(target.markerPath);
-  const marker = markerSnapshot.marker;
-  const copilotInstalled = installedHarnessName(target) === "copilot";
-  const exact = copilotInstalled && exactCopilotMarker(marker, target, context);
-  const current = exact && marker.kind === "load-steering" &&
-    marker.continue_token_sha256 === stateContentSha256(presentedToken);
   return {
     target,
-    authority: !exact ? "stateless" : current ? "current" : "superseded",
     stateSha256: context.stateSha256,
     statePresent: context.statePresent,
-    markerBytesSha256: markerSnapshot.bytesSha256,
-    copilotInstalled,
+    cursorHarness: installedHarnessName(target),
   };
 }
 
-export function advanceCopilotContinuation(
-  snapshot: CopilotContinuationSnapshot,
+export function advanceContinuationCursor(
+  snapshot: ContinuationCursorSnapshot,
   presentedToken: string,
   successor: Omit<CopilotDirectiveMetadata, "continueToken" | "stage"> & {
     stage: string; continue_token?: string; state_sha256: string;
   },
   resultSha256: string,
   attemptId?: string,
-): "advanced" | "stateless" | "superseded" | "drift" {
+): "advanced" | "superseded" | "drift" {
   if (!/^[0-9a-f]{64}$/.test(resultSha256) || successor.state_sha256 !== snapshot.stateSha256) {
     return "drift";
   }
@@ -3106,47 +3096,35 @@ export function advanceCopilotContinuation(
     if (context.stateSha256 !== snapshot.stateSha256 || context.statePresent !== snapshot.statePresent) {
       return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "superseded") {
-      return { marker: current, result: "superseded" as const, preserve: true };
+    const cursorHarness = installedHarnessName(target);
+    if (!cursorHarness || cursorHarness !== snapshot.cursorHarness) {
+      return { marker: current, result: "drift" as const, preserve: true };
     }
-    if (snapshot.authority === "stateless") {
-      if (readActiveDirectiveMarkerSnapshot(target.markerPath).bytesSha256 !== snapshot.markerBytesSha256 && exactCopilotMarker(current, target, context)) {
-        return { marker: current, result: "drift" as const, preserve: true };
-      }
-      const base = current?.version === 2 && current.project_sha256 === context.projectSha256 && current.intent_uuid === context.intentUuid
-        ? current
-        : freshActiveDirectiveMarker(target, stateContent, successor.stage);
-      const token = successor.continue_token;
-      const next: ActiveDirectiveMarker = {
-        ...base,
-        revision: (base.revision ?? 0) + 1,
-        state_present: context.statePresent,
-        state_sha256: successor.state_sha256,
-        kind: successor.kind,
-        stage: successor.stage,
-        ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
-        ...(successor.part ? { part: successor.part } : { part: undefined }),
-        ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
-        ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
-        delivery: "issued",
-        needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
-      };
-      return { marker: next, result: "stateless" as const };
-    }
-    if (!exactCopilotMarker(current, target, context) || current.kind !== "load-steering" ||
-      current.continue_token_sha256 !== stateContentSha256(presentedToken)) {
-      return { marker: current, result: "superseded" as const, preserve: true };
-    }
-    const nextRevision = (current.revision ?? 0) + 1;
-    const pending = current.active_attempt;
+    const exactContext = current?.version === 2 &&
+      current.project_sha256 === context.projectSha256 &&
+      current.intent_uuid === context.intentUuid &&
+      current.state_sha256 === context.stateSha256 &&
+      current.state_present === context.statePresent;
     const inputSha256 = stateContentSha256(presentedToken);
+    if (exactContext && (current.kind !== "load-steering" ||
+      current.continue_token_sha256 !== inputSha256)) {
+      return { marker: current, result: "superseded" as const, preserve: true };
+    }
+    const base = exactContext && current
+      ? current
+      : freshActiveDirectiveMarker(target, stateContent, successor.stage);
+    const nextRevision = (base.revision ?? 0) + 1;
+    const pending = exactContext && current ? current.active_attempt : undefined;
     const matchingAttempt = pending?.status === "pending" && attemptId !== undefined && pending.id === attemptId &&
       pending.command_kind === "continue" && pending.cursor_input_sha256 === inputSha256 &&
-      pending.owner_epoch === current.owner_epoch && pending.context_epoch === current.context_epoch;
+      pending.owner_epoch === base.owner_epoch && pending.context_epoch === base.context_epoch;
     const token = successor.continue_token;
     const next: ActiveDirectiveMarker = {
-      ...current,
+      ...base,
       revision: nextRevision,
+      cursor_harness: cursorHarness,
+      state_present: context.statePresent,
+      state_sha256: successor.state_sha256,
       kind: successor.kind,
       stage: successor.stage,
       ...(successor.unit ? { unit: successor.unit } : { unit: undefined }),
@@ -3154,7 +3132,7 @@ export function advanceCopilotContinuation(
       ...(successor.parts ? { parts: successor.parts } : { parts: undefined }),
       ...(token ? { continue_token: token, continue_token_sha256: stateContentSha256(token) } : { continue_token: undefined, continue_token_sha256: undefined }),
       delivery: "issued",
-      needs_rehydrate: true,
+      needs_rehydrate: !base.owner_session?.startsWith("sessionless:"),
       ...(pending ? { active_attempt: matchingAttempt
         ? { ...pending, result_sha256: resultSha256, result_revision: nextRevision }
         : pending.status === "pending" ? { ...pending, status: "failed" } : pending } : {}),

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -101,7 +101,7 @@ import {
 import {
   activeSpace,
   ActiveDirectiveLockContendedError,
-  advanceCopilotContinuation,
+  advanceContinuationCursor,
   activeUnitCheckpoint,
   artifactFilename,
   auditBlockField,
@@ -109,7 +109,6 @@ import {
   checkSummaryConfirmationEvidence,
   clearActiveDirectiveMarker,
   codekbRepoName,
-  copilotDirectiveCommitRequired,
   currentUnitLifecycleMode,
   errorMessage,
   filterProducesByKind,
@@ -118,7 +117,7 @@ import {
   freshReviewReceipts,
   getField,
   intentRepos,
-  inspectCopilotContinuation,
+  inspectContinuationCursor,
   isPerUnitStage,
   isRegularFile,
   listIntents,
@@ -276,23 +275,21 @@ function prepareEmission(directive: Directive): PreparedEmission {
         directive.kind === "run-stage" && directive.single === true &&
           existsSync(stateFilePath(route.codekbCtx.projectDir))
           ? sha256(readFileSync(stateFilePath(route.codekbCtx.projectDir), "utf-8"))
-          : null
+          : sha256("")
       );
-    if (markerStateHash) {
-      marker = {
-        kind: transported.kind,
-        stage: transported.stage,
-        ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
-        ...(transported.kind === "load-steering"
-          ? {
-              part: transported.part,
-              parts: transported.parts,
-              continue_token: transported.continue_token,
-            }
-          : {}),
-        state_sha256: markerStateHash,
-      };
-    }
+    marker = {
+      kind: transported.kind,
+      stage: transported.stage,
+      ...(directive.kind === "run-stage" && directive.unit ? { unit: directive.unit } : {}),
+      ...(transported.kind === "load-steering"
+        ? {
+            part: transported.part,
+            parts: transported.parts,
+            continue_token: transported.continue_token,
+          }
+        : {}),
+      state_sha256: markerStateHash,
+    };
   }
   return {
     transported,
@@ -304,15 +301,13 @@ function prepareEmission(directive: Directive): PreparedEmission {
 }
 
 function writePrepared(prepared: PreparedEmission): void {
-  process.stdout.write(`${prepared.serialized}\n`);
+  writeFileSync(1, `${prepared.serialized}\n`, "utf-8");
 }
 
 function emit(directive: Directive): void {
   const prepared = prepareEmission(directive);
   if (prepared.marker) {
     const projectDir = prepared.projectDir;
-    let requireCopilotCommit = !!projectDir && engineInvocation?.commandKind === "next" &&
-      copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
     try {
       if (projectDir) {
         const publication = writeActiveDirectiveMarker(projectDir, prepared.marker, {
@@ -320,7 +315,6 @@ function emit(directive: Directive): void {
           ...(engineInvocation ? { commandKind: engineInvocation.commandKind } : {}),
           ...(engineInvocation ? { commandSha256: engineInvocation.commandSha256 } : {}),
           resultSha256: prepared.resultSha256,
-          requireCopilotCommit,
         });
         if (publication === "stale-attempt") {
           recordHookDrop(projectDir, "active-directive", "tracked fresh next attempt was superseded before publication");
@@ -329,26 +323,22 @@ function emit(directive: Directive): void {
           )));
           return;
         }
-        if (requireCopilotCommit && publication !== "copilot-committed") {
-          recordHookDrop(projectDir, "active-directive", "fresh Copilot next did not commit its directive");
+        if (publication !== "copilot-committed" && publication !== "generic-committed") {
+          recordHookDrop(projectDir, "active-directive", "fresh next did not commit its directive");
           writePrepared(prepareEmission(errorDirective(
-            "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
+            "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
           )));
           return;
         }
       }
     } catch (e) {
       if (projectDir) {
-        requireCopilotCommit ||= engineInvocation?.commandKind === "next" &&
-          copilotDirectiveCommitRequired(projectDir, prepared.marker.state_sha256);
         recordHookDrop(projectDir, "active-directive", errorMessage(e));
       }
-      if (requireCopilotCommit) {
-        writePrepared(prepareEmission(errorDirective(
-          "The fresh Copilot directive could not be published, so no work directive was issued. Retry `next`; if coordination remains busy, run `/aidlc --doctor`.",
-        )));
-        return;
-      }
+      writePrepared(prepareEmission(errorDirective(
+        "The directive could not be published, so no work directive was issued. Retry the command; if coordination remains busy, run `/aidlc --doctor`.",
+      )));
+      return;
     }
   }
   writePrepared(prepared);
@@ -6024,7 +6014,7 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     ));
     return;
   }
-  const cursor = inspectCopilotContinuation(pd, liveState, token);
+  const cursor = inspectContinuationCursor(pd, liveState);
 
   const directive = buildRunStageDirective(
     node,
@@ -6076,50 +6066,23 @@ function handleContinue(args: string[], projectDir: string | undefined): void {
     return;
   }
   try {
-    const advanced = advanceCopilotContinuation(
+    const advanced = advanceContinuationCursor(
       cursor,
       token,
       prepared.marker,
       prepared.resultSha256,
       engineInvocation?.attemptId,
     );
-    if (advanced === "advanced" || advanced === "stateless") {
+    if (advanced === "advanced") {
       writePrepared(prepared);
       return;
     }
     const message = advanced === "superseded"
-      ? "This continuation token is no longer current for this Copilot workflow. Run a fresh `next`; do not reuse an earlier token."
+      ? "This continuation token is no longer current for this workflow. Run a fresh `next`; do not reuse an earlier token."
       : "The active workflow context changed while this continuation was prepared. Run a fresh `next`; do not use the prepared result.";
     writePrepared(prepareEmission(errorDirective(message)));
   } catch (error) {
     if (!(error instanceof ActiveDirectiveLockContendedError)) throw error;
-    if (cursor.authority === "stateless" && !cursor.copilotInstalled) {
-      try {
-        const latest = inspectCopilotContinuation(
-          pd,
-          loadStateFileIfPresent(pd),
-          token,
-        );
-        if (
-          latest.authority === "stateless" &&
-          !latest.copilotInstalled &&
-          latest.target.markerPath === cursor.target.markerPath &&
-          latest.target.intentUuid === cursor.target.intentUuid &&
-          latest.stateSha256 === cursor.stateSha256 &&
-          latest.statePresent === cursor.statePresent
-        ) {
-          recordHookDrop(
-            pd,
-            "active-directive",
-            "stateless continuation marker publication contended; delivered without updating the marker",
-          );
-          writePrepared(prepared);
-          return;
-        }
-      } catch {
-        // Keep the coordination-busy refusal when authority cannot be rechecked.
-      }
-    }
     writePrepared(prepareEmission(errorDirective(
       "Continuation coordination is busy. This call did not commit a cursor change. Retry the current token; if it is reported superseded, run a fresh `next`.",
     )));

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.50";
+export const AIDLC_VERSION = "2.6.51";

--- a/docs/guide/harnesses/copilot.md
+++ b/docs/guide/harnesses/copilot.md
@@ -112,19 +112,16 @@ git checkout v2
   argv the shell will eventually produce. Direct-looking compounds are refused. An
   explicit `--project-dir` outside the current physical project is refused
   before current-project coordination is written.
-- **The engine owns continuation replay.** For an exact-context,
-  non-sessionless marker in a current installation whose authored
-  `tools/data/harness.json` names `copilot`, `continue` validates the native
-  token first, builds the successor, then atomically compares the full token
-  digest and publishes the successor before stdout. Concurrent uses have one
-  winner. Missing, malformed, v1, stale, and `sessionless:` markers retain the
-  existing stateless behavior. Replacing Copilot with another harness also
-  restores that harness's stateless behavior even if an old Copilot marker is
-  still present. On a stable non-Copilot installation, a contended marker
-  publication cannot deny a revalidated stateless continuation: the engine
-  returns the prepared directive and records the dropped best-effort marker
-  update instead. Replacing an installed harness while one of its commands is
-  executing is not a supported upgrade path.
+- **The engine owns continuation replay on every harness.** Copilot uses the
+  same record-local, atomic single-use cursor as Claude, Codex, Cursor, Kiro,
+  Kiro IDE, and opencode. Native token validation runs first; the engine then
+  compares the complete token SHA-256 and publishes the exact successor before
+  stdout under the active-directive lock. Copilot's session ownership and
+  delivery evidence enrich that marker but do not own replay. Missing,
+  malformed, v1, and pre-shared markers recover once inside the same
+  transaction; a fresh `next` resets the cursor. See the shared cursor contract
+  in the Developer Reference for crash, migration, rollback, and filesystem
+  limits.
 - **Stop preserves the current delivered Copilot directive.** An exact host
   `tool_use_id`, or the adapter ID carried through rewritten engine input and
   returned by PostToolUse, can settle delivery for session-scoped Stop and

--- a/docs/reference/06-hooks-and-tools.md
+++ b/docs/reference/06-hooks-and-tools.md
@@ -170,6 +170,90 @@ See [Sensor System](07-sensor-system.md) for the manifest schema and the fire li
 
 Marker writers serialize through a record-local `.aidlc-active-directive.lock/` whose owner stamp follows the audit-lock dead-owner, unstamped-grace, live-over-age, CAS-reclaim, and exit-cleanup conventions. The canonical marker remains readable while a writer prepares a sibling candidate, and publish, clear, and release are fenced to the exact acquisition token. A waiter or `/aidlc --doctor` CAS-reclaims stamped dead owners, safely fenced over-age owners, and lock directories that remain unstamped beyond the acquisition grace window. Legacy `.aidlc-active-directive.json.transaction` debris still requires quiescent manual recovery because it has no owner identity to reverify.
 
+#### Atomic continuation cursor
+
+The active-directive marker is also the authoritative single-use steering
+continuation cursor for every shipped harness. Cursor identity is the canonical
+project, active space/record path, intent UUID, complete state SHA-256 plus
+presence, and the installed harness name from
+`tools/data/harness.json`. Harness directories alone are not identities: Kiro
+and Kiro IDE share `.kiro`, while Copilot and opencode share `.aidlc`.
+New marker publications record the harness as `cursor_harness`; existing v2
+markers without that field remain readable for migration.
+
+`continue` first performs the unchanged native token checks: decode, MAC,
+state, and route validation. It then takes the existing active-directive lock,
+revalidates the target and state, hashes every byte of the complete presented
+token, and compares that digest with the validated complete current token in
+the marker. While still holding that lock it atomically replaces the cursor
+with the exact prepared successor: another complete `load-steering` token, or a
+tokenless `run-stage`. Only after rename and lock release does the engine write
+stdout. Two processes racing the same current token therefore have exactly one
+winner; later contenders see the successor and receive a stale-token error.
+
+Fresh `next` uses the same lock and must publish its first work directive before
+stdout on all harnesses. It is an explicit reset. Because steering tokens are
+deterministic, a reset may reauthorize the same token bytes: if `next` commits
+before a concurrent `continue`, that continuation may consume the reset token;
+if `continue` commits first, the later `next` supersedes its successor and
+restores the first directive. Commit order, not process start time, is
+authoritative. Marker contention produces an error directive and no
+unrecorded work directive.
+
+Crash and retry behavior:
+
+| Boundary | Cursor and retry |
+| --- | --- |
+| Before marker rename | The old token remains current. A dead owner is reclaimed by the existing lock reaper; retry the same token. |
+| After rename, before stdout | The successor is current and the old token is stale across restart. Run fresh `next` to rehydrate; the cursor is at-most-once, not exactly-once delivery. |
+| After stdout begins or completes | The successor is current. If receipt of the complete directive is uncertain, run fresh `next`; never replay the old token. |
+| Final `run-stage` | The marker carries no continuation token, so the final steering token is stale on every retry. |
+
+Compatibility recovery remains atomic. Missing, malformed, oversized, and v1
+markers permit one natively validated continuation to bootstrap and publish its
+successor under the lock; concurrent recovery callers then see that successor
+and lose. A pre-change v2 marker without `cursor_harness`, or one written by a
+different installed harness, migrates only when its exact project, intent,
+state, and current-token digest match. A mismatch is stale. Fresh `next` is the
+universal reset. Hook marker reads remain fail-open for their advisory purpose,
+and Post/host hooks may read or enrich delivery evidence but never authorize
+replay.
+
+Upgrade and rollback must be quiescent: replace the engine, library, hooks, and
+generated harness tree together while no AI-DLC command or hook is running.
+Run fresh `next` after upgrade, rollback, or re-upgrade unless intentionally
+migrating a matching in-flight token. Older releases ignore
+`cursor_harness`, but rolling back restores their historical sessionless
+replay behavior until the fixed release is reinstalled. Mixed old/new tool
+files are unsupported.
+
+The exactly-one-winner claim requires one local filesystem with coherent
+cross-process visibility, exclusive directory creation, stable regular-file
+reads, and atomic same-filesystem rename for the marker and lock paths.
+NFS/SMB/FUSE/object-synchronized folders that do not honor those primitives
+are unsupported. The implementation does not `fsync` the candidate or parent
+directory, so sudden power-loss durability is outside the claim.
+
+Harness-specific residuals remain outside cursor authority. Pre-state
+continuations use the same cursor under the active space's `bare-space` bucket,
+with `state_present: false`, `intent_uuid: null`, and the SHA-256 of empty state.
+They therefore retain the same one-winner guarantee before an intent exists.
+
+| Harness | Residual host behavior |
+| --- | --- |
+| Claude | Stop retention, transcript reading, compaction, and session ownership remain hook-owned. |
+| Codex | Resume, compaction, and delivery behavior remain Codex-owned; the cursor creates no host correlation. |
+| Copilot | Adapter claims, Post settlement, Resume, ownership, conversation, delivery evidence, and Stop counts remain Copilot-only marker enrichment. |
+| Cursor | Hook correlation and subagent ledgers remain advisory and cannot authorize replay. |
+| Kiro CLI | Transcript-free Stop/conversation markers remain hook-owned. |
+| Kiro IDE | Modern and legacy IDE event/session differences remain adapter-owned. |
+| opencode | Plugin and session lifecycle evidence remains host-specific and read-only for replay. |
+
+The cursor guarantees one successful token consumption. It does not guarantee
+exactly-once `run-stage`, `report`, or `park` execution and does not change
+Cancel, prompt, compaction, TUI, Stop retention, Resume, ownership,
+conversation, or count semantics.
+
 ### PostToolUse: rebuild-stage-graph.ts
 
 **Source:** `.claude/hooks/aidlc-rebuild-stage-graph.ts`

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -20,9 +20,9 @@
     "render-surface": "tui"
   },
   "counts": {
-    "total": 607,
+    "total": 606,
     "enumeratedByClass": {
-      "function": 345,
+      "function": 344,
       "audit": 86,
       "scope": 11,
       "stage": 33,
@@ -1069,7 +1069,7 @@
     },
     {
       "unitClass": "function",
-      "unitId": "function:advanceCopilotContinuation",
+      "unitId": "function:advanceContinuationCursor",
       "minMechanism": "none",
       "coveredBy": [
         {
@@ -1566,13 +1566,6 @@
         }
       ],
       "status": "covered"
-    },
-    {
-      "unitClass": "function",
-      "unitId": "function:copilotDirectiveCommitRequired",
-      "minMechanism": "none",
-      "coveredBy": [],
-      "status": "UNCOVERED"
     },
     {
       "unitClass": "function",
@@ -2190,7 +2183,7 @@
     },
     {
       "unitClass": "function",
-      "unitId": "function:inspectCopilotContinuation",
+      "unitId": "function:inspectContinuationCursor",
       "minMechanism": "none",
       "coveredBy": [
         {

--- a/tests/unit/t248-steering-content-delivery.test.ts
+++ b/tests/unit/t248-steering-content-delivery.test.ts
@@ -379,7 +379,7 @@ describe("t248 deterministic steering delivery", () => {
     expect(otherKey).not.toBe(encodedKey);
   });
 
-  test("sessionless continuation remains deliberately stateless for the same token", () => {
+  test("sessionless continuation consumes the same token exactly once", () => {
     const proj = setupIntegrationProject({ withState: "state-brownfield-feature.md" });
     projects.push(proj);
     const orgPath = join(proj, "aidlc", "spaces", "default", "memory", "org.md");
@@ -393,10 +393,13 @@ describe("t248 deterministic steering delivery", () => {
     const token = first.continue_token ?? "";
     const once = invoke(proj, "continue", [token]).directive;
     const twice = invoke(proj, "continue", [token]).directive;
-    expect(twice).toEqual(once);
+    expect(once.kind).not.toBe("error");
+    expect(twice.kind).toBe("error");
+    expect(twice.message).toContain("no longer current");
     const marker = JSON.parse(
       readFileSync(join(seededRecordDir(proj), ".aidlc-active-directive.json"), "utf-8"),
-    ) as { owner_session?: string };
+    ) as { cursor_harness?: string; owner_session?: string };
+    expect(marker.cursor_harness).toBe("claude");
     expect(marker.owner_session).toStartWith("sessionless:");
   });
 

--- a/tests/unit/t283-copilot-engine-cursor.test.ts
+++ b/tests/unit/t283-copilot-engine-cursor.test.ts
@@ -1,8 +1,17 @@
-// covers: function:inspectCopilotContinuation, function:advanceCopilotContinuation, subcommand:aidlc-orchestrate:continue
+// covers: function:inspectContinuationCursor, function:advanceContinuationCursor, subcommand:aidlc-orchestrate:continue
 
 import { createHash, randomUUID } from "node:crypto";
 import { afterAll, describe, expect, test } from "bun:test";
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import {
   cleanupTestProject,
@@ -14,60 +23,200 @@ import {
 const BUN = process.execPath;
 const projects: string[] = [];
 
-type Directive = { kind: string; continue_token?: string; message?: string };
+const HARNESSES = [
+  { name: "claude", dir: ".claude" },
+  { name: "codex", dir: ".codex" },
+  { name: "copilot", dir: ".aidlc" },
+  { name: "cursor", dir: ".cursor" },
+  { name: "kiro", dir: ".kiro" },
+  { name: "kiro-ide", dir: ".kiro" },
+  { name: "opencode", dir: ".aidlc" },
+] as const;
 
-function installHarness(proj: string, harness: "copilot" | "opencode"): void {
-  cpSync(join(REPO_ROOT, "dist", harness, ".aidlc"), join(proj, ".aidlc"), { recursive: true });
-  cpSync(join(REPO_ROOT, "core", "tools", "aidlc-lib.ts"), join(proj, ".aidlc", "tools", "aidlc-lib.ts"));
-  cpSync(join(REPO_ROOT, "core", "tools", "aidlc-orchestrate.ts"), join(proj, ".aidlc", "tools", "aidlc-orchestrate.ts"));
+type Harness = (typeof HARNESSES)[number];
+type Directive = {
+  kind: string;
+  continue_token?: string;
+  message?: string;
+};
+
+interface InstalledProject {
+  dir: string;
+  harness: Harness;
+  tool: string;
+  markerPath: string;
 }
 
-function project(): string {
-  const proj = setupIntegrationProject({ withState: "state-brownfield-feature.md" });
-  projects.push(proj);
-  installHarness(proj, "copilot");
-  const org = join(proj, "aidlc", "spaces", "default", "memory", "org.md");
+function installHarness(proj: string, harness: Harness): string {
+  const destination = join(proj, harness.dir);
+  rmSync(destination, { recursive: true, force: true });
+  cpSync(join(REPO_ROOT, "dist", harness.name, harness.dir), destination, {
+    recursive: true,
+  });
+  cpSync(
+    join(REPO_ROOT, "core", "tools", "aidlc-lib.ts"),
+    join(destination, "tools", "aidlc-lib.ts"),
+  );
+  cpSync(
+    join(REPO_ROOT, "core", "tools", "aidlc-orchestrate.ts"),
+    join(destination, "tools", "aidlc-orchestrate.ts"),
+  );
+  return join(destination, "tools", "aidlc-orchestrate.ts");
+}
+
+function project(
+  harness: Harness,
+  options: { withState?: boolean } = {},
+): InstalledProject {
+  const withState = options.withState ?? true;
+  const dir = setupIntegrationProject(
+    withState
+      ? { withState: "state-brownfield-feature.md" }
+      : { noAidlcDocs: true },
+  );
+  projects.push(dir);
+  const tool = installHarness(dir, harness);
+  const org = join(
+    dir,
+    "aidlc",
+    "spaces",
+    "default",
+    "memory",
+    "org.md",
+  );
   writeFileSync(
     org,
-    Array.from({ length: 180 }, (_, i) => `## Cursor ${i}\n\n${"x".repeat(320)}\n\n`).join(""),
+    Array.from(
+      { length: 180 },
+      (_, i) => `## Cursor ${i}\n\n${"x".repeat(320)}\n\n`,
+    ).join(""),
     "utf-8",
   );
-  return proj;
+  return {
+    dir,
+    harness,
+    tool,
+    markerPath: withState
+      ? join(seededRecordDir(dir), ".aidlc-active-directive.json")
+      : join(
+          dir,
+          "aidlc",
+          "spaces",
+          "default",
+          "intents",
+          ".aidlc-active-directive.json",
+        ),
+  };
 }
 
 afterAll(() => {
   for (const proj of projects) cleanupTestProject(proj);
-});
+}, 30000);
+
+function command(
+  installed: InstalledProject,
+  verb: "next" | "continue",
+  arg?: string | string[],
+): string[] {
+  return [
+    BUN,
+    installed.tool,
+    verb,
+    ...(verb === "continue"
+      ? [typeof arg === "string" ? arg : ""]
+      : Array.isArray(arg)
+        ? arg
+        : []),
+    "--project-dir",
+    installed.dir,
+  ];
+}
 
 function invoke(
-  proj: string,
+  installed: InstalledProject,
+  verb: "next" | "continue",
+  arg?: string | string[],
+  env: Record<string, string> = {},
+): { directive: Directive; stdout: string; stderr: string } {
+  const proc = Bun.spawnSync(command(installed, verb, arg), {
+    cwd: installed.dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+  const stdout = proc.stdout.toString().trim();
+  const stderr = proc.stderr.toString();
+  expect(proc.exitCode, stderr).toBe(0);
+  return {
+    directive: JSON.parse(stdout) as Directive,
+    stdout,
+    stderr,
+  };
+}
+
+async function invokeAsync(
+  installed: InstalledProject,
   verb: "next" | "continue",
   arg?: string,
   env: Record<string, string> = {},
-): { directive: Directive; stdout: string } {
-  const proc = Bun.spawnSync([
-    BUN,
-    join(proj, ".aidlc", "tools", "aidlc-orchestrate.ts"),
-    verb,
-    ...(verb === "continue" ? [arg ?? ""] : []),
-    "--project-dir",
-    proj,
-  ], { cwd: proj, stdout: "pipe", stderr: "pipe", env: { ...process.env, ...env } });
-  const stdout = proc.stdout.toString().trim();
-  expect(proc.exitCode, proc.stderr.toString()).toBe(0);
-  return { directive: JSON.parse(stdout) as Directive, stdout };
+): Promise<{ code: number; directive: Directive; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(command(installed, verb, arg), {
+    cwd: installed.dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, ...env },
+  });
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return {
+    code,
+    directive: JSON.parse(stdout.trim()) as Directive,
+    stdout,
+    stderr,
+  };
 }
 
-function markerPath(proj: string): string {
-  return join(seededRecordDir(proj), ".aidlc-active-directive.json");
+function markerPath(proj: InstalledProject): string {
+  return proj.markerPath;
 }
 
-function marker(proj: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(markerPath(proj), "utf-8")) as Record<string, unknown>;
+function marker(proj: InstalledProject): Record<string, unknown> {
+  return JSON.parse(readFileSync(markerPath(proj), "utf-8")) as Record<
+    string,
+    unknown
+  >;
 }
 
-function makeCopilotOwned(proj: string): void {
-  const value = marker(proj);
+function tokenSha256(token: string): string {
+  return createHash("sha256").update(token, "utf-8").digest("hex");
+}
+
+function isStale(directive: Directive): boolean {
+  return directive.kind === "error" &&
+    directive.message?.includes("no longer current") === true;
+}
+
+function assertMarkerMatchesDirective(
+  installed: InstalledProject,
+  directive: Directive,
+): void {
+  const value = marker(installed);
+  expect(value.kind).toBe(directive.kind);
+  if (directive.kind === "load-steering") {
+    expect(value.continue_token_sha256).toBe(
+      tokenSha256(directive.continue_token ?? ""),
+    );
+  } else {
+    expect(value).not.toHaveProperty("continue_token");
+    expect(value).not.toHaveProperty("continue_token_sha256");
+  }
+}
+
+function makeCopilotOwned(installed: InstalledProject): void {
+  const value = marker(installed);
   const stateSha256 = String(value.state_sha256);
   value.owner_session = "cursor-owner";
   value.owner_epoch = 1;
@@ -83,193 +232,358 @@ function makeCopilotOwned(proj: string): void {
     context_epoch: value.context_epoch,
     status: "settled",
   };
-  writeFileSync(markerPath(proj), `${JSON.stringify(value, null, 2)}\n`, "utf-8");
+  writeFileSync(
+    markerPath(installed),
+    `${JSON.stringify(value, null, 2)}\n`,
+    "utf-8",
+  );
 }
 
-describe("t283 Copilot-owned engine continuation cursor", () => {
-  test("two real same-token processes have exactly one winner and one marker publication", async () => {
-    const proj = project();
-    const first = invoke(proj, "next").directive;
+describe("t283 engine-owned continuation cursor", () => {
+  test("pre-state tokens use the bare-space cursor and have one race winner", async () => {
+    const installed = project(HARNESSES[0], { withState: false });
+    const first = invoke(installed, "next", [
+      "--stage",
+      "requirements-analysis",
+      "--scope",
+      "feature",
+    ]).directive;
     expect(first.kind).toBe("load-steering");
-    makeCopilotOwned(proj);
+    expect(marker(installed)).toMatchObject({
+      version: 2,
+      state_present: false,
+      intent_uuid: null,
+      cursor_harness: "claude",
+    });
     const token = first.continue_token ?? "";
-    const beforeRevision = Number(marker(proj).revision);
-    const procs = Array.from({ length: 2 }, () => Bun.spawn([
-      BUN, join(proj, ".aidlc", "tools", "aidlc-orchestrate.ts"), "continue", token, "--project-dir", proj,
-    ], { cwd: proj, stdout: "pipe", stderr: "pipe" }));
-    const [codes, outputs, errors] = await Promise.all([
-      Promise.all(procs.map((proc) => proc.exited)),
-      Promise.all(procs.map((proc) => new Response(proc.stdout).text())),
-      Promise.all(procs.map((proc) => new Response(proc.stderr).text())),
+
+    const results = await Promise.all([
+      invokeAsync(installed, "continue", token),
+      invokeAsync(installed, "continue", token),
     ]);
-    expect(codes, errors.join("\n")).toEqual([0, 0]);
-    const directives = outputs.map((output) => JSON.parse(output.trim()) as Directive);
-    expect(directives.filter((directive) => directive.kind !== "error")).toHaveLength(1);
-    expect(directives.filter((directive) => directive.message?.includes("no longer current"))).toHaveLength(1);
-    expect(marker(proj).revision).toBe(beforeRevision + 1);
-    expect(marker(proj).continue_token_sha256).not.toBe(createHash("sha256").update(token).digest("hex"));
+
+    expect(results.map((result) => result.code)).toEqual([0, 0]);
+    expect(results.filter((result) => result.directive.kind !== "error"))
+      .toHaveLength(1);
+    expect(results.filter((result) => isStale(result.directive))).toHaveLength(
+      1,
+    );
+  });
+
+  test("all shipped harnesses consume one current token exactly once", () => {
+    for (const harness of HARNESSES) {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
+      expect(first.kind, harness.name).toBe("load-steering");
+      const token = first.continue_token ?? "";
+
+      const once = invoke(installed, "continue", token).directive;
+      const twice = invoke(installed, "continue", token).directive;
+
+      expect(once.kind, harness.name).not.toBe("error");
+      expect(isStale(twice), harness.name).toBe(true);
+      expect(marker(installed).cursor_harness, harness.name).toBe(harness.name);
+      expect(marker(installed).needs_rehydrate, harness.name).toBe(false);
+      assertMarkerMatchesDirective(installed, once);
+    }
+  }, 60000);
+
+  test("two real processes racing one token have exactly one winner on every harness", async () => {
+    for (const harness of HARNESSES) {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
+      const token = first.continue_token ?? "";
+      const beforeRevision = Number(marker(installed).revision);
+
+      const results = await Promise.all([
+        invokeAsync(installed, "continue", token),
+        invokeAsync(installed, "continue", token),
+      ]);
+
+      expect(results.map((result) => result.code), harness.name).toEqual([0, 0]);
+      expect(
+        results.filter((result) => result.directive.kind !== "error"),
+        harness.name,
+      ).toHaveLength(1);
+      expect(
+        results.filter((result) => isStale(result.directive)),
+        harness.name,
+      ).toHaveLength(1);
+      expect(marker(installed).revision, harness.name).toBe(beforeRevision + 1);
+      expect(marker(installed).continue_token_sha256, harness.name).not.toBe(
+        tokenSha256(token),
+      );
+    }
+  }, 60000);
+
+  test("Copilot session-owned markers use the same one-winner cursor", async () => {
+    const harness = HARNESSES.find((entry) => entry.name === "copilot")!;
+    const installed = project(harness);
+    const first = invoke(installed, "next").directive;
+    makeCopilotOwned(installed);
+    const token = first.continue_token ?? "";
+
+    const results = await Promise.all([
+      invokeAsync(installed, "continue", token),
+      invokeAsync(installed, "continue", token),
+    ]);
+
+    expect(results.filter((result) => result.directive.kind !== "error"))
+      .toHaveLength(1);
+    expect(results.filter((result) => isStale(result.directive))).toHaveLength(
+      1,
+    );
+    expect(marker(installed).owner_session).toBe("cursor-owner");
+  });
+
+  test("every delivered token advances once and final run-stage is tokenless", () => {
+    for (const harness of HARNESSES) {
+      const installed = project(harness);
+      let directive = invoke(installed, "next").directive;
+      let consumed = 0;
+
+      while (directive.kind === "load-steering") {
+        const token = directive.continue_token ?? "";
+        const successor = invoke(installed, "continue", token).directive;
+        const replay = invoke(installed, "continue", token).directive;
+        expect(successor.kind, harness.name).not.toBe("error");
+        expect(isStale(replay), harness.name).toBe(true);
+        directive = successor;
+        consumed += 1;
+        expect(consumed, harness.name).toBeLessThan(100);
+      }
+
+      expect(directive.kind, harness.name).toBe("run-stage");
+      expect(marker(installed).kind, harness.name).toBe("run-stage");
+      expect(marker(installed), harness.name).not.toHaveProperty(
+        "continue_token",
+      );
+      expect(marker(installed), harness.name).not.toHaveProperty(
+        "continue_token_sha256",
+      );
+    }
+  }, 60000);
+
+  test("missing, malformed, oversized, v1, legacy, and migrated markers recover once", async () => {
+    const harness = HARNESSES[0];
+    for (
+      const shape of [
+        "missing",
+        "malformed",
+        "oversized",
+        "v1",
+        "legacy-v2",
+        "migrated-harness",
+      ] as const
+    ) {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
+      const token = first.continue_token ?? "";
+      const current = marker(installed);
+
+      if (shape === "missing") rmSync(markerPath(installed));
+      if (shape === "malformed") {
+        writeFileSync(markerPath(installed), "{bad-json\n", "utf-8");
+      }
+      if (shape === "oversized") {
+        writeFileSync(
+          markerPath(installed),
+          `{"padding":"${"x".repeat(80 * 1024)}"}\n`,
+          "utf-8",
+        );
+      }
+      if (shape === "v1") {
+        writeFileSync(
+          markerPath(installed),
+          `${JSON.stringify({
+            version: 1,
+            stage: current.stage,
+            state_sha256: current.state_sha256,
+          })}\n`,
+          "utf-8",
+        );
+      }
+      if (shape === "legacy-v2") {
+        delete current.cursor_harness;
+        writeFileSync(
+          markerPath(installed),
+          `${JSON.stringify(current, null, 2)}\n`,
+          "utf-8",
+        );
+      }
+      if (shape === "migrated-harness") {
+        current.cursor_harness = "codex";
+        writeFileSync(
+          markerPath(installed),
+          `${JSON.stringify(current, null, 2)}\n`,
+          "utf-8",
+        );
+      }
+
+      const results = await Promise.all([
+        invokeAsync(installed, "continue", token),
+        invokeAsync(installed, "continue", token),
+      ]);
+      expect(
+        results.filter((result) => result.directive.kind !== "error"),
+        shape,
+      ).toHaveLength(1);
+      expect(
+        results.filter((result) => isStale(result.directive)),
+        shape,
+      ).toHaveLength(1);
+      expect(marker(installed).cursor_harness, shape).toBe("claude");
+    }
+  }, 60000);
+
+  test("fresh next and continue serialize in both lock orders", async () => {
+    const harness = HARNESSES[0];
+
+    {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
+      const token = first.continue_token ?? "";
+      const beforeRevision = Number(marker(installed).revision);
+      const continueResult = invoke(installed, "continue", token);
+      const nextResult = invoke(installed, "next");
+
+      expect(continueResult.directive.kind).not.toBe("error");
+      expect(nextResult.directive.kind).toBe("load-steering");
+      expect(marker(installed).revision).toBe(beforeRevision + 2);
+      assertMarkerMatchesDirective(installed, nextResult.directive);
+    }
+
+    {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
+      const token = first.continue_token ?? "";
+      const beforeRevision = Number(marker(installed).revision);
+      const nextResult = invoke(installed, "next");
+      const continueResult = invoke(installed, "continue", token);
+
+      expect(nextResult.directive.kind).toBe("load-steering");
+      expect(nextResult.directive.continue_token).toBe(token);
+      expect(continueResult.directive.kind).not.toBe("error");
+      expect(marker(installed).revision).toBe(beforeRevision + 2);
+      assertMarkerMatchesDirective(installed, continueResult.directive);
+    }
+
+    {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
+      const token = first.continue_token ?? "";
+      const lockDir = join(
+        seededRecordDir(installed.dir),
+        ".aidlc-active-directive.lock",
+      );
+      const lockToken = randomUUID();
+      mkdirSync(join(lockDir, lockToken), { recursive: true });
+      writeFileSync(
+        join(lockDir, "owner.json"),
+        JSON.stringify({
+          pid: process.pid,
+          startedAtMs: Math.floor(performance.timeOrigin + performance.now()),
+          reapLiveOwnerAfterStale: true,
+          token: lockToken,
+        }),
+      );
+
+      // The mixed-process race above proves a pre-lock validation is checked
+      // again after acquisition. Here a real waiter survives a live hold and
+      // succeeds after the owner releases within the bounded retry window.
+      const continued = invokeAsync(installed, "continue", token);
+      await Bun.sleep(100);
+      rmSync(lockDir, { recursive: true, force: true });
+      const result = await continued;
+
+      expect(result.code, result.stderr).toBe(0);
+      expect(result.directive.kind).not.toBe("error");
+      assertMarkerMatchesDirective(installed, result.directive);
+    }
   }, 30000);
 
-  test("an old Copilot marker becomes stateless after a real OpenCode install replaces Copilot", () => {
-    const proj = project();
-    const first = invoke(proj, "next").directive;
-    expect(first.kind).toBe("load-steering");
-    makeCopilotOwned(proj);
-    const token = first.continue_token ?? "";
-    installHarness(proj, "opencode");
-    const before = readFileSync(markerPath(proj), "utf-8");
-    const lockDir = join(seededRecordDir(proj), ".aidlc-active-directive.lock");
-    const lockToken = randomUUID();
-    mkdirSync(join(lockDir, lockToken), { recursive: true });
+  test("fresh next emits no work directive when cursor reset publication contends", () => {
+    const installed = project(HARNESSES[0]);
+    invoke(installed, "next");
+    const before = readFileSync(markerPath(installed), "utf-8");
+    const lockDir = join(
+      seededRecordDir(installed.dir),
+      ".aidlc-active-directive.lock",
+    );
+    const token = randomUUID();
+    mkdirSync(join(lockDir, token), { recursive: true });
     writeFileSync(
       join(lockDir, "owner.json"),
       JSON.stringify({
         pid: process.pid,
         startedAtMs: Math.floor(performance.timeOrigin + performance.now()),
         reapLiveOwnerAfterStale: true,
-        token: lockToken,
+        token,
       }),
     );
-    const once = invoke(proj, "continue", token).directive;
-    const twice = invoke(proj, "continue", token).directive;
-    expect(once.kind).not.toBe("error");
-    expect(twice).toEqual(once);
-    expect(readFileSync(markerPath(proj), "utf-8")).toBe(before);
-    expect(existsSync(lockDir)).toBe(true);
-  }, 30000);
 
-  test("fresh Copilot next emits no work directive when cursor reset publication contends", () => {
-    const proj = project();
-    invoke(proj, "next");
-    makeCopilotOwned(proj);
-    const before = readFileSync(markerPath(proj), "utf-8");
-    const lockDir = join(seededRecordDir(proj), ".aidlc-active-directive.lock");
-    const token = randomUUID();
-    const now = Math.floor(performance.timeOrigin + performance.now());
-    const owner = { pid: process.pid, startedAtMs: now, reapLiveOwnerAfterStale: true, token };
-    mkdirSync(join(lockDir, token), { recursive: true });
-    writeFileSync(join(lockDir, "owner.json"), JSON.stringify(owner));
-    const blocked = invoke(proj, "next").directive;
-    expect(blocked).toMatchObject({ kind: "error" });
+    const blocked = invoke(installed, "next").directive;
+
+    expect(blocked.kind).toBe("error");
     expect(blocked.message).toContain("no work directive was issued");
-    expect(readFileSync(markerPath(proj), "utf-8")).toBe(before);
+    expect(blocked.message).toContain("Retry the command");
+    expect(blocked.message).not.toContain("Retry `next`");
+    expect(readFileSync(markerPath(installed), "utf-8")).toBe(before);
     expect(existsSync(lockDir)).toBe(true);
-  }, 10000);
+  });
 
-  test("missing, malformed, and v1 markers keep the existing stateless path", () => {
-    for (const shape of ["missing", "malformed", "v1"] as const) {
-      const proj = project();
-      const first = invoke(proj, "next").directive;
+  test("crash boundaries preserve retry cardinality without production test seams", () => {
+    const harness = HARNESSES[0];
+
+    {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
       const token = first.continue_token ?? "";
-      if (shape === "missing") rmSync(markerPath(proj));
-      if (shape === "malformed") writeFileSync(markerPath(proj), "{bad-json\n", "utf-8");
-      if (shape === "v1") {
-        const current = marker(proj);
-        writeFileSync(markerPath(proj), `${JSON.stringify({
-          version: 1,
-          stage: current.stage,
-          state_sha256: current.state_sha256,
-        })}\n`, "utf-8");
-      }
-      const continued = invoke(proj, "continue", token).directive;
-      expect(continued.kind, shape).not.toBe("error");
+      const before = readFileSync(markerPath(installed), "utf-8");
+      const lockDir = join(
+        seededRecordDir(installed.dir),
+        ".aidlc-active-directive.lock",
+      );
+      const lockToken = randomUUID();
+      mkdirSync(join(lockDir, lockToken), { recursive: true });
+      writeFileSync(
+        join(lockDir, "owner.json"),
+        JSON.stringify({
+          pid: 2_000_000_000,
+          startedAtMs: 0,
+          reapLiveOwnerAfterStale: true,
+          token: lockToken,
+        }),
+      );
+      expect(readFileSync(markerPath(installed), "utf-8")).toBe(before);
+      const retried = invoke(installed, "continue", token).directive;
+      expect(retried.kind).not.toBe("error");
+      expect(existsSync(lockDir)).toBe(false);
+      expect(isStale(invoke(installed, "continue", token).directive)).toBe(true);
     }
-  }, 30000);
 
-  test("a Copilot sessionless marker keeps the existing stateless replay behavior", () => {
-    const proj = project();
-    const first = invoke(proj, "next").directive;
-    expect(first.kind).toBe("load-steering");
-    expect(String(marker(proj).owner_session)).toStartWith("sessionless:");
-    const once = invoke(
-      proj,
-      "continue",
-      first.continue_token ?? "",
-    ).directive;
-    const twice = invoke(
-      proj,
-      "continue",
-      first.continue_token ?? "",
-    ).directive;
-    expect(once.kind).not.toBe("error");
-    expect(twice).toEqual(once);
-  }, 10000);
+    {
+      const installed = project(harness);
+      const first = invoke(installed, "next").directive;
+      const token = first.continue_token ?? "";
+      const before = readFileSync(markerPath(installed), "utf-8");
+      const roFd = openSync(markerPath(installed), "r");
+      const failed = (() => {
+        try {
+          return Bun.spawnSync(command(installed, "continue", token), {
+            cwd: installed.dir,
+            stdout: roFd,
+            stderr: "pipe",
+          });
+        } finally {
+          closeSync(roFd);
+        }
+      })();
 
-  test("an oversized marker is rejected as absent and cannot deny stateless continuation", () => {
-    const proj = project();
-    const first = invoke(proj, "next").directive;
-    expect(first.kind).toBe("load-steering");
-    writeFileSync(
-      markerPath(proj),
-      `{"padding":"${"x".repeat(80 * 1024)}"}\n`,
-      "utf-8",
-    );
-    const once = invoke(proj, "continue", first.continue_token ?? "").directive;
-    expect(once.kind).not.toBe("error");
-    const republished = readFileSync(markerPath(proj), "utf-8");
-    expect(Buffer.byteLength(republished, "utf-8")).toBeLessThanOrEqual(64 * 1024);
-    const value = JSON.parse(republished) as { kind?: string; owner_session?: string };
-    expect(value.kind).toBe(once.kind);
-    expect(String(value.owner_session)).toStartWith("sessionless:");
-  }, 10000);
-
-  test("a real dead lock owner is reclaimed while the canonical marker stays readable", async () => {
-    const proj = project();
-    const first = invoke(proj, "next").directive;
-    makeCopilotOwned(proj);
-    const before = readFileSync(markerPath(proj), "utf-8");
-    const lockDir = join(seededRecordDir(proj), ".aidlc-active-directive.lock");
-    const ready = join(proj, `.cursor-lock-ready-${randomUUID()}`);
-    const holder = join(proj, `.cursor-lock-holder-${randomUUID()}.ts`);
-    writeFileSync(holder, [
-      'import { mkdirSync, writeFileSync } from "node:fs";',
-      'import { join } from "node:path";',
-      `const lockDir = ${JSON.stringify(lockDir)};`,
-      `const token = ${JSON.stringify(randomUUID())};`,
-      "mkdirSync(lockDir, { mode: 0o700 });",
-      "writeFileSync(join(lockDir, 'owner.json'), JSON.stringify({ pid: process.pid, startedAtMs: Math.floor(performance.timeOrigin + performance.now()), reapLiveOwnerAfterStale: true, token }));",
-      "mkdirSync(join(lockDir, token), { mode: 0o700 });",
-      `writeFileSync(${JSON.stringify(ready)}, 'ready');`,
-      "await Bun.sleep(30000);",
-    ].join("\n"));
-    const proc = Bun.spawn([BUN, holder], { cwd: proj, stdout: "pipe", stderr: "pipe" });
-    for (let i = 0; i < 200 && !existsSync(ready); i++) await Bun.sleep(10);
-    expect(existsSync(ready)).toBe(true);
-    expect(readFileSync(markerPath(proj), "utf-8")).toBe(before);
-    proc.kill(9);
-    await proc.exited;
-    const recovered = invoke(proj, "continue", first.continue_token ?? "").directive;
-    expect(recovered.kind).not.toBe("error");
-    expect(existsSync(lockDir)).toBe(false);
-  }, 30000);
-
-  test("a process killed before owner stamping is reclaimed after the unstamped grace", async () => {
-    const proj = project();
-    const first = invoke(proj, "next").directive;
-    makeCopilotOwned(proj);
-    const before = readFileSync(markerPath(proj), "utf-8");
-    const lockDir = join(seededRecordDir(proj), ".aidlc-active-directive.lock");
-    const ready = join(proj, `.unstamped-lock-ready-${randomUUID()}`);
-    const holder = join(proj, `.unstamped-lock-holder-${randomUUID()}.ts`);
-    const acquisitionToken = randomUUID();
-    writeFileSync(holder, [
-      'import { mkdirSync, writeFileSync } from "node:fs";',
-      `mkdirSync(${JSON.stringify(lockDir)}, { mode: 0o700 });`,
-      `mkdirSync(${JSON.stringify(join(lockDir, acquisitionToken))}, { mode: 0o700 });`,
-      `writeFileSync(${JSON.stringify(ready)}, "ready");`,
-      "await Bun.sleep(30000);",
-    ].join("\n"));
-    const proc = Bun.spawn([BUN, holder], { cwd: proj, stdout: "pipe", stderr: "pipe" });
-    for (let i = 0; i < 200 && !existsSync(ready); i++) await Bun.sleep(10);
-    expect(existsSync(ready)).toBe(true);
-    expect(readFileSync(markerPath(proj), "utf-8")).toBe(before);
-    proc.kill(9);
-    await proc.exited;
-    await Bun.sleep(5);
-    const recovered = invoke(proj, "continue", first.continue_token ?? "", {
-      AIDLC_LOCK_UNSTAMPED_GRACE_MS: "1",
-    }).directive;
-    expect(recovered.kind).not.toBe("error");
-    expect(existsSync(lockDir)).toBe(false);
+      expect(failed.exitCode).not.toBe(0);
+      expect(readFileSync(markerPath(installed), "utf-8")).not.toBe(before);
+      expect(isStale(invoke(installed, "continue", token).directive)).toBe(true);
+      expect(invoke(installed, "next").directive.kind).toBe("load-steering");
+    }
   }, 30000);
 });


### PR DESCRIPTION
Closes #762 — the required follow-up accepted during PR #749 review.

## What

Continuation tokens are now **single-use on every harness** — Claude, Codex, Copilot, Cursor, Kiro CLI, Kiro IDE, and opencode share one engine-owned, crash-safe continuation cursor stored in the existing `.aidlc-active-directive.json` marker and serialized by the existing `.aidlc-active-directive.lock/`. This closes the deliberate sessionless same-token replay carve-out from PR #749.

- `continue` keeps all native token validation (decode, MAC, state, route), then — inside the active-directive transaction — compares the SHA-256 of the complete presented token with the persisted current token and atomically publishes the exact successor (or a tokenless `run-stage`) **before stdout**. Replaying a consumed token returns an error directive; concurrent uses of one token have exactly one winner.
- Fresh `next` is an explicit cursor reset and must commit its first directive before emitting on every harness; the previous non-Copilot fail-open publication path is removed. Publication failure/contention yields an error directive and no work directive.
- Cursor identity = canonical project, active record, intent UUID, complete state digest + presence, and the installed harness name (`tools/data/harness.json`), recorded as a new optional `cursor_harness` field on marker v2. Harness *directories* are not identities (Kiro/Kiro IDE share `.kiro`; Copilot/opencode share `.aidlc`).
- Missing, malformed, oversized, v1, and cross-harness markers permit exactly one natively validated recovery continuation under the same transaction; a mismatched token is stale, not a bootstrap opportunity. Pre-upgrade markers migrate on the first matching `continue` or fresh `next`.
- Copilot claim/settlement/Resume/ownership/Stop-count semantics remain host-owned marker enrichment and do not own replay (issue AC 10/12).

## Behavior change

Presenting the same continuation token twice now errors with "This continuation token is no longer current for this workflow. Run a fresh `next`" instead of repeating the successor directive. Recovery is always a fresh `next`.

**Upgrade:** replace the whole `dist/<harness>/` shell in one quiescent swap, then run a fresh `next` (a matching in-flight token migrates atomically). **Rollback** restores the older release's sessionless replay behavior until re-upgraded. Full crash/retry matrix, migration, rollback, filesystem requirements, and per-harness residual limits are documented in the new "Atomic continuation cursor" section of `docs/reference/06-hooks-and-tools.md`.

## Tests

`t283` was rewritten from a Copilot-only cursor test into a production-path matrix that drives the real packaged engine as separate processes against all seven installed harness trees (real `harness.json` identities), with **no test seams in production code**:

- same-token exactly-once consumption per harness; full walk to the final tokenless `run-stage`
- two real processes racing one token — exactly one winner, per harness (+ Copilot session-owned variant)
- missing/malformed/oversized/v1/legacy-v2/migrated-harness recovery — exactly one winner
- both fresh-`next`/`continue` commit orders (deterministic reset token bytes pinned) + a real waiter surviving a live lock hold
- crash boundaries: fabricated dead-owner lock (production reaper reclaim) and committed-but-stdout-failed (read-only fd → EBADF after the marker rename)
- `t248` inverts the old regression that pinned sessionless replay, now pinning single-use + `cursor_harness`

Evidence: full deterministic tiers (smoke+unit+integration) green — 340 files, 8292 assertions, 0 failures — plus `bun scripts/package.ts --check`, `bun run typecheck`, `bun run check`, and the t68 version/changelog pin. Validated independently twice (author run + conductor re-run). Deterministic e2e + live-harness slices to run as the pre-merge gate on this PR.

## Non-goals (per issue)

No change to Stop retention, Resume, ownership, compaction, conversation, or count semantics; no exactly-once `run-stage`/`report`/`park` execution claim; the pre-existing no-state-file markerless-continuation branch is documented as a residual limit, not changed.
