### PR TITLE
fix: gate SUBAGENT_COMPLETED logging on running workflow state (2.6.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.54] - 2026-08-21
+
+Subagent completion auditing now runs only while the active workflow state is explicitly `Running`, instead of writing whenever a state file or audit shard remains from an earlier workflow. **Upgrade:** refresh your `dist/<harness>/` shell so project-wide SubagentStop hooks no longer write audit entries or health heartbeats during non-AI-DLC sessions or after workflow completion.
+
+* SubagentStop exits when active intent state is absent, unreadable, or does not declare `Status: Running`; a running workflow still records `SUBAGENT_COMPLETED` and creates the clone's audit shard if needed.
+
 ## [2.6.53] - 2026-08-21
 
 Kiro IDE hook guidance now reflects that tool-argument delivery varies across supported IDE generations instead of describing all payloads as empty. Hook registration and enforcement behavior are unchanged. **Upgrade:** refresh your `dist/<harness>/` shell to receive the corrected generated comments, Kiro IDE orchestrator guidance, and version metadata.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.53-blue)
+![version](https://img.shields.io/badge/version-2.6.54-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/hooks/aidlc-log-subagent.ts
+++ b/core/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/dist/claude/.claude/hooks/aidlc-log-subagent.ts
+++ b/dist/claude/.claude/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/dist/codex/.codex/hooks/aidlc-log-subagent.ts
+++ b/dist/codex/.codex/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/dist/copilot/.aidlc/hooks/aidlc-log-subagent.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/dist/cursor/.cursor/hooks/aidlc-log-subagent.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/dist/kiro-ide/.kiro/hooks/aidlc-log-subagent.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/dist/kiro/.kiro/hooks/aidlc-log-subagent.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/dist/opencode/.aidlc/hooks/aidlc-log-subagent.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-log-subagent.ts
@@ -2,62 +2,68 @@
 // Replaces the previous free-form `## Subagent Completed` markdown write with
 // a canonical audit event.
 //
-// Receives JSON on stdin with subagent info. No-op if no audit.md exists.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+// Receives JSON on stdin with subagent info. No-op unless a workflow is running.
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
-  auditFilePath,
   type ClaudeCodeHookInput,
   errorMessage,
+  getField,
   hooksHealthDir,
   isClaudeCodeHookInput,
   isoTimestamp,
+  readStateFile,
   recordHookDrop,
   resolveProjectDirFromHook,
 } from "../tools/aidlc-lib.ts";
 
 export async function run(input: string): Promise<number> {
-const projectDir = resolveProjectDirFromHook(import.meta.url);
+  const projectDir = resolveProjectDirFromHook(import.meta.url);
 
-// Write health heartbeat
-const healthDir = hooksHealthDir(projectDir);
-mkdirSync(healthDir, { recursive: true });
-writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
+  let stateContent: string;
+  try {
+    stateContent = readStateFile(projectDir);
+  } catch {
+    return 0;
+  }
+  if (getField(stateContent, "Status") !== "Running") return 0;
 
-// Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
-// coming) — avoids blocking on terminal read in test / debug-mode contexts.
-if (process.stdin.isTTY) return 0;
+  // Write health heartbeat
+  const healthDir = hooksHealthDir(projectDir);
+  mkdirSync(healthDir, { recursive: true });
+  writeFileSync(join(healthDir, "log-subagent.last"), isoTimestamp(), "utf-8");
 
-let parsed: ClaudeCodeHookInput;
-try {
-  const raw: unknown = JSON.parse(input);
-  if (!isClaudeCodeHookInput(raw)) return 0;
-  parsed = raw;
-} catch {
+  // Read JSON from stdin. Exit cleanly if stdin is a TTY (no Claude Code JSON
+  // coming) — avoids blocking on terminal read in test / debug-mode contexts.
+  if (process.stdin.isTTY) return 0;
+
+  let parsed: ClaudeCodeHookInput;
+  try {
+    const raw: unknown = JSON.parse(input);
+    if (!isClaudeCodeHookInput(raw)) return 0;
+    parsed = raw;
+  } catch {
+    return 0;
+  }
+
+  const agentType = parsed.agent_type ?? "unknown";
+  const agentId: string = parsed.agent_id ?? "";
+  const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
+
+  const fields: Record<string, string> = {
+    "Agent Type": agentType,
+  };
+  if (agentId) fields["Agent ID"] = agentId;
+  if (agentMessage) fields.Message = agentMessage;
+
+  try {
+    appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
+  } catch (e) {
+    recordHookDrop(projectDir, "log-subagent", errorMessage(e));
+    return 0;
+  }
   return 0;
-}
-
-const agentType = parsed.agent_type ?? "unknown";
-const agentId: string = parsed.agent_id ?? "";
-const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
-
-const auditFile = auditFilePath(projectDir);
-if (!existsSync(auditFile)) return 0;
-
-const fields: Record<string, string> = {
-  "Agent Type": agentType,
-};
-if (agentId) fields["Agent ID"] = agentId;
-if (agentMessage) fields.Message = agentMessage;
-
-try {
-  appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir);
-} catch (e) {
-  recordHookDrop(projectDir, "log-subagent", errorMessage(e));
-  return 0;
-}
-return 0;
 }
 
 if (import.meta.main) {

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.53";
+export const AIDLC_VERSION = "2.6.54";

--- a/docs/reference/03-orchestrator.md
+++ b/docs/reference/03-orchestrator.md
@@ -771,7 +771,7 @@ The framework hooks are registered project-wide in `settings.json` (the v0.6.0 h
 
 - **Matcher**: (empty -- matches all subagent completions)
 - **Trigger**: When any subagent finishes execution.
-- **Behavior**: Emits a canonical `SUBAGENT_COMPLETED` audit event via `appendAuditEntry` (replacing the earlier free-form `## Subagent Completed` markdown write). Fields: agent type, agent ID, and truncated message (first 200 characters). Uses `mkdir`-based locking via `lib.ts`.
+- **Behavior**: Exits silently unless the active workflow state has `Status: Running`. Otherwise emits a canonical `SUBAGENT_COMPLETED` audit event via `appendAuditEntry` (replacing the earlier free-form `## Subagent Completed` markdown write). Fields: agent type, agent ID, and truncated message (first 200 characters). Uses `mkdir`-based locking via `lib.ts`.
 
 These hooks are TypeScript and run via `bun`. They do not require `jq`.
 

--- a/docs/reference/06-hooks-and-tools.md
+++ b/docs/reference/06-hooks-and-tools.md
@@ -298,9 +298,9 @@ See [Runtime Graph](13-runtime-graph.md) for the compile lifecycle and the locke
 **Processing steps:**
 
 1. **Project directory resolution:** Same multi-fallback pattern as write-audit-log.ts.
-2. **Health heartbeat:** Writes to `.aidlc-hooks-health/log-subagent.last`.
-3. **JSON parsing:** Extracts `agent_type` (defaults to `"unknown"`), `agent_id`, and `last_assistant_message` (truncated to 200 characters).
-4. **Audit file guard:** Exits silently if the `audit/` shard does not exist.
+2. **Workflow-state guard:** Exits silently unless the active intent's `aidlc-state.md` has `Status: Running`.
+3. **Health heartbeat:** Writes to `.aidlc-hooks-health/log-subagent.last`.
+4. **JSON parsing:** Extracts `agent_type` (defaults to `"unknown"`), `agent_id`, and `last_assistant_message` (truncated to 200 characters).
 5. **Entry assembly:** Emits canonical `SUBAGENT_COMPLETED` event via `appendAuditEntry`. Fields: Timestamp, Event, Agent Type, and optionally Agent ID and truncated Message.
 6. **Atomic locking:** Same `mkdir`-based pattern as write-audit-log.ts (unified in `lib.ts`) but with a separate lock name to avoid contention.
 
@@ -610,7 +610,7 @@ A stage reported as skipped emits `STAGE_SKIPPED` instead of
 | Source | Events | When |
 |--------|--------|------|
 | `write-audit-log.ts` | `ARTIFACT_CREATED` / `ARTIFACT_UPDATED` | Every Write/Edit to the intent's record dir (except the `audit/` shards) |
-| `log-subagent.ts` | `SUBAGENT_COMPLETED` | Any subagent stop |
+| `log-subagent.ts` | `SUBAGENT_COMPLETED` | Any subagent stop while the active workflow has `Status: Running` |
 | `reviewer-scope.ts` | `REVIEWER_SCOPE_BLOCKED` | A per-unit reviewer's tool call refused for sibling-unit access (PreToolUse) |
 | `review-freeze.ts` | `REVIEW_FREEZE_BLOCKED` | A `produces[]` write refused for voiding a fresh terminal review receipt before the gate (PreToolUse) |
 | `plan-approval-guard.ts` | `PLAN_APPROVAL_BLOCKED` | A code-generation developer dispatch refused before the plan is approved (PreToolUse) |

--- a/tests/unit/t09.test.ts
+++ b/tests/unit/t09.test.ts
@@ -4,7 +4,7 @@
 // The unit under test is a HOOK — aidlc-log-subagent.ts, the SubagentStop hook
 // that emits SUBAGENT_COMPLETED. Hooks are mechanism=none: they receive a
 // Claude Code JSON payload on stdin and resolve the project dir from the
-// CLAUDE_PROJECT_DIR env var (aidlc-lib.ts:114-116). There is no exported pure
+// CLAUDE_PROJECT_DIR env var. There is no exported pure
 // function to import — the hook's contract is "JSON on stdin + env -> audit row
 // + heartbeat file + clean exit". So every .sh assertion is preserved by
 // SPAWNING the hook via node:child_process spawnSync with controlled stdin and
@@ -12,14 +12,14 @@
 // bun "$HOOK"`. We assert on res.status (the .sh's $? in tests 3 + 5) and on the
 // audit.md / heartbeat the hook writes (the .sh's assert_grep / assert_file_exists).
 //
-// AUDIT-ROW SHAPE (aidlc-log-subagent.ts:40-58 + aidlc-audit.ts:256-267): the
+// AUDIT-ROW SHAPE (aidlc-log-subagent.ts + aidlc-audit.ts): the
 // hook calls appendAuditEntry("SUBAGENT_COMPLETED", fields, projectDir) where
 // fields = { "Agent Type": agentType, ["Agent ID"]: agentId?, Message: msg? }.
 // appendAuditEntryUnlocked renders each as `**<key>**: <value>` under a
 // `## Subagent Completed` heading with `**Event**: SUBAGENT_COMPLETED`. Message
-// is sliced to the first 200 chars (hook line 42) — the truncation the .sh's
+// is sliced to the first 200 chars — the truncation the .sh's
 // test 6 asserts. agentType defaults to "unknown", agentId defaults to ""
-// (omitted when falsy, hook line 50).
+// (omitted when falsy).
 //
 // SEED BASELINE (load-bearing for parity strength). The .sh seeds audit-sample.md
 // (fixtures.sh seed_audit_file) which ALREADY CONTAINS one SUBAGENT_COMPLETED
@@ -42,16 +42,18 @@
 //       AND no Agent ID / Message line in that block (the .sh comment "no Agent ID
 //       line" asserted by absence — STRONGER than the original which only grepped
 //       the type was present).
-//   - .sh Test 3  no audit.md -> exits silently, audit.md NOT created  -> Test 3:
-//       res.status === 0 (the hook's process.exit(0), STRONGER than the .sh which
-//       only checked the file's absence) + audit.md still absent.
+//   - .sh Test 3  no active workflow -> exits silently, audit.md NOT created ->
+//       Tests 3a-3b: no state exits 0 without changing an existing shard or
+//       creating a shard/heartbeat. Tests 3c-3e prove completed and malformed
+//       state also fail closed. Test 3f proves that running state opens the gate:
+//       appendAuditEntry creates a missing shard.
 //   - .sh Test 4  assert_file_exists .aidlc-hooks-health/log-subagent.last -> Test 4:
 //       heartbeat file exists (same observable) + STRONGER: its contents are an
-//       ISO timestamp (the hook writes isoTimestamp(), aidlc-log-subagent.ts:24).
+//       ISO timestamp (the hook writes isoTimestamp()).
 //   - .sh Test 5  empty stdin -> exit 0 ($RC == 0)                     -> Test 5:
 //       res.status === 0 (same observable) + STRONGER: audit.md byte-unchanged
 //       (empty stdin -> JSON.parse("") throws -> process.exit(0) BEFORE any
-//       append, hook lines 30-38; the .sh captured BEFORE but never compared it).
+//       append; the .sh captured BEFORE but never compared it).
 //   - .sh Test 6a assert_grep audit.md "developer" (entry written)    -> Test 6a:
 //       new block Agent Type === "developer" (STRONGER, exact + block-scoped).
 //   - .sh Test 6b assert_not_grep audit.md "A\{500\}" (truncated)     -> Test 6b:
@@ -61,8 +63,8 @@
 //       new block's heading line is exactly `**Event**: SUBAGENT_COMPLETED`
 //       (block-scoped via the canonical-event count delta, STRONGER).
 //
-// 8 .sh asserts -> 8 expect()-bearing test() cases here (test 6's two asserts
-// kept as 6a + 6b to keep one observable per case, matching the .sh's two lines).
+// 8 .sh asserts map to the parity cases below (test 6's two asserts remain 6a +
+// 6b), with additional #710 gate-regression cases around original Test 3.
 //
 // FIXTURE DISCIPLINE (mirrors the .sh's create_test_project + seed_audit_file +
 // cleanup_test_project per case): each case uses a FRESH temp project dir
@@ -124,19 +126,32 @@ function pinnedShardName(): string {
 }
 
 /**
- * Fresh project seeded for the per-intent audit layout: state (so the
- * active-intent cursor resolves and docsRoot()/auditFilePath() point at the
- * record), a baseline seed shard carrying the audit-sample.md SUBAGENT_COMPLETED
- * block (when `seed`), and the empty pinned shard the hook resolves so its
- * "shard exists" gate passes. When `seed` is false, NO shard is created (test 3's
- * no-trail path). The clone-id token is pinned on disk for the spawned hook.
+ * Fresh project seeded for the per-intent audit layout. State is optional so
+ * the hook's workflow-state gate can be tested independently from audit-shard
+ * presence. When `audit` is true, a baseline shard carries the audit-sample.md
+ * SUBAGENT_COMPLETED block and the hook's pinned shard starts empty. The
+ * clone-id token is pinned on disk for deterministic shard resolution.
  */
-function proj(seed = true): string {
+type StateFixture = "running" | "completed" | "malformed" | false;
+
+function proj(
+  {
+    state = "running",
+    audit = true,
+  }: { state?: StateFixture; audit?: boolean } = {},
+): string {
   const p = createTestProject();
   tempDirs.push(p);
-  seedStateFile(p, join(FIXTURES_DIR, "state-mid-ideation.md"));
+  if (state === "running") {
+    seedStateFile(p, join(FIXTURES_DIR, "state-mid-ideation.md"));
+  } else if (state === "completed") {
+    seedStateFile(p, join(FIXTURES_DIR, "state-completed.md"));
+  } else if (state === "malformed") {
+    seedStateFile(p, join(FIXTURES_DIR, "state-mid-ideation.md"));
+    writeFileSync(join(seededRecordDir(p), "aidlc-state.md"), "# malformed\n", "utf-8");
+  }
   writeFileSync(join(p, "aidlc", ".aidlc-clone-id"), `${PINNED_CLONE_ID}\n`, "utf-8");
-  if (seed) {
+  if (audit) {
     const auditDir = seededAuditDir(p);
     mkdirSync(auditDir, { recursive: true });
     // Baseline (sorts first): the audit-sample.md SUBAGENT_COMPLETED block.
@@ -195,7 +210,7 @@ function subagentCompletedCount(body: string): number {
 
 /**
  * Field values from the LAST audit block whose `**Event**:` is SUBAGENT_COMPLETED.
- * The seed already has one such block (audit-sample.md:19-26); the hook appends a
+ * The seed already has one such block; the hook appends a
  * NEW one at end-of-file, so "last" isolates the row the hook just wrote — the
  * block-scoped equivalent of the .sh's file-wide grep, but pinned to the new row.
  * Splits `**label**: value` on the literal `**: ` separator (mirrors auditField in
@@ -234,7 +249,7 @@ function bodyContains(body: string, needle: string): boolean {
   return body.includes(needle);
 }
 
-describe("t09 aidlc-log-subagent hook (migrated from t09-hook-log-subagent.sh, plan 8)", () => {
+describe("t09 aidlc-log-subagent hook (migrated from t09-hook-log-subagent.sh + #710 regressions)", () => {
   test("1: logs subagent completion as SUBAGENT_COMPLETED event", () => {
     const p = proj();
     const before = subagentCompletedCount(readShards(p)); // seed baseline = 1
@@ -258,30 +273,95 @@ describe("t09 aidlc-log-subagent hook (migrated from t09-hook-log-subagent.sh, p
     const blk = lastSubagentBlock(readShards(p));
     // .sh grepped only that the type was present; here block-scoped exact value.
     expect(blk["Agent Type"]).toBe("developer");
-    // STRONGER: the hook omits Agent ID (and Message) when falsy (hook lines 50-51),
+    // STRONGER: the hook omits Agent ID (and Message) when falsy,
     // so the NEW block carries neither. The .sh comment named "no Agent ID line".
     expect(blk["Agent ID"]).toBeUndefined();
     expect(blk.Message).toBeUndefined();
   });
 
-  test("3: exits silently when no audit trail (status 0, trail not created)", () => {
-    const p = proj(false);
-    // No audit shard (proj seeded state but no trail).
+  test("3a: no state leaves an existing audit shard byte-identical", () => {
+    const p = proj({ state: false });
+    const shard = join(auditDirOf(p), pinnedShardName());
+    const before = readFileSync(shard);
+    const r = runHook(
+      '{"agent_type":"architect","agent_id":"abc-123","last_assistant_message":"Done"}',
+      p,
+    );
+    expect(r.status).toBe(0);
+    expect(readFileSync(shard)).toEqual(before);
+    expect(existsSync(heartbeatPath(p))).toBe(false);
+  });
+
+  test("3b: no state and no shard exits without creating hook artifacts", () => {
+    const p = proj({ state: false, audit: false });
     expect(existsSync(auditDirOf(p))).toBe(false);
     const r = runHook(
       '{"agent_type":"architect","agent_id":"abc-123","last_assistant_message":"Done"}',
       p,
     );
-    // STRONGER: the .sh only checked the trail's absence; we also pin the clean exit.
     expect(r.status).toBe(0);
     expect(existsSync(auditDirOf(p))).toBe(false);
+    expect(existsSync(heartbeatPath(p))).toBe(false);
+  });
+
+  test("3c: completed state leaves an existing audit shard byte-identical", () => {
+    const p = proj({ state: "completed" });
+    const shard = join(auditDirOf(p), pinnedShardName());
+    const before = readFileSync(shard);
+    const r = runHook(
+      '{"agent_type":"architect","agent_id":"abc-123","last_assistant_message":"Done"}',
+      p,
+    );
+    expect(r.status).toBe(0);
+    expect(readFileSync(shard)).toEqual(before);
+    expect(existsSync(heartbeatPath(p))).toBe(false);
+  });
+
+  test("3d: completed state and no shard exits without creating hook artifacts", () => {
+    const p = proj({ state: "completed", audit: false });
+    expect(existsSync(auditDirOf(p))).toBe(false);
+    const r = runHook(
+      '{"agent_type":"architect","agent_id":"abc-123","last_assistant_message":"Done"}',
+      p,
+    );
+    expect(r.status).toBe(0);
+    expect(existsSync(auditDirOf(p))).toBe(false);
+    expect(existsSync(heartbeatPath(p))).toBe(false);
+  });
+
+  test("3e: malformed state fails closed without creating hook artifacts", () => {
+    const p = proj({ state: "malformed", audit: false });
+    expect(existsSync(auditDirOf(p))).toBe(false);
+    const r = runHook(
+      '{"agent_type":"architect","agent_id":"abc-123","last_assistant_message":"Done"}',
+      p,
+    );
+    expect(r.status).toBe(0);
+    expect(existsSync(auditDirOf(p))).toBe(false);
+    expect(existsSync(heartbeatPath(p))).toBe(false);
+  });
+
+  test("3f: running state and no shard creates the shard and appends", () => {
+    const p = proj({ audit: false });
+    expect(existsSync(auditDirOf(p))).toBe(false);
+    const r = runHook(
+      '{"agent_type":"architect","agent_id":"abc-123","last_assistant_message":"Done"}',
+      p,
+    );
+    expect(r.status).toBe(0);
+    expect(existsSync(join(auditDirOf(p), pinnedShardName()))).toBe(true);
+    expect(subagentCompletedCount(readShards(p))).toBe(1);
+    const blk = lastSubagentBlock(readShards(p));
+    expect(blk["Agent Type"]).toBe("architect");
+    expect(blk["Agent ID"]).toBe("abc-123");
+    expect(blk.Message).toBe("Done");
   });
 
   test("4: writes heartbeat (ISO timestamp)", () => {
     const p = proj();
     runHook('{"agent_type":"quality"}', p);
     expect(existsSync(heartbeatPath(p))).toBe(true);
-    // STRONGER: the heartbeat carries an ISO timestamp (hook line 24).
+    // STRONGER: the heartbeat carries an ISO timestamp.
     const ts = readFileSync(heartbeatPath(p), "utf-8").trim();
     expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
   });
@@ -314,7 +394,7 @@ describe("t09 aidlc-log-subagent hook (migrated from t09-hook-log-subagent.sh, p
       `{"agent_type":"developer","agent_id":"xyz","last_assistant_message":"${longMsg}"}`,
       p,
     );
-    // STRONGER: pins the exact 200-char slice boundary (hook line 42), not merely
+    // STRONGER: pins the exact 200-char slice boundary, not merely
     // "the 500-run is absent". The Message field is exactly 200 'A's...
     const blk = lastSubagentBlock(readShards(p));
     expect(blk.Message).toBe("A".repeat(200));

--- a/tests/unit/t13-hook-input-robustness.test.ts
+++ b/tests/unit/t13-hook-input-robustness.test.ts
@@ -40,9 +40,9 @@
 //                                   :88-93 emit failure non-fatal
 //   hooks/aidlc-statusline.ts     :193 TTY -> "" stdin; :195-199 malformed JSON
 //                                   swallowed; :208-211 no state -> "[AIDLC] ready"
-//   hooks/aidlc-log-subagent.ts   :28 TTY exit0; :34-37 bad-JSON exit0;
-//                                   :40-42 agent_* ?? defaults; :45 no-audit exit0;
-//                                   :53-58 emit failure -> recordHookDrop + exit0
+//   hooks/aidlc-log-subagent.ts   : no-state exit0 before heartbeat; TTY exit0;
+//                                   bad-JSON exit0; agent_* ?? defaults; emit
+//                                   failure -> recordHookDrop + exit0
 //   hooks/aidlc-run-sensors.ts    :17 "always exit 0" contract; :53 TTY exit0;
 //                                   :61-67 bad-JSON exit0; :74 empty path exit0;
 //                                   :90 no-audit exit0
@@ -116,12 +116,13 @@ const HOOK_RUNTIME = join(AIDLC_SRC, "hooks", "aidlc-rebuild-stage-graph.ts");
 
 // P9 per-intent layout: the audit-logger now gates on the file_path being UNDER
 // the active intent's record root (docsRoot()), not on a bare "aidlc-docs/"
-// substring; and the audit-emitting hooks self-gate on their resolved shard
-// existing. So injection/space/unicode artifacts are written UNDER the seeded
-// record (keeping the adversarial token as an INNER path segment), and the
-// audit-emitting cases pin a clone-id + create the resolved shard. The
-// adversarial CONTRACT (always exit 0, token never executed) is unchanged — only
-// the path the artifact lives under moved from aidlc-docs/ to the record dir.
+// substring; and the audit-emitting hooks self-gate on workflow state and/or
+// their resolved shard existing. So injection/space/unicode artifacts are
+// written UNDER the seeded record (keeping the adversarial token as an INNER
+// path segment), and the audit-emitting cases pin a clone-id + create the
+// resolved shard. The adversarial CONTRACT (always exit 0, token never executed)
+// is unchanged — only the path the artifact lives under moved from aidlc-docs/
+// to the record dir.
 const PINNED_CLONE_ID = "testcloneid13";
 function pinnedShardName(): string {
   const host =
@@ -154,8 +155,8 @@ function seedShell(proj: string, space = DEFAULT_SPACE): void {
   );
 }
 
-/** Pin the clone-id + create the resolved empty audit shard so the audit-emitting
- *  hooks' "shard exists" gate passes. Returns the audit DIR. */
+/** Pin the clone-id + create the resolved empty audit shard for hooks that require
+ *  it and for deterministic log-subagent reads. Returns the audit DIR. */
 function seedAuditShard(proj: string): string {
   writeFileSync(join(proj, "aidlc", ".aidlc-clone-id"), `${PINNED_CLONE_ID}\n`, "utf-8");
   const auditDir = seededAuditDir(proj);
@@ -305,7 +306,10 @@ describe("t13 hook input robustness (mechanism cli — spawned hooks + adversari
   });
 
   test("log-subagent: survives shell injection (exit 0, token verbatim) [.sh test 5]", () => {
-    writeState(proj, "# AI-DLC State Tracking\n## Current Status\n## Stage Progress\n");
+    writeState(
+      proj,
+      "# AI-DLC State Tracking\n## Current Status\n- **Status**: Running\n## Stage Progress\n",
+    );
     seedAuditShard(proj);
     const r = fireStdin(
       HOOK_SUBAGENT,
@@ -373,7 +377,10 @@ describe("t13 hook input robustness (mechanism cli — spawned hooks + adversari
 
   test("log-subagent: handles a project dir with spaces (exit 0) [.sh test 10]", () => {
     const spaced = makeSpacedProject();
-    writeState(spaced, "# AI-DLC State Tracking\n## Current Status\n## Stage Progress\n");
+    writeState(
+      spaced,
+      "# AI-DLC State Tracking\n## Current Status\n- **Status**: Running\n## Stage Progress\n",
+    );
     seedAuditShard(spaced);
     expect(
       fireStdin(
@@ -402,7 +409,10 @@ describe("t13 hook input robustness (mechanism cli — spawned hooks + adversari
   });
 
   test("log-subagent: handles empty JSON {} (exit 0) [.sh test 12]", () => {
-    writeState(proj, "# AI-DLC State Tracking\n## Current Status\n## Stage Progress\n");
+    writeState(
+      proj,
+      "# AI-DLC State Tracking\n## Current Status\n- **Status**: Running\n## Stage Progress\n",
+    );
     seedAuditShard(proj);
     expect(fireStdin(HOOK_SUBAGENT, "{}", proj).exitCode).toBe(0);
     // {} is a valid ClaudeCodeHookInput shape -> agent fields default; the audit

--- a/tests/unit/t147-kiro-hook-adapter.test.ts
+++ b/tests/unit/t147-kiro-hook-adapter.test.ts
@@ -61,7 +61,7 @@ const FIXTURES = JSON.parse(
 // intent's record, not the flat aidlc-docs/ root. So the scratch project seeds
 // the per-intent workspace shell + the state fixture into the default record (so
 // the active-intent cursor resolves) + the resolved audit SHARD (pinned clone-id
-// so the log-subagent shard gate passes and reads are deterministic).
+// so audit reads are deterministic).
 const PINNED_CLONE_ID = "testcloneid147";
 function pinnedShardName(): string {
   const host =
@@ -104,8 +104,8 @@ function scratchProject(withState: boolean): string {
       seededStateFile(dir),
       readFileSync(join(REPO_ROOT, "tests", "fixtures", "state-brownfield-feature.md"), "utf-8"),
     );
-    // The resolved audit shard (pinned clone-id) so the log-subagent shard gate
-    // passes and the trail seeds the "# AI-DLC Audit Log" header.
+    // The resolved audit shard (pinned clone-id) keeps log-subagent writes
+    // deterministic and seeds the "# AI-DLC Audit Log" header.
     writeFileSync(join(dir, "aidlc", ".aidlc-clone-id"), `${PINNED_CLONE_ID}\n`, "utf-8");
     const auditDir = seededAuditDir(dir);
     mkdirSync(auditDir, { recursive: true });

--- a/tests/unit/t149-codex-hook-adapter.test.ts
+++ b/tests/unit/t149-codex-hook-adapter.test.ts
@@ -72,7 +72,7 @@ const FIXTURES = JSON.parse(
 // and the audit trail via auditFilePath() — under the active intent's record. So
 // the scratch project seeds the per-intent shell + the state fixture into the
 // default record (so the cursor resolves) + the resolved audit SHARD (pinned
-// clone-id so the log-subagent shard gate passes and reads are deterministic).
+// clone-id so audit reads are deterministic).
 // The Codex adapter's session heartbeat lives with the core session stamps at
 // aidlc/.aidlc-sessions/, independent of the active-intent cursor. That lets a
 // new session reconcile its predecessor after a second intent became active.


### PR DESCRIPTION
aidlc-log-subagent.ts was the one audit-emitting hook gating on its clone shard existing instead of on workflow state, so once a shard was committed every SubagentStop in every session (framework or not) appended chat-bearing SUBAGENT_COMPLETED entries to the ledger forever. It now self-gates on aidlc-state.md like its siblings (gate before heartbeat, matching session-start), with t09 regression coverage for the no-state/shard-present, no-state/no-shard, and state/no-shard paths, doc updates, and version 2.6.20. Closes #710