### PR TITLE
fix: compile rejects duplicate producers for a consumed artifact (2.6.65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.65] - 2026-08-23
+
+Stage graph compilation now rejects ambiguous producers before consumers can resolve an artifact by file order. **Upgrade:** refresh your `dist/<harness>/` shell; existing custom stages or plugins that declare the same consumed artifact in `produces` or `optional_produces` must rename one output or update the consumer.
+
+* `aidlc-graph compile` now reports `Duplicate producers for consumed artifact`, naming every producing stage file and slug plus one consuming stage.
+* Shared artifact names remain valid when no stage consumes them, including the shipped multi-stage `traceability` output pattern.
+
 ## [2.6.64] - 2026-08-23
 
 The Kiro IDE distribution now ships only IDE-native agent and permission surfaces. **Upgrade:** re-copy `dist/kiro-ide/` into your project, then remove any `.kiro/agents/aidlc.json`, `.kiro/agents/aidlc-*-agent.json`, and `.kiro/settings/cli.json` files left by an older overlay copy.
@@ -8,13 +15,6 @@ The Kiro IDE distribution now ships only IDE-native agent and permission surface
 * Kiro IDE now ships the conductor as `.kiro/agents/aidlc.md` and all 14 personas as Markdown with native `tools:` grants and `permissions.rules`; CLI agent-v1 JSON and `settings/cli.json` files are no longer included.
 * `/aidlc --doctor` accepts either the Kiro CLI JSON conductor or Kiro IDE Markdown conductor and checks `settings/cli.json` only for CLI-shaped installs.
 * Plugin composition validates Kiro IDE dispatch targets by their installed Markdown capability grants, rejecting empty or malformed permissions with actionable remediation while leaving Kiro CLI trust checks unchanged.
-
-## [2.6.62] - 2026-08-23
-
-Stage graph compilation now rejects ambiguous producers before consumers can resolve an artifact by file order. **Upgrade:** refresh your `dist/<harness>/` shell; existing custom stages or plugins that declare the same consumed artifact in `produces` or `optional_produces` must rename one output or update the consumer.
-
-* `aidlc-graph compile` now reports `Duplicate producers for consumed artifact`, naming every producing stage file and slug plus one consuming stage.
-* Shared artifact names remain valid when no stage consumes them, including the shipped multi-stage `traceability` output pattern.
 
 ## [2.6.62] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The Kiro IDE distribution now ships only IDE-native agent and permission surface
 
 ## [2.6.62] - 2026-08-23
 
+Stage graph compilation now rejects ambiguous producers before consumers can resolve an artifact by file order. **Upgrade:** refresh your `dist/<harness>/` shell; existing custom stages or plugins that declare the same consumed artifact in `produces` or `optional_produces` must rename one output or update the consumer.
+
+* `aidlc-graph compile` now reports `Duplicate producers for consumed artifact`, naming every producing stage file and slug plus one consuming stage.
+* Shared artifact names remain valid when no stage consumes them, including the shipped multi-stage `traceability` output pattern.
+
+## [2.6.62] - 2026-08-23
+
 Completed-stage artifact drift is now detected through optional audit receipts and surfaced as an advisory without changing workflow routing. Existing workflows require no migration: receipt-less completions remain untracked and fail open, while stages become tracked on their next normal completion. **Upgrade:** re-copy your `dist/<harness>/` shell into the project.
 
 * `next` keeps its normal directive kind and adds a machine-readable `stage_validity` advisory for drifted, downstream-revalidation, or unavailable results. Untracked-only completions are reported by `/aidlc --status` without adding per-turn noise for pre-upgrade histories or work to the statusline.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ cp dist/kiro-ide/AGENTS.md your-project/AGENTS.md   # merge if you already have 
 
 The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it.
 
