### PR TITLE
fix: add quality-target verification gate to Construction (never relax defined NFR targets) (2.6.74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.74] - 2026-08-24
+
+Defined quality targets now remain binding from Code Generation through Build and Test: every measurable target is inventoried from NFR Requirements, NFR Design, and the approved Testing Contract, then finalized with evidence before the stage can succeed. **Upgrade:** refresh your `dist/<harness>/` shell so the updated Construction stage and protocol guidance are installed.
+
+* Code Generation treats measurable quality targets as required inputs and forbids lowering, relaxing, or disabling a target to manufacture a pass.
+* Build and Test executes every applicable generated check, permits deployed-environment deferral only to a named owning validation stage, and keeps deferred or missing evidence visibly `Unverified`.
+* The target matrix records target ID and source, expected and actual values, evidence, owning stage, and a final `Met`, `Not Met`, or `Unverified` verdict on every exit path; `N/A` is valid only when no target applies.
+* `Not Met` and `Unverified` targets now enter the same bounded Build-and-Test failure-escalation ladder as command failures, preserving the Code Generation loop-back added in 2.6.20.
+
 ## [2.6.73] - 2026-08-24
 
 Scope cost previews now describe the workflow the engine will actually run, and approval gates expose how long the current gate attempt has been waiting for a person. **Upgrade:** refresh your `dist/<harness>/` shell to install the corrected preview, status, and doctor behavior; existing workflow records need no migration.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.73-blue)
