### PR TITLE
fix: emit ARTIFACT_* audit rows for relative-path native writes (Kiro CLI conductor deadlock) (2.6.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.19] - 2026-08-21
+
+Kiro CLI conductor writes now preserve the audit-backed artifact lifecycle when the native write tool reports a project-relative path, and sensor dispatch applies the same normalization before its recursion guard and glob matching. **Upgrade:** refresh your `dist/<harness>/` shell copies so the updated adapters and core hooks are installed.
+
+* Kiro CLI `write` / `fs_write` events now emit `ARTIFACT_CREATED` or `ARTIFACT_UPDATED` for relative paths under the active record, fixing the "no recorded native-tool write after the human's consolidated summary confirmation" gate refusal and resulting workflow deadlock.
+* The run-sensors hook now resolves relative write paths against the project before checking the `.aidlc-sensors/` recursion guard and applicable sensor globs.
+
 ## [2.6.18] - 2026-08-19
 
 Classic and Express are new scope options, and the implicit default scope is now Classic — a **declared behavior change**: invocations that name no scope and match no keyword now run the v1-style lifecycle without Ideation instead of the full-lifecycle Feature scope. Exactly two things control the implicit default: the `AWS_AIDLC_DEFAULT_SCOPE` env var (which overrides) and the framework's hard-coded `classic` fallback. Express has a deterministic requirements-to-conditional-deploy path, and conditional protocol modules reduce fixed context without dropping reviewer recovery behavior. **Upgrade:** refresh your `dist/<harness>/` shell; in-flight workflows keep their persisted scope and need no migration; set `AWS_AIDLC_DEFAULT_SCOPE=feature` (Claude: the `.claude/settings.json` `env` block, which now ships `classic`) to keep the previous full-lifecycle default.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.18-blue)