-Open `your-project/` in Kiro IDE. The `/aidlc` command loads the shipped conductor skill (the bundled `.kiro/settings/cli.json` is a Kiro CLI-only compatibility surface — the IDE ignores it and does not select a default agent from it). The install registers the framework hooks in both formats: `.kiro/hooks/aidlc-*.json` (v2 schema for IDE >= 1.0) and `.kiro/hooks/aidlc-*.kiro.hook` (legacy format for pre-1.0 IDEs). In the chat panel, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start.
+Open `your-project/` in Kiro IDE. The `/aidlc` command loads the shipped conductor skill, and `.kiro/agents/aidlc.md` exposes the conductor in the IDE agent selector. Agents are Markdown-only in this distribution; Kiro CLI's agent-v1 JSON files and `settings/cli.json` do not ship. The install registers the framework hooks in both formats: `.kiro/hooks/aidlc-*.json` (v2 schema for IDE >= 1.0) and `.kiro/hooks/aidlc-*.kiro.hook` (legacy format for pre-1.0 IDEs). In the chat panel, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start.
 
 > [!NOTE]
 > AI-DLC on Kiro works best with **Claude Opus 4.8**, which requires a **paid Kiro plan**. On weaker models the conductor may skip optional stage steps (reviewer pass, learnings ritual) or rush approval gates.
@@ -372,7 +372,7 @@ aidlc-claude/
 │
 ├── harness/                    # thin per-harness authored surfaces — small, divergent by design
 │   ├── claude/                 #   manifest.ts · orchestrator skill · settings.json · onboarding fills