+![version](https://img.shields.io/badge/version-2.6.74-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/protocols/stage-protocol.md
+++ b/core/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/core/aidlc-common/stages/construction/build-and-test.md
+++ b/core/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/core/aidlc-common/stages/construction/code-generation.md
+++ b/core/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/core/memory/org.md
+++ b/core/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/claude/.claude/aidlc-common/protocols/stage-protocol.md
+++ b/dist/claude/.claude/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/dist/claude/.claude/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/claude/.claude/tools/data/memory-seed/org.md
+++ b/dist/claude/.claude/tools/data/memory-seed/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/claude/aidlc/spaces/default/memory/org.md
+++ b/dist/claude/aidlc/spaces/default/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/codex/.codex/aidlc-common/protocols/stage-protocol.md
+++ b/dist/codex/.codex/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/dist/codex/.codex/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/codex/.codex/tools/data/memory-seed/org.md
+++ b/dist/codex/.codex/tools/data/memory-seed/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/codex/aidlc/spaces/default/memory/org.md
+++ b/dist/codex/aidlc/spaces/default/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/copilot/.aidlc/aidlc-common/protocols/stage-protocol.md
+++ b/dist/copilot/.aidlc/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/copilot/.aidlc/tools/data/memory-seed/org.md
+++ b/dist/copilot/.aidlc/tools/data/memory-seed/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/copilot/aidlc/spaces/default/memory/org.md
+++ b/dist/copilot/aidlc/spaces/default/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/cursor/.cursor/aidlc-common/protocols/stage-protocol.md
+++ b/dist/cursor/.cursor/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/cursor/.cursor/tools/data/memory-seed/org.md
+++ b/dist/cursor/.cursor/tools/data/memory-seed/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/cursor/aidlc/spaces/default/memory/org.md
+++ b/dist/cursor/aidlc/spaces/default/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/kiro-ide/.kiro/aidlc-common/protocols/stage-protocol.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/kiro-ide/.kiro/tools/data/memory-seed/org.md
+++ b/dist/kiro-ide/.kiro/tools/data/memory-seed/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/kiro-ide/aidlc/spaces/default/memory/org.md
+++ b/dist/kiro-ide/aidlc/spaces/default/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/kiro/.kiro/aidlc-common/protocols/stage-protocol.md
+++ b/dist/kiro/.kiro/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/kiro/.kiro/tools/data/memory-seed/org.md
+++ b/dist/kiro/.kiro/tools/data/memory-seed/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/kiro/aidlc/spaces/default/memory/org.md
+++ b/dist/kiro/aidlc/spaces/default/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/opencode/.aidlc/aidlc-common/protocols/stage-protocol.md
+++ b/dist/opencode/.aidlc/aidlc-common/protocols/stage-protocol.md
@@ -491,6 +491,8 @@ When contradictions are detected:
   - "Whatever you think is best" or "up to you" — ask what outcome they care about most
   - Contradictory signals between different answers
   - Answers that dodge the question or change the subject
+  - Relaxing, lowering, or disabling a previously defined quality target (e.g.
+    a test coverage threshold) instead of meeting it
 - When a user defers to AI judgment, reframe: "I want to make sure the design reflects YOUR priorities. Could you tell me [specific aspect]?"
 
 ### Plan and question file location

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/build-and-test.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/build-and-test.md
@@ -60,9 +60,20 @@ Read code generation outputs across all units from
 instructions from
 `<record>/construction/*/code-generation/unit-test-instructions.md`. For a
 zero-Unit scope such as `express`, read the stage-level equivalents under
-`<record>/construction/code-generation/`. Review NFR requirements across units
-(if they exist) to identify performance and security testing needs. Catalog all
-test types required.
+`<record>/construction/code-generation/`.
+
+Build a source-complete inventory of every measurable quality target before
+generating instructions. Read all applicable stage-level and per-unit sources:
+
+- every artifact under `nfr-requirements/`
+- every artifact under `nfr-design/`
+- every approved `## Testing Contract` in `code-generation-plan.md`
+
+For each target, record a stable target ID (derive one from the source path and
+section when the source has none), source path/section, expected value, the
+check or instruction file that will produce its actual value, and the later
+validation stage that owns it when Build and Test cannot execute it locally.
+Catalog all required test types from this inventory.
 
 ### Step 3: Generate Build Instructions
 
@@ -105,6 +116,12 @@ Create `<record>/construction/build-and-test/build-and-test-summary.md`:
 - Overall build status and prerequisites
 - Test type inventory (which test types were generated)
 - Coverage expectations per unit
+- A `## Target Verification Matrix` with one row per target and these columns:
+  Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict
+- Each applicable target begins with Actual and Evidence `Pending`, and Verdict
+  `Pending`. `N/A` is valid only when the source inventory found no applicable
+  measurable target; in that case write one explanatory `N/A` row. An
+  applicable target may never use `N/A`.
 - Readiness assessment (build-ready, test-ready, deployment-ready)
 - Known limitations or outstanding items
 
@@ -123,23 +140,48 @@ Attempt to execute the build and test commands documented in the instruction fil
    once, never N times. Capture and report stage-level/per-unit pass/fail
    results without double counting.
 3. **Integration tests** (if applicable): Run integration test commands. Capture results.
-4. **Report results**: Create or update `<record>/construction/build-and-test/test-results.md` with:
+4. **Other applicable checks**: Run every applicable command from performance,
+   security, contract, E2E, accessibility, and other generated instruction
+   files. A check may be deferred only when it requires a deployed or
+   production-like environment AND the current execution plan contains a later
+   validation stage that explicitly owns that check (for example,
+   `performance-validation`). Record the owning stage and expected evidence
+   path. A deferred target remains `Unverified` and cannot contribute to a
+   successful stage result. If no later owning stage is scheduled, the target
+   is `Unverified`, not deferred successfully.
+5. **Finalize and report results**: Create or update
+   `<record>/construction/build-and-test/test-results.md` and the Build and Test
+   Summary on every exit path, including loop-back, halt-and-ask, abort, and
+   accepted failure, with:
    - Build status (success/failure + output)
    - Test results (total, passed, failed, skipped)
    - Failure details (test name, assertion, stack trace)
    - Coverage report (if test framework supports it)
+   - The finalized Target Verification Matrix: actual value, evidence path or
+     command output, owning stage, and exactly one final verdict per applicable
+     target: `Met`, `Not Met`, or `Unverified`. `Pending` is allowed only while
+     Step 9 is being prepared; no `Pending` verdict may remain when Step 10
+     exits.
    - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires a
      loop-back): one `### Loop-back N — <ISO timestamp>` entry per attempt,
      carrying Diagnosis / Root-cause stage / Planned fix / Estimated impact. This section
      is APPEND-ONLY and must survive re-runs of this stage (choose Modify,
      never Redo, on loop-back re-entry — Redo would erase the ledger).
 
