### PR TITLE
fix: normalize relative paths in core write hooks (2.6.75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.75] - 2026-08-24
+
+Shared write hooks now normalize project-relative file payloads before applying audit and sensor path logic, enforcing the hooks' absolute-path invariant even if an adapter boundary is bypassed. **Upgrade:** refresh your `dist/<harness>/` shell; existing workflows require no migration.
+
+* Artifact audit logging resolves relative record paths before its path gates while preserving project-prefix redaction in the recorded `File` value.
+* Sensor dispatch resolves relative paths before its recursion guard, glob match, and `--output-path` argument while preserving gate-only sensor isolation.
+
 ## [2.6.74] - 2026-08-24
 
 Defined quality targets now remain binding from Code Generation through Build and Test: every measurable target is inventoried from NFR Requirements, NFR Design, and the approved Testing Contract, then finalized with evidence before the stage can succeed. **Upgrade:** refresh your `dist/<harness>/` shell so the updated Construction stage and protocol guidance are installed.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.74-blue)
+![version](https://img.shields.io/badge/version-2.6.75-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/hooks/aidlc-run-sensors.ts
+++ b/core/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/core/hooks/aidlc-write-audit-log.ts
+++ b/core/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/dist/claude/.claude/hooks/aidlc-run-sensors.ts
+++ b/dist/claude/.claude/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/claude/.claude/hooks/aidlc-write-audit-log.ts
+++ b/dist/claude/.claude/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/dist/codex/.codex/hooks/aidlc-run-sensors.ts
+++ b/dist/codex/.codex/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/codex/.codex/hooks/aidlc-write-audit-log.ts
+++ b/dist/codex/.codex/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/dist/copilot/.aidlc/hooks/aidlc-run-sensors.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/copilot/.aidlc/hooks/aidlc-write-audit-log.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/dist/cursor/.cursor/hooks/aidlc-run-sensors.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/cursor/.cursor/hooks/aidlc-write-audit-log.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/dist/kiro-ide/.kiro/hooks/aidlc-run-sensors.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/kiro-ide/.kiro/hooks/aidlc-write-audit-log.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/dist/kiro/.kiro/hooks/aidlc-run-sensors.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/kiro/.kiro/hooks/aidlc-write-audit-log.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/dist/opencode/.aidlc/hooks/aidlc-run-sensors.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-run-sensors.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type GraphStage, loadGraph } from "../tools/aidlc-graph.ts";
 import {
   auditFilePath,
@@ -71,12 +71,13 @@ try {
   return 0;
 }
 
-// Step 4 — Extract path. PostToolUse for Write/Edit always carries
-// `tool_input.file_path` as an absolute path (verified by inspection
-// of aidlc-write-audit-log.ts:42 — the includes-filter works precisely
-// because Claude Code passes absolute paths).
-const filePath: string = parsed?.tool_input?.file_path ?? "";
-if (!filePath) return 0;
+// Step 4 — Extract path. Harnesses may provide either an absolute path or a
+// project-relative path, so normalize it before path guards and glob matching.
+const rawFilePath: string = parsed?.tool_input?.file_path ?? "";
+if (!rawFilePath) return 0;
+const filePath = isAbsolute(rawFilePath)
+  ? rawFilePath
+  : join(projectDir, rawFilePath);
 
 // Step 5 — Recursion guard. Skip writes to the dispatcher's detail-file
 // directory. Post-workspace-move that dir re-roots per intent

--- a/dist/opencode/.aidlc/hooks/aidlc-write-audit-log.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-write-audit-log.ts
@@ -7,7 +7,7 @@
 // active workflow in this cwd) to preserve the existing "only log when
 // relevant" behaviour.
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { appendAuditEntry } from "../tools/aidlc-audit.ts";
 import {
   auditFilePath,
@@ -54,7 +54,9 @@ try {
 }
 
 const tool = parsed.tool_name ?? "";
-const file: string = parsed.tool_input?.file_path ?? "";
+const rawFile: string = parsed.tool_input?.file_path ?? "";
+if (!rawFile) return 0;
+const file = isAbsolute(rawFile) ? rawFile : join(projectDir, rawFile);
 const auditFileValue = file.replace(/\\/g, "/");
 const fileNorm = auditFileValue; // forward-slash form for all path matching below
 

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.74";
+export const AIDLC_VERSION = "2.6.75";

--- a/tests/integration/t305-build-test-loopback-prose.test.ts
+++ b/tests/integration/t305-build-test-loopback-prose.test.ts
@@ -77,7 +77,8 @@ const CODE_GENERATION = readFileSync(
 describe("t305 build-and-test.md — Step 10 failure-escalation ladder", () => {
   test("On-failure block is the ladder, not the old flat retry list", () => {
     expect(STAGE).toContain(
-      "**On failure**: If build or tests fail, run the failure-escalation ladder:",
+      "**On failure**: Run the same failure-escalation ladder for command failures,\n" +
+        "`Not Met` targets, and `Unverified` targets:",
     );
     // The retired flat prose must be gone (replaced, not duplicated).
     expect(STAGE).not.toContain(

--- a/tests/unit/t07-hook-audit-logger.test.ts
+++ b/tests/unit/t07-hook-audit-logger.test.ts
@@ -68,7 +68,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { hostname } from "node:os";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { docsRoot } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import {
   AIDLC_SRC,
@@ -197,6 +197,25 @@ describe("t07 audit-logger PostToolUse hook (mechanism cli — spawned hook + st
     // not a record subdir, so it is not a record-artifact example).
     fire(writeJson(join(recordRoot, "inception", "requirements-analysis", "requirements.md")), proj);
     expect(readShards(auditDir)).toContain("ARTIFACT_CREATED");
+  });
+
+  test("logs a project-relative record artifact path with a normalized redacted File field", () => {
+    const { auditDir, recordRoot } = seedIntentShard(proj);
+    const absoluteFile = join(
+      recordRoot,
+      "inception",
+      "requirements-analysis",
+      "relative-requirements.md",
+    );
+    mkdirSync(dirname(absoluteFile), { recursive: true });
+    writeFileSync(absoluteFile, "# Requirements\n", "utf-8");
+
+    fire(writeJson(relative(proj, absoluteFile)), proj);
+
+    const audit = readShards(auditDir);
+    const projectRelativeFile = relative(proj, absoluteFile).replace(/\\/g, "/");
+    expect(audit).toMatch(/\*\*Event\*\*: ARTIFACT_(CREATED|UPDATED)/);
+    expect(audit).toContain(`**File**: <project-dir>/${projectRelativeFile}`);
   });
 
   test("extracts the ideation breadcrumb [.sh test 4]", () => {

--- a/tests/unit/t94-sensor-fire-hook.test.ts
+++ b/tests/unit/t94-sensor-fire-hook.test.ts
@@ -90,7 +90,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { hostname, tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import {
   AIDLC_SRC,
   cleanupTestProject,
@@ -359,6 +359,34 @@ describe("t94 aidlc-run-sensors hook — guards + early exits (migrated from t94
     ]);
   });
 
+  test("project-relative payload fires sensors with an absolute output path", () => {
+    const proj = makeProjectActive();
+    const graph = writeDispatchGraph(proj);
+    const absoluteFilePath = join(
+      proj,
+      "aidlc-docs",
+      "inception",
+      "requirements-analysis",
+      "relative-intent.md",
+    );
+    const r = runHook(proj, relative(proj, absoluteFilePath), graph);
+    expect(r.status).toBe(0);
+
+    const lines = readFileSync(spawnLogPath(proj), "utf-8")
+      .split("\n")
+      .filter(Boolean);
+    expect(lines.length).toBe(1);
+    const firstArgv = JSON.parse(lines[0]) as string[];
+    expect(firstArgv.slice(2)).toEqual([
+      "fire",
+      "write-sensor",
+      "--stage",
+      "requirements-analysis",
+      "--output-path",
+      absoluteFilePath,
+    ]);
+  });
+
   test("malformed, stale, and unknown active-directive markers fall back to Current Stage", () => {
     for (const marker of [
       "{not json",
@@ -410,6 +438,18 @@ describe("t94 aidlc-run-sensors hook — guards + early exits (migrated from t94
     );
     const r = runHook(proj, filePath);
     expect(r.status).toBe(0);
+    expect(existsSync(spawnLogPath(proj))).toBe(false);
+  });
+
+  test("recursion guard catches project-relative writes under the active sensor detail dir", () => {
+    const proj = makeProjectActive();
+    const filePath = relative(
+      proj,
+      join(seededRecordDir(proj), ".aidlc-sensors", "requirements-analysis", "detail.md"),
+    );
+    const r = runHook(proj, filePath);
+    expect(r.status).toBe(0);
+    expect(existsSync(heartbeatPath(proj))).toBe(false);
     expect(existsSync(spawnLogPath(proj))).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Resolve project-relative `tool_input.file_path` values in the shared audit and sensor hooks before any path-sensitive behavior.
- Preserve absolute-path behavior, gate-only sensor isolation, audit path redaction, and regenerate all harness distributions.
- Add focused coverage for audit logging, sensor dispatch, and the sensor recursion guard.

## Why this is separate from #788

#788 normalized Kiro adapter payloads. This PR does not change any adapter or `t147`.

On the current `v2` base, the shared hooks still consumed the raw payload in `core/hooks/aidlc-write-audit-log.ts` and `core/hooks/aidlc-run-sensors.ts`; the sensor hook also documented absolute paths as an assumption. Shipped adapters already normalize paths, so this is defense in depth: the shared hooks now enforce the invariant they previously only assumed.

## Tests

- `t07`: project-relative artifact paths pass the absolute path gates and retain `<project-dir>` redaction in the recorded `File` value.
- `t94`: project-relative paths reach write-fired sensor globs and `--output-path` as absolute paths, the recursion guard catches relative sensor-detail writes, and gate-fired sensors remain excluded from per-write dispatch.
- `t305`: the Build-and-Test prose pin recognizes the quality-target-aware failure ladder from `v2`.
- 86 focused `t07`, `t68`, `t94`, and `t305` tests pass.
- `bun scripts/package.ts --check`
- `bun run typecheck`
- `bun run lint`
- `bun tests/gen-coverage-registry.ts --check`

Version slot: `2.6.75`.