### PR TITLE
fix: make Testing Posture HTML-comment-aware (2.6.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.38] - 2026-08-21
+
+Testing Posture resolution now ignores HTML-commented examples while preserving visible prose, structured fields, and fenced notes. **Upgrade:** refresh your `dist/<harness>/` shell; contracts whose Testing Posture sections contain comments will re-resolve, so re-approve affected Code Generation plans.
+
+* Commented headings and comment-only `Testing Posture` sections no longer select, truncate, or affirm a methodology; the resolver falls through to the real visible section or next visible memory layer.
+* Visible `Methodology` and `Ordering` fields remain authoritative beside comments, and visible prose and fenced content remain in `applicable_notes`.
+* Testing Contract input fingerprints retain each raw resolved section, including comments and fenced content, so comment-only changes still invalidate stale approvals.
+
 ## [2.6.37] - 2026-08-21
 
 Code-generation review receipts are now bound to the workspace source state the reviewer inspected, and every completion route refuses when that state is stale. The same binding follows autonomous swarm work from finalize through source merge. **Upgrade:** refresh your `dist/<harness>/` shell so the source-fingerprint tools, guards, audit schema, and generated harness files are installed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.37-blue)
+![version](https://img.shields.io/badge/version-2.6.38-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-testing-posture.ts
+++ b/core/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/core/tools/aidlc-testing-posture.ts
+++ b/core/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/dist/claude/.claude/tools/aidlc-testing-posture.ts
+++ b/dist/claude/.claude/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/dist/claude/.claude/tools/aidlc-testing-posture.ts
+++ b/dist/claude/.claude/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/dist/codex/.codex/tools/aidlc-testing-posture.ts
+++ b/dist/codex/.codex/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/dist/codex/.codex/tools/aidlc-testing-posture.ts
+++ b/dist/codex/.codex/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/dist/copilot/.aidlc/tools/aidlc-testing-posture.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/dist/copilot/.aidlc/tools/aidlc-testing-posture.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/dist/cursor/.cursor/tools/aidlc-testing-posture.ts
+++ b/dist/cursor/.cursor/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/dist/cursor/.cursor/tools/aidlc-testing-posture.ts
+++ b/dist/cursor/.cursor/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/dist/kiro-ide/.kiro/tools/aidlc-testing-posture.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/dist/kiro-ide/.kiro/tools/aidlc-testing-posture.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/dist/kiro/.kiro/tools/aidlc-testing-posture.ts
+++ b/dist/kiro/.kiro/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/dist/kiro/.kiro/tools/aidlc-testing-posture.ts
+++ b/dist/kiro/.kiro/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/dist/opencode/.aidlc/tools/aidlc-testing-posture.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-testing-posture.ts
@@ -205,8 +205,12 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+function visiblePostureText(section: string): string {
+  return visibleMarkdownLines(section).join("\n").trim();
+}
+
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = section.trim();
+  const body = visiblePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -459,7 +463,10 @@ export function resolveTestingPostureFromSections(
               },
             };
   const applicableNotes = (["org", "team", "project"] as const)