-**On failure**: If build or tests fail, run the failure-escalation ladder:
+**Failure predicate**: Build and Test has failed when any build or test command
+fails OR any applicable target is `Not Met` or `Unverified`. Before entering
+failure handling, finalize the matrix and summary with all evidence available
+on that exit path. Weakening, relaxing, lowering, or disabling a defined
+quality target is never an acceptable fix.
+
+**On failure**: Run the same failure-escalation ladder for command failures,
+`Not Met` targets, and `Unverified` targets:
 
 1. **In-stage fix (max 2 attempts)** — for root causes inside this stage's own
-   remit (test config, build scripts, environment setup): read the error
-   output, identify the failing configuration or scaffolding, apply the fix,
-   re-run the failing step.
+   remit (test config, build scripts, environment setup, or an executable target
+   check): read the failure evidence, identify the failing configuration or
+   scaffolding, apply the fix, re-run the failing step, and refresh the target
+   matrix.
 2. **Classify and estimate impact** — when in-stage attempts are exhausted OR the
    diagnosis points upstream: decide whether the root cause lies in the
    generated source or test code — regardless of defect size — or an approach
@@ -183,7 +225,9 @@ iteration the replay uses the serial per-unit walk, never the autonomous swarm.
 to move. Stop at rung 2, log the diagnosis + impact-estimated options in
 test-results.md, and present them in this run's isolated-run summary.
 
-**On success**: Update the Build and Test Summary with actual results (not just instructions).
+**On success**: Only when every executed command passed AND every applicable
+target is `Met` (or the inventory has the single explanatory `N/A` row), update
+the Build and Test Summary with a successful readiness result.
 
 ### Step 11: Cross-Unit Final Coverage Gate
 

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -72,6 +72,10 @@ MANDATORY: Follow stage-protocol.md for approval gates, question format, and com
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Step 1: Read All Unit Artifacts
 
@@ -249,6 +253,11 @@ Include in the delegation prompt:
   reinterpret memory. TDD records each Red command's failing output before
   Green; BDD and ATDD follow their scenario/acceptance-first cross-layer
   profiles; custom/mixed follows the exact approved ordering.
+- The instruction that measurable quality targets from NFR Requirements, NFR
+  Design, and the Testing Contract coverage floor are inputs, not suggestions.
+  The subagent must NEVER relax, lower, or disable a defined target, including
+  threshold settings in test or build configuration, to make a step pass; it
+  must surface the gap instead.
 
 The subagent generates all code, test files, and configuration artifacts in the workspace.
 

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.73";
+export const AIDLC_VERSION = "2.6.74";

--- a/dist/opencode/.aidlc/tools/data/memory-seed/org.md
+++ b/dist/opencode/.aidlc/tools/data/memory-seed/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/dist/opencode/aidlc/spaces/default/memory/org.md
+++ b/dist/opencode/aidlc/spaces/default/memory/org.md
@@ -68,6 +68,9 @@ The active `Test Strategy` still applies in every scope and determines test
 volume/types. Scope floors are additive; they never reduce or replace the
 selected strategy.
 
+Build and Test verifies defined coverage floors and affirmed quality targets;
+they may not be weakened to make a step pass.
+
 Affirm a stricter posture in `team.md` if the team commits to one.
 
 ## Deployment

--- a/docs/reference/04-stage-protocol.md
+++ b/docs/reference/04-stage-protocol.md
@@ -433,7 +433,9 @@ ask targeted follow-up. Do NOT proceed until resolved.
 **Overconfidence prevention:**
 - Default to asking, not assuming. Never proceed with ambiguity.
 - Red flags requiring follow-up: single-word answers to open-ended questions;
-  "whatever you think" / "up to you"; contradictory signals; question-dodging
+  "whatever you think" / "up to you"; contradictory signals; question-dodging;
+  relaxing, lowering, or disabling a previously defined quality target (for
+  example, a test coverage threshold) instead of meeting it
 - When user defers to AI: "I want to make sure the design reflects YOUR
   priorities. Could you tell me [specific aspect]?"
 

