### PR TITLE
chore(tests): renumber duplicate t304 test files to t314-t316

### DIFF
--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -320,7 +320,7 @@
       "minMechanism": "none",
       "coveredBy": [
         {
-          "file": "tests/unit/t304-pipeline-link-receipts.test.ts",
+          "file": "tests/unit/t315-pipeline-link-receipts.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -1687,7 +1687,7 @@
       "minMechanism": "none",
       "coveredBy": [
         {
-          "file": "tests/unit/t304-pipeline-link-receipts.test.ts",
+          "file": "tests/unit/t315-pipeline-link-receipts.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -2153,7 +2153,7 @@
       "minMechanism": "none",
       "coveredBy": [
         {
-          "file": "tests/unit/t304-source-freshness-receipts.test.ts",
+          "file": "tests/unit/t314-source-freshness-receipts.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -3246,7 +3246,7 @@
       "minMechanism": "none",
       "coveredBy": [
         {
-          "file": "tests/unit/t304-pipeline-link-receipts.test.ts",
+          "file": "tests/unit/t315-pipeline-link-receipts.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -3258,7 +3258,7 @@
       "minMechanism": "none",
       "coveredBy": [
         {
-          "file": "tests/unit/t304-pipeline-link-receipts.test.ts",
+          "file": "tests/unit/t315-pipeline-link-receipts.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -4892,7 +4892,7 @@
       "minMechanism": "none",
       "coveredBy": [
         {
-          "file": "tests/unit/t304-source-freshness-receipts.test.ts",
+          "file": "tests/unit/t314-source-freshness-receipts.test.ts",
           "mechanism": "cli"
         }
       ],
@@ -6761,7 +6761,7 @@
       "minMechanism": "cli",
       "coveredBy": [
         {
-          "file": "tests/unit/t304-pipeline-link-receipts.test.ts",
+          "file": "tests/unit/t315-pipeline-link-receipts.test.ts",
           "mechanism": "cli"
         }
       ],

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -822,10 +822,10 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     // tests stayed green. A journey through the documented workflow cannot be
     // run in-process without bypassing the exact layer under test.
     "unit/t293-knowledge-journey.test.ts",
-    // t304 spawns the real directive-emitting CLI because memory bootstrap is
+    // t316 spawns the real directive-emitting CLI because memory bootstrap is
     // observable only at the process boundary where projectDir and the shipped
     // harness template are both present.
-    "unit/t304-run-stage-memory-bootstrap.test.ts",
+    "unit/t316-run-stage-memory-bootstrap.test.ts",
     // t301 spawns `aidlc.ts knowledge summarize` through the compiled
     // dispatcher (same §8.12 discipline as t293), and its two ACTION-only
     // probes drive real concurrent subprocesses (a race between two
@@ -992,7 +992,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t291-review-receipt-recovery.test.ts",
     "unit/t302-protocol-modules.test.ts",
     "unit/t317-gate-pending-doctor.test.ts",
-    "unit/t304-pipeline-link-receipts.test.ts",
+    "unit/t315-pipeline-link-receipts.test.ts",
     "unit/t313-plugin-doctor-checks.test.ts",
     "unit/t320-review-confirmation-deadlock.test.ts",
     "unit/t321-source-recovery-freeze.test.ts",
@@ -1000,7 +1000,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t323-review-verdict-closure.test.ts",
     "unit/t312-orchestrate-session-binding.test.ts",
     "unit/t255-workspace-sync.test.ts",
-    "unit/t304-source-freshness-receipts.test.ts",
+    "unit/t314-source-freshness-receipts.test.ts",
     // t305 runs the shipped review/state tools because source-attribution
     // acceptance depends on actual audit receipts and completion refusals.
     "unit/t305-per-unit-attribution-receipts.test.ts",

--- a/tests/unit/t236-ensemble-evidence-gate.test.ts
+++ b/tests/unit/t236-ensemble-evidence-gate.test.ts
@@ -9,7 +9,7 @@
 // refuses `--result approved` while any is missing or malformed, naming the
 // gap and the remediation; AIDLC_DISABLE_ENSEMBLE_EVIDENCE=1 is the escape
 // hatch; inline stages carry no requirement (pipeline receipts are covered by
-// t304); an already-[x]
+// t315); an already-[x]
 // stage is an idempotent replay and is never blocked.
 //
 // SOURCE UNDER TEST: the ensemble-evidence guard in handleReport

--- a/tests/unit/t272-unit-major-code-gen.test.ts
+++ b/tests/unit/t272-unit-major-code-gen.test.ts
@@ -230,7 +230,7 @@ function runReport(proj: string, args: string[]): Directive {
       const e: NodeJS.ProcessEnv = {
         ...process.env,
         // This routing fixture is intentionally not a Git checkout. Source
-        // freshness is exercised end to end by t304; keep this test scoped to
+        // freshness is exercised end to end by t314; keep this test scoped to
         // the unit-major cascade instead of minting unbindable review receipts.
         AIDLC_SKIP_SOURCE_FRESHNESS: "1",
       };

--- a/tests/unit/t314-source-freshness-receipts.test.ts
+++ b/tests/unit/t314-source-freshness-receipts.test.ts
@@ -1,7 +1,7 @@
 // covers: function:workspaceSourceFingerprint
 // covers: function:gitCommitSourceListing
 //
-// t304 - reviewer receipts bound to workspace source state (#629).
+// t314 - reviewer receipts bound to workspace source state (#629).
 //
 // PR #569's freshness guard invalidates receipts via ARTIFACT_CREATED/UPDATED
 // events for declared record artifacts - but code-generation produces
@@ -298,10 +298,10 @@ function registerRepos(projectDir: string, repos: string[]): void {
   );
 }
 
-describe("t304 workspace source fingerprint (in-process)", () => {
+describe("t314 workspace source fingerprint (in-process)", () => {
   let dir: string;
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "t304-fp-"));
+    dir = mkdtempSync(join(tmpdir(), "t314-fp-"));
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
@@ -334,7 +334,7 @@ describe("t304 workspace source fingerprint (in-process)", () => {
     // The edit stays UNSTAGED (` M`) - a staged `M ` would mean the real index
     // was touched by the temp-index walk.
     expect(status).toContain(" M app.ts");
-    const plain = mkdtempSync(join(tmpdir(), "t304-plain-"));
+    const plain = mkdtempSync(join(tmpdir(), "t314-plain-"));
     try {
       expect(workspaceSourceFingerprint(plain)).toMatch(/^[0-9a-f]{64}$/);
       writeFileSync(join(plain, "raw.ts"), "unbound\n");
@@ -350,7 +350,7 @@ describe("t304 workspace source fingerprint (in-process)", () => {
   // parent's own write-tree sha - unchanged, shipping a reviewed-then-edited
   // submodule as if nothing had changed.
   test("recurses into an initialized submodule: an uncommitted edit inside it changes the fingerprint", () => {
-    const subDir = mkdtempSync(join(tmpdir(), "t304-fp-sub-"));
+    const subDir = mkdtempSync(join(tmpdir(), "t314-fp-sub-"));
     try {
       git(subDir, ["init", "-q"]);
       git(subDir, ["config", "user.email", "t@test"]);
@@ -389,7 +389,7 @@ describe("t304 workspace source fingerprint (in-process)", () => {
   // the submodule is silently skipped and a reviewed-then-edited submodule at
   // such a path ships unreviewed.
   test("detects a submodule at a non-ASCII path (git core.quotePath) via -z, not the default quoted form", () => {
-    const subDir = mkdtempSync(join(tmpdir(), "t304-fp-sub-"));
+    const subDir = mkdtempSync(join(tmpdir(), "t314-fp-sub-"));
     try {
       git(subDir, ["init", "-q"]);
       git(subDir, ["config", "user.email", "t@test"]);
@@ -811,7 +811,7 @@ process.stdin.on("data", (chunk) => {
   // The same defect one level further down: the recursion fingerprinted each
   // submodule with the shell exclusion applied to the submodule's own root.
   test("a directory named aidlc inside an initialized submodule is that submodule's source", () => {
-    const subDir = mkdtempSync(join(tmpdir(), "t304-fp-sub-"));
+    const subDir = mkdtempSync(join(tmpdir(), "t314-fp-sub-"));
     try {
       git(subDir, ["init", "-q"]);
       git(subDir, ["config", "user.email", "t@test"]);
@@ -880,7 +880,7 @@ process.stdin.on("data", (chunk) => {
   });
 });
 
-describe("t304 receipt stamping + completion guard (cli)", () => {
+describe("t314 receipt stamping + completion guard (cli)", () => {
   let proj: string;
   let src: string;
 
@@ -1075,7 +1075,7 @@ describe("t304 receipt stamping + completion guard (cli)", () => {
 // stage-entry baseline then rejects every changed path outside the fresh claim
 // union. The cases below pin legitimate sequential/rework/shared integration,
 // owner-specific stale invalidation, and fail-closed unclaimed additions.
-describe("t304 multi-unit source attribution", () => {
+describe("t314 multi-unit source attribution", () => {
   let proj: string;
 
   beforeEach(() => {
@@ -1332,7 +1332,7 @@ describe("t304 multi-unit source attribution", () => {
 // never edited anything. isSettledSwarmForArtifactGuard's exemption (already
 // proven for the produces-existence guard, t185) is reused here to skip the
 // fingerprint reconciliation entirely once every DAG unit has converged.
-describe("t304 settled-swarm exemption from fingerprint reconciliation (#646 review P1#2)", () => {
+describe("t314 settled-swarm exemption from fingerprint reconciliation (#646 review P1#2)", () => {
   let proj: string;
   const UNITS = ["alpha", "beta"];
 
@@ -1400,7 +1400,7 @@ describe("t304 settled-swarm exemption from fingerprint reconciliation (#646 rev
 // `reviewerReceiptError` (aidlc-swarm.ts) accepted any terminal READY/NOT-READY
 // verdict and never read the receipt's own Source Fingerprint, so finalize
 // could merge a unit whose worktree source was edited after its review.
-describe("t304 swarm finalize source-fingerprint check (#646 review P1#3)", () => {
+describe("t314 swarm finalize source-fingerprint check (#646 review P1#3)", () => {
   const fixtures: string[] = [];
   const extraDirs: string[] = [];
   afterAll(() => {
@@ -1504,7 +1504,7 @@ describe("t304 swarm finalize source-fingerprint check (#646 review P1#3)", () =
   test("finalize fails closed when reviewed bytes live only in a dirty initialized submodule", () => {
     const proj = makeFixture();
     ensureDagUnit(proj, "subdirty");
-    const origin = mkdtempSync(join(tmpdir(), "aidlc-t304-submodule-"));
+    const origin = mkdtempSync(join(tmpdir(), "aidlc-t314-submodule-"));
     extraDirs.push(origin);
     seedGitRepo(origin);
     git(proj, ["-c", "protocol.file.allow=always", "submodule", "add", "-q", origin, "vendor/sub"]);

--- a/tests/unit/t315-pipeline-link-receipts.test.ts
+++ b/tests/unit/t315-pipeline-link-receipts.test.ts
@@ -135,7 +135,7 @@ function rewriteIntentRepos(proj: string, repos: string[]): void {
   writeFileSync(registry, `${JSON.stringify(rows, null, 2)}\n`);
 }
 
-describe("t304 pipeline link receipts", () => {
+describe("t315 pipeline link receipts", () => {
   test("emits the ordered tool-owned receipt fields", () => {
     const proj = pipelineProject();
     appendAuditEntry("STAGE_STARTED", { Stage: RE_STAGE, Agent: LEAD }, proj);

--- a/tests/unit/t316-run-stage-memory-bootstrap.test.ts
+++ b/tests/unit/t316-run-stage-memory-bootstrap.test.ts
@@ -62,7 +62,7 @@ function emitRunStage(project: string): Record<string, unknown> {
   return result.directive ?? {};
 }
 
-describe("t304 run-stage memory bootstrap", () => {
+describe("t316 run-stage memory bootstrap", () => {
   test("directive emission creates memory.md with the exact template bytes", () => {
     const project = installedProject();
     const directive = emitRunStage(project);


### PR DESCRIPTION
## What

Renumbers three test files so each test number is unique again. Four files currently share `t304`:

| file | introduced by | action |
|---|---|---|
| `tests/integration/t304-loopback-review-receipt-replay.test.ts` | #616 | keeps `t304` (first merged) |
| `tests/unit/t304-source-freshness-receipts.test.ts` | #646 | renamed to `t314-source-freshness-receipts.test.ts` |
| `tests/unit/t304-pipeline-link-receipts.test.ts` | #850 | renamed to `t315-pipeline-link-receipts.test.ts` |
| `tests/unit/t304-run-stage-memory-bootstrap.test.ts` | #845 | renamed to `t316-run-stage-memory-bootstrap.test.ts` |

New numbers are assigned by introduction order. `t314`-`t316` rather than `t310`-`t312`: the lower block is already targeted by in-flight work (#797 carries `t313`; the #803 thread asks that PR to take the next free `t3xx`; #858's description references `t310`-`t312`), so this chore takes the next clean block above them to avoid renumber churn in open PRs.

## Scope

Pure rename + self-reference updates; zero behavioral change:

- the three files' `describe` label prefixes (`t304 ...` to `t314/t315/t316 ...`),
- `tests/unit/gen-coverage-registry.test.ts` list entries + the one comment naming the old number,
- `tests/.coverage-registry.json` entries for the renamed paths.

Test-only change, so no version bump / CHANGELOG entry per the repo's changelog policy. No references to the old filenames exist outside `tests/` (docs/README/CI grep-verified clean).

## Verification

Renames proven pure: each old file with `s/t304/t31N/g` applied is byte-identical to its renamed counterpart. Repo-wide grep for the old filenames returns zero hits; `t304` now appears only in the keeper integration file and its registry entries.

Targeted run (`bash tests/run-tests.sh --debug -P 8 --filter 't314-source-freshness-receipts|t315-pipeline-link-receipts|t316-run-stage-memory-bootstrap|gen-coverage-registry'`): Result: PASS, 4 files, 105 assertions, 0 failed (t314: 57, t315: 10, t316: 4, gen-coverage-registry: 34). `bun run typecheck`, `bun run check`, and `bun scripts/package.ts --check` all exit 0.