-│   ├── kiro-ide/               #   manifest.ts · orchestrator · agent JSONs · v2 .json + legacy .kiro.hook files · settings · onboarding fills
+│   ├── kiro-ide/               #   manifest.ts · orchestrator · conductor Markdown · v2 .json + legacy .kiro.hook files · onboarding fills
 │   ├── kiro/                   #   manifest.ts · orchestrator · agent JSONs · settings · onboarding fills (CLI — agent-JSON hooks)
 │   ├── codex/                  #   manifest.ts · emit.ts (Codex-only emissions) · orchestrator · hooks adapter
 │   ├── cursor/                 #   manifest.ts · orchestrator · hooks adapter · installer · rules · onboarding fills

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.64-blue)
+![version](https://img.shields.io/badge/version-2.6.65-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)
@@ -135,7 +135,7 @@ cp dist/kiro-ide/AGENTS.md your-project/AGENTS.md   # merge if you already have 
 
 The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it.
 
-Open `your-project/` in Kiro IDE. The `/aidlc` command loads the shipped conductor skill, and `.kiro/agents/aidlc.md` exposes the conductor in the IDE agent selector. Agents are Markdown-only in this distribution; Kiro CLI's agent-v1 JSON files and `settings/cli.json` do not ship. The install registers the framework hooks in both formats: `.kiro/hooks/aidlc-*.json` (v2 schema for IDE >= 1.0) and `.kiro/hooks/aidlc-*.kiro.hook` (legacy format for pre-1.0 IDEs). In the chat panel, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start.
+Open `your-project/` in Kiro IDE. The `/aidlc` command loads the shipped conductor skill (the bundled `.kiro/settings/cli.json` is a Kiro CLI-only compatibility surface — the IDE ignores it and does not select a default agent from it). The install registers the framework hooks in both formats: `.kiro/hooks/aidlc-*.json` (v2 schema for IDE >= 1.0) and `.kiro/hooks/aidlc-*.kiro.hook` (legacy format for pre-1.0 IDEs). In the chat panel, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start.
 
 > [!NOTE]
 > AI-DLC on Kiro works best with **Claude Opus 4.8**, which requires a **paid Kiro plan**. On weaker models the conductor may skip optional stage steps (reviewer pass, learnings ritual) or rush approval gates.
@@ -372,7 +372,7 @@ aidlc-claude/
 │
 ├── harness/                    # thin per-harness authored surfaces — small, divergent by design
 │   ├── claude/                 #   manifest.ts · orchestrator skill · settings.json · onboarding fills
-│   ├── kiro-ide/               #   manifest.ts · orchestrator · conductor Markdown · v2 .json + legacy .kiro.hook files · onboarding fills
+│   ├── kiro-ide/               #   manifest.ts · orchestrator · agent JSONs · v2 .json + legacy .kiro.hook files · settings · onboarding fills
 │   ├── kiro/                   #   manifest.ts · orchestrator · agent JSONs · settings · onboarding fills (CLI — agent-JSON hooks)
 │   ├── codex/                  #   manifest.ts · emit.ts (Codex-only emissions) · orchestrator · hooks adapter
 │   ├── cursor/                 #   manifest.ts · orchestrator · hooks adapter · installer · rules · onboarding fills

--- a/core/tools/aidlc-graph.ts
+++ b/core/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/dist/claude/.claude/tools/aidlc-graph.ts
+++ b/dist/claude/.claude/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/dist/codex/.codex/tools/aidlc-graph.ts
+++ b/dist/codex/.codex/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/dist/copilot/.aidlc/tools/aidlc-graph.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/dist/cursor/.cursor/tools/aidlc-graph.ts
+++ b/dist/cursor/.cursor/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
+++ b/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/dist/kiro-ide/.kiro/tools/aidlc-graph.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/dist/kiro/.kiro/tools/aidlc-graph.ts
+++ b/dist/kiro/.kiro/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/dist/opencode/.aidlc/tools/aidlc-graph.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-graph.ts
@@ -1674,6 +1674,9 @@ export function compileStageGraph(): {
   const newByPrefix = new Map<number, NewStageSeed[]>();
   // Track slug-to-first-file so duplicate-slug errors name both files.
   const slugToFile = new Map<string, string>();
+  type StageDeclaration = { file: string; slug: string };
+  const artifactProducers = new Map<string, StageDeclaration[]>();
+  const artifactConsumers = new Map<string, StageDeclaration[]>();
 
   // Known agent slugs (the `name:` field of each .claude/agents/*.md), passed
   // to validateStageFrontmatter so a stage referencing a lead_agent or
@@ -1756,6 +1759,26 @@ export function compileStageGraph(): {
       }
       slugToFile.set(slug, filePath);
 
+      const declaration = { file: filePath, slug };
+      // Match producersOf(): required and optional outputs share one artifact
+      // producer namespace. Set semantics avoid counting one stage twice if an
+      // author repeats a name across both lists.
+      for (const artifact of new Set([
+        ...(validation.data.produces ?? []),
+        ...(validation.data.optional_produces ?? []),
+      ])) {
+        const producers = artifactProducers.get(artifact) ?? [];
+        producers.push(declaration);
+        artifactProducers.set(artifact, producers);
+      }
+      for (const artifact of new Set(
+        (validation.data.consumes ?? []).map((consume) => consume.artifact),
+      )) {
+        const consumers = artifactConsumers.get(artifact) ?? [];
+        consumers.push(declaration);
+        artifactConsumers.set(artifact, consumers);
+      }
+
       // Existing slug -> keep its pinned number + name (the "computed once,
       // stable thereafter" contract; a pinned row missing only its name
       // seeds the name inline). New slug -> DEFER numbering to the per-phase
@@ -1784,6 +1807,24 @@ export function compileStageGraph(): {
           newByPrefix.set(prefix, [{ data: validation.data, phase, prefix, name }]);
       }
     }
+  }
+
+  for (const [artifact, producers] of artifactProducers) {
+    if (producers.length < 2) continue;
+    const consumer = artifactConsumers.get(artifact)?.[0];
+    if (!consumer) continue;
+
+    // Shared artifact names are legal when unconsumed: traceability is
+    // produced by eight stages and consumed by none, so only consumed names
+    // require a unique producer.
+    const producerList = producers
+      .map(({ file, slug }) => `${file} (stage "${slug}")`)
+      .join(", ");
+    throw new Error(
+      `Duplicate producers for consumed artifact "${artifact}" in ${producerList} — ` +
+        `consumed by stage "${consumer.slug}" in ${consumer.file}. ` +
+        `Rename one produced artifact or update the consumer.`
+    );
   }
 
   // Per-phase topological seed for NEW slugs. Numbers are assigned by the

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -1604,12 +1604,11 @@ function codekbArtifactRepos(ctx: CodekbCtx): string[] {
 // that PRODUCES it. For produces[] the owner is trivially the directive's own
 // node (the node IS the producer). For consumes[] the owner is the OTHER stage
 // that produced the artifact (resolved via producersOf), because a consumed
-// artifact is "a canonical identifier declared by exactly one PRODUCING stage"
-// (docs/reference/16-artifact-vocabulary.md:20-24, 44-48) and lives in that
-// producer's directory, NOT the consuming stage's. The per-unit decision is
-// likewise the OWNER's — a consume of a per-unit-produced artifact resolves
-// under construction/{unit}/<producer>/, a consume of a non-per-unit artifact
-// under <producer-phase>/<producer-slug>/ with no construction prefix.
+// artifact has exactly one producing stage (enforced by graph compile) and
+// lives in that producer's directory, NOT the consuming stage's. The per-unit
+// decision is likewise the OWNER's — a consume of a per-unit-produced artifact
+// resolves under construction/{unit}/<producer>/, a consume of a non-per-unit
+// artifact under <producer-phase>/<producer-slug>/ with no construction prefix.
 function resolveArtifactPath(
   name: string,
   owner: GraphStage,
@@ -1652,9 +1651,11 @@ function resolveArtifactPaths(
   return [resolveArtifactPath(name, owner, unit, recordPrefix, codekbCtx)];
 }
 
-// Resolve a consumed artifact under its producer. Multi-repo codekb producers
-// expand to one path per registered repo; an orphan consume defensively falls
-// back to the consuming node so the directive remains well formed.
+// Resolve a consumed artifact under its producer. Compile enforces exactly one
+// producer for every consumed name; unconsumed shared names never reach here.
+// Multi-repo codekb producers expand to one path per registered repo; an orphan
+// consume defensively falls back to the consuming node so the directive remains
+// well formed.
 function resolveConsumePaths(
   name: string,
   node: GraphStage,

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.64";
+export const AIDLC_VERSION = "2.6.65";

--- a/docs/harness-engineering/00-overview.md
+++ b/docs/harness-engineering/00-overview.md
@@ -101,10 +101,13 @@ author in `core/`.
 ## Naming rules and where they are enforced
 
 Stage filename stems must equal frontmatter `slug`; `aidlc-graph compile` rejects
-stem mismatches and duplicate stage slugs as hard errors. Sensor filename/id
-checks are compile-time hard errors. Scope and agent duplicate declared names are
-loader errors that name both files; scope/agent filename-to-name drift is reported
-by `/aidlc --doctor` as an advisory so authors can rename the file or fix `name`.
+stem mismatches, duplicate stage slugs, and multiple producers for any consumed
+artifact as hard errors. The duplicate-producer error names the producing stage
+files and one consumer; shared artifact names remain valid when no stage consumes
+them. Sensor filename/id checks are compile-time hard errors. Scope and agent
+duplicate declared names are loader errors that name both files; scope/agent
+filename-to-name drift is reported by `/aidlc --doctor` as an advisory so authors
+can rename the file or fix `name`.
 
 ---
 

--- a/docs/harness-engineering/02-adding-a-stage.md
+++ b/docs/harness-engineering/02-adding-a-stage.md
@@ -111,6 +111,10 @@ wiring, and they must agree with each other:
 - **`produces`** lists the forward edges. When a downstream stage asks "who
   produces artifact Z?", the graph answers via `producersOf()` — so the stage
   that declares `produces: [Z]` is the one that gets wired in upstream of it.
+  Every consumed artifact must resolve to exactly one producer across
+  `produces` and `optional_produces`; `aidlc-graph compile` rejects duplicates
+  and names both producer files. Reusing an artifact name is valid only when no
+  stage consumes it.
 
 Get these three consistent and the compiler places the stage automatically;
 you never edit `stage-graph.json` by hand to position it. The nuances of

--- a/docs/reference/16-artifact-vocabulary.md
+++ b/docs/reference/16-artifact-vocabulary.md
@@ -131,7 +131,7 @@ disambiguate.
 
 Shared names are valid when no stage consumes them. The shipped `traceability`
 artifact follows this pattern: eight stages each write their own
-`traceability.md` under their own record directory, and no downstream stage
+`traceability.json` under their own record directory, and no downstream stage
 resolves `traceability` through `producersOf()`.
 
 Today's one example: both `build-and-test` (Construction) and

--- a/docs/reference/16-artifact-vocabulary.md
+++ b/docs/reference/16-artifact-vocabulary.md
@@ -22,10 +22,12 @@ drift that parallel hand-maintained lists invite.
 
 ## What an artifact is here
 
-An artifact is a **canonical identifier** declared by exactly one
-producing stage in its YAML frontmatter. Other stages reference the same
-identifier in `consumes[]` to declare a read dependency. The identifier is
-a short kebab-case string — no file extension, no folder prefix, no slash.
+An artifact is a **canonical identifier** declared by a producing stage in its
+YAML frontmatter. Other stages reference the same identifier in `consumes[]` to
+declare a read dependency. Every consumed identifier has exactly one producer;
+unconsumed names may be shared by stages that write independent files under
+their own record directories. The identifier is a short kebab-case string — no
+file extension, no folder prefix, no slash.
 
 Concrete example from milestone 4's worked example in
 `dist/claude/.claude/aidlc-common/protocols/stage-definition.md`:
@@ -75,8 +77,8 @@ Things that are **not** artifacts in this registry:
 2. **The registry is computed, not written.** Run
    `bun dist/claude/.claude/tools/aidlc-graph.ts artifacts` to
    print the live registry — one name per line, sorted alphabetically.
-   The tool unions every stage's `produces[]` from the compiled
-   `stage-graph.json`.
+   The tool unions every stage's `produces[]` and `optional_produces[]` from the
+   compiled `stage-graph.json`.
 3. **No parallel list in this chapter.** If a reader wants the enumeration,
    they run the tool. This chapter never lists canonical names as a
    registry table.
@@ -120,10 +122,17 @@ agent slugs, scope names, stage slugs, phase names are all flat kebab.
 
 ## Collision policy
 
-Two stages **must not** declare the same canonical name in their
-`produces[]` lists. The registry is a set; names must be globally unique.
-When the same underlying concept is emitted by two stages, pick two
-distinct names that disambiguate.
+Two stages **must not** declare the same canonical name across `produces[]` and
+`optional_produces[]` when any stage consumes that name. `aidlc-graph compile`
+rejects the ambiguity because runtime consume resolution needs one owning
+producer; the error names all producing files and one consuming stage. When the
+same consumed concept is emitted by two stages, pick distinct names that
+disambiguate.
+
+Shared names are valid when no stage consumes them. The shipped `traceability`
+artifact follows this pattern: eight stages each write their own
+`traceability.md` under their own record directory, and no downstream stage
+resolves `traceability` through `producersOf()`.
 
 Today's one example: both `build-and-test` (Construction) and
 `performance-validation` (Operation) write a file called `test-results.md`.

--- a/tests/integration/t-custom-harness-compile.test.ts
+++ b/tests/integration/t-custom-harness-compile.test.ts
@@ -613,6 +613,58 @@ outputs: none
     }
   });
 