-    .map((layer) => ({ layer, text: (sections[layer] ?? "").trim() }))
+    .map((layer) => ({
+      layer,
+      text: visiblePostureText(sections[layer] ?? ""),
+    }))
     .filter((entry) => entry.text.length > 0);
   const input = {
     sections: {

--- a/dist/opencode/.aidlc/tools/aidlc-testing-posture.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-testing-posture.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import {
   activeSpace,
   docsRoot,
-  extractMarkdownSection,
   getField,
   resolveProjectDir,
   stateFilePath,
@@ -205,12 +204,207 @@ function structuredField(section: string, field: string): string | null {
   return match?.[1].trim() || null;
 }
 
+type MarkdownFence = { marker: "`" | "~"; length: number };
+
+function isEscaped(line: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let index = offset - 1; index >= 0 && line[index] === "\\"; index--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function hasMatchingTickRun(
+  line: string,
+  from: number,
+  ticks: number,
+): boolean {
+  for (let cursor = from; cursor < line.length; cursor++) {
+    if (line[cursor] !== "`" || isEscaped(line, cursor)) continue;
+    let end = cursor + 1;
+    while (line[end] === "`") end++;
+    if (end - cursor === ticks) return true;
+    cursor = end - 1;
+  }
+  return false;
+}
+
+function stripHtmlCommentsFromLine(
+  rawLine: string,
+  state: { inComment: boolean; inlineCodeTicks: number },
+): string {
+  let line = "";
+  let cursor = 0;
+  while (cursor < rawLine.length) {
+    if (state.inComment) {
+      const end = rawLine.indexOf("-->", cursor);
+      if (end < 0) break;
+      state.inComment = false;
+      cursor = end + 3;
+      continue;
+    }
+    if (
+      rawLine[cursor] === "`" &&
+      (state.inlineCodeTicks > 0 || !isEscaped(rawLine, cursor))
+    ) {
+      let end = cursor + 1;
+      while (rawLine[end] === "`") end++;
+      const ticks = end - cursor;
+      if (
+        state.inlineCodeTicks === 0 &&
+        hasMatchingTickRun(rawLine, end, ticks)
+      ) {
+        state.inlineCodeTicks = ticks;
+      } else if (state.inlineCodeTicks === ticks) state.inlineCodeTicks = 0;
+      line += rawLine.slice(cursor, end);
+      cursor = end;
+      continue;
+    }
+    if (
+      state.inlineCodeTicks === 0 &&
+      !isEscaped(rawLine, cursor) &&
+      rawLine.startsWith("<!--", cursor)
+    ) {
+      state.inComment = true;
+      cursor += 4;
+      continue;
+    }
+    line += rawLine[cursor];
+    cursor++;
+  }
+  return line;
+}
+
+function fenceOpening(line: string): MarkdownFence | null {
+  const opening = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+  if (opening?.[1][0] === "`" && opening[2].includes("`")) return null;
+  return opening
+    ? {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length,
+      }
+    : null;
+}
+
+function closesFence(line: string, fence: MarkdownFence): boolean {
+  const closing = /^ {0,3}([`~]+)[ \t]*$/.exec(line);
+  return Boolean(
+    closing &&
+      closing[1][0] === fence.marker &&
+      Array.from(closing[1]).every((marker) => marker === fence.marker) &&
+      closing[1].length >= fence.length,
+  );
+}
+
+// Remove only rendered HTML comments. Fenced Markdown remains visible content,
+// including literal <!-- tokens inside a fence.
+function markdownWithoutHtmlComments(body: string): string {
+  const lines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const state = { inComment: false, inlineCodeTicks: 0 };
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((rawLine) => {
+      if (fence) {
+        if (closesFence(rawLine, fence)) fence = null;
+        return rawLine;
+      }
+      const startedInComment = state.inComment;
+      const line = stripHtmlCommentsFromLine(rawLine, state);
+      const commentStart = rawLine.indexOf("<!--");
+      const structuralPrefix =
+        startedInComment || (line !== rawLine && commentStart < 0)
+          ? ""
+          : commentStart < 0
+            ? rawLine
+            : rawLine.slice(0, commentStart);
+      const opening = fenceOpening(structuralPrefix);
+      if (opening) {
+        state.inComment = false;
+        state.inlineCodeTicks = 0;
+      }
+      fence = opening;
+      return opening ? rawLine : line;
+    })
+    .join("\n");
+}
+
+function structuralMarkdownLines(body: string): string[] {
+  const rawLines = body.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = markdownWithoutHtmlComments(body).split("\n");
+  return visibleLines.map((line, index) => {
+    const rawLine = rawLines[index];
+    if (line === rawLine) return line;
+    const opening = rawLine.indexOf("<!--");
+    const closing = rawLine.indexOf("-->");
+    return opening >= 0 && (closing < 0 || opening < closing)
+      ? rawLine.slice(0, opening)
+      : "";
+  });
+}
+
 function visiblePostureText(section: string): string {
-  return visibleMarkdownLines(section).join("\n").trim();
+  return markdownWithoutHtmlComments(section).trim();
+}
+
+function classifiablePostureText(section: string): string {
+  const lines = markdownWithoutHtmlComments(section).split("\n");
+  const structuralLines = structuralMarkdownLines(section);
+  let fence: MarkdownFence | null = null;
+  return lines
+    .map((line, index) => {
+      const structuralLine = structuralLines[index];
+      if (fence) {
+        if (closesFence(structuralLine, fence)) fence = null;
+        return "";
+      }
+      const opening = fenceOpening(structuralLine);
+      if (opening) {
+        fence = opening;
+        return "";
+      }
+      return line;
+    })
+    .join("\n")
+    .trim();
+}
+
+// Find the real Testing Posture section while ignoring headings hidden inside
+// HTML comments or fenced examples. Return the original raw lines so comments
+// and fences remain part of input_sha256 even though classification uses the
+// visible projection above.
+function extractTestingPostureSection(content: string): string {
+  const rawLines = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n").split("\n");
+  const visibleLines = structuralMarkdownLines(content);
+  let fence: MarkdownFence | null = null;
+  let bodyStart = -1;
+  let bodyEnd = rawLines.length;
+
+  for (let index = 0; index < visibleLines.length; index++) {
+    const line = visibleLines[index];
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+    const opening = fenceOpening(line);
+    if (opening) {
+      fence = opening;
+      continue;
+    }
+    if (bodyStart < 0) {
+      if (line.trimEnd() === TESTING_HEADING) bodyStart = index + 1;
+      continue;
+    }
+    if (/^## [^\n]*$/.test(line)) {
+      bodyEnd = index;
+      break;
+    }
+  }
+
+  return bodyStart < 0 ? "" : rawLines.slice(bodyStart, bodyEnd).join("\n");
 }
 
 function classifyPosture(section: string): ClassifiedPosture | null {
-  const body = visiblePostureText(section);
+  const body = classifiablePostureText(section);
   if (!body) return null;
 
   const structuredMethod = structuredField(body, "Methodology");
@@ -507,10 +701,7 @@ export function resolveTestingPosture(
   for (const layer of ["org", "team", "project"] as const) {
     const file = join(memoryDir, `${layer}.md`);
     if (!existsSync(file)) continue;
-    sections[layer] = extractMarkdownSection(
-      readFileSync(file, "utf-8"),
-      TESTING_HEADING,
-    );
+    sections[layer] = extractTestingPostureSection(readFileSync(file, "utf-8"));
   }
   let state = "";
   try {

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.37";
+export const AIDLC_VERSION = "2.6.38";

--- a/tests/unit/t299-testing-posture-wiring.test.ts
+++ b/tests/unit/t299-testing-posture-wiring.test.ts
@@ -28,6 +28,7 @@ import {
   type TestStrategy,
   type TestingMethodology,
 } from "../../dist/claude/.claude/tools/aidlc-testing-posture.ts";
+import { extractMarkdownSection } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { REPO_ROOT } from "../harness/fixtures.ts";
 
 const STAGE_REL = "core/aidlc-common/stages/construction/code-generation.md";
@@ -39,6 +40,8 @@ const SWARM_PROTOCOL_REL =
   "core/aidlc-common/protocols/stage-protocol-swarm.md";
 const AGENT_REL = "core/agents/aidlc-developer-agent.md";
 const ORG_REL = "core/memory/org.md";
+const TEAM_REL = "core/memory/team.md";
+const PROJECT_REL = "core/memory/project.md";
 
 function read(rel: string): string {
   return readFileSync(join(REPO_ROOT, rel), "utf-8");
@@ -78,6 +81,54 @@ function resolve(
 }
 
 describe("t299 (1) additive methodology resolution", () => {
+  test("shipped commented examples fall through to the org default", () => {
+    const sections = {
+      org: extractMarkdownSection(read(ORG_REL), "## Testing Posture"),
+      team: extractMarkdownSection(read(TEAM_REL), "## Testing Posture"),
+      project: extractMarkdownSection(read(PROJECT_REL), "## Testing Posture"),
+    };
+    const contract = resolve(sections);
+
+    expect(contract.methodology).toBe("test-after");
+    expect(contract.source).toBe("org");
+    expect(contract.applicable_notes.map((note) => note.layer)).toEqual([
+      "org",
+    ]);
+  });
+
+  test("visible structured fields remain authoritative beside comments", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "<!-- Example: Methodology: bdd -->",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first, then implementation.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+    expect(contract.ordering).toBe("tests first, then implementation.");
+  });
+
+  test("multi-line comments cannot affirm a methodology", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "<!-- Example posture:",
+        "We use BDD scenarios before implementation.",
+        "Unit tests use TDD.",
+        "-->",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("test-after");
+    expect(contract.source).toBe("org");
+    expect(contract.applicable_notes.map((note) => note.layer)).toEqual([
+      "org",
+    ]);
+  });
+
   test("a project coverage note does not erase team TDD", () => {
     const contract = resolve({
       org: ORG,

--- a/tests/unit/t299-testing-posture-wiring.test.ts
+++ b/tests/unit/t299-testing-posture-wiring.test.ts
@@ -129,6 +129,228 @@ describe("t299 (1) additive methodology resolution", () => {
     ]);
   });
 
+  test("a fence inside a multi-line comment cannot expose hidden methodology", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "<!-- Hidden example:",
+        "```yaml",
+        "Methodology: bdd",
+        "```",
+        "-->",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+  });
+
+  test("an HTML comment token in a fence info string stays literal", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "~~~text <!-- literal token",
+        "example content",
+        "~~~",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+    expect(contract.applicable_notes.find((note) => note.layer === "team")?.text)
+      .toContain("<!-- literal token");
+  });
+
+  test("visible fenced notes remain in applicable_notes", () => {
+    const contract = resolve({
+      org: ORG,
+      project: [
+        "Run the package-specific test command:",
+        "```bash",
+        "bun test packages/payments",
+        "```",
+      ].join("\n"),
+    });
+
+    expect(
+      contract.applicable_notes.find((note) => note.layer === "project")?.text,
+    ).toContain("bun test packages/payments");
+  });
+
+  test("a fenced methodology example remains a note but does not affirm the methodology", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "Example only:",
+        "~~~yaml",
+        "Methodology: bdd",
+        "Ordering: scenarios before implementation",
+        "~~~",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("test-after");
+    expect(contract.source).toBe("org");
+    expect(contract.applicable_notes.find((note) => note.layer === "team")?.text)
+      .toContain("Methodology: bdd");
+  });
+
+  test("HTML comment tokens inside inline code remain visible and do not hide later fields", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "Snapshot the literal `<!--` and `-->` tokens in parser tests.",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+    expect(contract.applicable_notes.find((note) => note.layer === "team")?.text)
+      .toContain("`<!--`");
+  });
+
+  test("mixed fence markers do not close a fenced methodology example", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "~~~~yaml",
+        "Example setup",
+        "~~~~`",
+        "Methodology: bdd",
+        "~~~~",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("test-after");
+    expect(contract.source).toBe("org");
+  });
+
+  test("unmatched backticks and escaped comment openers do not hide later fields", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "Document the unmatched ` marker.",
+        "Snapshot the escaped \\<!-- token.",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+    expect(contract.applicable_notes.find((note) => note.layer === "team")?.text)
+      .toContain("\\<!--");
+  });
+
+  test("escaped backticks do not turn a real HTML comment into inline code", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "Escaped delimiters \\` <!-- Methodology: bdd --> \\` stay prose.",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+    expect(contract.applicable_notes.find((note) => note.layer === "team")?.text)
+      .not.toContain("Methodology: bdd");
+  });
+
+  test("an invalid backtick fence info string does not hide visible methodology", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "```bad`info",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+  });
+
+  test("comment removal cannot synthesize a fence that hides later fields", () => {
+    const contract = resolve({
+      org: ORG,
+      team: [
+        "<!-- hidden prefix -->```yaml",
+        "example: true",
+        "- **Methodology**: tdd",
+        "- **Ordering**: tests first.",
+      ].join("\n"),
+    });
+
+    expect(contract.methodology).toBe("tdd");
+    expect(contract.source).toBe("team");
+  });
+
+  test("commented headings cannot select or truncate the visible Testing Posture section", () => {
+    const project = mkdtempSync(join(tmpdir(), "t299-comment-heading-"));
+    try {
+      const memoryDir = join(project, "aidlc", "spaces", "default", "memory");
+      mkdirSync(memoryDir, { recursive: true });
+      writeFileSync(
+        join(memoryDir, "org.md"),
+        `# Org\n\n## Testing Posture\n\n${ORG}\n`,
+      );
+      writeFileSync(
+        join(memoryDir, "team.md"),
+        [
+          "# Team",
+          "",
+          "<!-- Hidden example section:",
+          "## Testing Posture -->",
+          "- **Methodology**: bdd",
+          "",
+          "## Testing Posture <!-- real section -->",
+          "",
+          "<!-- Hidden nested example:",
+          "## Example",
+          "- **Methodology**: bdd",
+          "-->",
+          "<!-- hidden prefix -->## Deployment",
+          "- **Methodology**: tdd",
+          "- **Ordering**: tests first, then implementation.",
+          "",
+          "## Deployment <!-- next section -->",
+          "- **Methodology**: bdd",
+        ].join("\n"),
+      );
+      writeFileSync(join(memoryDir, "project.md"), "# Project\n");
+
+      const contract = resolveTestingPosture(project);
+      expect(contract.methodology).toBe("tdd");
+      expect(contract.source).toBe("team");
+      expect(contract.ordering).toBe("tests first, then implementation.");
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test("comment-only changes alter input_sha256 without entering applicable_notes", () => {
+    const first = resolve({
+      org: ORG,
+      team: "<!-- alpha -->\n- **Methodology**: tdd\n- **Ordering**: tests first.",
+    });
+    const second = resolve({
+      org: ORG,
+      team: "<!-- beta -->\n- **Methodology**: tdd\n- **Ordering**: tests first.",
+    });
+
+    expect(second.methodology).toBe("tdd");
+    expect(second.applicable_notes).toEqual(first.applicable_notes);
+    expect(second.input_sha256).not.toBe(first.input_sha256);
+  });
+
   test("a project coverage note does not erase team TDD", () => {
     const contract = resolve({
       org: ORG,


### PR DESCRIPTION
The posture resolver classified methodology from raw section text, so the shipped team.md commented-out BDD example silently affirmed BDD for every fresh project and fingerprinted the wrong Testing Contract into Plan Approval. Comment content is now stripped (via the existing multi-line-aware visibleMarkdownLines) before structured-field/keyword detection and applicable_notes, while raw sections still feed input_sha256 and visible prose/structured affirmations keep their #724 behavior; regression tests pin the unmodified shipped templates to methodology=test-after, source=org. Closes #841