--- a/docs/reference/04-stages/construction.md
+++ b/docs/reference/04-stages/construction.md
@@ -645,6 +645,10 @@ the execution plan. Code is written to the workspace root, never to
 - Before review, write the engine-required companion `source-manifest.json`
   listing every application-source path this unit created, modified, or deleted,
   including files written by shell commands, scaffolding, or generators
+- Measurable quality targets from NFR Requirements, NFR Design, and the Testing
+  Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
+  disable a defined target, including threshold settings in test or build
+  configuration, to make a step pass; surface the gap instead.
 
 ### Inputs
 
@@ -784,6 +788,11 @@ This stage has a **two-part structure**: planning followed by generation.
    - The approved Testing Contract is authoritative. The subagent does not
      independently re-resolve memory; it executes the approved TDD, BDD, ATDD,
      test-after, or custom/mixed profile exactly.
+   - Measurable quality targets from NFR Requirements, NFR Design, and the
+     Testing Contract coverage floor are inputs, not suggestions. The subagent
+     must NEVER relax, lower, or disable a defined target, including threshold
+     settings in test or build configuration, to make a step pass; it must
+     surface the gap instead.
 
    **Context budget:** Pass only the current unit's design artifacts, not all
    units. Summarize inception artifacts with file paths rather than embedding
@@ -897,8 +906,10 @@ with the aidlc-devsecops-agent providing security testing expertise.
   `<record>/construction/*/code-generation/code-summary.md`
 - Per-unit test instructions from
   `<record>/construction/*/code-generation/unit-test-instructions.md`
-- NFR requirements across units (if they exist) for performance and security
-  testing needs
+- Every applicable artifact under each unit's `nfr-requirements/` and
+  `nfr-design/` directory
+- Every approved `## Testing Contract` in the stage-level or per-unit
+  `code-generation-plan.md`
 
 ### Steps
 
@@ -906,9 +917,11 @@ with the aidlc-devsecops-agent providing security testing expertise.
    aidlc-devsecops-agent persona and knowledge for security testing input.
 
 2. **Analyze Testing Requirements** -- Read code generation summaries and
-   per-unit test instructions across all units. Review NFR requirements (if
-   they exist) to identify performance and security testing needs. Catalog
-   all test types required.
+   per-unit test instructions across all units. Build a source-complete
+   inventory of every measurable target from NFR Requirements, NFR Design, and
+   every approved Testing Contract. For each target, record a stable ID, source
+   path/section, expected value, the check that produces its actual value, and
+   any later validation stage that owns it. Catalog all required test types.
 
 3. **Generate Build Instructions** -- Create
    `<record>/construction/build-and-test/build-instructions.md`:
@@ -939,6 +952,10 @@ with the aidlc-devsecops-agent providing security testing expertise.
    - Overall build status and prerequisites
    - Test type inventory (which test types were generated)
    - Coverage expectations per unit
+   - A Target Verification Matrix with Target ID, Source, Expected, Actual,
+     Evidence, Owning Stage, and Verdict
+   - Applicable targets begin `Pending`; `N/A` is valid only when the
+     source-complete inventory found no applicable measurable target
    - Readiness assessment (build-ready, test-ready, deployment-ready)
    - Known limitations or outstanding items
 
@@ -954,24 +971,40 @@ with the aidlc-devsecops-agent providing security testing expertise.
        never once per unit. Report per-unit pass/fail without double counting.
     c. **Integration tests** (if applicable): Run integration test commands.
        Capture results.
-    d. **Report results**: Create or update
-       `<record>/construction/build-and-test/test-results.md` with:
+    d. **Other applicable checks**: Run every applicable command from
+       performance, security, contract, E2E, accessibility, and other generated
+       instruction files. Defer only a check that requires a deployed or
+       production-like environment and has a named owning validation stage in
+       the current execution plan. Record that stage and its expected evidence
+       path; the target remains `Unverified` and cannot make this stage
+       successful. Without a scheduled owning stage, it is simply
+       `Unverified`.
+    e. **Finalize and report results**: Create or update
+       `<record>/construction/build-and-test/test-results.md` and
+       `build-and-test-summary.md` on every exit path with:
        - Build status (success/failure + output)
        - Test results (total, passed, failed, skipped)
        - Failure details (test name, assertion, stack trace)
        - Coverage report (if test framework supports it)