+  // E10a — two stages produce the same artifact and a third consumes it.
+  // Guard: compileStageGraph duplicate-producer check in aidlc-graph.ts.
+  test("E10a: duplicate producers for a consumed artifact fail compile and name both files", () => {
+    const proj = setupIntegrationProject({ customHarness: true });
+    try {
+      const original = stagePath(proj, SNAPSHOT_STAGE_PHASE, SNAPSHOT_STAGE_SLUG);
+      const duplicateSlug = "schema-snapshot-shadow";
+      const duplicate = stagePath(proj, SNAPSHOT_STAGE_PHASE, duplicateSlug);
+      writeFileSync(
+        duplicate,
+        readFileSync(original, "utf8").replace(
+          `slug: ${SNAPSHOT_STAGE_SLUG}`,
+          `slug: ${duplicateSlug}`,
+        ),
+      );
+
+      const r = graph(proj, ["compile"]);
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain(
+        `Duplicate producers for consumed artifact "${SNAPSHOT_ARTIFACT}"`,
+      );
+      expect(r.stderr).toContain(`${SNAPSHOT_STAGE_SLUG}.md`);
+      expect(r.stderr).toContain(`${duplicateSlug}.md`);
+      expect(r.stderr).toContain(`stage "${PLAN_STAGE_SLUG}"`);
+    } finally {
+      cleanupTestProject(proj);
+    }
+  });
+
+  // E10b — duplicate producer names are legal when no stage consumes the
+  // artifact. This preserves the shipped traceability pattern.
+  test("E10b: duplicate producers for an unconsumed artifact compile successfully", () => {
+    const proj = setupIntegrationProject({ customHarness: true });
+    try {
+      const original = stagePath(proj, SNAPSHOT_STAGE_PHASE, PLAN_STAGE_SLUG);
+      const duplicateSlug = "migration-plan-shadow";
+      const duplicate = stagePath(proj, SNAPSHOT_STAGE_PHASE, duplicateSlug);
+      writeFileSync(
+        duplicate,
+        readFileSync(original, "utf8").replace(
+          `slug: ${PLAN_STAGE_SLUG}`,
+          `slug: ${duplicateSlug}`,
+        ),
+      );
+
+      const r = graph(proj, ["compile"]);
+      expect(r.status).toBe(0);
+    } finally {
+      cleanupTestProject(proj);
+    }
+  });
+
   // The custom rule marker reaches the agent's RESOLVED context — not just the
   // seeded file, but the file the COMPILED head-stage node points at. This is
   // the deterministic "the rule is in the agent's context" proof (surface 3a):