+![version](https://img.shields.io/badge/version-2.6.19-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/hooks/aidlc-run-sensors.ts
+++ b/core/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/core/hooks/aidlc-write-audit-log.ts
+++ b/core/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/dist/claude/.claude/hooks/aidlc-run-sensors.ts
+++ b/dist/claude/.claude/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/claude/.claude/hooks/aidlc-write-audit-log.ts
+++ b/dist/claude/.claude/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/dist/codex/.codex/hooks/aidlc-run-sensors.ts
+++ b/dist/codex/.codex/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/codex/.codex/hooks/aidlc-write-audit-log.ts
+++ b/dist/codex/.codex/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/dist/copilot/.aidlc/hooks/aidlc-run-sensors.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/copilot/.aidlc/hooks/aidlc-write-audit-log.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/dist/cursor/.cursor/hooks/aidlc-run-sensors.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/cursor/.cursor/hooks/aidlc-write-audit-log.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/dist/kiro-ide/.kiro/hooks/aidlc-run-sensors.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/kiro-ide/.kiro/hooks/aidlc-write-audit-log.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/dist/kiro/.kiro/hooks/aidlc-kiro-adapter.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-kiro-adapter.ts
@@ -781,8 +781,11 @@ function buildForward(): Forward {
     case "audit-and-sensors": {
       // postToolUse(write) → write-audit-log THEN run-sensors (both ship core).
       if (tool !== "Write") return null;
-      const filePath = (ti.path as string) ?? (ti.file_path as string) ?? "";
-      if (!filePath) return null;
+      const rawFilePath = (ti.path as string) ?? (ti.file_path as string) ?? "";
+      if (!rawFilePath) return null;
+      const filePath = isAbsolute(rawFilePath)
+        ? rawFilePath
+        : join(projectDir, rawFilePath);
       return {
         hook: "__audit_and_sensors__", // handled specially below (two hooks)
         input: {

--- a/dist/kiro/.kiro/hooks/aidlc-run-sensors.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/kiro/.kiro/hooks/aidlc-write-audit-log.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/dist/opencode/.aidlc/hooks/aidlc-run-sensors.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/opencode/.aidlc/hooks/aidlc-write-audit-log.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,8 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.18";
+export const AIDLC_VERSION = "2.6.19";

--- a/harness/kiro/hooks/aidlc-kiro-adapter.ts
+++ b/harness/kiro/hooks/aidlc-kiro-adapter.ts
@@ -781,8 +781,11 @@ function buildForward(): Forward {
     case "audit-and-sensors": {
       // postToolUse(write) → write-audit-log THEN run-sensors (both ship core).
       if (tool !== "Write") return null;
-      const filePath = (ti.path as string) ?? (ti.file_path as string) ?? "";
-      if (!filePath) return null;
+      const rawFilePath = (ti.path as string) ?? (ti.file_path as string) ?? "";
+      if (!rawFilePath) return null;
+      const filePath = isAbsolute(rawFilePath)
+        ? rawFilePath
+        : join(projectDir, rawFilePath);
       return {
         hook: "__audit_and_sensors__", // handled specially below (two hooks)
         input: {

--- a/tests/unit/t07-hook-audit-logger.test.ts
+++ b/tests/unit/t07-hook-audit-logger.test.ts
@@ -68,7 +68,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { hostname } from "node:os";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { docsRoot } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import {
   AIDLC_SRC,
@@ -197,6 +197,24 @@ describe("t07 audit-logger PostToolUse hook (mechanism cli — spawned hook + st
     // not a record subdir, so it is not a record-artifact example).
     fire(writeJson(join(recordRoot, "inception", "requirements-analysis", "requirements.md")), proj);
     expect(readShards(auditDir)).toContain("ARTIFACT_CREATED");
+  });
+
+  test("logs a project-relative record artifact path with an absolute File field", () => {
+    const { auditDir, recordRoot } = seedIntentShard(proj);
+    const absoluteFile = join(
+      recordRoot,
+      "inception",
+      "requirements-analysis",
+      "relative-requirements.md",
+    );
+    mkdirSync(dirname(absoluteFile), { recursive: true });
+    writeFileSync(absoluteFile, "# Requirements\n", "utf-8");
+
+    fire(writeJson(relative(proj, absoluteFile)), proj);
+
+    const audit = readShards(auditDir);
+    expect(audit).toMatch(/\*\*Event\*\*: ARTIFACT_(CREATED|UPDATED)/);
+    expect(audit).toContain(`**File**: ${absoluteFile.replace(/\\/g, "/")}`);
   });
 
   test("extracts the ideation breadcrumb [.sh test 4]", () => {

--- a/tests/unit/t147-kiro-hook-adapter.test.ts
+++ b/tests/unit/t147-kiro-hook-adapter.test.ts
@@ -33,7 +33,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { hostname, tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createIntent,
@@ -566,11 +566,37 @@ describe("t147 Kiro hook adapter (live-captured payload fixtures)", () => {
     }
   });
 
-  test("7: write-event target normalizes path→file_path and exits 0 (advisory)", () => {
+  test("7: write-event target audits a project-relative path from the Kiro payload", () => {
     const dir = scratchProject(true);
     try {
-      const r = runAdapter(dir, "audit-and-sensors", FIXTURES.postToolUse_write);
+      const captured = FIXTURES.postToolUse_write as {
+        tool_input?: Record<string, unknown>;
+        [key: string]: unknown;
+      };
+      const absoluteFile = join(
+        seededRecordDir(dir),
+        "ideation",
+        "intent-capture",
+        "intent-statement.md",
+      );
+      mkdirSync(dirname(absoluteFile), { recursive: true });
+      writeFileSync(absoluteFile, "PROBE\n", "utf-8");
+      const relativePayload = {
+        ...captured,
+        cwd: dir,
+        tool_input: {
+          ...captured.tool_input,
+          path: relative(dir, absoluteFile),
+        },
+      };
+
+      const before = readAudit(dir);
+      const r = runAdapter(dir, "audit-and-sensors", relativePayload);
       expect(r.code).toBe(0);
+      const audit = readAudit(dir);
+      expect(audit).not.toBe(before);
+      expect(audit).toMatch(/\*\*Event\*\*: ARTIFACT_(CREATED|UPDATED)/);
+      expect(audit).toContain(`**File**: ${absoluteFile.replace(/\\/g, "/")}`);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/t94-sensor-fire-hook.test.ts
+++ b/tests/unit/t94-sensor-fire-hook.test.ts
@@ -90,7 +90,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { hostname, tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import {
   AIDLC_SRC,
   cleanupTestProject,
@@ -376,6 +376,18 @@ describe("t94 aidlc-run-sensors hook — guards + early exits (migrated from t94
     );
     const r = runHook(proj, filePath);
     expect(r.status).toBe(0);
+    expect(existsSync(spawnLogPath(proj))).toBe(false);
+  });
+
+  test("recursion guard catches project-relative writes under the active sensor detail dir", () => {
+    const proj = makeProjectActive();
+    const filePath = relative(
+      proj,
+      join(seededRecordDir(proj), ".aidlc-sensors", "requirements-analysis", "detail.md"),
+    );
+    const r = runHook(proj, filePath);
+    expect(r.status).toBe(0);
+    expect(existsSync(heartbeatPath(proj))).toBe(false);
     expect(existsSync(spawnLogPath(proj))).toBe(false);
   });
 


### PR DESCRIPTION
## Problem

On Kiro CLI, the main session's `write`/`fs_write` tool passes a **model-composed** `tool_input.path` that can be project-relative. The write-audit hook's path-gate compared it verbatim (`startsWith`) against absolute record/codekb roots, so every conductor-authored `produces[]` artifact write fell out at "not under record or codekb root" and emitted **no** `ARTIFACT_CREATED`/`ARTIFACT_UPDATED` row.

Downstream this deadlocks the workflow: `aidlc-state gate-start`'s completion precondition finds no native-tool write after the consolidated summary confirmation and refuses the approval gate, while every workaround is blocked by design — re-saving trips the review-freeze (which *does* normalize relative paths), and manual append of `ARTIFACT_*` is CLI-reserved. Stages whose artifacts are subagent-authored were unaffected only because those sessions happened to pass absolute paths.

From a user-filed report with `AIDLC_HOOK_DEBUG` evidence: `path-gate tool="Write" file="aidlc/spaces/default/intents/…" recordRoot="/Users/…/intents/…" underRecord=false` → `exit: not under record or codekb root`; the identical write with an absolute path emits correctly.

## Fix

- **`core/hooks/aidlc-write-audit-log.ts`** — absolutize `file_path` against `projectDir` before the path-gate; the absolutized form flows into the audit `File:` field, context breadcrumb, and CREATE-vs-UPDATE stat probe. Fixes every harness at once.
- **`harness/kiro/hooks/aidlc-kiro-adapter.ts`** (`audit-and-sensors`) — absolutize before forwarding, matching the codex adapter idiom (`isAbsolute(p) ? p : join(projectDir, p)`); kiro-ide already did this.
- **`core/hooks/aidlc-run-sensors.ts`** — same normalization before the `.aidlc-sensors/` recursion guard (which a relative path silently bypassed) and glob matching; corrected the falsified "always an absolute path" comment.

Deliberately **not** taken from the report: a gate-start mtime fallback — it would weaken the audit-backed invariant; fixing the row producer removes the deadlock.

## Why tests missed it, and the coverage added

The kiro payload fixture was live-captured once with an absolute path (the shape is model-chosen, not harness-fixed); every unit test built `file_path` via `join(proj, …)`; and the one test on this seam asserted only exit 0 against an always-exit-0 advisory hook — structurally blind to a silently dropped row. Added:

- `t07`: relative `file_path` under the record root emits an `ARTIFACT_*` row with an absolute `File:` field (**revert-checked**: fails without the core fix).
- `t147` test 7: upgraded from exit-code-only to asserting the audit row lands from a relative Kiro payload.
- `t94`: relative-path write into the sensors detail dir is caught by the recursion guard.

## Release

`2.6.19` — version, CHANGELOG entry (upgrade: refresh `dist/<harness>/` shell copies), README badge; all dists regenerated, `bun scripts/package.ts --check` green.

## Evidence

- smoke+unit: 236 files / 6847 assertions, 0 failed (`tests/logs/2026-08-21T07-11-01Z-p3`)
- integration: 104 files / 1447 assertions, 1 environmental red (`t145`, missing worktree `node_modules` for its scratch symlink) re-run green-alone after `bun install` (`tests/logs/2026-08-21T07-27-11Z-p3994994`, rerun `2026-08-21T07-46-08Z-p4157211`)
- typecheck + biome clean