+       - The finalized Target Verification Matrix. Every applicable target has
+         an actual value, evidence, owning stage, and final `Met`, `Not Met`, or
+         `Unverified` verdict. No `Pending` verdict remains after Step 10.
        - `## Loop-Back Log` (only when the failure ladder's rung 3 or 4 fires
          a loop-back): one `### Loop-back N -- <ISO timestamp>` entry per
          attempt (Diagnosis / Root-cause stage / Planned fix / Estimated impact).
          Append-only; survives re-runs (Modify, never Redo, on loop-back
          re-entry).
 
-    **Failure-escalation ladder:** On failure, if build or tests fail:
+    **Failure-escalation ladder:** The stage has failed when a build or test
+    command fails or an applicable target is `Not Met` or `Unverified`. Finalize
+    the matrix and summary before entering the same ladder for every failure
+    kind. Lowering, relaxing, or disabling a target is never an acceptable fix.
 
     1. **In-stage fix (max 2 attempts)** -- for root causes inside this
-       stage's own remit (test config, build scripts, environment setup):
-       read the error output, identify the failing configuration or
-       scaffolding, apply the fix, re-run the failing step.
+       stage's own remit (test config, build scripts, environment setup, or an
+       executable target check): read the evidence, identify the failing
+       configuration or scaffolding, apply the fix, re-run the failing step,
+       and refresh the target matrix.
     2. **Classify and estimate impact** -- when in-stage attempts are exhausted or the
        diagnosis points upstream: decide whether the root cause lies in
        generated source or test code -- regardless of defect size -- or a
@@ -1024,8 +1057,9 @@ with the aidlc-devsecops-agent providing security testing expertise.
     main-workflow position to move; the impact-estimated options are logged and
     presented in that run's isolated-run summary.
 
-    **On success:** Update the Build and Test Summary with actual results (not
-    just instructions).
+    **On success:** A successful readiness result requires every command to
+    pass and every applicable target to be `Met`, or the single explanatory
+    `N/A` row when no target applies.
 
 11. **Prepare Completion** -- Verify the build/test evidence. Do not edit
     stage or phase state; the reported gate outcome owns the transition.
@@ -1056,6 +1090,9 @@ Strictly 2-option: Approve / Request Changes.
   instructions -- it actually runs the build and test commands via Bash and
   captures real results. This is one of the few stages that executes
   real commands against the codebase.
+- **Quality target evidence**: The source-complete matrix is finalized on every
+  exit path. Deployed-environment checks may name a later owning stage, but
+  remain `Unverified`; `Not Met` and `Unverified` both enter the failure ladder.
 - **Failure-escalation ladder**: In-stage fixes are bounded at 2 attempts;
   when the root cause lies upstream in generated code or a code-generation
   approach choice, the stage classifies and estimates the impact of a fix, then either runs