--- a/tests/integration/t-custom-harness-compile.test.ts
+++ b/tests/integration/t-custom-harness-compile.test.ts
@@ -642,9 +642,43 @@ outputs: none
     }
   });
 
-  // E10b — duplicate producer names are legal when no stage consumes the
+  // E10b — optional_produces shares the same producer namespace as produces.
+  test("E10b: an optional producer colliding on a consumed artifact fails compile", () => {
+    const proj = setupIntegrationProject({ customHarness: true });
+    try {
+      const original = stagePath(proj, SNAPSHOT_STAGE_PHASE, SNAPSHOT_STAGE_SLUG);
+      const duplicateSlug = "schema-snapshot-optional";
+      const duplicate = stagePath(proj, SNAPSHOT_STAGE_PHASE, duplicateSlug);
+      const optionalProducer = readFileSync(original, "utf8")
+        .replace(
+          `slug: ${SNAPSHOT_STAGE_SLUG}`,
+          `slug: ${duplicateSlug}`,
+        )
+        .replace(
+          `produces:\n  - ${SNAPSHOT_ARTIFACT}`,
+          `produces: []\noptional_produces:\n  - ${SNAPSHOT_ARTIFACT}`,
+        );
+      expect(optionalProducer).toContain(
+        `produces: []\noptional_produces:\n  - ${SNAPSHOT_ARTIFACT}`,
+      );
+      writeFileSync(duplicate, optionalProducer);
+
+      const r = graph(proj, ["compile"]);
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain(
+        `Duplicate producers for consumed artifact "${SNAPSHOT_ARTIFACT}"`,
+      );
+      expect(r.stderr).toContain(`${SNAPSHOT_STAGE_SLUG}.md`);
+      expect(r.stderr).toContain(`${duplicateSlug}.md`);
+      expect(r.stderr).toContain(`stage "${PLAN_STAGE_SLUG}"`);
+    } finally {
+      cleanupTestProject(proj);
+    }
+  });
+
+  // E10c — duplicate producer names are legal when no stage consumes the
   // artifact. This preserves the shipped traceability pattern.
-  test("E10b: duplicate producers for an unconsumed artifact compile successfully", () => {
+  test("E10c: duplicate producers for an unconsumed artifact compile successfully", () => {
     const proj = setupIntegrationProject({ customHarness: true });
     try {
       const original = stagePath(proj, SNAPSHOT_STAGE_PHASE, PLAN_STAGE_SLUG);


### PR DESCRIPTION
Two stages could declare the same artifact in produces/optional_produces and the graph compiled clean, leaving every consumer to resolve to whichever producer came first in load order via producersOf(name)[0]. aidlc-graph compile now fails loud — naming every producing stage file and one consumer — whenever an artifact with two or more producers is consumed by any stage, while unconsumed shared names (the shipped 8-producer traceability pattern) remain valid and are pinned by a new test. Ships as 2.6.65 with regenerated dist trees, E10a/E10b compile tests, and updated collision-policy docs. Closes #804