--- a/tests/unit/t317-quality-target-gate.test.ts
+++ b/tests/unit/t317-quality-target-gate.test.ts
@@ -1,0 +1,100 @@
+// covers: file:aidlc-common/stages/construction/code-generation.md, file:aidlc-common/stages/construction/build-and-test.md, file:aidlc-common/protocols/stage-protocol.md, file:memory/org.md
+//
+// t317 - Defined quality targets remain binding during generation and are
+// measured explicitly at the Build and Test approval gate.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { REPO_ROOT } from "../harness/fixtures.ts";
+
+const CORE_ROOT = join(REPO_ROOT, "core");
+const CLAUDE_ROOT = join(REPO_ROOT, "dist", "claude", ".claude");
+const CLAUDE_ORG = join(
+  REPO_ROOT,
+  "dist",
+  "claude",
+  "aidlc",
+  "spaces",
+  "default",
+  "memory",
+  "org.md",
+);
+
+const FILES = {
+  codeGeneration: "aidlc-common/stages/construction/code-generation.md",
+  buildAndTest: "aidlc-common/stages/construction/build-and-test.md",
+  stageProtocol: "aidlc-common/protocols/stage-protocol.md",
+  org: "memory/org.md",
+} as const;
+
+function read(root: string, rel: string): string {
+  return readFileSync(join(root, rel), "utf-8");
+}
+
+function assertQualityTargetGate(root: string, orgPath: string): void {
+  const codeGeneration = read(root, FILES.codeGeneration);
+  expect(codeGeneration).toContain(
+    "Measurable quality targets from NFR Requirements, NFR Design, and the Testing\n" +
+      "  Contract coverage floor are inputs, not suggestions.",
+  );
+  expect(codeGeneration).toContain(
+    "NEVER relax, lower, or\n  disable a defined target, including threshold settings in test or build",
+  );
+  expect(codeGeneration).toContain(
+    "The subagent must NEVER relax, lower, or disable a defined target",
+  );
+
+  const buildAndTest = read(root, FILES.buildAndTest);
+  expect(buildAndTest).toContain(
+    "every approved `## Testing Contract` in `code-generation-plan.md`",
+  );
+  expect(buildAndTest).toContain(
+    "Target ID, Source, Expected, Actual, Evidence, Owning Stage, Verdict",
+  );
+  expect(buildAndTest).toContain(
+    "`Pending` is allowed only while\n     Step 9 is being prepared",
+  );
+  expect(buildAndTest).toContain(
+    "Run every applicable command from performance,\n" +
+      "   security, contract, E2E, accessibility, and other generated instruction",
+  );
+  expect(buildAndTest).toContain(
+    "A check may be deferred only when it requires a deployed or\n" +
+      "   production-like environment",
+  );
+  expect(buildAndTest).toContain(
+    "A deferred target remains `Unverified` and cannot contribute to a\n" +
+      "   successful stage result.",
+  );
+  expect(buildAndTest).toContain(
+    "**Failure predicate**: Build and Test has failed when any build or test command\n" +
+      "fails OR any applicable target is `Not Met` or `Unverified`.",
+  );
+  expect(buildAndTest).toContain(
+    "including loop-back, halt-and-ask, abort, and\n   accepted failure",
+  );
+  expect(buildAndTest).toContain(
+    "Weakening, relaxing, lowering, or disabling a defined\n" +
+      "quality target is never an acceptable fix.",
+  );
+
+  expect(read(root, FILES.stageProtocol)).toContain(
+    "Relaxing, lowering, or disabling a previously defined quality target (e.g.\n" +
+      "    a test coverage threshold) instead of meeting it",
+  );
+  expect(readFileSync(orgPath, "utf-8")).toContain(
+    "Build and Test verifies defined coverage floors and affirmed quality targets;\n" +
+      "they may not be weakened to make a step pass.",
+  );
+}
+
+describe("t317 quality-target verification gate", () => {
+  test("authored core carries the non-relaxation and target-verification rules", () => {
+    assertQualityTargetGate(CORE_ROOT, join(CORE_ROOT, FILES.org));
+  });
+
+  test("Claude projection carries the same quality-target gate", () => {
+    assertQualityTargetGate(CLAUDE_ROOT, CLAUDE_ORG);
+  });
+});


### PR DESCRIPTION
Measurable NFR targets (e.g. coverage thresholds) could be silently relaxed downstream: Code Generation had no rule forbidding a developer agent from lowering test-config thresholds to pass, and Build and Test never compared actual results against the defined targets. This ports the reporter's v1 PR #274 direction to the v2 architecture: a never-relax Critical Rule + developer-subagent instruction in code-generation, Coverage Target / Target Met verdicts and a per-target actuals comparison plus a no-weakening on-failure rule in build-and-test, an overconfidence red flag in the stage protocol, and an org Testing Posture invariant - pinned by tests/unit/t317-quality-target-gate.test.ts (v2.6.74). Closes #273