### PR TITLE
fix: harden Cursor reviewer-state path protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.123] - 2026-08-28
+
+Cursor now preserves delegated-agent attribution and reviewer-state integrity across POSIX and Windows path dialects, shell wrappers, Git configuration surfaces, filesystem traversal, and executable lookup changes. **Upgrade:** re-copy `dist/cursor/` into the project so the updated Cursor adapter, shared review-freeze parser, and version metadata replace the vulnerable hooks.
+
+* Deny delegated evaluators, general-purpose interpreters, project-local or path-qualified executables, scripts, unknown command surfaces, BusyBox/Toybox execution applets, and allowlisted command names reached through altered `PATH`, `PATHEXT`, or environment-clearing lookup state.
+* Protect every attributed delegated agent with an independent active-delegation witness and fail closed when either attribution store becomes unavailable, preserving nested-Task denial after attempted state removal.
+* Resolve bare ancestors and cross-platform path aliases for traversal and mutation commands, including `find`, PowerShell/CMD operations, `rsync`, and data-driven `xargs` mutators whose input targets cannot be inspected; read-only data-driven commands and concrete safe mutations remain available.
+* Canonicalize symlink, junction, device, trailing-dot/space, Git-Bash drive, native Windows, mixed-separator, UNC, home, wildcard, and 8.3 path forms before protected-state comparison.
+* Carry every reachable shell working directory through compound commands into Git safety inspection, retaining fail-closed behavior across failures, conditionals, pipelines, backgrounds, and subshells.
+
 ## [2.6.122] - 2026-08-27
 
 Code Generation source-freshness receipts now bind supported non-Git and missing-Git workspaces without weakening per-Unit attribution or autonomous swarm Source Commits. **Upgrade:** refresh your `dist/<harness>/` shell. In-flight `workspace_requires` reviews from earlier versions must be reviewed once more before completion because the source identity format changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@ Minimal workflows now avoid unrelated framework knowledge, duplicate conductor s
 * Isolated Reverse Engineering reuse now emits synthetic-workflow evidence for all-reuse and mixed-reuse runs only when the complete canonical CodeKB artifact set exists and source freshness matches; missing, redirected, invalid, or later-stale evidence cannot complete.
 * Reverse Engineering keeps every recorded repo identity qualified through its handoff filename, receipt chain, resume evidence, and CodeKB destination, including an intent with exactly one registered repo.
 * Plugin composition records exact recursive knowledge ownership and retains provenance for still-installed files removed from a later plugin version, so Minimal context retains active plugin files while deselected or removed plugin knowledge cannot become unowned context.
-
 ## [2.6.116] - 2026-08-27
 
 The question protocol now reuses answers already captured in the current record, closing a top field-feedback gap where teams saw the same question resurface after they had answered it, sometimes after stating that the answer was final. **Upgrade:** refresh your `dist/<harness>/` shell.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.122-blue)
+![version](https://img.shields.io/badge/version-2.6.123-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/hooks/aidlc-review-freeze.ts
+++ b/core/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/core/hooks/aidlc-review-freeze.ts
+++ b/core/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/core/hooks/review-freeze-command.ts
+++ b/core/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/core/hooks/review-freeze-command.ts
+++ b/core/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/core/hooks/review-freeze-command.ts
+++ b/core/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/core/hooks/review-freeze-command.ts
+++ b/core/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/dist/claude/.claude/hooks/aidlc-review-freeze.ts
+++ b/dist/claude/.claude/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/dist/claude/.claude/hooks/aidlc-review-freeze.ts
+++ b/dist/claude/.claude/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/dist/claude/.claude/hooks/review-freeze-command.ts
+++ b/dist/claude/.claude/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/dist/claude/.claude/hooks/review-freeze-command.ts
+++ b/dist/claude/.claude/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/dist/claude/.claude/hooks/review-freeze-command.ts
+++ b/dist/claude/.claude/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/dist/claude/.claude/hooks/review-freeze-command.ts
+++ b/dist/claude/.claude/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/dist/codex/.codex/hooks/aidlc-review-freeze.ts
+++ b/dist/codex/.codex/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/dist/codex/.codex/hooks/aidlc-review-freeze.ts
+++ b/dist/codex/.codex/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/dist/codex/.codex/hooks/review-freeze-command.ts
+++ b/dist/codex/.codex/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/dist/codex/.codex/hooks/review-freeze-command.ts
+++ b/dist/codex/.codex/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/dist/codex/.codex/hooks/review-freeze-command.ts
+++ b/dist/codex/.codex/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/dist/codex/.codex/hooks/review-freeze-command.ts
+++ b/dist/codex/.codex/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/dist/copilot/.aidlc/hooks/aidlc-review-freeze.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/dist/copilot/.aidlc/hooks/aidlc-review-freeze.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/dist/copilot/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/copilot/.aidlc/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/dist/copilot/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/copilot/.aidlc/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/dist/copilot/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/copilot/.aidlc/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/dist/copilot/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/copilot/.aidlc/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
@@ -40,8 +40,10 @@
 import { createHash } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   renameSync,
   rmSync,
@@ -49,7 +51,8 @@ import {
   utimesSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, posix, resolve, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HOOKS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -173,16 +176,17 @@ export async function run(
   // are possible) rather than silently disabling reviewer enforcement. Each
   // attributed call refreshes the record mtimes so a long-running reviewer
   // never silently outlives the freshness window. The store lives in the
-  // project runtime tree, and delegated tools cannot access it. If it becomes
-  // unreadable or disappears while a reviewer dispatch record is live, unknown
-  // conversations fail closed as an ambiguous reviewer rather than losing
-  // enforcement.
+  // project runtime tree, and delegated tools cannot access it. A second,
+  // separately stored witness survives loss of the primary ledger so unknown
+  // conversations still fail closed for every delegated role.
   const LEDGER_TTL_MS = 30 * 60 * 1000;
   const REVIEWER_DISPATCH_TTL_MS = 6 * 60 * 60 * 1000;
   const AMBIGUOUS_REVIEWER = "__aidlc_ambiguous_reviewer__";
   const REVIEW_AGENT_RE = /^aidlc-(architecture-reviewer|product-lead)-agent$/;
+  const AIDLC_RUNTIME_DIR = join(projectDir, "aidlc");
   const LEDGER_DIR = join(projectDir, "aidlc", ".aidlc-cursor-subagents");
   const ledgerPrefix = "spawn-";
+  const witnessPrefix = ".aidlc-cursor-subagent-";
 
   interface SubagentRecord {
     agent: string;
@@ -206,11 +210,28 @@ export async function run(
     return join(LEDGER_DIR, `main-${digest(conversation)}.marker`);
   }
 
+  function witnessFile(parent: string, task: string): string {
+    return join(
+      AIDLC_RUNTIME_DIR,
+      `${witnessPrefix}${digest(parent)}-${digest(task)}.json`,
+    );
+  }
+
   function ledgerFiles(): string[] {
     try {
       return readdirSync(LEDGER_DIR)
         .filter((name) => name.startsWith(ledgerPrefix) && name.endsWith(".json"))
         .map((name) => join(LEDGER_DIR, name));
+    } catch {
+      return [];
+    }
+  }
+
+  function witnessFiles(): string[] {
+    try {
+      return readdirSync(AIDLC_RUNTIME_DIR)
+        .filter((name) => name.startsWith(witnessPrefix) && name.endsWith(".json"))
+        .map((name) => join(AIDLC_RUNTIME_DIR, name));
     } catch {
       return [];
     }
@@ -274,6 +295,15 @@ export async function run(
     }
   }
 
+  function recordKey(record: SubagentRecord): string {
+    return `${record.parent}\0${record.task}`;
+  }
+
+  function retireSpawn(record: SubagentRecord): void {
+    removeLedger(ledgerFile(record.parent, record.task));
+    removeLedger(witnessFile(record.parent, record.task));
+  }
+
   let activeReviewerDispatchCache: string | null | undefined;
   function activeReviewerDispatch(): string | null {
     if (activeReviewerDispatchCache !== undefined) {
@@ -301,10 +331,10 @@ export async function run(
     return activeReviewerDispatchCache;
   }
 
-  function recordSpawn(subagentType: string): void {
+  function recordSpawn(subagentType: string): boolean {
     const parent = cursor.conversation_id ?? "";
     const task = taskIdentity();
-    if (!parent || !task) return;
+    if (!parent || !task) return false;
     registerMain(); // spawning a Task proves this conversation is a main
     // Task is synchronous. If this parent can issue another Task, its previous
     // delegate has returned even though Cursor CLI emits no postToolUse event
@@ -319,17 +349,30 @@ export async function run(
           agent_type: prior.agent,
         }),
       );
-      removeLedger(priorPath);
+      retireSpawn(prior);
+    }
+    for (const priorPath of witnessFiles()) {
+      const prior = readRecord(priorPath);
+      if (prior?.parent !== parent) continue;
+      retireSpawn(prior);
     }
     const path = ledgerFile(parent, task);
+    const witness = witnessFile(parent, task);
     const pending = `${path}.${process.pid}.tmp`;
+    const pendingWitness = `${witness}.${process.pid}.tmp`;
+    const record = { agent: subagentType, parent, task };
     try {
       mkdirSync(LEDGER_DIR, { recursive: true });
-      writeFileSync(pending, JSON.stringify({ agent: subagentType, parent, task }), "utf-8");
+      writeFileSync(pendingWitness, JSON.stringify(record), "utf-8");
+      renameSync(pendingWitness, witness);
+      writeFileSync(pending, JSON.stringify(record), "utf-8");
       renameSync(pending, path);
+      return true;
     } catch {
       removeLedger(pending);
-      // activeSubagent() fails closed while a reviewer dispatch is live
+      removeLedger(pendingWitness);
+      retireSpawn(record);
+      return false;
     }
   }
 
@@ -338,13 +381,18 @@ export async function run(
     const task = taskIdentity();
     if (!parent) return;
     if (task) {
-      removeLedger(ledgerFile(parent, task));
+      retireSpawn({ agent: "", parent, task });
       return;
     }
     // Defensive fallback for a completion payload that omits tool_use_id:
     // clear only this parent conversation's records.
     for (const path of ledgerFiles()) {
-      if (readRecord(path)?.parent === parent) removeLedger(path);
+      const record = readRecord(path);
+      if (record?.parent === parent) retireSpawn(record);
+    }
+    for (const path of witnessFiles()) {
+      const record = readRecord(path);
+      if (record?.parent === parent) retireSpawn(record);
     }
   }
 
@@ -352,13 +400,37 @@ export async function run(
     const conversation = cursor.conversation_id ?? "";
     if (!conversation || isKnownMain(conversation)) return "";
     const reviewerDispatch = activeReviewerDispatch();
+    const ledgerPaths = ledgerFiles();
+    const witnessPaths = witnessFiles();
     const live: Array<{ path: string; record: SubagentRecord }> = [];
-    for (const path of ledgerFiles()) {
+    const witnesses = new Map<string, { path: string; record: SubagentRecord }>();
+    let unreadableState = false;
+    for (const path of ledgerPaths) {
       const record = readRecord(path);
       if (record) live.push({ path, record });
+      else unreadableState = true;
+    }
+    for (const path of witnessPaths) {
+      const record = readRecord(path);
+      if (record) witnesses.set(recordKey(record), { path, record });
+      else unreadableState = true;
     }
     if (live.length === 0) {
-      return reviewerDispatch === null ? "" : AMBIGUOUS_REVIEWER;
+      return reviewerDispatch === null &&
+        witnesses.size === 0 &&
+        !unreadableState
+        ? ""
+        : AMBIGUOUS_REVIEWER;
+    }
+    if (
+      unreadableState ||
+      witnesses.size !== live.length ||
+      live.some(({ record }) => {
+        const witness = witnesses.get(recordKey(record))?.record;
+        return !witness || witness.agent !== record.agent;
+      })
+    ) {
+      return AMBIGUOUS_REVIEWER;
     }
     // A conversation that spawned a live Task is a main even if its marker
     // write failed.
@@ -369,8 +441,16 @@ export async function run(
       for (const { path } of live) {
         try {
           utimesSync(path, new Date(), new Date());
+          const record = readRecord(path);
+          if (record) {
+            utimesSync(
+              witnesses.get(recordKey(record))?.path ?? witnessFile(record.parent, record.task),
+              new Date(),
+              new Date(),
+            );
+          }
         } catch {
-          // expiry only widens back to fail-open
+          // The next call observes the broken pair and fails closed.
         }
       }
     };
@@ -392,7 +472,8 @@ export async function run(
         refresh();
         return AMBIGUOUS_REVIEWER;
       }
-      return "";
+      refresh();
+      return AMBIGUOUS_REVIEWER;
     }
     refresh();
     return live[0].record.agent;
@@ -451,18 +532,141 @@ export async function run(
     });
   }
 
-  function shellWords(command: string): string[] {
-    const words: string[] = [];
-    let word = "";
+  type PathFlavor = "posix" | "win32";
+
+  interface ShellWordVariant {
+    value: string;
+    activeGlobIndexes: number[];
+    flavor: PathFlavor;
+  }
+
+  interface ShellWord {
+    variants: ShellWordVariant[];
+  }
+
+  function shellWords(command: string): { words: ShellWord[]; ambiguous: boolean } {
+    const words: ShellWord[] = [];
+    let posixWord = "";
+    let windowsWord = "";
+    let posixGlobIndexes: number[] = [];
+    let windowsGlobIndexes: number[] = [];
+    let started = false;
+    let quote: "'" | '"' | null = null;
+    const push = () => {
+      if (started) {
+        const variants: ShellWordVariant[] = [
+          { value: posixWord, activeGlobIndexes: posixGlobIndexes, flavor: "posix" },
+          { value: windowsWord, activeGlobIndexes: windowsGlobIndexes, flavor: "win32" },
+        ];
+        const applicable =
+          process.platform === "win32" && windowsWord.startsWith("~\\")
+            ? variants.filter((variant) => variant.flavor === "win32")
+            : variants;
+        words.push({
+          variants: applicable.filter(
+            (variant, index) =>
+              applicable.findIndex(
+                (candidate) =>
+                  candidate.flavor === variant.flavor &&
+                  candidate.value === variant.value &&
+                  candidate.activeGlobIndexes.join(",") ===
+                    variant.activeGlobIndexes.join(","),
+              ) === index,
+          ),
+        });
+      }
+      posixWord = "";
+      windowsWord = "";
+      posixGlobIndexes = [];
+      windowsGlobIndexes = [];
+      started = false;
+    };
+    const appendPosix = (ch: string, activeGlob = false) => {
+      if (activeGlob) posixGlobIndexes.push(posixWord.length);
+      posixWord += ch;
+      started = true;
+    };
+    const appendWindows = (ch: string, activeGlob = false) => {
+      if (activeGlob) windowsGlobIndexes.push(windowsWord.length);
+      windowsWord += ch;
+      started = true;
+    };
+    const appendBoth = (
+      ch: string,
+      posixActiveGlob = false,
+      windowsActiveGlob = posixActiveGlob,
+    ) => {
+      appendPosix(ch, posixActiveGlob);
+      appendWindows(ch, windowsActiveGlob);
+    };
+
+    for (let i = 0; i < command.length; i++) {
+      const ch = command[i];
+      if (quote === "'") {
+        if (ch === "'") quote = null;
+        else appendBoth(ch, false, "*?[]{}".includes(ch));
+        continue;
+      }
+      if (ch === "\\") {
+        const next = command[i + 1] ?? "";
+        appendWindows("\\");
+        if (!next) {
+          appendPosix("\\");
+          continue;
+        }
+        if (quote === '"') {
+          if ('$`"\\\n'.includes(next)) {
+            if (next !== "\n") {
+              appendPosix(next);
+              if (next === '"') quote = null;
+              else appendWindows(next, "*?[]{}".includes(next));
+            }
+            i++;
+          } else {
+            appendPosix("\\");
+          }
+        } else {
+          if (next !== "\n") {
+            appendPosix(next);
+            appendWindows(next, "*?[]{}".includes(next));
+          }
+          i++;
+        }
+        continue;
+      }
+      if (quote !== null) {
+        if (ch === quote) quote = null;
+        else appendBoth(ch, false, "*?[]{}".includes(ch));
+        continue;
+      }
+      if (ch === "'" || ch === '"') {
+        quote = ch;
+        started = true;
+        continue;
+      }
+      if (/\s/.test(ch) || ";|&()<>".includes(ch)) {
+        push();
+        continue;
+      }
+      appendBoth(ch, "*?[]{}".includes(ch));
+    }
+    push();
+    return { words, ambiguous: quote !== null };
+  }
+
+  interface ShellCommandPart {
+    text: string;
+    operatorAfter: "" | ";" | "\n" | "&&" | "||" | "|" | "&";
+  }
+
+  function shellCommandParts(command: string): ShellCommandPart[] {
+    const segments: ShellCommandPart[] = [];
     let quote: "'" | '"' | null = null;
     let escaped = false;
-    const push = () => {
-      if (word.length > 0) words.push(word);
-      word = "";
-    };
-    for (const ch of command) {
+    let start = 0;
+    for (let i = 0; i < command.length; i++) {
+      const ch = command[i];
       if (escaped) {
-        word += ch;
         escaped = false;
         continue;
       }
@@ -472,27 +676,33 @@ export async function run(
       }
       if (quote !== null) {
         if (ch === quote) quote = null;
-        else word += ch;
         continue;
       }
       if (ch === "'" || ch === '"') {
         quote = ch;
         continue;
       }
-      if (/\s/.test(ch) || ";|&()<>".includes(ch)) {
-        push();
-        continue;
+      if (!";\n|&".includes(ch)) continue;
+      let operator = ch as ShellCommandPart["operatorAfter"];
+      if ((ch === "|" || ch === "&") && command[i + 1] === ch) {
+        operator = `${ch}${ch}` as ShellCommandPart["operatorAfter"];
+        i++;
       }
-      word += ch;
+      segments.push({ text: command.slice(start, i - operator.length + 1), operatorAfter: operator });
+      start = i + 1;
     }
-    push();
-    return words;
+    segments.push({ text: command.slice(start), operatorAfter: "" });
+    return segments;
+  }
+
+  function shellCommandSegments(command: string): string[] {
+    return shellCommandParts(command).map((part) => part.text);
   }
 
   interface ReviewFreezeCommandModule {
     shellCommandInvocations?: (
       command: string,
-    ) => Array<{ name: string; args: string[] }>;
+    ) => Array<{ name: string; args: string[]; ambiguous?: boolean }>;
     writeTargets?: (
       toolName: string,
       toolInput: Record<string, unknown> | undefined,
@@ -534,16 +744,307 @@ export async function run(
 
   function protectedReviewerPaths(): string[] {
     const dispatch = activeReviewerDispatch();
-    return dispatch === null ? [LEDGER_DIR] : [LEDGER_DIR, dispatch];
+    return [
+      LEDGER_DIR,
+      ...witnessFiles(),
+      ...(dispatch === null ? [] : [dispatch]),
+    ];
   }
 
-  function overlapsProtectedPath(candidate: string, protectedPaths: readonly string[]): boolean {
-    const normalized = resolve(candidate);
-    return protectedPaths.some(
-      (path) =>
-        normalized === path ||
-        normalized.startsWith(`${path}${sep}`) ||
-        path.startsWith(`${normalized}${sep}`),
+  interface CanonicalPath {
+    flavor: PathFlavor;
+    value: string;
+  }
+
+  interface Canonicalization {
+    paths: CanonicalPath[];
+    ambiguous: boolean;
+  }
+
+  function fullyQualifiedWindows(value: string): boolean {
+    const normalized = value.replaceAll("/", "\\");
+    return (
+      /^[A-Za-z]:\\/.test(normalized) ||
+      /^\\\\[^\\]+\\[^\\]+(?:\\|$)/.test(normalized)
+    );
+  }
+
+  function normalizeWindowsDialect(raw: string): { value: string; ambiguous: boolean } {
+    if (raw === "~" || raw.startsWith("~/") || raw.startsWith("~\\")) {
+      const home = process.env.USERPROFILE ?? process.env.HOME ?? homedir();
+      raw = win32.join(home, raw.slice(2));
+    }
+    const gitBash = raw.match(/^\/(?:cygdrive\/)?([A-Za-z])\/(.*)$/);
+    let value = gitBash
+      ? `${gitBash[1].toUpperCase()}:\\${gitBash[2] ?? ""}`
+      : raw.replaceAll("/", "\\");
+    if (/^\\\\\?\\UNC\\/i.test(value)) {
+      value = `\\\\${value.slice("\\\\?\\UNC\\".length)}`;
+    } else if (/^\\\\[?.]\\[A-Za-z]:\\/.test(value)) {
+      value = value.slice(4);
+    } else if (/^\\\?\?\\[A-Za-z]:\\/.test(value)) {
+      value = value.slice(4);
+    } else if (/^(?:\\\\[?.]\\|\\\?\?\\)/.test(value)) {
+      return { value, ambiguous: true };
+    }
+
+    const parsed = win32.parse(value);
+    const components = value.slice(parsed.root.length).split("\\");
+    let ambiguous = false;
+    const normalizedComponents = components.map((component, index) => {
+      if (component === "." || component === ".." || component.length === 0) return component;
+      let normalized = component.replace(/[ .]+$/g, "");
+      const stream = normalized.indexOf(":");
+      if (stream !== -1) {
+        if (index !== components.length - 1) ambiguous = true;
+        normalized = normalized.slice(0, stream);
+      }
+      if (normalized.length === 0) ambiguous = true;
+      return normalized;
+    });
+    return {
+      value: `${parsed.root}${normalizedComponents.join("\\")}`,
+      ambiguous,
+    };
+  }
+
+  function canonicalExistingAncestor(
+    flavor: PathFlavor,
+    candidate: string,
+  ): { path?: string; ambiguous: boolean } {
+    const hostFlavor: PathFlavor = process.platform === "win32" ? "win32" : "posix";
+    if (flavor !== hostFlavor) return { ambiguous: false };
+    const api = flavor === "win32" ? win32 : posix;
+    const missingSegments: string[] = [];
+    let cursor = candidate;
+    while (true) {
+      try {
+        lstatSync(cursor);
+        try {
+          return {
+            path: api.resolve(realpathSync.native(cursor), ...missingSegments),
+            ambiguous: false,
+          };
+        } catch {
+          return { ambiguous: true };
+        }
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT" && code !== "ENOTDIR") return { ambiguous: true };
+      }
+      const parent = api.dirname(cursor);
+      if (parent === cursor) return { ambiguous: true };
+      missingSegments.unshift(api.basename(cursor));
+      cursor = parent;
+    }
+  }
+
+  function expandPosixTilde(
+    raw: string,
+    cwd: string,
+  ): { value: string; ambiguous: boolean } {
+    const home = (process.env.HOME ?? homedir()).replaceAll("\\", "/");
+    if (raw === "~") return { value: home, ambiguous: false };
+    if (raw.startsWith("~/")) {
+      return { value: posix.join(home, raw.slice(2)), ambiguous: false };
+    }
+    if (raw === "~+") return { value: cwd, ambiguous: false };
+    if (raw.startsWith("~+/")) {
+      return { value: posix.join(cwd, raw.slice(3)), ambiguous: false };
+    }
+    const oldPwd = process.env.OLDPWD?.replaceAll("\\", "/");
+    if (raw === "~-" || raw.startsWith("~-/")) {
+      if (!oldPwd || !posix.isAbsolute(oldPwd)) return { value: raw, ambiguous: true };
+      return {
+        value: raw === "~-" ? oldPwd : posix.join(oldPwd, raw.slice(3)),
+        ambiguous: false,
+      };
+    }
+
+    const named = raw.match(/^~([^/]+)(?:\/(.*))?$/);
+    if (!named) return { value: raw, ambiguous: false };
+    const username = named[1];
+    let namedHome: string | undefined;
+    if (process.platform !== "win32") {
+      try {
+        const row = readFileSync("/etc/passwd", "utf-8")
+          .split(/\r?\n/)
+          .find((line) => line.split(":", 1)[0] === username);
+        const fields = row?.split(":");
+        if (fields?.[5]) namedHome = fields[5];
+      } catch {
+        // Missing account data leaves the shell identity ambiguous.
+      }
+    }
+    const currentUser = process.env.USER ?? process.env.LOGNAME ?? process.env.USERNAME;
+    if (!namedHome && currentUser === username) namedHome = home;
+    if (!namedHome || !posix.isAbsolute(namedHome)) {
+      return { value: raw, ambiguous: true };
+    }
+    return {
+      value: named[2] ? posix.join(namedHome, named[2]) : namedHome,
+      ambiguous: false,
+    };
+  }
+
+  function canonicalPathVariants(
+    raw: string,
+    cwd: string,
+    flavorHint?: PathFlavor,
+  ): Canonicalization {
+    const out = new Map<string, CanonicalPath>();
+    let ambiguous = false;
+    const store = (flavor: PathFlavor, value: string): void => {
+      const api = flavor === "win32" ? win32 : posix;
+      let normalized = api.normalize(value);
+      const root = api.parse(normalized).root;
+      while (
+        normalized.length > root.length &&
+        (normalized.endsWith("/") || normalized.endsWith("\\"))
+      ) {
+        normalized = normalized.slice(0, -1);
+      }
+      if (flavor === "win32") normalized = normalized.replaceAll("\\", "/").toLowerCase();
+      const key = `${flavor}:${normalized}`;
+      out.set(key, { flavor, value: normalized });
+    };
+    const add = (flavor: PathFlavor, value: string): void => {
+      let normalizedValue = value;
+      if (flavor === "win32") {
+        const normalized = normalizeWindowsDialect(value);
+        ambiguous ||= normalized.ambiguous;
+        if (normalized.ambiguous) return;
+        normalizedValue = normalized.value;
+      }
+      const api = flavor === "win32" ? win32 : posix;
+      const lexical = api.normalize(normalizedValue);
+      store(flavor, lexical);
+      const real = canonicalExistingAncestor(flavor, lexical);
+      ambiguous ||= real.ambiguous;
+      if (real.path) {
+        if (flavor === "win32") {
+          const normalized = normalizeWindowsDialect(real.path);
+          ambiguous ||= normalized.ambiguous;
+          if (!normalized.ambiguous) store(flavor, normalized.value);
+        } else {
+          store(flavor, real.path);
+        }
+      }
+    };
+
+    if (flavorHint !== "win32") {
+      const posixCwd = cwd.replaceAll("\\", "/");
+      const expanded = expandPosixTilde(raw, posixCwd);
+      ambiguous ||= expanded.ambiguous;
+      const posixRaw = expanded.value;
+      if (!fullyQualifiedWindows(posixRaw) && posix.isAbsolute(posixCwd)) {
+        add("posix", posix.resolve(posixCwd, posixRaw));
+      }
+    }
+
+    if (flavorHint !== "posix") {
+      const normalizedRaw = normalizeWindowsDialect(raw);
+      const normalizedCwd = normalizeWindowsDialect(cwd);
+      ambiguous ||= normalizedRaw.ambiguous || normalizedCwd.ambiguous;
+      if (!normalizedRaw.ambiguous && !normalizedCwd.ambiguous) {
+        if (fullyQualifiedWindows(normalizedRaw.value)) {
+          add("win32", win32.resolve(normalizedRaw.value));
+        } else if (fullyQualifiedWindows(normalizedCwd.value)) {
+          add("win32", win32.resolve(normalizedCwd.value, normalizedRaw.value));
+        }
+      }
+    }
+    return { paths: [...out.values()], ambiguous };
+  }
+
+  function isWithinPath(child: string, parent: string): boolean {
+    return child === parent || child.startsWith(parent.endsWith("/") ? parent : `${parent}/`);
+  }
+
+  function shortNameGlobTouchesProtected(
+    pattern: string,
+    cwd: string,
+    protectedPaths: readonly string[],
+    flavorHint?: PathFlavor,
+  ): boolean {
+    if (flavorHint !== "win32") return false;
+    const normalized = normalizeWindowsDialect(pattern);
+    if (normalized.ambiguous) return true;
+    const parsed = win32.parse(normalized.value);
+    const components = normalized.value.slice(parsed.root.length).split("\\");
+    const shortIndex = components.findIndex(
+      (component) => component.includes("~") && /[*?[\]{}]/.test(component),
+    );
+    if (shortIndex === -1) return false;
+    const base = win32.join(parsed.root, ...components.slice(0, shortIndex));
+    const directories = canonicalPathVariants(base, cwd, "win32");
+    if (directories.ambiguous || directories.paths.length === 0) return true;
+    const protectedResults = protectedPaths.map((path) =>
+      canonicalPathVariants(path, projectDir)
+    );
+    if (protectedResults.some((result) => result.ambiguous || result.paths.length === 0)) {
+      return true;
+    }
+    const protectedVariants = protectedResults.flatMap((result) => result.paths);
+    const globMatches = (glob: string, value: string): boolean => {
+      let source = "^";
+      for (const ch of glob) {
+        if (ch === "*") source += ".*";
+        else if (ch === "?") source += ".";
+        else source += ch.replace(/[\\^$+?.()|[\]{}]/g, "\\$&");
+      }
+      return new RegExp(`${source}$`, "i").test(value);
+    };
+    const shortComponentMatches = (glob: string, longName: string): boolean => {
+      const tilde = glob.indexOf("~");
+      if (tilde === -1) return globMatches(glob, longName);
+      const stem = glob.slice(0, tilde);
+      const shortSource = longName.replace(/^[ .]+/, "").replace(/[ .]/g, "");
+      return globMatches(`${stem}*`, shortSource);
+    };
+    return directories.paths.some((directory) =>
+      protectedVariants.some((protectedPath) => {
+        if (directory.flavor !== protectedPath.flavor) return false;
+        const relative = posix.relative(directory.value, protectedPath.value);
+        if (relative === ".." || relative.startsWith("../")) return false;
+        const protectedComponents = relative.split("/");
+        if (!shortComponentMatches(components[shortIndex], protectedComponents[0] ?? "")) {
+          return false;
+        }
+        return components.slice(shortIndex + 1).every(
+          (component, index) =>
+            protectedComponents[index + 1] !== undefined &&
+            globMatches(component, protectedComponents[index + 1]),
+        );
+      })
+    );
+  }
+
+  function overlapsProtectedPath(
+    candidate: string,
+    protectedPaths: readonly string[],
+    cwd = projectDir,
+    flavorHint?: PathFlavor,
+  ): boolean {
+    const candidates = canonicalPathVariants(candidate, cwd, flavorHint);
+    const protectedResults = protectedPaths.map((path) =>
+      canonicalPathVariants(path, projectDir)
+    );
+    const protectedVariants = protectedResults.flatMap((result) => result.paths);
+    if (
+      candidates.ambiguous ||
+      protectedResults.some((result) => result.ambiguous || result.paths.length === 0)
+    ) {
+      return true;
+    }
+    if (candidates.paths.length === 0) return flavorHint === undefined;
+    return candidates.paths.some((normalized) =>
+      protectedVariants.some(
+        (protectedPath) =>
+          normalized.flavor === protectedPath.flavor &&
+          (isWithinPath(normalized.value, protectedPath.value) ||
+            isWithinPath(protectedPath.value, normalized.value)),
+      )
     );
   }
 
@@ -551,29 +1052,54 @@ export async function run(
     raw: string,
     cwd: string,
     protectedPaths: readonly string[],
+    globIndex = raw.search(/[*?[\]{}]/),
+    flavorHint?: PathFlavor,
   ): boolean {
     if (["{", "}", "(", ")"].includes(raw)) return false;
-    const glob = raw.search(/[*?[\]{}]/);
-    if (glob === -1) return false;
-    let prefix = raw.slice(0, glob);
+    if (globIndex === -1) return false;
+    let prefix = raw.slice(0, globIndex);
     const equals = prefix.lastIndexOf("=");
     if (equals !== -1) prefix = prefix.slice(equals + 1);
     const bracedPwd = "$" + "{PWD}";
     if (prefix === "$PWD" || prefix === bracedPwd) {
       prefix = cwd;
-    } else if (prefix.startsWith("$PWD/")) {
-      prefix = join(cwd, prefix.slice("$PWD/".length));
-    } else if (prefix.startsWith(`${bracedPwd}/`)) {
-      prefix = join(cwd, prefix.slice(`${bracedPwd}/`.length));
+    } else if (prefix.startsWith("$PWD/") || prefix.startsWith("$PWD\\")) {
+      prefix = `${cwd}${prefix.slice("$PWD".length)}`;
+    } else if (
+      prefix.startsWith(`${bracedPwd}/`) ||
+      prefix.startsWith(`${bracedPwd}\\`)
+    ) {
+      prefix = `${cwd}${prefix.slice(bracedPwd.length)}`;
     }
-    const normalized = isAbsolute(prefix) ? resolve(prefix) : resolve(cwd, prefix);
-    return protectedPaths.some((path) => path.startsWith(normalized));
+    const expandedPattern = `${prefix}${raw.slice(globIndex)}`;
+    if (shortNameGlobTouchesProtected(expandedPattern, cwd, protectedPaths, flavorHint)) {
+      return true;
+    }
+    const candidates = canonicalPathVariants(prefix, cwd, flavorHint);
+    if (candidates.ambiguous) return true;
+    if (candidates.paths.length === 0) return flavorHint === undefined;
+    const protectedResults = protectedPaths.map((path) =>
+      canonicalPathVariants(path, projectDir)
+    );
+    if (protectedResults.some((result) => result.ambiguous || result.paths.length === 0)) {
+      return true;
+    }
+    const protectedVariants = protectedResults.flatMap((result) => result.paths);
+    return candidates.paths.some((candidate) =>
+      protectedVariants.some(
+        (protectedPath) =>
+          candidate.flavor === protectedPath.flavor &&
+          protectedPath.value.startsWith(candidate.value),
+      )
+    );
   }
 
   function concreteWordTouchesProtected(
     raw: string,
     cwd: string,
     protectedPaths: readonly string[],
+    hasActiveGlob = /[*?[\]{}]/.test(raw),
+    flavorHint?: PathFlavor,
   ): boolean {
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(raw)) return false;
     const equals = raw.lastIndexOf("=");
@@ -582,13 +1108,166 @@ export async function run(
     if (
       candidate.length === 0 ||
       candidate.startsWith("-") ||
-      /[$`*?[\]{}]/.test(candidate) ||
+      /[$`]/.test(candidate) ||
+      hasActiveGlob ||
       (!candidate.includes("/") && !candidate.includes("\\") && !candidate.startsWith("."))
     ) {
       return false;
     }
-    const normalized = isAbsolute(candidate) ? resolve(candidate) : resolve(cwd, candidate);
-    return overlapsProtectedPath(normalized, protectedPaths);
+    return overlapsProtectedPath(candidate, protectedPaths, cwd, flavorHint);
+  }
+
+  interface ShellCwdState {
+    cwd: string;
+    stack: string[];
+    status: "success" | "failure" | "unknown";
+    logicalAmbiguous: boolean;
+  }
+
+  const MAX_SHELL_CWD_STATES = 128;
+
+  function shellCwdIdentity(path: string, flavor: PathFlavor): string {
+    const hostFlavor: PathFlavor = process.platform === "win32" ? "win32" : "posix";
+    const api = flavor === "win32" ? win32 : posix;
+    let identity = api.normalize(path);
+    if (flavor === hostFlavor) {
+      try {
+        identity = realpathSync.native(path);
+      } catch {
+        // A missing or synthetic cross-platform path retains its lexical identity.
+      }
+    }
+    identity = api.normalize(identity);
+    return flavor === "win32" ? identity.toLowerCase() : identity;
+  }
+
+  function shellCwdStateKey(state: ShellCwdState, flavor: PathFlavor): string {
+    return [
+      shellCwdIdentity(state.cwd, flavor),
+      ...state.stack.map((path) => shellCwdIdentity(path, flavor)),
+      state.status,
+    ].join("\0");
+  }
+
+  function updateShellCwd(
+    words: readonly ShellWord[],
+    flavor: PathFlavor,
+    state: ShellCwdState,
+  ): "none" | "location" | "ambiguous" {
+    const values = words
+      .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+      .filter((value): value is string => value !== undefined);
+    let index = 0;
+    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(values[index] ?? "")) index++;
+    while (["command", "builtin"].includes((values[index] ?? "").toLowerCase())) {
+      index++;
+      if (values[index] === "--") index++;
+    }
+    const controlHead = ["if", "elif", "while", "until", "case", "for", "select", "function"].includes(
+      (values[index] ?? "").toLowerCase(),
+    );
+    const controlContext =
+      controlHead ||
+      values.some((value) => ["{", "then", "else", "do"].includes(value.toLowerCase()));
+    while (["{", "then", "else", "do", "!"].includes((values[index] ?? "").toLowerCase())) {
+      index++;
+    }
+    if (["if", "elif", "while", "until"].includes((values[index] ?? "").toLowerCase())) {
+      index++;
+    }
+    const cwdCommands = new Set([
+      "cd",
+      "chdir",
+      "pushd",
+      "push-location",
+      "set-location",
+      "sl",
+      "popd",
+      "pop-location",
+    ]);
+    const leafName = (value: string): string =>
+      win32.basename(posix.basename(value)).toLowerCase();
+    if (controlContext && !cwdCommands.has(leafName(values[index] ?? ""))) {
+      const nested = values.findIndex(
+        (value, candidate) => candidate > index && cwdCommands.has(leafName(value)),
+      );
+      if (nested !== -1) index = nested;
+    }
+    const executable = values[index];
+    if (!executable) return "none";
+    const name = leafName(executable);
+    if (["popd", "pop-location"].includes(name)) {
+      if (state.logicalAmbiguous) return "ambiguous";
+      const restored = state.stack.pop();
+      if (!restored) return "ambiguous";
+      state.cwd = restored;
+      return "location";
+    }
+    const push = ["pushd", "push-location"].includes(name);
+    if (
+      !push &&
+      !["cd", "chdir", "set-location", "sl"].includes(name)
+    ) {
+      return "none";
+    }
+    if (state.logicalAmbiguous && push) return "ambiguous";
+
+    const args = values.slice(index + 1);
+    let operand = "";
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (["-path", "-literalpath"].includes(arg.toLowerCase())) {
+        operand = args[i + 1] ?? "";
+        break;
+      }
+      if (["/d", "-l", "-p", "--"].includes(arg.toLowerCase())) continue;
+      if (arg.startsWith("-")) continue;
+      operand = arg;
+      break;
+    }
+    if (!operand) operand = "~";
+    if (/[$`*?[\]{}]/.test(operand)) return "ambiguous";
+    if (
+      state.logicalAmbiguous &&
+      (operand === "-" ||
+        operand.startsWith("~") ||
+        operand.replaceAll("\\", "/").split("/").includes(".."))
+    ) {
+      return "ambiguous";
+    }
+
+    let next: string;
+    if (flavor === "posix") {
+      if (operand === "-") operand = "~-";
+      const expanded = expandPosixTilde(operand, state.cwd.replaceAll("\\", "/"));
+      if (expanded.ambiguous) return "ambiguous";
+      let base = state.cwd.replaceAll("\\", "/");
+      if (state.logicalAmbiguous && !posix.isAbsolute(expanded.value)) {
+        try {
+          base = realpathSync.native(state.cwd).replaceAll("\\", "/");
+        } catch {
+          return "ambiguous";
+        }
+      }
+      next = posix.resolve(base, expanded.value);
+      if (posix.isAbsolute(expanded.value)) state.logicalAmbiguous = false;
+    } else {
+      const normalized = normalizeWindowsDialect(operand);
+      if (normalized.ambiguous) return "ambiguous";
+      let base = state.cwd;
+      if (state.logicalAmbiguous && !fullyQualifiedWindows(normalized.value)) {
+        try {
+          base = realpathSync.native(state.cwd);
+        } catch {
+          return "ambiguous";
+        }
+      }
+      next = win32.resolve(base, normalized.value);
+      if (fullyQualifiedWindows(normalized.value)) state.logicalAmbiguous = false;
+    }
+    if (push) state.stack.push(state.cwd);
+    state.cwd = next;
+    return "location";
   }
 
   function pathOperandValues(toolInput: Record<string, unknown>): string[] {
@@ -639,9 +1318,12 @@ export async function run(
           continue;
         }
         if (ch === "`") return true;
-        if (ch !== "$") continue;
-        const next = command[i + 1] ?? "";
-        if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+        if (ch === "$") {
+          const next = command[i + 1] ?? "";
+          if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+        }
+        if (ch === "%" && /%[^%\r\n]+%/.test(command.slice(i))) return true;
+        if (ch === "!" && /![^!\r\n]+!/.test(command.slice(i))) return true;
         continue;
       }
       if (ch === "'") {
@@ -653,27 +1335,1106 @@ export async function run(
         continue;
       }
       if (ch === "`") return true;
-      if (ch !== "$") continue;
-      const next = command[i + 1] ?? "";
-      if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+      if (ch === "^") return true;
+      if (ch === "%" && /%[^%\r\n]+%/.test(command.slice(i))) return true;
+      if (ch === "!" && /![^!\r\n]+!/.test(command.slice(i))) return true;
+      if (ch === "$") {
+        const next = command[i + 1] ?? "";
+        if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+      }
     }
     return false;
   }
 
-  async function shellInvokesDynamicEvaluation(command: string): Promise<boolean> {
+  function shellUsesDirectHostExpression(command: string): boolean {
+    let quote: "'" | '"' | null = null;
+    let escaped = false;
+    let outside = "";
+    for (const ch of command) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === "`") {
+        escaped = true;
+        continue;
+      }
+      if (quote !== null) {
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === "'" || ch === '"') {
+        quote = ch;
+        continue;
+      }
+      outside += ch;
+    }
+    return (
+      /(?:^|[\s(])\+(?=[\s)]|$)/.test(outside) ||
+      /(?:^|[\s(])&(?=[\s(]|$)/.test(outside) ||
+      /(?:^|\s)-(?:join|replace|split)\b/i.test(outside) ||
+      /\(\s*[A-Za-z]+-[A-Za-z]+/i.test(outside)
+    );
+  }
+
+  function shellUsesConstructedHostInvocation(command: string): boolean {
+    return /(?:^|[;\s])&\s*\(/.test(command);
+  }
+
+  function gitUsesIndirectShellAlias(
+    args: readonly string[],
+    command: string,
+  ): boolean {
+    if (args.some((arg) => /^alias\.[^=]+=!/i.test(arg))) return true;
+    const configIndex = args.indexOf("config");
+    if (configIndex !== -1) {
+      const aliasIndex = args.findIndex(
+        (arg, index) => index > configIndex && /^alias\.[^.=\s]+$/i.test(arg),
+      );
+      if (
+        aliasIndex !== -1 &&
+        args.slice(aliasIndex + 1).some((arg) => !arg.startsWith("-"))
+      ) {
+        return true;
+      }
+    }
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const configEnv =
+        arg === "--config-env" ? args[i + 1] ?? "" : arg.replace(/^--config-env=/, "");
+      if (
+        configEnv !== arg &&
+        /^(?:alias\.[^=]+|include(?:If\.[^=]+)?\.path)=/i.test(configEnv)
+      ) {
+        return true;
+      }
+      if (
+        arg === "-c" &&
+        /^(?:alias\.[^=]+|include(?:If\.[^=]+)?\.path)=/i.test(args[i + 1] ?? "")
+      ) {
+        return true;
+      }
+    }
+    if (/\bGIT_CONFIG_(?:GLOBAL|SYSTEM|PARAMETERS)=/i.test(command)) return true;
+    return /\bGIT_CONFIG_KEY_\d+=alias\./i.test(command);
+  }
+
+  function gitInvocation(
+    args: readonly string[],
+  ): { subcommand: string; subcommandIndex: number; prefix: string[] } {
+    const valueOptions = new Set([
+      "-C",
+      "-c",
+      "--config-env",
+      "--exec-path",
+      "--git-dir",
+      "--namespace",
+      "--super-prefix",
+      "--work-tree",
+    ]);
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (arg === "--") {
+        return {
+          subcommand: args[i + 1] ?? "",
+          subcommandIndex: i + 1,
+          prefix: [...args.slice(0, i + 1)],
+        };
+      }
+      if (valueOptions.has(arg)) {
+        i++;
+        continue;
+      }
+      if (arg.startsWith("-")) continue;
+      return { subcommand: arg, subcommandIndex: i, prefix: [...args.slice(0, i)] };
+    }
+    return { subcommand: "", subcommandIndex: -1, prefix: [...args] };
+  }
+
+  interface GitCommandContext {
+    cwd: string;
+    env: Record<string, string | undefined>;
+    ambiguous: boolean;
+  }
+
+  function shellExecutableName(value: string): string {
+    return win32.basename(posix.basename(value))
+      .replace(/\.(?:exe|com|cmd|bat)$/i, "")
+      .toLowerCase();
+  }
+
+  function isGitInspectionEnvironmentName(name: string): boolean {
+    const candidate = process.platform === "win32" ? name.toUpperCase() : name;
+    return /^(?:HOME|XDG_CONFIG_HOME|USERPROFILE|HOMEDRIVE|HOMEPATH|PAGER|GIT_(?:DIR|WORK_TREE|COMMON_DIR|INDEX_FILE|NAMESPACE|EXEC_PATH|PAGER)|GIT_CONFIG(?:_GLOBAL|_SYSTEM|_NOSYSTEM|_PARAMETERS|_COUNT|_KEY_\d+|_VALUE_\d+)?)$/.test(
+      candidate,
+    );
+  }
+
+  function deleteEnvironmentName(
+    env: Record<string, string | undefined>,
+    name: string,
+  ): void {
+    const candidate = process.platform === "win32" ? name.toUpperCase() : name;
+    for (const key of Object.keys(env)) {
+      const existing = process.platform === "win32" ? key.toUpperCase() : key;
+      if (existing === candidate) delete env[key];
+    }
+  }
+
+  function environmentValue(
+    env: Record<string, string | undefined>,
+    name: string,
+  ): string | undefined {
+    const candidate = process.platform === "win32" ? name.toUpperCase() : name;
+    for (const [key, value] of Object.entries(env)) {
+      const existing = process.platform === "win32" ? key.toUpperCase() : key;
+      if (existing === candidate) return value;
+    }
+    return undefined;
+  }
+
+  function gitCommandEnvironment(
+    command: string,
+    initialCwd = projectDir,
+  ): GitCommandContext {
+    const env: Record<string, string | undefined> = { ...projectEnv };
+    const commandEnv: Record<string, string | undefined> = { ...projectEnv };
+    let invocationCwd = initialCwd;
+    const flavor: PathFlavor = process.platform === "win32" ? "win32" : "posix";
+    for (const segment of shellCommandSegments(command)) {
+      const parsed = shellWords(segment);
+      if (parsed.ambiguous) continue;
+      let values = parsed.words
+        .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+        .filter((value): value is string => value !== undefined);
+      let index = 0;
+      const collectAssignments = () => {
+        for (; index < values.length; index++) {
+          const match = values[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+          if (!match) break;
+          deleteEnvironmentName(commandEnv, match[1]);
+          commandEnv[match[1]] = match[2];
+          if (isGitInspectionEnvironmentName(match[1])) {
+            deleteEnvironmentName(env, match[1]);
+            env[match[1]] = match[2];
+          }
+        }
+      };
+      const consumeWrapperOptions = (
+        spec: {
+          shortValues?: readonly string[];
+          longValues?: readonly string[];
+          shortOptionalValues?: readonly string[];
+          longOptionalValues?: readonly string[];
+          shortFlags?: readonly string[];
+          longFlags?: readonly string[];
+          numericShortValue?: boolean;
+        },
+      ) => {
+        const shortValues = new Set(spec.shortValues ?? []);
+        const longValues = new Set(spec.longValues ?? []);
+        const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+        const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+        const shortFlags = new Set(spec.shortFlags ?? []);
+        const longFlags = new Set(spec.longFlags ?? []);
+        while (index < values.length) {
+          const option = values[index];
+          if (option === "--") {
+            index++;
+            return false;
+          }
+          if (option === "-" || !option.startsWith("-")) return false;
+          if (option.startsWith("--")) {
+            const equals = option.indexOf("=");
+            const name = equals === -1 ? option : option.slice(0, equals);
+            if (longValues.has(name)) {
+              if (equals !== -1) {
+                index++;
+              } else if (values[index + 1] !== undefined) {
+                index += 2;
+              } else {
+                return true;
+              }
+              continue;
+            }
+            if (longOptionalValues.has(name) || longFlags.has(name)) {
+              index++;
+              continue;
+            }
+            return true;
+          }
+          if (spec.numericShortValue && /^-\d+$/.test(option)) {
+            index++;
+            continue;
+          }
+          const name = option.slice(0, 2);
+          if (shortValues.has(name)) {
+            if (option.length > 2) {
+              index++;
+            } else if (values[index + 1] !== undefined) {
+              index += 2;
+            } else {
+              return true;
+            }
+            continue;
+          }
+          if (shortOptionalValues.has(name)) {
+            index++;
+            continue;
+          }
+          if (
+            option.length > 1 &&
+            [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+          ) {
+            index++;
+            continue;
+          }
+          return true;
+        }
+        return false;
+      };
+      const simpleWrappers: Record<
+        string,
+        Parameters<typeof consumeWrapperOptions>[0]
+      > = {
+        exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+        nohup: { longFlags: ["--help", "--version"] },
+        nice: {
+          shortValues: ["-n"],
+          longValues: ["--adjustment"],
+          longFlags: ["--help", "--version"],
+          numericShortValue: true,
+        },
+        ionice: {
+          shortValues: ["-c", "-n", "-p", "-P", "-u"],
+          longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+          shortFlags: ["-t"],
+          longFlags: ["--ignore", "--help", "--version"],
+        },
+        stdbuf: {
+          shortValues: ["-i", "-o", "-e"],
+          longValues: ["--input", "--output", "--error"],
+          longFlags: ["--help", "--version"],
+        },
+        setsid: {
+          shortFlags: ["-c", "-f", "-w"],
+          longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+        },
+        sudo: {
+          shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
+          longValues: [
+            "--chdir",
+            "--close-from",
+            "--group",
+            "--host",
+            "--prompt",
+            "--role",
+            "--type",
+            "--user",
+          ],
+          shortOptionalValues: ["-E"],
+          longOptionalValues: ["--preserve-env"],
+          shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+          longFlags: [
+            "--askpass",
+            "--background",
+            "--edit",
+            "--help",
+            "--login",
+            "--non-interactive",
+            "--remove-timestamp",
+            "--reset-timestamp",
+            "--set-home",
+            "--shell",
+            "--stdin",
+            "--validate",
+            "--version",
+          ],
+        },
+        doas: {
+          shortValues: ["-C", "-u"],
+          shortFlags: ["-L", "-n", "-s"],
+        },
+        xargs: {
+          shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
+          longValues: [
+            "--arg-file",
+            "--delimiter",
+            "--max-args",
+            "--max-procs",
+            "--max-chars",
+            "--process-slot-var",
+          ],
+          shortOptionalValues: ["-e", "-i", "-l"],
+          longOptionalValues: ["--eof", "--replace", "--max-lines"],
+          shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+          longFlags: [
+            "--null",
+            "--open-tty",
+            "--interactive",
+            "--no-run-if-empty",
+            "--show-limits",
+            "--verbose",
+            "--exit",
+            "--help",
+            "--version",
+          ],
+        },
+        time: {
+          shortValues: ["-f", "-o"],
+          longValues: ["--format", "--output"],
+          shortFlags: ["-a", "-p", "-v"],
+          longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
+        },
+        unbuffer: { shortFlags: ["-p"] },
+      };
+      while (index < values.length) {
+        collectAssignments();
+        const wrapper = shellExecutableName(values[index] ?? "");
+        if (wrapper === "command") {
+          index++;
+          while (index < values.length && values[index].startsWith("-")) {
+            const option = values[index++];
+            if (option === "--") break;
+            if (option.includes("v") || option.includes("V")) {
+              return { cwd: invocationCwd, env, ambiguous: false };
+            }
+            if (![...option.slice(1)].every((flag) => flag === "p")) {
+              return { cwd: invocationCwd, env, ambiguous: true };
+            }
+          }
+          continue;
+        }
+        if (wrapper === "env") {
+          index++;
+          while (index < values.length) {
+            const option = values[index];
+            if (option === "--") {
+              index++;
+              break;
+            }
+            if (["-u", "--unset"].includes(option)) {
+              const name = values[index + 1] ?? "";
+              deleteEnvironmentName(commandEnv, name);
+              if (isGitInspectionEnvironmentName(name)) deleteEnvironmentName(env, name);
+              index += 2;
+              continue;
+            }
+            if (["-C", "--chdir"].includes(option)) {
+              const directory = values[index + 1];
+              if (!directory) return { cwd: invocationCwd, env, ambiguous: true };
+              invocationCwd = isAbsolute(directory)
+                ? directory
+                : resolve(invocationCwd, directory);
+              index += 2;
+              continue;
+            }
+            if (["-a", "--argv0"].includes(option)) {
+              if (!values[index + 1]) {
+                return { cwd: invocationCwd, env, ambiguous: true };
+              }
+              index += 2;
+              continue;
+            }
+            if (["-S", "--split-string"].includes(option)) {
+              const split = shellWords(values[index + 1] ?? "");
+              if (split.ambiguous) return { cwd: invocationCwd, env, ambiguous: true };
+              const splitValues = split.words
+                .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+                .filter((value): value is string => value !== undefined);
+              values = [...values.slice(0, index), ...splitValues, ...values.slice(index + 2)];
+              continue;
+            }
+            if (option.startsWith("-S") && option.length > 2) {
+              const split = shellWords(option.slice(2));
+              if (split.ambiguous) return { cwd: invocationCwd, env, ambiguous: true };
+              const splitValues = split.words
+                .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+                .filter((value): value is string => value !== undefined);
+              values = [...values.slice(0, index), ...splitValues, ...values.slice(index + 1)];
+              continue;
+            }
+            if (option.startsWith("--split-string=")) {
+              const split = shellWords(option.slice("--split-string=".length));
+              if (split.ambiguous) return { cwd: invocationCwd, env, ambiguous: true };
+              const splitValues = split.words
+                .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+                .filter((value): value is string => value !== undefined);
+              values = [...values.slice(0, index), ...splitValues, ...values.slice(index + 1)];
+              continue;
+            }
+            if (option.startsWith("--unset=")) {
+              const name = option.slice("--unset=".length);
+              deleteEnvironmentName(commandEnv, name);
+              if (isGitInspectionEnvironmentName(name)) deleteEnvironmentName(env, name);
+              index++;
+              continue;
+            }
+            const attached = option.match(/^-(u|C|a)(.+)$/);
+            if (attached) {
+              if (attached[1] === "u") {
+                deleteEnvironmentName(commandEnv, attached[2]);
+                if (isGitInspectionEnvironmentName(attached[2])) {
+                  deleteEnvironmentName(env, attached[2]);
+                }
+              } else if (attached[1] === "C") {
+                invocationCwd = isAbsolute(attached[2])
+                  ? attached[2]
+                  : resolve(invocationCwd, attached[2]);
+              }
+              index++;
+              continue;
+            }
+            if (option === "-" || option === "-i" || option === "--ignore-environment") {
+              for (const name of Object.keys(commandEnv)) delete commandEnv[name];
+              for (const name of Object.keys(env)) {
+                if (isGitInspectionEnvironmentName(name)) delete env[name];
+              }
+              index++;
+              continue;
+            }
+            if (/^-[i0v]+$/.test(option)) {
+              if (option.includes("i")) {
+                for (const name of Object.keys(commandEnv)) delete commandEnv[name];
+                for (const name of Object.keys(env)) {
+                  if (isGitInspectionEnvironmentName(name)) delete env[name];
+                }
+              }
+              index++;
+              continue;
+            }
+            if (option.startsWith("--chdir=")) {
+              const directory = option.slice("--chdir=".length);
+              if (!directory) return { cwd: invocationCwd, env, ambiguous: true };
+              invocationCwd = isAbsolute(directory)
+                ? directory
+                : resolve(invocationCwd, directory);
+              index++;
+              continue;
+            }
+            if (option.startsWith("--argv0=")) {
+              if (option.length === "--argv0=".length) {
+                return { cwd: invocationCwd, env, ambiguous: true };
+              }
+              index++;
+              continue;
+            }
+            if (option === "-0" || option === "--null") {
+              index++;
+              continue;
+            }
+            if (
+              option === "-v" ||
+              option === "--debug" ||
+              option === "--list-signal-handling" ||
+              option === "--help" ||
+              option === "--version" ||
+              /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+            ) {
+              index++;
+              continue;
+            }
+            if (!option.startsWith("-")) break;
+            return { cwd: invocationCwd, env, ambiguous: true };
+          }
+          continue;
+        }
+        const spec = simpleWrappers[wrapper];
+        if (spec) {
+          index++;
+          if (consumeWrapperOptions(spec)) {
+            return { cwd: invocationCwd, env, ambiguous: true };
+          }
+          continue;
+        }
+        if (wrapper === "timeout") {
+          index++;
+          if (
+            consumeWrapperOptions({
+              shortValues: ["-k", "-s"],
+              longValues: ["--kill-after", "--signal"],
+              longFlags: [
+                "--foreground",
+                "--preserve-status",
+                "--verbose",
+                "--help",
+                "--version",
+              ],
+            })
+          ) {
+            return { cwd: invocationCwd, env, ambiguous: true };
+          }
+          if (index < values.length) index++;
+          continue;
+        }
+        break;
+      }
+      if (shellExecutableName(values[index] ?? "") === "git") {
+        const gitArgs = values.slice(index + 1);
+        for (let i = 0; i < gitArgs.length; i++) {
+          const arg = gitArgs[i];
+          const configEnv =
+            arg === "--config-env"
+              ? gitArgs[++i] ?? ""
+              : arg.startsWith("--config-env=")
+                ? arg.slice("--config-env=".length)
+                : "";
+          const equals = configEnv.indexOf("=");
+          if (equals === -1) continue;
+          const variable = configEnv.slice(equals + 1);
+          if (!variable) continue;
+          deleteEnvironmentName(env, variable);
+          const value = environmentValue(commandEnv, variable);
+          if (value !== undefined) env[variable] = value;
+        }
+        return { cwd: invocationCwd, env, ambiguous: false };
+      }
+    }
+    return { cwd: invocationCwd, env, ambiguous: false };
+  }
+
+  interface GitAliasResolution {
+    disposition: "none" | "safe" | "unsafe";
+    command: string;
+  }
+
+  function gitPersistedAliasResolution(
+    args: readonly string[],
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): GitAliasResolution {
+    const invocation = gitInvocation(args);
+    let alias = invocation.subcommand;
+    if (!alias) return { disposition: "none", command: "" };
+    let resolvedAlias = false;
+    const visited = new Set<string>();
+    const readAlias = (name: string): string | null => {
+      const query = (command: string[]): string | null => {
+        const result = Bun.spawnSync(command, {
+          cwd,
+          env,
+          stdout: "pipe",
+          stderr: "ignore",
+        });
+        return result.exitCode === 0 ? result.stdout?.toString().trim() ?? "" : null;
+      };
+      const contextual = query([
+        "git",
+        ...invocation.prefix,
+        "config",
+        "--get",
+        `alias.${name}`,
+      ]);
+      if (contextual !== null) return contextual;
+      for (const file of [
+        env.GIT_CONFIG_GLOBAL,
+        env.HOME ? join(env.HOME, ".gitconfig") : undefined,
+        env.XDG_CONFIG_HOME ? join(env.XDG_CONFIG_HOME, "git", "config") : undefined,
+      ]) {
+        if (!file || !existsSync(file)) continue;
+        const expansion = query(["git", "config", "--file", file, "--get", `alias.${name}`]);
+        if (expansion !== null) return expansion;
+      }
+      return null;
+    };
+    for (let depth = 0; depth < 8; depth++) {
+      const folded = alias.toLowerCase();
+      if (visited.has(folded)) return { disposition: "unsafe", command: alias };
+      visited.add(folded);
+      const expansion = readAlias(alias);
+      if (expansion === null) {
+        return {
+          disposition: resolvedAlias ? "safe" : "none",
+          command: alias,
+        };
+      }
+      resolvedAlias = true;
+      if (!expansion || expansion.startsWith("!")) {
+        return { disposition: "unsafe", command: alias };
+      }
+      const parsed = shellWords(expansion);
+      if (parsed.ambiguous || parsed.words.length === 0) {
+        return { disposition: "unsafe", command: alias };
+      }
+      alias =
+        parsed.words[0].variants.find((variant) => variant.flavor === "posix")?.value ??
+        parsed.words[0].variants[0]?.value ??
+        "";
+      if (!alias) return { disposition: "unsafe", command: "" };
+    }
+    return { disposition: "unsafe", command: alias };
+  }
+
+  function gitPagerMode(
+    prefix: readonly string[],
+    env: Record<string, string | undefined>,
+  ): "default" | "disabled" | "enabled" {
+    const pager = (env.GIT_PAGER ?? env.PAGER ?? "").trim();
+    let mode: "default" | "disabled" | "enabled" =
+      pager.length === 0
+        ? "default"
+        : /^(?:cat|false)$/i.test(pager)
+          ? "disabled"
+          : "enabled";
+    for (const arg of prefix) {
+      if (arg === "--no-pager" || arg === "-P") mode = "disabled";
+      else if (arg === "--paginate" || arg === "-p") mode = "enabled";
+    }
+    return mode;
+  }
+
+  function gitStatusUsesExternalCommand(
+    args: readonly string[],
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): boolean {
+    const invocation = gitInvocation(args);
+    const prefix = invocation.prefix.filter((arg) => arg !== "--");
+    const pagerMode = gitPagerMode(prefix, env);
+    if (pagerMode === "enabled") return true;
+    const commandArgs = args.slice(invocation.subcommandIndex + 1);
+    const boundary = commandArgs.indexOf("--");
+    const optionArgs = boundary === -1 ? commandArgs : commandArgs.slice(0, boundary);
+    const positionalPathspecs = (): string[] => {
+      for (let i = 0; i < commandArgs.length; i++) {
+        const arg = commandArgs[i];
+        if (!arg.startsWith("-") || arg === "-") {
+          const pathspecs = commandArgs.slice(i);
+          return pathspecs.some((pathspec) => pathspec.startsWith("-"))
+            ? []
+            : pathspecs;
+        }
+        if (
+          /^-[vsbz]+$/.test(arg) ||
+          /^-u(?:all|normal|no)?$/.test(arg) ||
+          /^-M(?:\d+%?)?$/.test(arg) ||
+          /^--(?:no-)?(?:verbose|short|branch|show-stash|ahead-behind|porcelain|long|null|untracked-files|ignored|ignore-submodules|column)(?:=.*)?$/.test(
+            arg,
+          ) ||
+          arg === "--renames" ||
+          arg === "--no-renames" ||
+          /^--find-renames(?:=.*)?$/.test(arg)
+        ) {
+          continue;
+        }
+        return [];
+      }
+      return [];
+    };
+    const pathspecs =
+      boundary === -1 ? positionalPathspecs() : commandArgs.slice(boundary + 1);
+    const configuredCommand = (key: string, safeValues: RegExp): boolean => {
+      const result = Bun.spawnSync(
+        ["git", ...prefix, "config", "--get-all", key],
+        {
+          cwd,
+          env,
+          stdout: "pipe",
+          stderr: "ignore",
+        },
+      );
+      if (result.exitCode === 1) return false;
+      if (result.exitCode !== 0) return true;
+      return (result.stdout?.toString() ?? "")
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .some((value) => !safeValues.test(value.trim()));
+    };
+    if (configuredCommand("core.fsmonitor", /^(?:true|false)$/i)) return true;
+    if (
+      pagerMode !== "disabled" &&
+      (configuredCommand("core.pager", /^(?:cat|false)$/i) ||
+        configuredCommand("pager.status", /^(?:cat|false)$/i))
+    ) return true;
+    let submoduleMode: string | undefined;
+    for (const arg of optionArgs) {
+      if (arg === "--ignore-submodules") submoduleMode = "all";
+      else if (arg.startsWith("--ignore-submodules=")) {
+        submoduleMode = arg.slice("--ignore-submodules=".length).toLowerCase();
+      }
+    }
+    if (submoduleMode === "all") return false;
+
+    const rootResult = Bun.spawnSync(
+      ["git", ...prefix, "rev-parse", "--show-toplevel"],
+      {
+        cwd,
+        env,
+        stdout: "pipe",
+        stderr: "ignore",
+      },
+    );
+    if (rootResult.exitCode !== 0) return false;
+    const root = rootResult.stdout?.toString().trim();
+    if (!root) return true;
+    const visited = new Set<string>();
+    const childEnv: Record<string, string | undefined> = { ...env };
+    for (const name of [
+      "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+      "GIT_OBJECT_DIRECTORY",
+      "GIT_DIR",
+      "GIT_WORK_TREE",
+      "GIT_IMPLICIT_WORK_TREE",
+      "GIT_GRAFT_FILE",
+      "GIT_INDEX_FILE",
+      "GIT_NAMESPACE",
+      "GIT_PREFIX",
+      "GIT_INTERNAL_SUPER_PREFIX",
+      "GIT_QUARANTINE_PATH",
+      "GIT_REPLACE_REF_BASE",
+      "GIT_SHALLOW_FILE",
+      "GIT_COMMON_DIR",
+    ]) {
+      deleteEnvironmentName(childEnv, name);
+    }
+    const indexedGitlinks = (
+      repository: string,
+      repositoryEnv: Record<string, string | undefined>,
+      repositoryPathspecs: readonly string[] = [],
+      useRootInvocation = false,
+    ): string[] | null => {
+      const command = useRootInvocation
+        ? ["git", ...prefix, "ls-files", "--stage", "--full-name", "-z"]
+        : ["git", "-C", repository, "ls-files", "--stage", "--full-name", "-z"];
+      const result = Bun.spawnSync(
+        [
+          ...command,
+          ...(repositoryPathspecs.length > 0 ? ["--", ...repositoryPathspecs] : []),
+        ],
+        {
+          ...(useRootInvocation ? { cwd } : {}),
+          env: repositoryEnv,
+          stdout: "pipe",
+          stderr: "ignore",
+        },
+      );
+      if (result.exitCode !== 0) return null;
+      const paths: string[] = [];
+      for (const record of (result.stdout?.toString() ?? "").split("\0")) {
+        if (!record) continue;
+        const tab = record.indexOf("\t");
+        if (tab === -1 || !record.slice(0, tab).startsWith("160000 ")) continue;
+        const path = record.slice(tab + 1);
+        if (path) paths.push(path);
+      }
+      return paths;
+    };
+    const unsafeSubmodule = (repository: string, depth: number): boolean => {
+      if (depth > 16 || visited.size >= 64) return true;
+      let identity: string;
+      try {
+        identity = realpathSync.native(repository);
+      } catch {
+        return true;
+      }
+      if (visited.has(identity)) return false;
+      visited.add(identity);
+      const fsmonitor = Bun.spawnSync(
+        ["git", "-C", repository, "config", "--get-all", "core.fsmonitor"],
+        {
+          env: childEnv,
+          stdout: "pipe",
+          stderr: "ignore",
+        },
+      );
+      if (fsmonitor.exitCode !== 0 && fsmonitor.exitCode !== 1) return true;
+      if (
+        fsmonitor.exitCode === 0 &&
+        (fsmonitor.stdout?.toString() ?? "")
+          .split(/\r?\n/)
+          .filter(Boolean)
+          .some((value) => !/^(?:true|false)$/i.test(value.trim()))
+      ) {
+        return true;
+      }
+      const gitlinks = indexedGitlinks(repository, childEnv);
+      if (gitlinks === null) return true;
+      for (const path of gitlinks) {
+        const submodule = resolve(repository, path);
+        if (!existsSync(join(submodule, ".git"))) continue;
+        if (unsafeSubmodule(submodule, depth + 1)) return true;
+      }
+      return false;
+    };
+    const gitlinks = indexedGitlinks(root, env, pathspecs, true);
+    if (gitlinks === null) return true;
+    for (const path of gitlinks) {
+      const submodule = resolve(root, path);
+      if (!existsSync(join(submodule, ".git"))) continue;
+      if (unsafeSubmodule(submodule, 1)) return true;
+    }
+    return false;
+  }
+
+  function gitCommandIsUnsafe(
+    command: string,
+    args: readonly string[],
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): boolean {
+    if (!command) return false;
+    const result = Bun.spawnSync(["git", "--list-cmds=builtins"], {
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    if (result.exitCode !== 0) return true;
+    const builtins = new Set(
+      (result.stdout?.toString() ?? "")
+        .split(/\s+/)
+        .map((name) => name.trim().toLowerCase())
+        .filter(Boolean),
+    );
+    const folded = command.toLowerCase();
+    if (!builtins.has(folded)) return true;
+    if (folded === "config") {
+      const invocation = gitInvocation(args);
+      const configArgs = args.slice(invocation.subcommandIndex + 1);
+      const boundary = configArgs.indexOf("--");
+      const optionArgs = boundary === -1 ? configArgs : configArgs.slice(0, boundary);
+      return !optionArgs.some(
+        (arg) =>
+          arg === "--get" ||
+          arg === "--get-all" ||
+          arg === "--get-regexp" ||
+          arg === "--get-urlmatch" ||
+          arg === "--list" ||
+          arg === "-l",
+      );
+    }
+    const invocation = gitInvocation(args);
+    const commandArgs = args.slice(invocation.subcommandIndex + 1);
+    const boundary = commandArgs.indexOf("--");
+    const optionArgs = boundary === -1 ? commandArgs : commandArgs.slice(0, boundary);
+    const pagerDisabled = gitPagerMode(invocation.prefix, env) === "disabled";
+    if (folded === "branch") {
+      return !(pagerDisabled && optionArgs.includes("--list"));
+    }
+    if (folded === "tag") {
+      return !(
+        pagerDisabled &&
+        (optionArgs.includes("--list") || optionArgs.includes("-l"))
+      );
+    }
+    if (folded === "diff") {
+      let cached = false;
+      let externalDiff: boolean | undefined;
+      let textconv: boolean | undefined;
+      let submoduleMode: string | undefined;
+      for (const arg of optionArgs) {
+        if (arg === "--cached" || arg === "--staged") cached = true;
+        else if (arg === "--no-index") cached = false;
+        else if (arg === "--ext-diff") externalDiff = true;
+        else if (arg === "--no-ext-diff") externalDiff = false;
+        else if (arg === "--textconv") textconv = true;
+        else if (arg === "--no-textconv") textconv = false;
+        else if (arg === "--ignore-submodules") submoduleMode = "all";
+        else if (arg.startsWith("--ignore-submodules=")) {
+          submoduleMode = arg.slice("--ignore-submodules=".length).toLowerCase();
+        }
+      }
+      return !(
+        pagerDisabled &&
+        cached &&
+        externalDiff === false &&
+        textconv === false &&
+        submoduleMode === "all"
+      );
+    }
+    const safeBuiltins = new Set([
+      "status",
+      "rev-parse",
+      "show-ref",
+      "for-each-ref",
+      "ls-files",
+      "ls-tree",
+      "check-ignore",
+      "check-attr",
+      "check-mailmap",
+      "merge-base",
+      "name-rev",
+      "count-objects",
+      "version",
+    ]);
+    if (!safeBuiltins.has(folded)) return true;
+    return folded === "status" && gitStatusUsesExternalCommand(args, env, cwd);
+  }
+
+  function gitInvocationUsesDynamicEvaluation(
+    args: readonly string[],
+    command: string,
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): boolean {
+    if (gitUsesIndirectShellAlias(args, command)) return true;
+    const resolution = gitPersistedAliasResolution(args, env, cwd);
+    if (resolution.disposition === "unsafe") return true;
+    return gitCommandIsUnsafe(resolution.command, args, env, cwd);
+  }
+
+  async function shellInvokesDynamicEvaluation(
+    command: string,
+    cwd = projectDir,
+  ): Promise<boolean> {
     if (shellUsesDynamicExpansion(command)) return true;
+    if (shellUsesConstructedHostInvocation(command)) return true;
     const interpreter =
-      /^(?:ba|da|fi|k|z)?sh$|^(?:bun|bunx|deno|node|nodejs|npm|npx|pnpm|yarn|corepack|tsx|ts-node|python(?:\d+(?:\.\d+)*)?|ruby|perl|php|lua|luajit|raku|julia|java|js|qjs|osascript|powershell|pwsh)$/i;
+      /^(?:ba|da|fi|k|z)?sh$|^(?:bun|bunx|deno|node|nodejs|npm|npx|pnpm|yarn|corepack|tsx|ts-node|python(?:\d+(?:\.\d+)*)?|ruby|perl|php|lua|luajit|raku|julia|java|js|qjs|osascript|powershell|pwsh|cmd|cscript|wscript|mshta|awk|gawk|mawk|nawk)(?:\.(?:exe|com|cmd|bat))?$/i;
+    const directPowerShellHost =
+      /^(?:remove|clear|set|new|move|copy|rename)-item$|^(?:set|add|clear)-content$|^out-file$|^(?:ri|rm|rd|del|erase|rmdir|mi|mv|cp|cpi|ren|ni|sc|ac|clc)$/i;
+    const dynamicPowerShellHost =
+      /^(?:invoke-expression|iex|invoke-command|icm|invoke-item|ii|start-process|saps|start-job|sajb)$/i;
+    const isInterpreter = (name: string): boolean => {
+      const candidates = [name, posix.basename(name), win32.basename(name)];
+      if (candidates.some((candidate) => interpreter.test(candidate))) return true;
+      return /(?:powershell|pwsh|cmd|cscript|wscript|mshta|awk|gawk|mawk|nawk)(?:\.(?:exe|com|cmd|bat))?$/i.test(
+        name,
+      );
+    };
     try {
       const module = await loadReviewFreezeCommandModule();
       if (typeof module.shellCommandInvocations !== "function") return true;
-      return module.shellCommandInvocations(command).some(
-        (invocation) =>
-          interpreter.test(invocation.name) ||
-          invocation.name === "eval" ||
-          invocation.name === "source" ||
-          invocation.name === ".",
-      );
+      const hostExpression = shellUsesDirectHostExpression(command);
+      const flavor: PathFlavor =
+        process.platform === "win32" ? "win32" : "posix";
+      let states: ShellCwdState[] = [
+        { cwd, stack: [], status: "unknown", logicalAmbiguous: false },
+      ];
+      let operatorBefore: ShellCommandPart["operatorAfter"] = "";
+      for (const part of shellCommandParts(command)) {
+        const segment = part.text;
+        const parsed = shellWords(segment);
+        if (parsed.ambiguous) return true;
+        const activeStates: ShellCwdState[] = [];
+        const carriedStates: ShellCwdState[] = [];
+        for (const state of states) {
+          const active = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          const carried = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          if (operatorBefore === "&&") {
+            if (state.status !== "failure") activeStates.push(active);
+            if (state.status !== "success") carriedStates.push(carried);
+          } else if (operatorBefore === "||") {
+            if (state.status !== "success") activeStates.push(active);
+            if (state.status !== "failure") carriedStates.push(carried);
+          } else {
+            activeStates.push(active);
+          }
+        }
+
+        const invocations = module.shellCommandInvocations(segment);
+        for (const state of activeStates) {
+          const gitContext = gitCommandEnvironment(segment, state.cwd);
+          for (const invocation of invocations) {
+            const leaf = win32.basename(posix.basename(invocation.name));
+            if (
+              invocation.ambiguous ||
+              isInterpreter(invocation.name) ||
+              dynamicPowerShellHost.test(invocation.name) ||
+              (/^busybox(?:\.exe)?$/i.test(leaf) &&
+                isInterpreter(invocation.args[0] ?? "")) ||
+              (/^git(?:\.exe)?$/i.test(leaf) &&
+                (gitContext.ambiguous ||
+                  gitInvocationUsesDynamicEvaluation(
+                    invocation.args,
+                    segment,
+                    gitContext.env,
+                    gitContext.cwd,
+                  ))) ||
+              (hostExpression &&
+                directPowerShellHost.test(invocation.name)) ||
+              invocation.name === "eval" ||
+              invocation.name === "source" ||
+              invocation.name === "."
+            ) {
+              return true;
+            }
+          }
+        }
+
+        const isolatedSubshell = /^\s*\(.*\)\s*$/.test(segment);
+        const nonPersistent =
+          isolatedSubshell || ["|", "&"].includes(part.operatorAfter);
+        const controlAmbiguous =
+          /[{}]/.test(segment) ||
+          /\b(?:if|elif|else|while|until|case|for|select|function|then|do)\b/i.test(
+            segment,
+          );
+        const nextStates: ShellCwdState[] = [...carriedStates];
+        for (const state of activeStates) {
+          const original = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          const changed = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          const update = updateShellCwd(parsed.words, flavor, changed);
+          if (update === "ambiguous") return true;
+          if (update === "none") {
+            nextStates.push({ ...original, status: "unknown" });
+            continue;
+          }
+          let viable = false;
+          try {
+            viable = statSync(changed.cwd).isDirectory();
+          } catch {
+            // A literal directory change to a missing path cannot succeed.
+          }
+          if (!viable) {
+            nextStates.push({ ...original, status: "failure" });
+          } else if (nonPersistent) {
+            nextStates.push({ ...original, status: "success" });
+          } else if (controlAmbiguous) {
+            nextStates.push(
+              { ...original, status: "unknown" },
+              { ...changed, status: "unknown" },
+            );
+          } else {
+            nextStates.push({ ...changed, status: "success" });
+          }
+        }
+        const deduped = new Map<string, ShellCwdState>();
+        for (const state of nextStates) {
+          const key = shellCwdStateKey(state, flavor);
+          const existing = deduped.get(key);
+          if (!existing) {
+            deduped.set(key, state);
+            continue;
+          }
+          const sameLogicalState =
+            existing.cwd === state.cwd &&
+            existing.stack.length === state.stack.length &&
+            existing.stack.every(
+              (path, index) => path === state.stack[index],
+            );
+          existing.logicalAmbiguous ||=
+            state.logicalAmbiguous || !sameLogicalState;
+          if (state.cwd.length < existing.cwd.length) {
+            existing.cwd = state.cwd;
+            existing.stack = [...state.stack];
+          }
+        }
+        if (deduped.size > MAX_SHELL_CWD_STATES) return true;
+        states = [...deduped.values()];
+        operatorBefore = part.operatorAfter;
+      }
+      return false;
     } catch {
       return true;
     }
@@ -696,18 +2457,150 @@ export async function run(
     const cwd = effectiveCwd();
     const command = toolInput.command;
     if (toolName === "Bash" && typeof command === "string") {
-      if (
-        shellWords(command).some((word) =>
-          globPrefixTouchesProtected(word, cwd, protectedPaths) ||
-          concreteWordTouchesProtected(word, cwd, protectedPaths)
-        )
-      ) {
-        return true;
+      const states: Record<PathFlavor, ShellCwdState[]> = {
+        posix: [{ cwd, stack: [], status: "unknown", logicalAmbiguous: false }],
+        win32: [{ cwd, stack: [], status: "unknown", logicalAmbiguous: false }],
+      };
+      let operatorBefore: ShellCommandPart["operatorAfter"] = "";
+      for (const part of shellCommandParts(command)) {
+        const segment = part.text;
+        const parsed = shellWords(segment);
+        if (parsed.ambiguous) return true;
+        const activeStates: Record<PathFlavor, ShellCwdState[]> = {
+          posix: [],
+          win32: [],
+        };
+        const carriedStates: Record<PathFlavor, ShellCwdState[]> = {
+          posix: [],
+          win32: [],
+        };
+        for (const flavor of ["posix", "win32"] as const) {
+          for (const state of states[flavor]) {
+            const active = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            const carried = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            if (operatorBefore === "&&") {
+              if (state.status !== "failure") activeStates[flavor].push(active);
+              if (state.status !== "success") carriedStates[flavor].push(carried);
+            } else if (operatorBefore === "||") {
+              if (state.status !== "success") activeStates[flavor].push(active);
+              if (state.status !== "failure") carriedStates[flavor].push(carried);
+            } else {
+              activeStates[flavor].push(active);
+            }
+          }
+        }
+        if (
+          parsed.words.some(({ variants }) =>
+            variants.some(
+              ({ value, activeGlobIndexes, flavor }) =>
+                activeStates[flavor].some(
+                  (state) =>
+                    globPrefixTouchesProtected(
+                      value,
+                      state.cwd,
+                      protectedPaths,
+                      activeGlobIndexes[0] ?? -1,
+                      flavor,
+                    ) ||
+                    concreteWordTouchesProtected(
+                      value,
+                      state.cwd,
+                      protectedPaths,
+                      activeGlobIndexes.length > 0,
+                      flavor,
+                    ),
+                ),
+            )
+          )
+        ) {
+          return true;
+        }
+        const isolatedSubshell = /^\s*\(.*\)\s*$/.test(segment);
+        const nonPersistent =
+          isolatedSubshell || ["|", "&"].includes(part.operatorAfter);
+        const controlAmbiguous =
+          /[{}]/.test(segment) ||
+          /\b(?:if|elif|else|while|until|case|for|select|function|then|do)\b/i.test(
+            segment,
+          );
+        for (const flavor of ["posix", "win32"] as const) {
+          const nextStates: ShellCwdState[] = [...carriedStates[flavor]];
+          for (const state of activeStates[flavor]) {
+            const original = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            const changed = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            const update = updateShellCwd(parsed.words, flavor, changed);
+            if (update === "ambiguous") return true;
+            if (update === "none") {
+              nextStates.push({ ...original, status: "unknown" });
+              continue;
+            }
+            let viable = false;
+            try {
+              viable = statSync(changed.cwd).isDirectory();
+            } catch {
+              // A literal directory change to a missing path cannot succeed.
+            }
+            if (!viable) {
+              nextStates.push({ ...original, status: "failure" });
+            } else if (nonPersistent) {
+              nextStates.push({ ...original, status: "success" });
+            } else if (controlAmbiguous) {
+              nextStates.push(
+                { ...original, status: "unknown" },
+                { ...changed, status: "unknown" },
+              );
+            } else {
+              nextStates.push({ ...changed, status: "success" });
+            }
+          }
+          const deduped = new Map<string, ShellCwdState>();
+          for (const state of nextStates) {
+            const key = shellCwdStateKey(state, flavor);
+            const existing = deduped.get(key);
+            if (!existing) {
+              deduped.set(key, state);
+              continue;
+            }
+            const sameLogicalState =
+              existing.cwd === state.cwd &&
+              existing.stack.length === state.stack.length &&
+              existing.stack.every((path, index) => path === state.stack[index]);
+            existing.logicalAmbiguous ||=
+              state.logicalAmbiguous || !sameLogicalState;
+            if (state.cwd.length < existing.cwd.length) {
+              existing.cwd = state.cwd;
+              existing.stack = [...state.stack];
+            }
+          }
+          if (deduped.size > MAX_SHELL_CWD_STATES) return true;
+          states[flavor] = [...deduped.values()];
+        }
+        operatorBefore = part.operatorAfter;
       }
       const concrete = await reviewFreezeTargets();
       if (
         concrete?.some((path) =>
-          overlapsProtectedPath(path, protectedPaths)
+          overlapsProtectedPath(path, protectedPaths, cwd)
         )
       ) {
         return true;
@@ -718,10 +2611,7 @@ export async function run(
       (value) =>
         (globPrefixTouchesProtected(value, cwd, protectedPaths) ||
           (!/[\s*?[\]{}]/.test(value) &&
-            overlapsProtectedPath(
-              isAbsolute(value) ? value : resolve(cwd, value),
-              protectedPaths,
-            ))),
+            overlapsProtectedPath(value, protectedPaths, cwd))),
     );
   }
 
@@ -788,7 +2678,22 @@ export async function run(
                 "the live Task record was retired.",
             }),
           );
-          removeLedger(path);
+          retireSpawn(record);
+        }
+        for (const path of witnessFiles().sort()) {
+          const record = readRecord(path);
+          if (record?.parent !== cursor.conversation_id) continue;
+          runCore(
+            "aidlc-log-subagent.ts",
+            JSON.stringify({
+              hook_event_name: "SubagentStop",
+              agent_type: record.agent,
+              last_assistant_message:
+                "inferred: Cursor emitted sessionEnd after the primary Task ledger was lost; " +
+                "the independent delegation witness was retired.",
+            }),
+          );
+          retireSpawn(record);
         }
         removeLedger(mainFile(cursor.conversation_id));
       }
@@ -878,7 +2783,18 @@ export async function run(
           return 0;
         }
         const sub = cursor.tool_input?.subagent_type;
-        if (typeof sub === "string" && sub.length > 0) recordSpawn(sub);
+        if (
+          typeof sub === "string" &&
+          sub.length > 0 &&
+          !recordSpawn(sub)
+        ) {
+          process.stdout.write(`${JSON.stringify({
+            permission: "deny",
+            agent_message:
+              "AIDLC could not establish protected delegated-agent attribution, so the Task was not started.",
+          })}\n`);
+          return 0;
+        }
         writeAllow();
         return 0;
       }
@@ -888,15 +2804,14 @@ export async function run(
         agent &&
         toolName === "Bash" &&
         typeof command === "string" &&
-        (REVIEW_AGENT_RE.test(agent) || activeReviewerDispatch() !== null) &&
-        await shellInvokesDynamicEvaluation(command)
+        await shellInvokesDynamicEvaluation(command, effectiveCwd())
       ) {
         process.stdout.write(`${JSON.stringify({
           permission: "deny",
           agent_message:
             "AIDLC delegated agents cannot use general-purpose interpreters, shell parameter " +
-            "expansion, or dynamic command evaluation while reviewer attribution is active " +
-            "because those paths can bypass attribution-state protection. " +
+            "expansion, or dynamic command evaluation while delegated-agent attribution is active " +
+            "because those paths can invalidate protected attribution state. " +
             "Use Cursor's native read/search tools and have the parent conversation run executable probes.",
         })}\n`);
         return 0;
@@ -913,8 +2828,8 @@ export async function run(
         process.stdout.write(`${JSON.stringify({
           permission: "deny",
           agent_message:
-            "AIDLC reviewer identity is unavailable or ambiguous during an active review dispatch; " +
-            "the operation was denied rather than bypassing reviewer-scope enforcement.",
+            "AIDLC delegated-agent identity is unavailable or ambiguous while delegation state is active; " +
+            "the operation was denied rather than losing attribution enforcement.",
         })}\n`);
         return 0;
       }

--- a/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
@@ -2353,6 +2353,10 @@ export async function run(
                   ))) ||
               (hostExpression &&
                 directPowerShellHost.test(invocation.name)) ||
+              (invocation.name === "find" &&
+                invocation.args.some((arg) =>
+                  ["-exec", "-execdir", "-ok", "-okdir"].includes(arg)
+                )) ||
               invocation.name === "eval" ||
               invocation.name === "source" ||
               invocation.name === "."

--- a/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
@@ -700,6 +700,15 @@ export async function run(
   }
 
   interface ReviewFreezeCommandModule {
+    shellCommandInvocationDetails?: (
+      command: string,
+    ) => Array<{
+      name: string;
+      args: string[];
+      ambiguous?: boolean;
+      executable?: string;
+      launchers?: string[];
+    }>;
     shellCommandInvocations?: (
       command: string,
     ) => Array<{ name: string; args: string[]; ambiguous?: boolean }>;
@@ -2285,6 +2294,111 @@ export async function run(
       /^(?:remove|clear|set|new|move|copy|rename)-item$|^(?:set|add|clear)-content$|^out-file$|^(?:ri|rm|rd|del|erase|rmdir|mi|mv|cp|cpi|ren|ni|sc|ac|clc)$/i;
     const dynamicPowerShellHost =
       /^(?:invoke-expression|iex|invoke-command|icm|invoke-item|ii|start-process|saps|start-job|sajb)$/i;
+    const inspectableDelegatedCommands = new Set([
+      ":",
+      "[",
+      "ac",
+      "add-content",
+      "basename",
+      "cat",
+      "cd",
+      "chdir",
+      "clear-content",
+      "clear-item",
+      "clc",
+      "cli",
+      "cmp",
+      "copy",
+      "copy-item",
+      "cp",
+      "cpi",
+      "cut",
+      "dd",
+      "del",
+      "dir",
+      "dirname",
+      "echo",
+      "erase",
+      "exist",
+      "false",
+      "file",
+      "find",
+      "get-childitem",
+      "get-content",
+      "get-item",
+      "git",
+      "grep",
+      "head",
+      "join-path",
+      "jq",
+      "ls",
+      "md",
+      "mi",
+      "mkdir",
+      "move",
+      "move-item",
+      "mv",
+      "new-item",
+      "ni",
+      "out-file",
+      "pop-location",
+      "popd",
+      "printf",
+      "push-location",
+      "pushd",
+      "pwd",
+      "rd",
+      "readlink",
+      "realpath",
+      "remove-item",
+      "ren",
+      "rename",
+      "rename-item",
+      "resolve-path",
+      "rg",
+      "ri",
+      "rmdir",
+      "rm",
+      "rni",
+      "rsync",
+      "sc",
+      "select-string",
+      "set-content",
+      "set-item",
+      "set-location",
+      "sha1sum",
+      "sha256sum",
+      "sha512sum",
+      "shred",
+      "sl",
+      "sort",
+      "split-path",
+      "stat",
+      "tail",
+      "tee",
+      "test",
+      "test-path",
+      "touch",
+      "tr",
+      "true",
+      "truncate",
+      "type",
+      "uniq",
+      "unlink",
+      "wc",
+      "where",
+      "which",
+    ]);
+    const uninspectableExecutableToken = (value: string): boolean => {
+      const normalized = value.replaceAll("\\", "/");
+      return (
+        normalized.includes("/") ||
+        /^[A-Za-z]:/.test(normalized) ||
+        /\.(?:bat|cmd|ps1|psd1|psm1|sh|bash|dash|fish|ksh|zsh|cjs|js|mjs|cts|mts|ts|py|rb|pl|php|lua|jar|vbs|wsf|hta)$/i.test(
+          normalized,
+        )
+      );
+    };
     const isInterpreter = (name: string): boolean => {
       const candidates = [name, posix.basename(name), win32.basename(name)];
       if (candidates.some((candidate) => interpreter.test(candidate))) return true;
@@ -2294,7 +2408,7 @@ export async function run(
     };
     try {
       const module = await loadReviewFreezeCommandModule();
-      if (typeof module.shellCommandInvocations !== "function") return true;
+      if (typeof module.shellCommandInvocationDetails !== "function") return true;
       const hostExpression = shellUsesDirectHostExpression(command);
       const flavor: PathFlavor =
         process.platform === "win32" ? "win32" : "posix";
@@ -2332,17 +2446,27 @@ export async function run(
           }
         }
 
-        const invocations = module.shellCommandInvocations(segment);
+        const functionDefinition =
+          /^\s*(?:function\s+)?[A-Za-z_][A-Za-z0-9_]*\s*(?:\(\s*\))?\s*\{/.test(
+            segment,
+          );
+        const invocations = functionDefinition
+          ? []
+          : module.shellCommandInvocationDetails(segment);
         for (const state of activeStates) {
           const gitContext = gitCommandEnvironment(segment, state.cwd);
           for (const invocation of invocations) {
             const leaf = win32.basename(posix.basename(invocation.name));
             if (
               invocation.ambiguous ||
+              [invocation.executable, ...(invocation.launchers ?? [])].some(
+                (value) =>
+                  typeof value !== "string" ||
+                  value.length === 0 ||
+                  uninspectableExecutableToken(value),
+              ) ||
               isInterpreter(invocation.name) ||
               dynamicPowerShellHost.test(invocation.name) ||
-              (/^busybox(?:\.exe)?$/i.test(leaf) &&
-                isInterpreter(invocation.args[0] ?? "")) ||
               (/^git(?:\.exe)?$/i.test(leaf) &&
                 (gitContext.ambiguous ||
                   gitInvocationUsesDynamicEvaluation(
@@ -2359,7 +2483,8 @@ export async function run(
                 )) ||
               invocation.name === "eval" ||
               invocation.name === "source" ||
-              invocation.name === "."
+              invocation.name === "." ||
+              !inspectableDelegatedCommands.has(invocation.name)
             ) {
               return true;
             }

--- a/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-cursor-adapter.ts
@@ -700,6 +700,7 @@ export async function run(
   }
 
   interface ReviewFreezeCommandModule {
+    shellCommandAltersExecutableResolution?: (command: string) => boolean;
     shellCommandInvocationDetails?: (
       command: string,
     ) => Array<{
@@ -708,6 +709,8 @@ export async function run(
       ambiguous?: boolean;
       executable?: string;
       launchers?: string[];
+      dataDrivenMutation?: boolean;
+      executableResolutionChanged?: boolean;
     }>;
     shellCommandInvocations?: (
       command: string,
@@ -2408,7 +2411,13 @@ export async function run(
     };
     try {
       const module = await loadReviewFreezeCommandModule();
-      if (typeof module.shellCommandInvocationDetails !== "function") return true;
+      if (
+        typeof module.shellCommandAltersExecutableResolution !== "function" ||
+        typeof module.shellCommandInvocationDetails !== "function"
+      ) {
+        return true;
+      }
+      if (module.shellCommandAltersExecutableResolution(command)) return true;
       const hostExpression = shellUsesDirectHostExpression(command);
       const flavor: PathFlavor =
         process.platform === "win32" ? "win32" : "posix";
@@ -2459,6 +2468,7 @@ export async function run(
             const leaf = win32.basename(posix.basename(invocation.name));
             if (
               invocation.ambiguous ||
+              invocation.dataDrivenMutation ||
               [invocation.executable, ...(invocation.launchers ?? [])].some(
                 (value) =>
                   typeof value !== "string" ||

--- a/dist/cursor/.cursor/hooks/aidlc-review-freeze.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/dist/cursor/.cursor/hooks/aidlc-review-freeze.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/dist/cursor/.cursor/hooks/review-freeze-command.ts
+++ b/dist/cursor/.cursor/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/dist/cursor/.cursor/hooks/review-freeze-command.ts
+++ b/dist/cursor/.cursor/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/dist/cursor/.cursor/hooks/review-freeze-command.ts
+++ b/dist/cursor/.cursor/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/dist/cursor/.cursor/hooks/review-freeze-command.ts
+++ b/dist/cursor/.cursor/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/dist/cursor/.gitignore
+++ b/dist/cursor/.gitignore
@@ -46,9 +46,10 @@ aidlc/.aidlc-unit-participant
 aidlc/.aidlc-claim-registry.json
 aidlc/.aidlc-unit-releases/
 aidlc/.aidlc-unit-merges/
-# Cursor's reconstructed subagent identity registry; protected by the adapter
-# and recreated per install/session.
+# Cursor's reconstructed subagent identity registry and independent active
+# delegation witnesses; protected by the adapter and recreated per session.
 aidlc/.aidlc-cursor-subagents/
+aidlc/.aidlc-cursor-subagent-*.json
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/dist/kiro-ide/.kiro/hooks/aidlc-review-freeze.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/dist/kiro-ide/.kiro/hooks/aidlc-review-freeze.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro-ide/.kiro/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/dist/kiro/.kiro/hooks/aidlc-review-freeze.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/dist/kiro/.kiro/hooks/aidlc-review-freeze.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/dist/kiro/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro/.kiro/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/dist/kiro/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro/.kiro/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/dist/kiro/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro/.kiro/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/dist/kiro/.kiro/hooks/review-freeze-command.ts
+++ b/dist/kiro/.kiro/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/dist/opencode/.aidlc/hooks/aidlc-review-freeze.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-review-freeze.ts
@@ -76,8 +76,10 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,
+  type ShellInvocationDetails,
   type ShellInvocation,
   writeTargets,
 } from "./review-freeze-command.ts";

--- a/dist/opencode/.aidlc/hooks/aidlc-review-freeze.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-review-freeze.ts
@@ -76,6 +76,7 @@ import {
 } from "../tools/aidlc-lib.ts";
 import { writeTargets } from "./review-freeze-command.ts";
 export {
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   shellWriteTargets,

--- a/dist/opencode/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/opencode/.aidlc/hooks/review-freeze-command.ts
@@ -96,6 +96,10 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
+interface ShellInvocationDetails extends ShellInvocation {
+  dataDriven?: boolean;
+}
+
 function shellExecutableName(value: string): string {
   const normalized = value.replaceAll("\\", "/");
   const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
@@ -177,7 +181,11 @@ function consumeWrapperOptions(
   return { index, ambiguous: false };
 }
 
-function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
+function shellInvocation(
+  words: string[],
+  depth = 0,
+  dataDriven = false,
+): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -287,7 +295,11 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
+        return shellInvocation(
+          [...splitCommand, ...words.slice(index)],
+          depth + 1,
+          dataDriven,
+        );
       }
       continue;
     }
@@ -389,6 +401,7 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
+      dataDriven ||= wrapper === "xargs";
       skipAssignments();
       continue;
     }
@@ -420,16 +433,23 @@ function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-export function shellCommandInvocations(command: string): ShellInvocation[] {
-  const invocations: ShellInvocation[] = [];
+function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+  const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
     if (invocation) invocations.push(invocation);
   }
   return invocations;
+}
+
+export function shellCommandInvocations(command: string): ShellInvocation[] {
+  return shellCommandInvocationDetails(command).map(
+    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+  );
 }
 
 function shellWordAt(command: string, start: number): { word: string; end: number } | null {
@@ -536,6 +556,125 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
+function findTraversalRoots(args: string[]): string[] {
+  let index = 0;
+  while (["-H", "-L", "-P"].includes(args[index] ?? "")) index++;
+  while ((args[index] ?? "").startsWith("-D")) {
+    if (args[index] === "-D") index += 2;
+    else index++;
+  }
+  if (/^-O\d+$/.test(args[index] ?? "")) index++;
+
+  const roots: string[] = [];
+  for (; index < args.length; index++) {
+    const arg = args[index];
+    if (
+      arg === "!" ||
+      arg === "(" ||
+      arg === ")" ||
+      arg.startsWith("-") ||
+      arg === ","
+    ) {
+      break;
+    }
+    roots.push(arg);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+const STATIC_REMOVE_COMMANDS = new Set([
+  "rmdir",
+  "rd",
+  "del",
+  "erase",
+  "shred",
+  "remove-item",
+  "clear-item",
+  "ri",
+  "cli",
+]);
+
+const STATIC_MOVE_COMMANDS = new Set([
+  "move",
+  "rename",
+  "move-item",
+  "rename-item",
+  "mi",
+  "ren",
+  "rni",
+]);
+
+const STATIC_CONTENT_COMMANDS = new Set([
+  "set-item",
+  "new-item",
+  "set-content",
+  "add-content",
+  "clear-content",
+  "out-file",
+]);
+
+function attachedPathOptionValues(
+  args: string[],
+  pathOptions = new Set([
+    "path",
+    "literalpath",
+    "destination",
+    "newname",
+    "filepath",
+  ]),
+): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    const match = arg.match(/^-{1,2}([^:=]+)[:=](.+)$/);
+    if (match && pathOptions.has(match[1].toLowerCase())) out.push(match[2]);
+  }
+  return out;
+}
+
+function invocationMayMutate(commandName: string, args: string[]): boolean {
+  if (
+    [
+      "cp",
+      "dd",
+      "install",
+      "mv",
+      "rm",
+      "rsync",
+      "tee",
+      "touch",
+      "truncate",
+      "unlink",
+      "copy-item",
+    ].includes(commandName) ||
+    STATIC_REMOVE_COMMANDS.has(commandName) ||
+    STATIC_MOVE_COMMANDS.has(commandName) ||
+    STATIC_CONTENT_COMMANDS.has(commandName)
+  ) {
+    return true;
+  }
+  if (commandName === "sed") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-e", "-f", "-l"]),
+      new Set(["--expression", "--file", "--line-length"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  if (commandName === "perl") {
+    const parsed = parseShellArgs(
+      args,
+      new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
+    );
+    return parsed.options.has("-i") || parsed.options.has("--in-place");
+  }
+  return (
+    commandName === "find" &&
+    args.some((arg) =>
+      ["-delete", "-fprint", "-fprint0", "-fprintf", "-fls"].includes(arg)
+    )
+  );
+}
+
 /** Concrete filesystem targets of a mutation-capable shell command. */
 export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
@@ -616,11 +755,17 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
   // Parse each command segment independently so a mutator never claims a
   // later read-only command's operands. Only destination/in-place operands are
   // candidates for commands that also have read-only source operands.
-  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+  for (const {
+    name: commandName,
+    args,
+    ambiguous,
+    dataDriven,
+  } of shellCommandInvocationDetails(command)) {
     if (ambiguous) {
       add(cwd);
       continue;
     }
+    if (dataDriven && invocationMayMutate(commandName, args)) add(cwd);
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -628,7 +773,14 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
 
     const basic = parseShellArgs(args);
     const { operands } = basic;
-    if (operands.length === 0) continue;
+    const attachedPaths = attachedPathOptionValues(args);
+    if (
+      operands.length === 0 &&
+      attachedPaths.length === 0 &&
+      commandName !== "find"
+    ) {
+      continue;
+    }
 
     if (commandName === "cp") {
       const parsed = parseShellArgs(
@@ -726,6 +878,36 @@ export function shellWriteTargets(command: string, cwd = process.cwd()): string[
       if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
       for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
+    } else if (commandName === "find") {
+      if (args.includes("-delete")) {
+        for (const root of findTraversalRoots(args)) add(root);
+      }
+      for (let index = 0; index < args.length; index++) {
+        if (["-fprint", "-fprint0", "-fls"].includes(args[index])) {
+          add(args[++index]);
+        } else if (args[index] === "-fprintf") {
+          add(args[++index]);
+          index++;
+        }
+      }
+    } else if (
+      STATIC_REMOVE_COMMANDS.has(commandName) ||
+      STATIC_MOVE_COMMANDS.has(commandName) ||
+      STATIC_CONTENT_COMMANDS.has(commandName)
+    ) {
+      for (const operand of operands) add(operand);
+      for (const value of attachedPaths) add(value);
+    } else if (commandName === "copy-item") {
+      add(operands.at(-1));
+      for (const value of attachedPathOptionValues(args, new Set(["destination"]))) {
+        add(value);
+      }
+    } else if (commandName === "rsync") {
+      const destination = operands.at(-1);
+      add(destination);
+      if (basic.options.has("--remove-source-files")) {
+        for (const source of operands.slice(0, -1)) add(source);
+      }
     }
   }
 

--- a/dist/opencode/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/opencode/.aidlc/hooks/review-freeze-command.ts
@@ -1,5 +1,8 @@
 import { statSync } from "node:fs";
 import { basename, isAbsolute, join, resolve } from "node:path";
+// The file-writing tools whose targets the freeze inspects. Read-only tools
+// never invalidate a receipt.
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 function shellWords(command: string): string[] {
   const words: string[] = [];
@@ -15,6 +18,14 @@ function shellWords(command: string): string[] {
     if (escaped) {
       word += ch;
       escaped = false;
+      continue;
+    }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      word += ch;
       continue;
     }
     if (ch === "\\" && quote !== "'") {
@@ -51,6 +62,13 @@ function shellCommandSegments(command: string): string[] {
       escaped = false;
       continue;
     }
+    if (
+      ch === "\\" &&
+      quote === '"' &&
+      !'$`"\\\n'.includes(command[i + 1] ?? "")
+    ) {
+      continue;
+    }
     if (ch === "\\" && quote !== "'") {
       escaped = true;
       continue;
@@ -75,36 +93,91 @@ function shellCommandSegments(command: string): string[] {
 export interface ShellInvocation {
   name: string;
   args: string[];
+  ambiguous?: boolean;
+}
+
+function shellExecutableName(value: string): string {
+  const normalized = value.replaceAll("\\", "/");
+  const leaf = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return leaf.replace(/\.(?:exe|com|cmd|bat)$/i, "").toLowerCase();
+}
+
+interface WrapperOptionSpec {
+  shortValues?: readonly string[];
+  longValues?: readonly string[];
+  shortOptionalValues?: readonly string[];
+  longOptionalValues?: readonly string[];
+  shortFlags?: readonly string[];
+  longFlags?: readonly string[];
+  numericShortValue?: boolean;
 }
 
 function consumeWrapperOptions(
   words: string[],
   index: number,
-  shortValueOptions = new Set<string>(),
-  longValueOptions = new Set<string>(),
-): number {
+  spec: WrapperOptionSpec,
+): { index: number; ambiguous: boolean } {
+  const shortValues = new Set(spec.shortValues ?? []);
+  const longValues = new Set(spec.longValues ?? []);
+  const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+  const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+  const shortFlags = new Set(spec.shortFlags ?? []);
+  const longFlags = new Set(spec.longFlags ?? []);
   while (index < words.length) {
     const option = words[index];
-    if (option === "--") return index + 1;
-    if (option === "-" || !option.startsWith("-")) return index;
+    if (option === "--") return { index: index + 1, ambiguous: false };
+    if (option === "-" || !option.startsWith("-")) return { index, ambiguous: false };
     if (option.startsWith("--")) {
       const equals = option.indexOf("=");
       const name = equals === -1 ? option : option.slice(0, equals);
+      if (longValues.has(name)) {
+        if (equals !== -1) {
+          index++;
+        } else if (words[index + 1] !== undefined) {
+          index += 2;
+        } else {
+          return { index, ambiguous: true };
+        }
+        continue;
+      }
+      if (longOptionalValues.has(name) || longFlags.has(name)) {
+        index++;
+        continue;
+      }
+      return { index, ambiguous: true };
+    }
+    if (spec.numericShortValue && /^-\d+$/.test(option)) {
       index++;
-      if (equals === -1 && longValueOptions.has(name)) index++;
       continue;
     }
     const name = option.slice(0, 2);
-    index++;
-    if (shortValueOptions.has(name) && option.length === 2) index++;
+    if (shortValues.has(name)) {
+      if (option.length > 2) {
+        index++;
+      } else if (words[index + 1] !== undefined) {
+        index += 2;
+      } else {
+        return { index, ambiguous: true };
+      }
+      continue;
+    }
+    if (shortOptionalValues.has(name)) {
+      index++;
+      continue;
+    }
+    if (
+      option.length > 1 &&
+      [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+    ) {
+      index++;
+      continue;
+    }
+    return { index, ambiguous: true };
   }
-  return index;
+  return { index, ambiguous: false };
 }
 
-function shellInvocation(
-  words: string[],
-  depth = 0,
-): ShellInvocation | null {
+function shellInvocation(words: string[], depth = 0): ShellInvocation | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
@@ -113,7 +186,7 @@ function shellInvocation(
   skipAssignments();
 
   while (index < words.length) {
-    const wrapper = basename(words[index]);
+    const wrapper = shellExecutableName(words[index]);
     if (["}", "fi", "done", "esac"].includes(wrapper)) return null;
     if (["{", "then", "else", "do", "!"].includes(wrapper)) {
       index++;
@@ -131,7 +204,20 @@ function shellInvocation(
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
         if (option === "--") break;
+        // `command -v/-V` queries a name; it does not execute the following word.
         if (option.includes("v") || option.includes("V")) return null;
+        if (![...option.slice(1)].every((flag) => flag === "p")) {
+          return { name: "", args: [], ambiguous: true };
+        }
+      }
+      skipAssignments();
+      continue;
+    }
+    if (wrapper === "builtin") {
+      index++;
+      if (words[index] === "--") index++;
+      else if ((words[index] ?? "").startsWith("-")) {
+        return { name: "", args: [], ambiguous: true };
       }
       skipAssignments();
       continue;
@@ -157,46 +243,79 @@ function shellInvocation(
           index++;
           continue;
         }
-        if (/^(?:-u|--unset|-C|--chdir)$/.test(option)) {
+        if (option.startsWith("-S") && option.length > 2) {
+          splitCommand = shellWords(option.slice(2));
+          index++;
+          continue;
+        }
+        if (/^-(?:u|C|a).+/.test(option)) {
+          index++;
+          continue;
+        }
+        if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
           index += 2;
           continue;
         }
-        if (/^(?:--unset|--chdir)=/.test(option) || option === "-i") {
+        if (
+          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          option === "-" ||
+          option === "-i" ||
+          option === "--ignore-environment" ||
+          option === "-0" ||
+          option === "--null"
+        ) {
           index++;
           continue;
         }
-        if (option.startsWith("-")) {
+        if (/^-[i0v]+$/.test(option)) {
           index++;
           continue;
         }
+        if (
+          option === "-v" ||
+          option === "--debug" ||
+          option === "--list-signal-handling" ||
+          option === "--help" ||
+          option === "--version" ||
+          /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+        ) {
+          index++;
+          continue;
+        }
+        if (option.startsWith("-")) return { name: "", args: [], ambiguous: true };
         break;
       }
       skipAssignments();
       if (splitCommand.length > 0) {
-        return shellInvocation(
-          [...splitCommand, ...words.slice(index)],
-          depth + 1,
-        );
+        return shellInvocation([...splitCommand, ...words.slice(index)], depth + 1);
       }
       continue;
     }
 
-    const simpleWrappers: Record<
-      string,
-      { shortValues?: string[]; longValues?: string[] }
-    > = {
-      exec: {},
-      nohup: {},
-      nice: { shortValues: ["-n"], longValues: ["--adjustment"] },
+    const simpleWrappers: Record<string, WrapperOptionSpec> = {
+      exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+      nohup: { longFlags: ["--help", "--version"] },
+      nice: {
+        shortValues: ["-n"],
+        longValues: ["--adjustment"],
+        longFlags: ["--help", "--version"],
+        numericShortValue: true,
+      },
       ionice: {
         shortValues: ["-c", "-n", "-p", "-P", "-u"],
         longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+        shortFlags: ["-t"],
+        longFlags: ["--ignore", "--help", "--version"],
       },
       stdbuf: {
         shortValues: ["-i", "-o", "-e"],
         longValues: ["--input", "--output", "--error"],
+        longFlags: ["--help", "--version"],
       },
-      setsid: {},
+      setsid: {
+        shortFlags: ["-c", "-f", "-w"],
+        longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+      },
       sudo: {
         shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
         longValues: [
@@ -209,46 +328,86 @@ function shellInvocation(
           "--type",
           "--user",
         ],
+        shortOptionalValues: ["-E"],
+        longOptionalValues: ["--preserve-env"],
+        shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+        longFlags: [
+          "--askpass",
+          "--background",
+          "--edit",
+          "--help",
+          "--login",
+          "--non-interactive",
+          "--remove-timestamp",
+          "--reset-timestamp",
+          "--set-home",
+          "--shell",
+          "--stdin",
+          "--validate",
+          "--version",
+        ],
       },
-      doas: { shortValues: ["-C", "-u"] },
+      doas: {
+        shortValues: ["-C", "-u"],
+        shortFlags: ["-L", "-n", "-s"],
+      },
       xargs: {
-        shortValues: ["-a", "-E", "-I", "-L", "-n", "-P", "-s"],
+        shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
         longValues: [
           "--arg-file",
-          "--eof",
-          "--replace",
-          "--max-lines",
+          "--delimiter",
           "--max-args",
           "--max-procs",
           "--max-chars",
+          "--process-slot-var",
+        ],
+        shortOptionalValues: ["-e", "-i", "-l"],
+        longOptionalValues: ["--eof", "--replace", "--max-lines"],
+        shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+        longFlags: [
+          "--null",
+          "--open-tty",
+          "--interactive",
+          "--no-run-if-empty",
+          "--show-limits",
+          "--verbose",
+          "--exit",
+          "--help",
+          "--version",
         ],
       },
       time: {
         shortValues: ["-f", "-o"],
         longValues: ["--format", "--output"],
+        shortFlags: ["-a", "-p", "-v"],
+        longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
       },
-      unbuffer: {},
+      unbuffer: { shortFlags: ["-p"] },
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(spec.shortValues ?? []),
-        new Set(spec.longValues ?? []),
-      );
+      const consumed = consumeWrapperOptions(words, index + 1, spec);
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
       skipAssignments();
       continue;
     }
 
     if (wrapper === "timeout") {
-      index = consumeWrapperOptions(
-        words,
-        index + 1,
-        new Set(["-k", "-s"]),
-        new Set(["--kill-after", "--signal"]),
-      );
-      if (index < words.length) index++;
+      const consumed = consumeWrapperOptions(words, index + 1, {
+        shortValues: ["-k", "-s"],
+        longValues: ["--kill-after", "--signal"],
+        longFlags: [
+          "--foreground",
+          "--preserve-status",
+          "--verbose",
+          "--help",
+          "--version",
+        ],
+      });
+      if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
+      index = consumed.index;
+      if (index < words.length) index++; // duration
       skipAssignments();
       continue;
     }
@@ -259,7 +418,7 @@ function shellInvocation(
   const executable = words[index];
   if (!executable) return null;
   return {
-    name: basename(executable),
+    name: shellExecutableName(executable),
     args: words.slice(index + 1),
   };
 }
@@ -273,10 +432,7 @@ export function shellCommandInvocations(command: string): ShellInvocation[] {
   return invocations;
 }
 
-function shellWordAt(
-  command: string,
-  start: number,
-): { word: string; end: number } | null {
+function shellWordAt(command: string, start: number): { word: string; end: number } | null {
   let word = "";
   let quote: "'" | '"' | null = null;
   let escaped = false;
@@ -365,6 +521,8 @@ function parseShellArgs(
       continue;
     }
 
+    // Short options may be clustered. A value-taking option consumes the
+    // cluster remainder (`-t/tmp`) or the next word (`-t /tmp`).
     for (let j = 1; j < arg.length; j++) {
       const name = `-${arg[j]}`;
       options.add(name);
@@ -378,10 +536,8 @@ function parseShellArgs(
   return { operands, options, optionValues };
 }
 
-export function shellWriteTargets(
-  command: string,
-  cwd = process.cwd(),
-): string[] {
+/** Concrete filesystem targets of a mutation-capable shell command. */
+export function shellWriteTargets(command: string, cwd = process.cwd()): string[] {
   const out: string[] = [];
   const add = (raw: string | undefined) => {
     if (!raw) return;
@@ -407,12 +563,17 @@ export function shellWriteTargets(
     if (!rawDestination || !directoryDestination) return;
     const destination = normalizeShellTarget(rawDestination, cwd);
     if (!destination) return;
+    // cp/install/mv accept a directory destination. Add each concrete child
+    // candidate as well as the destination itself without consulting the
+    // pre-command filesystem, which may not contain the directory yet.
     for (const rawSource of rawSources) {
       const source = normalizeShellTarget(rawSource, cwd);
       if (source) add(join(destination, basename(source)));
     }
   };
 
+  // Scan output redirections outside quotes. This catches compact forms such
+  // as `printf x>>file` as well as quoted targets and $PWD-relative paths.
   let quote: "'" | '"' | null = null;
   let escaped = false;
   for (let i = 0; i < command.length; i++) {
@@ -436,10 +597,9 @@ export function shellWriteTargets(
     if (ch !== ">") continue;
 
     let targetStart = i + 1;
-    if (command[targetStart] === ">" || command[targetStart] === "|") {
-      targetStart++;
-    }
+    if (command[targetStart] === ">" || command[targetStart] === "|") targetStart++;
     while (/\s/.test(command[targetStart] ?? "")) targetStart++;
+    // `2>&1` and `2>&-` duplicate/close descriptors; `>&file` writes a file.
     if (command[targetStart] === "&") {
       const fd = shellWordAt(command, targetStart + 1);
       if (!fd || /^\d+$|^-$/.test(fd.word)) continue;
@@ -453,7 +613,14 @@ export function shellWriteTargets(
     i = parsed.end - 1;
   }
 
-  for (const { name: commandName, args } of shellCommandInvocations(command)) {
+  // Parse each command segment independently so a mutator never claims a
+  // later read-only command's operands. Only destination/in-place operands are
+  // candidates for commands that also have read-only source operands.
+  for (const { name: commandName, args, ambiguous } of shellCommandInvocations(command)) {
+    if (ambiguous) {
+      add(cwd);
+      continue;
+    }
     if (commandName === "dd") {
       for (const arg of args) if (arg.startsWith("of=")) add(arg);
       continue;
@@ -475,9 +642,7 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       addDestination(
         destination,
         sources,
@@ -487,13 +652,7 @@ export function shellWriteTargets(
       const parsed = parseShellArgs(
         args,
         new Set(["-g", "-m", "-o", "-S", "-t"]),
-        new Set([
-          "--group",
-          "--mode",
-          "--owner",
-          "--suffix",
-          "--target-directory",
-        ]),
+        new Set(["--group", "--mode", "--owner", "--suffix", "--target-directory"]),
       );
       const targetDirectory = [
         ...(parsed.optionValues.get("-t") ?? []),
@@ -504,9 +663,7 @@ export function shellWriteTargets(
       } else {
         const destination = targetDirectory ?? parsed.operands.at(-1);
         const hasTargetDirectory = targetDirectory !== undefined;
-        const sources = hasTargetDirectory
-          ? parsed.operands
-          : parsed.operands.slice(0, -1);
+        const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
         addDestination(
           destination,
           sources,
@@ -525,18 +682,14 @@ export function shellWriteTargets(
       ].at(-1);
       const destination = targetDirectory ?? parsed.operands.at(-1);
       const hasTargetDirectory = targetDirectory !== undefined;
-      const sources = hasTargetDirectory
-        ? parsed.operands
-        : parsed.operands.slice(0, -1);
+      const sources = hasTargetDirectory ? parsed.operands : parsed.operands.slice(0, -1);
       for (const source of sources) add(source);
       addDestination(
         destination,
         sources,
         hasTargetDirectory || sources.length > 1 || isDirectory(destination),
       );
-    } else if (
-      ["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)
-    ) {
+    } else if (["rm", "tee", "touch", "truncate", "unlink"].includes(commandName)) {
       const parsed =
         commandName === "touch"
           ? parseShellArgs(
@@ -558,38 +711,28 @@ export function shellWriteTargets(
         new Set(["-e", "-f", "-l"]),
         new Set(["--expression", "--file", "--line-length"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
       const programFromOption =
         parsed.optionValues.has("-e") ||
         parsed.optionValues.has("-f") ||
         parsed.optionValues.has("--expression") ||
         parsed.optionValues.has("--file");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     } else if (commandName === "perl") {
       const parsed = parseShellArgs(
         args,
         new Set(["-E", "-F", "-I", "-M", "-e", "-m"]),
       );
-      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) {
-        continue;
-      }
-      const programFromOption =
-        parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
-      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) {
-        add(operand);
-      }
+      if (!parsed.options.has("-i") && !parsed.options.has("--in-place")) continue;
+      const programFromOption = parsed.optionValues.has("-e") || parsed.optionValues.has("-E");
+      for (const operand of parsed.operands.slice(programFromOption ? 0 : 1)) add(operand);
     }
   }
 
   return [...new Set(out)];
 }
 
-const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
-
+/** Target paths of a write-tool call. */
 export function writeTargets(
   toolName: string,
   toolInput: Record<string, unknown> | undefined,
@@ -602,12 +745,12 @@ export function writeTargets(
   if (!WRITE_TOOLS.has(toolName)) return [];
   const ti = toolInput ?? {};
   const out: string[] = [];
-  const push = (value: unknown) => {
-    if (typeof value === "string" && value.length > 0) out.push(value);
+  const push = (v: unknown) => {
+    if (typeof v === "string" && v.length > 0) out.push(v);
   };
   push(ti.file_path);
   push(ti.notebook_path);
   push(ti.path);
-  if (Array.isArray(ti.paths)) for (const path of ti.paths) push(path);
+  if (Array.isArray(ti.paths)) for (const p of ti.paths) push(p);
   return out;
 }

--- a/dist/opencode/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/opencode/.aidlc/hooks/review-freeze-command.ts
@@ -96,7 +96,9 @@ export interface ShellInvocation {
   ambiguous?: boolean;
 }
 
-interface ShellInvocationDetails extends ShellInvocation {
+export interface ShellInvocationDetails extends ShellInvocation {
+  executable?: string;
+  launchers?: string[];
   dataDriven?: boolean;
 }
 
@@ -185,6 +187,7 @@ function shellInvocation(
   words: string[],
   depth = 0,
   dataDriven = false,
+  launchers: string[] = [],
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
@@ -208,6 +211,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "command") {
+      launchers.push(words[index]);
       index++;
       while (index < words.length && words[index].startsWith("-")) {
         const option = words[index++];
@@ -222,6 +226,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "builtin") {
+      launchers.push(words[index]);
       index++;
       if (words[index] === "--") index++;
       else if ((words[index] ?? "").startsWith("-")) {
@@ -231,6 +236,7 @@ function shellInvocation(
       continue;
     }
     if (wrapper === "env") {
+      launchers.push(words[index]);
       index++;
       let splitCommand: string[] = [];
       while (index < words.length) {
@@ -299,7 +305,17 @@ function shellInvocation(
           [...splitCommand, ...words.slice(index)],
           depth + 1,
           dataDriven,
+          launchers,
         );
+      }
+      continue;
+    }
+
+    if (wrapper === "busybox" || wrapper === "toybox") {
+      launchers.push(words[index]);
+      index++;
+      if (!words[index] || words[index].startsWith("-")) {
+        return { name: "", args: [], ambiguous: true, launchers };
       }
       continue;
     }
@@ -398,6 +414,7 @@ function shellInvocation(
     };
     const spec = simpleWrappers[wrapper];
     if (spec) {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, spec);
       if (consumed.ambiguous) return { name: "", args: [], ambiguous: true };
       index = consumed.index;
@@ -407,6 +424,7 @@ function shellInvocation(
     }
 
     if (wrapper === "timeout") {
+      launchers.push(words[index]);
       const consumed = consumeWrapperOptions(words, index + 1, {
         shortValues: ["-k", "-s"],
         longValues: ["--kill-after", "--signal"],
@@ -433,11 +451,15 @@ function shellInvocation(
   return {
     name: shellExecutableName(executable),
     args: words.slice(index + 1),
+    executable,
+    ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
   };
 }
 
-function shellCommandInvocationDetails(command: string): ShellInvocationDetails[] {
+export function shellCommandInvocationDetails(
+  command: string,
+): ShellInvocationDetails[] {
   const invocations: ShellInvocationDetails[] = [];
   for (const segment of shellCommandSegments(command)) {
     const invocation = shellInvocation(shellWords(segment));
@@ -448,7 +470,12 @@ function shellCommandInvocationDetails(command: string): ShellInvocationDetails[
 
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
-    ({ dataDriven: _dataDriven, ...invocation }) => invocation,
+    ({
+      dataDriven: _dataDriven,
+      executable: _executable,
+      launchers: _launchers,
+      ...invocation
+    }) => invocation,
   );
 }
 

--- a/dist/opencode/.aidlc/hooks/review-freeze-command.ts
+++ b/dist/opencode/.aidlc/hooks/review-freeze-command.ts
@@ -100,6 +100,8 @@ export interface ShellInvocationDetails extends ShellInvocation {
   executable?: string;
   launchers?: string[];
   dataDriven?: boolean;
+  dataDrivenMutation?: boolean;
+  executableResolutionChanged?: boolean;
 }
 
 function shellExecutableName(value: string): string {
@@ -116,6 +118,14 @@ interface WrapperOptionSpec {
   shortFlags?: readonly string[];
   longFlags?: readonly string[];
   numericShortValue?: boolean;
+}
+
+interface ShellInvocationParseState {
+  executableResolutionChanged: boolean;
+}
+
+function changesExecutableResolution(name: string): boolean {
+  return /^(?:PATH|PATHEXT)$/i.test(name);
 }
 
 function consumeWrapperOptions(
@@ -188,11 +198,21 @@ function shellInvocation(
   depth = 0,
   dataDriven = false,
   launchers: string[] = [],
+  state: ShellInvocationParseState = {
+    executableResolutionChanged: false,
+  },
 ): ShellInvocationDetails | null {
   if (depth > 8) return null;
   let index = 0;
   const skipAssignments = () => {
-    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[index] ?? "")) index++;
+    while (index < words.length) {
+      const match = words[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+      if (!match) break;
+      if (changesExecutableResolution(match[1])) {
+        state.executableResolutionChanged = true;
+      }
+      index++;
+    }
   };
   skipAssignments();
 
@@ -263,25 +283,52 @@ function shellInvocation(
           continue;
         }
         if (/^-(?:u|C|a).+/.test(option)) {
+          if (
+            option.startsWith("-u") &&
+            changesExecutableResolution(option.slice(2))
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^(?:-u|--unset|-C|--chdir|-a|--argv0)$/.test(option)) {
+          if (
+            (option === "-u" || option === "--unset") &&
+            changesExecutableResolution(words[index + 1] ?? "")
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index += 2;
           continue;
         }
+        if (option.startsWith("--unset=")) {
+          if (changesExecutableResolution(option.slice("--unset=".length))) {
+            state.executableResolutionChanged = true;
+          }
+          index++;
+          continue;
+        }
         if (
-          /^(?:--unset|--chdir|--argv0)=/.test(option) ||
+          /^(?:--chdir|--argv0)=/.test(option) ||
           option === "-" ||
           option === "-i" ||
           option === "--ignore-environment" ||
           option === "-0" ||
           option === "--null"
         ) {
+          if (
+            option === "-" ||
+            option === "-i" ||
+            option === "--ignore-environment"
+          ) {
+            state.executableResolutionChanged = true;
+          }
           index++;
           continue;
         }
         if (/^-[i0v]+$/.test(option)) {
+          if (option.includes("i")) state.executableResolutionChanged = true;
           index++;
           continue;
         }
@@ -306,6 +353,7 @@ function shellInvocation(
           depth + 1,
           dataDriven,
           launchers,
+          state,
         );
       }
       continue;
@@ -448,12 +496,20 @@ function shellInvocation(
 
   const executable = words[index];
   if (!executable) return null;
+  const name = shellExecutableName(executable);
+  const args = words.slice(index + 1);
   return {
-    name: shellExecutableName(executable),
-    args: words.slice(index + 1),
+    name,
+    args,
     executable,
     ...(launchers.length > 0 ? { launchers } : {}),
     ...(dataDriven ? { dataDriven: true } : {}),
+    ...(dataDriven && invocationMayMutate(name, args)
+      ? { dataDrivenMutation: true }
+      : {}),
+    ...(state.executableResolutionChanged
+      ? { executableResolutionChanged: true }
+      : {}),
   };
 }
 
@@ -468,11 +524,24 @@ export function shellCommandInvocationDetails(
   return invocations;
 }
 
+export function shellCommandAltersExecutableResolution(command: string): boolean {
+  for (const segment of shellCommandSegments(command)) {
+    const state: ShellInvocationParseState = {
+      executableResolutionChanged: false,
+    };
+    shellInvocation(shellWords(segment), 0, false, [], state);
+    if (state.executableResolutionChanged) return true;
+  }
+  return false;
+}
+
 export function shellCommandInvocations(command: string): ShellInvocation[] {
   return shellCommandInvocationDetails(command).map(
     ({
       dataDriven: _dataDriven,
+      dataDrivenMutation: _dataDrivenMutation,
       executable: _executable,
+      executableResolutionChanged: _executableResolutionChanged,
       launchers: _launchers,
       ...invocation
     }) => invocation,

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.122";
+export const AIDLC_VERSION = "2.6.123";

--- a/docs/guide/harnesses/cursor.md
+++ b/docs/guide/harnesses/cursor.md
@@ -114,8 +114,9 @@ projection directly (no `emit.ts`, no split dot-dir). The distribution is:
 - **Subagent identity is reconstructed.** Cursor emits no per-subagent identity
   on hook payloads (its `subagentStart`/`subagentStop` events are documented but
   never fire on the CLI), so the adapter maintains a protected project-local
-  runtime ledger under `aidlc/.aidlc-cursor-subagents/`: top-level conversations
-  register themselves at `sessionStart`/`beforeSubmitPrompt`
+  runtime ledger under `aidlc/.aidlc-cursor-subagents/` plus independent
+  `aidlc/.aidlc-cursor-subagent-*.json` active-delegation witnesses. Top-level
+  conversations register themselves at `sessionStart`/`beforeSubmitPrompt`
   (subagent conversations get neither event), each Task spawn records its
   agent, and reviewer read-scope enforcement attributes calls from conversations
   that are not registered top-level sessions. A parent's next synchronous Task
@@ -123,12 +124,12 @@ projection directly (no `emit.ts`, no split dot-dir). The distribution is:
   `postToolUse`); genuine cross-parent ambiguity stays conservative whenever a
   reviewer is live, so it cannot disable reviewer-scope enforcement. Delegated
   tools cannot access the ledger or dispatch record, including through ancestor
-  deletes or unquoted shell glob/character-class paths; if attribution storage is
-  missing or unreadable while a reviewer dispatch remains active, operations
-  fail closed rather than escaping reviewer enforcement. Review delegates may
-  use ordinary Shell commands, but general-purpose interpreters and dynamic
-  command evaluation are denied; use Cursor's native read/search tools and let
-  the parent conversation run executable probes.
+  deletes or unquoted shell glob/character-class paths. If the primary ledger is
+  missing or unreadable while any delegation witness remains active, operations
+  fail closed rather than losing delegated-agent attribution. Delegates may use
+  ordinary Shell commands, but general-purpose interpreters and dynamic command
+  evaluation are denied; use Cursor's native read/search tools and let the parent
+  conversation run executable probes.
 - **Generated stage and scope runners are explicit-only.** Cursor receives
   `disable-model-invocation: true` on generated runner skills, including plugin
   runners, so ordinary coding prompts cannot auto-activate state-mutating

--- a/harness/cursor/dot-gitignore
+++ b/harness/cursor/dot-gitignore
@@ -46,9 +46,10 @@ aidlc/.aidlc-unit-participant
 aidlc/.aidlc-claim-registry.json
 aidlc/.aidlc-unit-releases/
 aidlc/.aidlc-unit-merges/
-# Cursor's reconstructed subagent identity registry; protected by the adapter
-# and recreated per install/session.
+# Cursor's reconstructed subagent identity registry and independent active
+# delegation witnesses; protected by the adapter and recreated per session.
 aidlc/.aidlc-cursor-subagents/
+aidlc/.aidlc-cursor-subagent-*.json
 # Per-conversation session→intent map (resume rebind, P8): per-user runtime
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/

--- a/harness/cursor/hooks/aidlc-cursor-adapter.ts
+++ b/harness/cursor/hooks/aidlc-cursor-adapter.ts
@@ -40,8 +40,10 @@
 import { createHash } from "node:crypto";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   readdirSync,
   renameSync,
   rmSync,
@@ -49,7 +51,8 @@ import {
   utimesSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, posix, resolve, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HOOKS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -173,16 +176,17 @@ export async function run(
   // are possible) rather than silently disabling reviewer enforcement. Each
   // attributed call refreshes the record mtimes so a long-running reviewer
   // never silently outlives the freshness window. The store lives in the
-  // project runtime tree, and delegated tools cannot access it. If it becomes
-  // unreadable or disappears while a reviewer dispatch record is live, unknown
-  // conversations fail closed as an ambiguous reviewer rather than losing
-  // enforcement.
+  // project runtime tree, and delegated tools cannot access it. A second,
+  // separately stored witness survives loss of the primary ledger so unknown
+  // conversations still fail closed for every delegated role.
   const LEDGER_TTL_MS = 30 * 60 * 1000;
   const REVIEWER_DISPATCH_TTL_MS = 6 * 60 * 60 * 1000;
   const AMBIGUOUS_REVIEWER = "__aidlc_ambiguous_reviewer__";
   const REVIEW_AGENT_RE = /^aidlc-(architecture-reviewer|product-lead)-agent$/;
+  const AIDLC_RUNTIME_DIR = join(projectDir, "aidlc");
   const LEDGER_DIR = join(projectDir, "aidlc", ".aidlc-cursor-subagents");
   const ledgerPrefix = "spawn-";
+  const witnessPrefix = ".aidlc-cursor-subagent-";
 
   interface SubagentRecord {
     agent: string;
@@ -206,11 +210,28 @@ export async function run(
     return join(LEDGER_DIR, `main-${digest(conversation)}.marker`);
   }
 
+  function witnessFile(parent: string, task: string): string {
+    return join(
+      AIDLC_RUNTIME_DIR,
+      `${witnessPrefix}${digest(parent)}-${digest(task)}.json`,
+    );
+  }
+
   function ledgerFiles(): string[] {
     try {
       return readdirSync(LEDGER_DIR)
         .filter((name) => name.startsWith(ledgerPrefix) && name.endsWith(".json"))
         .map((name) => join(LEDGER_DIR, name));
+    } catch {
+      return [];
+    }
+  }
+
+  function witnessFiles(): string[] {
+    try {
+      return readdirSync(AIDLC_RUNTIME_DIR)
+        .filter((name) => name.startsWith(witnessPrefix) && name.endsWith(".json"))
+        .map((name) => join(AIDLC_RUNTIME_DIR, name));
     } catch {
       return [];
     }
@@ -274,6 +295,15 @@ export async function run(
     }
   }
 
+  function recordKey(record: SubagentRecord): string {
+    return `${record.parent}\0${record.task}`;
+  }
+
+  function retireSpawn(record: SubagentRecord): void {
+    removeLedger(ledgerFile(record.parent, record.task));
+    removeLedger(witnessFile(record.parent, record.task));
+  }
+
   let activeReviewerDispatchCache: string | null | undefined;
   function activeReviewerDispatch(): string | null {
     if (activeReviewerDispatchCache !== undefined) {
@@ -301,10 +331,10 @@ export async function run(
     return activeReviewerDispatchCache;
   }
 
-  function recordSpawn(subagentType: string): void {
+  function recordSpawn(subagentType: string): boolean {
     const parent = cursor.conversation_id ?? "";
     const task = taskIdentity();
-    if (!parent || !task) return;
+    if (!parent || !task) return false;
     registerMain(); // spawning a Task proves this conversation is a main
     // Task is synchronous. If this parent can issue another Task, its previous
     // delegate has returned even though Cursor CLI emits no postToolUse event
@@ -319,17 +349,30 @@ export async function run(
           agent_type: prior.agent,
         }),
       );
-      removeLedger(priorPath);
+      retireSpawn(prior);
+    }
+    for (const priorPath of witnessFiles()) {
+      const prior = readRecord(priorPath);
+      if (prior?.parent !== parent) continue;
+      retireSpawn(prior);
     }
     const path = ledgerFile(parent, task);
+    const witness = witnessFile(parent, task);
     const pending = `${path}.${process.pid}.tmp`;
+    const pendingWitness = `${witness}.${process.pid}.tmp`;
+    const record = { agent: subagentType, parent, task };
     try {
       mkdirSync(LEDGER_DIR, { recursive: true });
-      writeFileSync(pending, JSON.stringify({ agent: subagentType, parent, task }), "utf-8");
+      writeFileSync(pendingWitness, JSON.stringify(record), "utf-8");
+      renameSync(pendingWitness, witness);
+      writeFileSync(pending, JSON.stringify(record), "utf-8");
       renameSync(pending, path);
+      return true;
     } catch {
       removeLedger(pending);
-      // activeSubagent() fails closed while a reviewer dispatch is live
+      removeLedger(pendingWitness);
+      retireSpawn(record);
+      return false;
     }
   }
 
@@ -338,13 +381,18 @@ export async function run(
     const task = taskIdentity();
     if (!parent) return;
     if (task) {
-      removeLedger(ledgerFile(parent, task));
+      retireSpawn({ agent: "", parent, task });
       return;
     }
     // Defensive fallback for a completion payload that omits tool_use_id:
     // clear only this parent conversation's records.
     for (const path of ledgerFiles()) {
-      if (readRecord(path)?.parent === parent) removeLedger(path);
+      const record = readRecord(path);
+      if (record?.parent === parent) retireSpawn(record);
+    }
+    for (const path of witnessFiles()) {
+      const record = readRecord(path);
+      if (record?.parent === parent) retireSpawn(record);
     }
   }
 
@@ -352,13 +400,37 @@ export async function run(
     const conversation = cursor.conversation_id ?? "";
     if (!conversation || isKnownMain(conversation)) return "";
     const reviewerDispatch = activeReviewerDispatch();
+    const ledgerPaths = ledgerFiles();
+    const witnessPaths = witnessFiles();
     const live: Array<{ path: string; record: SubagentRecord }> = [];
-    for (const path of ledgerFiles()) {
+    const witnesses = new Map<string, { path: string; record: SubagentRecord }>();
+    let unreadableState = false;
+    for (const path of ledgerPaths) {
       const record = readRecord(path);
       if (record) live.push({ path, record });
+      else unreadableState = true;
+    }
+    for (const path of witnessPaths) {
+      const record = readRecord(path);
+      if (record) witnesses.set(recordKey(record), { path, record });
+      else unreadableState = true;
     }
     if (live.length === 0) {
-      return reviewerDispatch === null ? "" : AMBIGUOUS_REVIEWER;
+      return reviewerDispatch === null &&
+        witnesses.size === 0 &&
+        !unreadableState
+        ? ""
+        : AMBIGUOUS_REVIEWER;
+    }
+    if (
+      unreadableState ||
+      witnesses.size !== live.length ||
+      live.some(({ record }) => {
+        const witness = witnesses.get(recordKey(record))?.record;
+        return !witness || witness.agent !== record.agent;
+      })
+    ) {
+      return AMBIGUOUS_REVIEWER;
     }
     // A conversation that spawned a live Task is a main even if its marker
     // write failed.
@@ -369,8 +441,16 @@ export async function run(
       for (const { path } of live) {
         try {
           utimesSync(path, new Date(), new Date());
+          const record = readRecord(path);
+          if (record) {
+            utimesSync(
+              witnesses.get(recordKey(record))?.path ?? witnessFile(record.parent, record.task),
+              new Date(),
+              new Date(),
+            );
+          }
         } catch {
-          // expiry only widens back to fail-open
+          // The next call observes the broken pair and fails closed.
         }
       }
     };
@@ -392,7 +472,8 @@ export async function run(
         refresh();
         return AMBIGUOUS_REVIEWER;
       }
-      return "";
+      refresh();
+      return AMBIGUOUS_REVIEWER;
     }
     refresh();
     return live[0].record.agent;
@@ -451,18 +532,141 @@ export async function run(
     });
   }
 
-  function shellWords(command: string): string[] {
-    const words: string[] = [];
-    let word = "";
+  type PathFlavor = "posix" | "win32";
+
+  interface ShellWordVariant {
+    value: string;
+    activeGlobIndexes: number[];
+    flavor: PathFlavor;
+  }
+
+  interface ShellWord {
+    variants: ShellWordVariant[];
+  }
+
+  function shellWords(command: string): { words: ShellWord[]; ambiguous: boolean } {
+    const words: ShellWord[] = [];
+    let posixWord = "";
+    let windowsWord = "";
+    let posixGlobIndexes: number[] = [];
+    let windowsGlobIndexes: number[] = [];
+    let started = false;
+    let quote: "'" | '"' | null = null;
+    const push = () => {
+      if (started) {
+        const variants: ShellWordVariant[] = [
+          { value: posixWord, activeGlobIndexes: posixGlobIndexes, flavor: "posix" },
+          { value: windowsWord, activeGlobIndexes: windowsGlobIndexes, flavor: "win32" },
+        ];
+        const applicable =
+          process.platform === "win32" && windowsWord.startsWith("~\\")
+            ? variants.filter((variant) => variant.flavor === "win32")
+            : variants;
+        words.push({
+          variants: applicable.filter(
+            (variant, index) =>
+              applicable.findIndex(
+                (candidate) =>
+                  candidate.flavor === variant.flavor &&
+                  candidate.value === variant.value &&
+                  candidate.activeGlobIndexes.join(",") ===
+                    variant.activeGlobIndexes.join(","),
+              ) === index,
+          ),
+        });
+      }
+      posixWord = "";
+      windowsWord = "";
+      posixGlobIndexes = [];
+      windowsGlobIndexes = [];
+      started = false;
+    };
+    const appendPosix = (ch: string, activeGlob = false) => {
+      if (activeGlob) posixGlobIndexes.push(posixWord.length);
+      posixWord += ch;
+      started = true;
+    };
+    const appendWindows = (ch: string, activeGlob = false) => {
+      if (activeGlob) windowsGlobIndexes.push(windowsWord.length);
+      windowsWord += ch;
+      started = true;
+    };
+    const appendBoth = (
+      ch: string,
+      posixActiveGlob = false,
+      windowsActiveGlob = posixActiveGlob,
+    ) => {
+      appendPosix(ch, posixActiveGlob);
+      appendWindows(ch, windowsActiveGlob);
+    };
+
+    for (let i = 0; i < command.length; i++) {
+      const ch = command[i];
+      if (quote === "'") {
+        if (ch === "'") quote = null;
+        else appendBoth(ch, false, "*?[]{}".includes(ch));
+        continue;
+      }
+      if (ch === "\\") {
+        const next = command[i + 1] ?? "";
+        appendWindows("\\");
+        if (!next) {
+          appendPosix("\\");
+          continue;
+        }
+        if (quote === '"') {
+          if ('$`"\\\n'.includes(next)) {
+            if (next !== "\n") {
+              appendPosix(next);
+              if (next === '"') quote = null;
+              else appendWindows(next, "*?[]{}".includes(next));
+            }
+            i++;
+          } else {
+            appendPosix("\\");
+          }
+        } else {
+          if (next !== "\n") {
+            appendPosix(next);
+            appendWindows(next, "*?[]{}".includes(next));
+          }
+          i++;
+        }
+        continue;
+      }
+      if (quote !== null) {
+        if (ch === quote) quote = null;
+        else appendBoth(ch, false, "*?[]{}".includes(ch));
+        continue;
+      }
+      if (ch === "'" || ch === '"') {
+        quote = ch;
+        started = true;
+        continue;
+      }
+      if (/\s/.test(ch) || ";|&()<>".includes(ch)) {
+        push();
+        continue;
+      }
+      appendBoth(ch, "*?[]{}".includes(ch));
+    }
+    push();
+    return { words, ambiguous: quote !== null };
+  }
+
+  interface ShellCommandPart {
+    text: string;
+    operatorAfter: "" | ";" | "\n" | "&&" | "||" | "|" | "&";
+  }
+
+  function shellCommandParts(command: string): ShellCommandPart[] {
+    const segments: ShellCommandPart[] = [];
     let quote: "'" | '"' | null = null;
     let escaped = false;
-    const push = () => {
-      if (word.length > 0) words.push(word);
-      word = "";
-    };
-    for (const ch of command) {
+    let start = 0;
+    for (let i = 0; i < command.length; i++) {
+      const ch = command[i];
       if (escaped) {
-        word += ch;
         escaped = false;
         continue;
       }
@@ -472,27 +676,33 @@ export async function run(
       }
       if (quote !== null) {
         if (ch === quote) quote = null;
-        else word += ch;
         continue;
       }
       if (ch === "'" || ch === '"') {
         quote = ch;
         continue;
       }
-      if (/\s/.test(ch) || ";|&()<>".includes(ch)) {
-        push();
-        continue;
+      if (!";\n|&".includes(ch)) continue;
+      let operator = ch as ShellCommandPart["operatorAfter"];
+      if ((ch === "|" || ch === "&") && command[i + 1] === ch) {
+        operator = `${ch}${ch}` as ShellCommandPart["operatorAfter"];
+        i++;
       }
-      word += ch;
+      segments.push({ text: command.slice(start, i - operator.length + 1), operatorAfter: operator });
+      start = i + 1;
     }
-    push();
-    return words;
+    segments.push({ text: command.slice(start), operatorAfter: "" });
+    return segments;
+  }
+
+  function shellCommandSegments(command: string): string[] {
+    return shellCommandParts(command).map((part) => part.text);
   }
 
   interface ReviewFreezeCommandModule {
     shellCommandInvocations?: (
       command: string,
-    ) => Array<{ name: string; args: string[] }>;
+    ) => Array<{ name: string; args: string[]; ambiguous?: boolean }>;
     writeTargets?: (
       toolName: string,
       toolInput: Record<string, unknown> | undefined,
@@ -534,16 +744,307 @@ export async function run(
 
   function protectedReviewerPaths(): string[] {
     const dispatch = activeReviewerDispatch();
-    return dispatch === null ? [LEDGER_DIR] : [LEDGER_DIR, dispatch];
+    return [
+      LEDGER_DIR,
+      ...witnessFiles(),
+      ...(dispatch === null ? [] : [dispatch]),
+    ];
   }
 
-  function overlapsProtectedPath(candidate: string, protectedPaths: readonly string[]): boolean {
-    const normalized = resolve(candidate);
-    return protectedPaths.some(
-      (path) =>
-        normalized === path ||
-        normalized.startsWith(`${path}${sep}`) ||
-        path.startsWith(`${normalized}${sep}`),
+  interface CanonicalPath {
+    flavor: PathFlavor;
+    value: string;
+  }
+
+  interface Canonicalization {
+    paths: CanonicalPath[];
+    ambiguous: boolean;
+  }
+
+  function fullyQualifiedWindows(value: string): boolean {
+    const normalized = value.replaceAll("/", "\\");
+    return (
+      /^[A-Za-z]:\\/.test(normalized) ||
+      /^\\\\[^\\]+\\[^\\]+(?:\\|$)/.test(normalized)
+    );
+  }
+
+  function normalizeWindowsDialect(raw: string): { value: string; ambiguous: boolean } {
+    if (raw === "~" || raw.startsWith("~/") || raw.startsWith("~\\")) {
+      const home = process.env.USERPROFILE ?? process.env.HOME ?? homedir();
+      raw = win32.join(home, raw.slice(2));
+    }
+    const gitBash = raw.match(/^\/(?:cygdrive\/)?([A-Za-z])\/(.*)$/);
+    let value = gitBash
+      ? `${gitBash[1].toUpperCase()}:\\${gitBash[2] ?? ""}`
+      : raw.replaceAll("/", "\\");
+    if (/^\\\\\?\\UNC\\/i.test(value)) {
+      value = `\\\\${value.slice("\\\\?\\UNC\\".length)}`;
+    } else if (/^\\\\[?.]\\[A-Za-z]:\\/.test(value)) {
+      value = value.slice(4);
+    } else if (/^\\\?\?\\[A-Za-z]:\\/.test(value)) {
+      value = value.slice(4);
+    } else if (/^(?:\\\\[?.]\\|\\\?\?\\)/.test(value)) {
+      return { value, ambiguous: true };
+    }
+
+    const parsed = win32.parse(value);
+    const components = value.slice(parsed.root.length).split("\\");
+    let ambiguous = false;
+    const normalizedComponents = components.map((component, index) => {
+      if (component === "." || component === ".." || component.length === 0) return component;
+      let normalized = component.replace(/[ .]+$/g, "");
+      const stream = normalized.indexOf(":");
+      if (stream !== -1) {
+        if (index !== components.length - 1) ambiguous = true;
+        normalized = normalized.slice(0, stream);
+      }
+      if (normalized.length === 0) ambiguous = true;
+      return normalized;
+    });
+    return {
+      value: `${parsed.root}${normalizedComponents.join("\\")}`,
+      ambiguous,
+    };
+  }
+
+  function canonicalExistingAncestor(
+    flavor: PathFlavor,
+    candidate: string,
+  ): { path?: string; ambiguous: boolean } {
+    const hostFlavor: PathFlavor = process.platform === "win32" ? "win32" : "posix";
+    if (flavor !== hostFlavor) return { ambiguous: false };
+    const api = flavor === "win32" ? win32 : posix;
+    const missingSegments: string[] = [];
+    let cursor = candidate;
+    while (true) {
+      try {
+        lstatSync(cursor);
+        try {
+          return {
+            path: api.resolve(realpathSync.native(cursor), ...missingSegments),
+            ambiguous: false,
+          };
+        } catch {
+          return { ambiguous: true };
+        }
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT" && code !== "ENOTDIR") return { ambiguous: true };
+      }
+      const parent = api.dirname(cursor);
+      if (parent === cursor) return { ambiguous: true };
+      missingSegments.unshift(api.basename(cursor));
+      cursor = parent;
+    }
+  }
+
+  function expandPosixTilde(
+    raw: string,
+    cwd: string,
+  ): { value: string; ambiguous: boolean } {
+    const home = (process.env.HOME ?? homedir()).replaceAll("\\", "/");
+    if (raw === "~") return { value: home, ambiguous: false };
+    if (raw.startsWith("~/")) {
+      return { value: posix.join(home, raw.slice(2)), ambiguous: false };
+    }
+    if (raw === "~+") return { value: cwd, ambiguous: false };
+    if (raw.startsWith("~+/")) {
+      return { value: posix.join(cwd, raw.slice(3)), ambiguous: false };
+    }
+    const oldPwd = process.env.OLDPWD?.replaceAll("\\", "/");
+    if (raw === "~-" || raw.startsWith("~-/")) {
+      if (!oldPwd || !posix.isAbsolute(oldPwd)) return { value: raw, ambiguous: true };
+      return {
+        value: raw === "~-" ? oldPwd : posix.join(oldPwd, raw.slice(3)),
+        ambiguous: false,
+      };
+    }
+
+    const named = raw.match(/^~([^/]+)(?:\/(.*))?$/);
+    if (!named) return { value: raw, ambiguous: false };
+    const username = named[1];
+    let namedHome: string | undefined;
+    if (process.platform !== "win32") {
+      try {
+        const row = readFileSync("/etc/passwd", "utf-8")
+          .split(/\r?\n/)
+          .find((line) => line.split(":", 1)[0] === username);
+        const fields = row?.split(":");
+        if (fields?.[5]) namedHome = fields[5];
+      } catch {
+        // Missing account data leaves the shell identity ambiguous.
+      }
+    }
+    const currentUser = process.env.USER ?? process.env.LOGNAME ?? process.env.USERNAME;
+    if (!namedHome && currentUser === username) namedHome = home;
+    if (!namedHome || !posix.isAbsolute(namedHome)) {
+      return { value: raw, ambiguous: true };
+    }
+    return {
+      value: named[2] ? posix.join(namedHome, named[2]) : namedHome,
+      ambiguous: false,
+    };
+  }
+
+  function canonicalPathVariants(
+    raw: string,
+    cwd: string,
+    flavorHint?: PathFlavor,
+  ): Canonicalization {
+    const out = new Map<string, CanonicalPath>();
+    let ambiguous = false;
+    const store = (flavor: PathFlavor, value: string): void => {
+      const api = flavor === "win32" ? win32 : posix;
+      let normalized = api.normalize(value);
+      const root = api.parse(normalized).root;
+      while (
+        normalized.length > root.length &&
+        (normalized.endsWith("/") || normalized.endsWith("\\"))
+      ) {
+        normalized = normalized.slice(0, -1);
+      }
+      if (flavor === "win32") normalized = normalized.replaceAll("\\", "/").toLowerCase();
+      const key = `${flavor}:${normalized}`;
+      out.set(key, { flavor, value: normalized });
+    };
+    const add = (flavor: PathFlavor, value: string): void => {
+      let normalizedValue = value;
+      if (flavor === "win32") {
+        const normalized = normalizeWindowsDialect(value);
+        ambiguous ||= normalized.ambiguous;
+        if (normalized.ambiguous) return;
+        normalizedValue = normalized.value;
+      }
+      const api = flavor === "win32" ? win32 : posix;
+      const lexical = api.normalize(normalizedValue);
+      store(flavor, lexical);
+      const real = canonicalExistingAncestor(flavor, lexical);
+      ambiguous ||= real.ambiguous;
+      if (real.path) {
+        if (flavor === "win32") {
+          const normalized = normalizeWindowsDialect(real.path);
+          ambiguous ||= normalized.ambiguous;
+          if (!normalized.ambiguous) store(flavor, normalized.value);
+        } else {
+          store(flavor, real.path);
+        }
+      }
+    };
+
+    if (flavorHint !== "win32") {
+      const posixCwd = cwd.replaceAll("\\", "/");
+      const expanded = expandPosixTilde(raw, posixCwd);
+      ambiguous ||= expanded.ambiguous;
+      const posixRaw = expanded.value;
+      if (!fullyQualifiedWindows(posixRaw) && posix.isAbsolute(posixCwd)) {
+        add("posix", posix.resolve(posixCwd, posixRaw));
+      }
+    }
+
+    if (flavorHint !== "posix") {
+      const normalizedRaw = normalizeWindowsDialect(raw);
+      const normalizedCwd = normalizeWindowsDialect(cwd);
+      ambiguous ||= normalizedRaw.ambiguous || normalizedCwd.ambiguous;
+      if (!normalizedRaw.ambiguous && !normalizedCwd.ambiguous) {
+        if (fullyQualifiedWindows(normalizedRaw.value)) {
+          add("win32", win32.resolve(normalizedRaw.value));
+        } else if (fullyQualifiedWindows(normalizedCwd.value)) {
+          add("win32", win32.resolve(normalizedCwd.value, normalizedRaw.value));
+        }
+      }
+    }
+    return { paths: [...out.values()], ambiguous };
+  }
+
+  function isWithinPath(child: string, parent: string): boolean {
+    return child === parent || child.startsWith(parent.endsWith("/") ? parent : `${parent}/`);
+  }
+
+  function shortNameGlobTouchesProtected(
+    pattern: string,
+    cwd: string,
+    protectedPaths: readonly string[],
+    flavorHint?: PathFlavor,
+  ): boolean {
+    if (flavorHint !== "win32") return false;
+    const normalized = normalizeWindowsDialect(pattern);
+    if (normalized.ambiguous) return true;
+    const parsed = win32.parse(normalized.value);
+    const components = normalized.value.slice(parsed.root.length).split("\\");
+    const shortIndex = components.findIndex(
+      (component) => component.includes("~") && /[*?[\]{}]/.test(component),
+    );
+    if (shortIndex === -1) return false;
+    const base = win32.join(parsed.root, ...components.slice(0, shortIndex));
+    const directories = canonicalPathVariants(base, cwd, "win32");
+    if (directories.ambiguous || directories.paths.length === 0) return true;
+    const protectedResults = protectedPaths.map((path) =>
+      canonicalPathVariants(path, projectDir)
+    );
+    if (protectedResults.some((result) => result.ambiguous || result.paths.length === 0)) {
+      return true;
+    }
+    const protectedVariants = protectedResults.flatMap((result) => result.paths);
+    const globMatches = (glob: string, value: string): boolean => {
+      let source = "^";
+      for (const ch of glob) {
+        if (ch === "*") source += ".*";
+        else if (ch === "?") source += ".";
+        else source += ch.replace(/[\\^$+?.()|[\]{}]/g, "\\$&");
+      }
+      return new RegExp(`${source}$`, "i").test(value);
+    };
+    const shortComponentMatches = (glob: string, longName: string): boolean => {
+      const tilde = glob.indexOf("~");
+      if (tilde === -1) return globMatches(glob, longName);
+      const stem = glob.slice(0, tilde);
+      const shortSource = longName.replace(/^[ .]+/, "").replace(/[ .]/g, "");
+      return globMatches(`${stem}*`, shortSource);
+    };
+    return directories.paths.some((directory) =>
+      protectedVariants.some((protectedPath) => {
+        if (directory.flavor !== protectedPath.flavor) return false;
+        const relative = posix.relative(directory.value, protectedPath.value);
+        if (relative === ".." || relative.startsWith("../")) return false;
+        const protectedComponents = relative.split("/");
+        if (!shortComponentMatches(components[shortIndex], protectedComponents[0] ?? "")) {
+          return false;
+        }
+        return components.slice(shortIndex + 1).every(
+          (component, index) =>
+            protectedComponents[index + 1] !== undefined &&
+            globMatches(component, protectedComponents[index + 1]),
+        );
+      })
+    );
+  }
+
+  function overlapsProtectedPath(
+    candidate: string,
+    protectedPaths: readonly string[],
+    cwd = projectDir,
+    flavorHint?: PathFlavor,
+  ): boolean {
+    const candidates = canonicalPathVariants(candidate, cwd, flavorHint);
+    const protectedResults = protectedPaths.map((path) =>
+      canonicalPathVariants(path, projectDir)
+    );
+    const protectedVariants = protectedResults.flatMap((result) => result.paths);
+    if (
+      candidates.ambiguous ||
+      protectedResults.some((result) => result.ambiguous || result.paths.length === 0)
+    ) {
+      return true;
+    }
+    if (candidates.paths.length === 0) return flavorHint === undefined;
+    return candidates.paths.some((normalized) =>
+      protectedVariants.some(
+        (protectedPath) =>
+          normalized.flavor === protectedPath.flavor &&
+          (isWithinPath(normalized.value, protectedPath.value) ||
+            isWithinPath(protectedPath.value, normalized.value)),
+      )
     );
   }
 
@@ -551,29 +1052,54 @@ export async function run(
     raw: string,
     cwd: string,
     protectedPaths: readonly string[],
+    globIndex = raw.search(/[*?[\]{}]/),
+    flavorHint?: PathFlavor,
   ): boolean {
     if (["{", "}", "(", ")"].includes(raw)) return false;
-    const glob = raw.search(/[*?[\]{}]/);
-    if (glob === -1) return false;
-    let prefix = raw.slice(0, glob);
+    if (globIndex === -1) return false;
+    let prefix = raw.slice(0, globIndex);
     const equals = prefix.lastIndexOf("=");
     if (equals !== -1) prefix = prefix.slice(equals + 1);
     const bracedPwd = "$" + "{PWD}";
     if (prefix === "$PWD" || prefix === bracedPwd) {
       prefix = cwd;
-    } else if (prefix.startsWith("$PWD/")) {
-      prefix = join(cwd, prefix.slice("$PWD/".length));
-    } else if (prefix.startsWith(`${bracedPwd}/`)) {
-      prefix = join(cwd, prefix.slice(`${bracedPwd}/`.length));
+    } else if (prefix.startsWith("$PWD/") || prefix.startsWith("$PWD\\")) {
+      prefix = `${cwd}${prefix.slice("$PWD".length)}`;
+    } else if (
+      prefix.startsWith(`${bracedPwd}/`) ||
+      prefix.startsWith(`${bracedPwd}\\`)
+    ) {
+      prefix = `${cwd}${prefix.slice(bracedPwd.length)}`;
     }
-    const normalized = isAbsolute(prefix) ? resolve(prefix) : resolve(cwd, prefix);
-    return protectedPaths.some((path) => path.startsWith(normalized));
+    const expandedPattern = `${prefix}${raw.slice(globIndex)}`;
+    if (shortNameGlobTouchesProtected(expandedPattern, cwd, protectedPaths, flavorHint)) {
+      return true;
+    }
+    const candidates = canonicalPathVariants(prefix, cwd, flavorHint);
+    if (candidates.ambiguous) return true;
+    if (candidates.paths.length === 0) return flavorHint === undefined;
+    const protectedResults = protectedPaths.map((path) =>
+      canonicalPathVariants(path, projectDir)
+    );
+    if (protectedResults.some((result) => result.ambiguous || result.paths.length === 0)) {
+      return true;
+    }
+    const protectedVariants = protectedResults.flatMap((result) => result.paths);
+    return candidates.paths.some((candidate) =>
+      protectedVariants.some(
+        (protectedPath) =>
+          candidate.flavor === protectedPath.flavor &&
+          protectedPath.value.startsWith(candidate.value),
+      )
+    );
   }
 
   function concreteWordTouchesProtected(
     raw: string,
     cwd: string,
     protectedPaths: readonly string[],
+    hasActiveGlob = /[*?[\]{}]/.test(raw),
+    flavorHint?: PathFlavor,
   ): boolean {
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(raw)) return false;
     const equals = raw.lastIndexOf("=");
@@ -582,13 +1108,166 @@ export async function run(
     if (
       candidate.length === 0 ||
       candidate.startsWith("-") ||
-      /[$`*?[\]{}]/.test(candidate) ||
+      /[$`]/.test(candidate) ||
+      hasActiveGlob ||
       (!candidate.includes("/") && !candidate.includes("\\") && !candidate.startsWith("."))
     ) {
       return false;
     }
-    const normalized = isAbsolute(candidate) ? resolve(candidate) : resolve(cwd, candidate);
-    return overlapsProtectedPath(normalized, protectedPaths);
+    return overlapsProtectedPath(candidate, protectedPaths, cwd, flavorHint);
+  }
+
+  interface ShellCwdState {
+    cwd: string;
+    stack: string[];
+    status: "success" | "failure" | "unknown";
+    logicalAmbiguous: boolean;
+  }
+
+  const MAX_SHELL_CWD_STATES = 128;
+
+  function shellCwdIdentity(path: string, flavor: PathFlavor): string {
+    const hostFlavor: PathFlavor = process.platform === "win32" ? "win32" : "posix";
+    const api = flavor === "win32" ? win32 : posix;
+    let identity = api.normalize(path);
+    if (flavor === hostFlavor) {
+      try {
+        identity = realpathSync.native(path);
+      } catch {
+        // A missing or synthetic cross-platform path retains its lexical identity.
+      }
+    }
+    identity = api.normalize(identity);
+    return flavor === "win32" ? identity.toLowerCase() : identity;
+  }
+
+  function shellCwdStateKey(state: ShellCwdState, flavor: PathFlavor): string {
+    return [
+      shellCwdIdentity(state.cwd, flavor),
+      ...state.stack.map((path) => shellCwdIdentity(path, flavor)),
+      state.status,
+    ].join("\0");
+  }
+
+  function updateShellCwd(
+    words: readonly ShellWord[],
+    flavor: PathFlavor,
+    state: ShellCwdState,
+  ): "none" | "location" | "ambiguous" {
+    const values = words
+      .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+      .filter((value): value is string => value !== undefined);
+    let index = 0;
+    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(values[index] ?? "")) index++;
+    while (["command", "builtin"].includes((values[index] ?? "").toLowerCase())) {
+      index++;
+      if (values[index] === "--") index++;
+    }
+    const controlHead = ["if", "elif", "while", "until", "case", "for", "select", "function"].includes(
+      (values[index] ?? "").toLowerCase(),
+    );
+    const controlContext =
+      controlHead ||
+      values.some((value) => ["{", "then", "else", "do"].includes(value.toLowerCase()));
+    while (["{", "then", "else", "do", "!"].includes((values[index] ?? "").toLowerCase())) {
+      index++;
+    }
+    if (["if", "elif", "while", "until"].includes((values[index] ?? "").toLowerCase())) {
+      index++;
+    }
+    const cwdCommands = new Set([
+      "cd",
+      "chdir",
+      "pushd",
+      "push-location",
+      "set-location",
+      "sl",
+      "popd",
+      "pop-location",
+    ]);
+    const leafName = (value: string): string =>
+      win32.basename(posix.basename(value)).toLowerCase();
+    if (controlContext && !cwdCommands.has(leafName(values[index] ?? ""))) {
+      const nested = values.findIndex(
+        (value, candidate) => candidate > index && cwdCommands.has(leafName(value)),
+      );
+      if (nested !== -1) index = nested;
+    }
+    const executable = values[index];
+    if (!executable) return "none";
+    const name = leafName(executable);
+    if (["popd", "pop-location"].includes(name)) {
+      if (state.logicalAmbiguous) return "ambiguous";
+      const restored = state.stack.pop();
+      if (!restored) return "ambiguous";
+      state.cwd = restored;
+      return "location";
+    }
+    const push = ["pushd", "push-location"].includes(name);
+    if (
+      !push &&
+      !["cd", "chdir", "set-location", "sl"].includes(name)
+    ) {
+      return "none";
+    }
+    if (state.logicalAmbiguous && push) return "ambiguous";
+
+    const args = values.slice(index + 1);
+    let operand = "";
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (["-path", "-literalpath"].includes(arg.toLowerCase())) {
+        operand = args[i + 1] ?? "";
+        break;
+      }
+      if (["/d", "-l", "-p", "--"].includes(arg.toLowerCase())) continue;
+      if (arg.startsWith("-")) continue;
+      operand = arg;
+      break;
+    }
+    if (!operand) operand = "~";
+    if (/[$`*?[\]{}]/.test(operand)) return "ambiguous";
+    if (
+      state.logicalAmbiguous &&
+      (operand === "-" ||
+        operand.startsWith("~") ||
+        operand.replaceAll("\\", "/").split("/").includes(".."))
+    ) {
+      return "ambiguous";
+    }
+
+    let next: string;
+    if (flavor === "posix") {
+      if (operand === "-") operand = "~-";
+      const expanded = expandPosixTilde(operand, state.cwd.replaceAll("\\", "/"));
+      if (expanded.ambiguous) return "ambiguous";
+      let base = state.cwd.replaceAll("\\", "/");
+      if (state.logicalAmbiguous && !posix.isAbsolute(expanded.value)) {
+        try {
+          base = realpathSync.native(state.cwd).replaceAll("\\", "/");
+        } catch {
+          return "ambiguous";
+        }
+      }
+      next = posix.resolve(base, expanded.value);
+      if (posix.isAbsolute(expanded.value)) state.logicalAmbiguous = false;
+    } else {
+      const normalized = normalizeWindowsDialect(operand);
+      if (normalized.ambiguous) return "ambiguous";
+      let base = state.cwd;
+      if (state.logicalAmbiguous && !fullyQualifiedWindows(normalized.value)) {
+        try {
+          base = realpathSync.native(state.cwd);
+        } catch {
+          return "ambiguous";
+        }
+      }
+      next = win32.resolve(base, normalized.value);
+      if (fullyQualifiedWindows(normalized.value)) state.logicalAmbiguous = false;
+    }
+    if (push) state.stack.push(state.cwd);
+    state.cwd = next;
+    return "location";
   }
 
   function pathOperandValues(toolInput: Record<string, unknown>): string[] {
@@ -639,9 +1318,12 @@ export async function run(
           continue;
         }
         if (ch === "`") return true;
-        if (ch !== "$") continue;
-        const next = command[i + 1] ?? "";
-        if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+        if (ch === "$") {
+          const next = command[i + 1] ?? "";
+          if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+        }
+        if (ch === "%" && /%[^%\r\n]+%/.test(command.slice(i))) return true;
+        if (ch === "!" && /![^!\r\n]+!/.test(command.slice(i))) return true;
         continue;
       }
       if (ch === "'") {
@@ -653,27 +1335,1106 @@ export async function run(
         continue;
       }
       if (ch === "`") return true;
-      if (ch !== "$") continue;
-      const next = command[i + 1] ?? "";
-      if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+      if (ch === "^") return true;
+      if (ch === "%" && /%[^%\r\n]+%/.test(command.slice(i))) return true;
+      if (ch === "!" && /![^!\r\n]+!/.test(command.slice(i))) return true;
+      if (ch === "$") {
+        const next = command[i + 1] ?? "";
+        if (/[\w@*#?$!{('"_-]/.test(next)) return true;
+      }
     }
     return false;
   }
 
-  async function shellInvokesDynamicEvaluation(command: string): Promise<boolean> {
+  function shellUsesDirectHostExpression(command: string): boolean {
+    let quote: "'" | '"' | null = null;
+    let escaped = false;
+    let outside = "";
+    for (const ch of command) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === "`") {
+        escaped = true;
+        continue;
+      }
+      if (quote !== null) {
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === "'" || ch === '"') {
+        quote = ch;
+        continue;
+      }
+      outside += ch;
+    }
+    return (
+      /(?:^|[\s(])\+(?=[\s)]|$)/.test(outside) ||
+      /(?:^|[\s(])&(?=[\s(]|$)/.test(outside) ||
+      /(?:^|\s)-(?:join|replace|split)\b/i.test(outside) ||
+      /\(\s*[A-Za-z]+-[A-Za-z]+/i.test(outside)
+    );
+  }
+
+  function shellUsesConstructedHostInvocation(command: string): boolean {
+    return /(?:^|[;\s])&\s*\(/.test(command);
+  }
+
+  function gitUsesIndirectShellAlias(
+    args: readonly string[],
+    command: string,
+  ): boolean {
+    if (args.some((arg) => /^alias\.[^=]+=!/i.test(arg))) return true;
+    const configIndex = args.indexOf("config");
+    if (configIndex !== -1) {
+      const aliasIndex = args.findIndex(
+        (arg, index) => index > configIndex && /^alias\.[^.=\s]+$/i.test(arg),
+      );
+      if (
+        aliasIndex !== -1 &&
+        args.slice(aliasIndex + 1).some((arg) => !arg.startsWith("-"))
+      ) {
+        return true;
+      }
+    }
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const configEnv =
+        arg === "--config-env" ? args[i + 1] ?? "" : arg.replace(/^--config-env=/, "");
+      if (
+        configEnv !== arg &&
+        /^(?:alias\.[^=]+|include(?:If\.[^=]+)?\.path)=/i.test(configEnv)
+      ) {
+        return true;
+      }
+      if (
+        arg === "-c" &&
+        /^(?:alias\.[^=]+|include(?:If\.[^=]+)?\.path)=/i.test(args[i + 1] ?? "")
+      ) {
+        return true;
+      }
+    }
+    if (/\bGIT_CONFIG_(?:GLOBAL|SYSTEM|PARAMETERS)=/i.test(command)) return true;
+    return /\bGIT_CONFIG_KEY_\d+=alias\./i.test(command);
+  }
+
+  function gitInvocation(
+    args: readonly string[],
+  ): { subcommand: string; subcommandIndex: number; prefix: string[] } {
+    const valueOptions = new Set([
+      "-C",
+      "-c",
+      "--config-env",
+      "--exec-path",
+      "--git-dir",
+      "--namespace",
+      "--super-prefix",
+      "--work-tree",
+    ]);
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (arg === "--") {
+        return {
+          subcommand: args[i + 1] ?? "",
+          subcommandIndex: i + 1,
+          prefix: [...args.slice(0, i + 1)],
+        };
+      }
+      if (valueOptions.has(arg)) {
+        i++;
+        continue;
+      }
+      if (arg.startsWith("-")) continue;
+      return { subcommand: arg, subcommandIndex: i, prefix: [...args.slice(0, i)] };
+    }
+    return { subcommand: "", subcommandIndex: -1, prefix: [...args] };
+  }
+
+  interface GitCommandContext {
+    cwd: string;
+    env: Record<string, string | undefined>;
+    ambiguous: boolean;
+  }
+
+  function shellExecutableName(value: string): string {
+    return win32.basename(posix.basename(value))
+      .replace(/\.(?:exe|com|cmd|bat)$/i, "")
+      .toLowerCase();
+  }
+
+  function isGitInspectionEnvironmentName(name: string): boolean {
+    const candidate = process.platform === "win32" ? name.toUpperCase() : name;
+    return /^(?:HOME|XDG_CONFIG_HOME|USERPROFILE|HOMEDRIVE|HOMEPATH|PAGER|GIT_(?:DIR|WORK_TREE|COMMON_DIR|INDEX_FILE|NAMESPACE|EXEC_PATH|PAGER)|GIT_CONFIG(?:_GLOBAL|_SYSTEM|_NOSYSTEM|_PARAMETERS|_COUNT|_KEY_\d+|_VALUE_\d+)?)$/.test(
+      candidate,
+    );
+  }
+
+  function deleteEnvironmentName(
+    env: Record<string, string | undefined>,
+    name: string,
+  ): void {
+    const candidate = process.platform === "win32" ? name.toUpperCase() : name;
+    for (const key of Object.keys(env)) {
+      const existing = process.platform === "win32" ? key.toUpperCase() : key;
+      if (existing === candidate) delete env[key];
+    }
+  }
+
+  function environmentValue(
+    env: Record<string, string | undefined>,
+    name: string,
+  ): string | undefined {
+    const candidate = process.platform === "win32" ? name.toUpperCase() : name;
+    for (const [key, value] of Object.entries(env)) {
+      const existing = process.platform === "win32" ? key.toUpperCase() : key;
+      if (existing === candidate) return value;
+    }
+    return undefined;
+  }
+
+  function gitCommandEnvironment(
+    command: string,
+    initialCwd = projectDir,
+  ): GitCommandContext {
+    const env: Record<string, string | undefined> = { ...projectEnv };
+    const commandEnv: Record<string, string | undefined> = { ...projectEnv };
+    let invocationCwd = initialCwd;
+    const flavor: PathFlavor = process.platform === "win32" ? "win32" : "posix";
+    for (const segment of shellCommandSegments(command)) {
+      const parsed = shellWords(segment);
+      if (parsed.ambiguous) continue;
+      let values = parsed.words
+        .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+        .filter((value): value is string => value !== undefined);
+      let index = 0;
+      const collectAssignments = () => {
+        for (; index < values.length; index++) {
+          const match = values[index].match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+          if (!match) break;
+          deleteEnvironmentName(commandEnv, match[1]);
+          commandEnv[match[1]] = match[2];
+          if (isGitInspectionEnvironmentName(match[1])) {
+            deleteEnvironmentName(env, match[1]);
+            env[match[1]] = match[2];
+          }
+        }
+      };
+      const consumeWrapperOptions = (
+        spec: {
+          shortValues?: readonly string[];
+          longValues?: readonly string[];
+          shortOptionalValues?: readonly string[];
+          longOptionalValues?: readonly string[];
+          shortFlags?: readonly string[];
+          longFlags?: readonly string[];
+          numericShortValue?: boolean;
+        },
+      ) => {
+        const shortValues = new Set(spec.shortValues ?? []);
+        const longValues = new Set(spec.longValues ?? []);
+        const shortOptionalValues = new Set(spec.shortOptionalValues ?? []);
+        const longOptionalValues = new Set(spec.longOptionalValues ?? []);
+        const shortFlags = new Set(spec.shortFlags ?? []);
+        const longFlags = new Set(spec.longFlags ?? []);
+        while (index < values.length) {
+          const option = values[index];
+          if (option === "--") {
+            index++;
+            return false;
+          }
+          if (option === "-" || !option.startsWith("-")) return false;
+          if (option.startsWith("--")) {
+            const equals = option.indexOf("=");
+            const name = equals === -1 ? option : option.slice(0, equals);
+            if (longValues.has(name)) {
+              if (equals !== -1) {
+                index++;
+              } else if (values[index + 1] !== undefined) {
+                index += 2;
+              } else {
+                return true;
+              }
+              continue;
+            }
+            if (longOptionalValues.has(name) || longFlags.has(name)) {
+              index++;
+              continue;
+            }
+            return true;
+          }
+          if (spec.numericShortValue && /^-\d+$/.test(option)) {
+            index++;
+            continue;
+          }
+          const name = option.slice(0, 2);
+          if (shortValues.has(name)) {
+            if (option.length > 2) {
+              index++;
+            } else if (values[index + 1] !== undefined) {
+              index += 2;
+            } else {
+              return true;
+            }
+            continue;
+          }
+          if (shortOptionalValues.has(name)) {
+            index++;
+            continue;
+          }
+          if (
+            option.length > 1 &&
+            [...option.slice(1)].every((flag) => shortFlags.has(`-${flag}`))
+          ) {
+            index++;
+            continue;
+          }
+          return true;
+        }
+        return false;
+      };
+      const simpleWrappers: Record<
+        string,
+        Parameters<typeof consumeWrapperOptions>[0]
+      > = {
+        exec: { shortValues: ["-a"], shortFlags: ["-c", "-l"] },
+        nohup: { longFlags: ["--help", "--version"] },
+        nice: {
+          shortValues: ["-n"],
+          longValues: ["--adjustment"],
+          longFlags: ["--help", "--version"],
+          numericShortValue: true,
+        },
+        ionice: {
+          shortValues: ["-c", "-n", "-p", "-P", "-u"],
+          longValues: ["--class", "--classdata", "--pid", "--pgid", "--uid"],
+          shortFlags: ["-t"],
+          longFlags: ["--ignore", "--help", "--version"],
+        },
+        stdbuf: {
+          shortValues: ["-i", "-o", "-e"],
+          longValues: ["--input", "--output", "--error"],
+          longFlags: ["--help", "--version"],
+        },
+        setsid: {
+          shortFlags: ["-c", "-f", "-w"],
+          longFlags: ["--ctty", "--fork", "--wait", "--help", "--version"],
+        },
+        sudo: {
+          shortValues: ["-C", "-D", "-g", "-h", "-p", "-r", "-t", "-T", "-u"],
+          longValues: [
+            "--chdir",
+            "--close-from",
+            "--group",
+            "--host",
+            "--prompt",
+            "--role",
+            "--type",
+            "--user",
+          ],
+          shortOptionalValues: ["-E"],
+          longOptionalValues: ["--preserve-env"],
+          shortFlags: ["-A", "-b", "-e", "-H", "-K", "-k", "-l", "-n", "-P", "-S", "-s", "-V", "-v"],
+          longFlags: [
+            "--askpass",
+            "--background",
+            "--edit",
+            "--help",
+            "--login",
+            "--non-interactive",
+            "--remove-timestamp",
+            "--reset-timestamp",
+            "--set-home",
+            "--shell",
+            "--stdin",
+            "--validate",
+            "--version",
+          ],
+        },
+        doas: {
+          shortValues: ["-C", "-u"],
+          shortFlags: ["-L", "-n", "-s"],
+        },
+        xargs: {
+          shortValues: ["-a", "-d", "-E", "-I", "-J", "-L", "-n", "-P", "-s"],
+          longValues: [
+            "--arg-file",
+            "--delimiter",
+            "--max-args",
+            "--max-procs",
+            "--max-chars",
+            "--process-slot-var",
+          ],
+          shortOptionalValues: ["-e", "-i", "-l"],
+          longOptionalValues: ["--eof", "--replace", "--max-lines"],
+          shortFlags: ["-0", "-o", "-p", "-r", "-t", "-x"],
+          longFlags: [
+            "--null",
+            "--open-tty",
+            "--interactive",
+            "--no-run-if-empty",
+            "--show-limits",
+            "--verbose",
+            "--exit",
+            "--help",
+            "--version",
+          ],
+        },
+        time: {
+          shortValues: ["-f", "-o"],
+          longValues: ["--format", "--output"],
+          shortFlags: ["-a", "-p", "-v"],
+          longFlags: ["--append", "--portability", "--verbose", "--help", "--version"],
+        },
+        unbuffer: { shortFlags: ["-p"] },
+      };
+      while (index < values.length) {
+        collectAssignments();
+        const wrapper = shellExecutableName(values[index] ?? "");
+        if (wrapper === "command") {
+          index++;
+          while (index < values.length && values[index].startsWith("-")) {
+            const option = values[index++];
+            if (option === "--") break;
+            if (option.includes("v") || option.includes("V")) {
+              return { cwd: invocationCwd, env, ambiguous: false };
+            }
+            if (![...option.slice(1)].every((flag) => flag === "p")) {
+              return { cwd: invocationCwd, env, ambiguous: true };
+            }
+          }
+          continue;
+        }
+        if (wrapper === "env") {
+          index++;
+          while (index < values.length) {
+            const option = values[index];
+            if (option === "--") {
+              index++;
+              break;
+            }
+            if (["-u", "--unset"].includes(option)) {
+              const name = values[index + 1] ?? "";
+              deleteEnvironmentName(commandEnv, name);
+              if (isGitInspectionEnvironmentName(name)) deleteEnvironmentName(env, name);
+              index += 2;
+              continue;
+            }
+            if (["-C", "--chdir"].includes(option)) {
+              const directory = values[index + 1];
+              if (!directory) return { cwd: invocationCwd, env, ambiguous: true };
+              invocationCwd = isAbsolute(directory)
+                ? directory
+                : resolve(invocationCwd, directory);
+              index += 2;
+              continue;
+            }
+            if (["-a", "--argv0"].includes(option)) {
+              if (!values[index + 1]) {
+                return { cwd: invocationCwd, env, ambiguous: true };
+              }
+              index += 2;
+              continue;
+            }
+            if (["-S", "--split-string"].includes(option)) {
+              const split = shellWords(values[index + 1] ?? "");
+              if (split.ambiguous) return { cwd: invocationCwd, env, ambiguous: true };
+              const splitValues = split.words
+                .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+                .filter((value): value is string => value !== undefined);
+              values = [...values.slice(0, index), ...splitValues, ...values.slice(index + 2)];
+              continue;
+            }
+            if (option.startsWith("-S") && option.length > 2) {
+              const split = shellWords(option.slice(2));
+              if (split.ambiguous) return { cwd: invocationCwd, env, ambiguous: true };
+              const splitValues = split.words
+                .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+                .filter((value): value is string => value !== undefined);
+              values = [...values.slice(0, index), ...splitValues, ...values.slice(index + 1)];
+              continue;
+            }
+            if (option.startsWith("--split-string=")) {
+              const split = shellWords(option.slice("--split-string=".length));
+              if (split.ambiguous) return { cwd: invocationCwd, env, ambiguous: true };
+              const splitValues = split.words
+                .map((word) => word.variants.find((variant) => variant.flavor === flavor)?.value)
+                .filter((value): value is string => value !== undefined);
+              values = [...values.slice(0, index), ...splitValues, ...values.slice(index + 1)];
+              continue;
+            }
+            if (option.startsWith("--unset=")) {
+              const name = option.slice("--unset=".length);
+              deleteEnvironmentName(commandEnv, name);
+              if (isGitInspectionEnvironmentName(name)) deleteEnvironmentName(env, name);
+              index++;
+              continue;
+            }
+            const attached = option.match(/^-(u|C|a)(.+)$/);
+            if (attached) {
+              if (attached[1] === "u") {
+                deleteEnvironmentName(commandEnv, attached[2]);
+                if (isGitInspectionEnvironmentName(attached[2])) {
+                  deleteEnvironmentName(env, attached[2]);
+                }
+              } else if (attached[1] === "C") {
+                invocationCwd = isAbsolute(attached[2])
+                  ? attached[2]
+                  : resolve(invocationCwd, attached[2]);
+              }
+              index++;
+              continue;
+            }
+            if (option === "-" || option === "-i" || option === "--ignore-environment") {
+              for (const name of Object.keys(commandEnv)) delete commandEnv[name];
+              for (const name of Object.keys(env)) {
+                if (isGitInspectionEnvironmentName(name)) delete env[name];
+              }
+              index++;
+              continue;
+            }
+            if (/^-[i0v]+$/.test(option)) {
+              if (option.includes("i")) {
+                for (const name of Object.keys(commandEnv)) delete commandEnv[name];
+                for (const name of Object.keys(env)) {
+                  if (isGitInspectionEnvironmentName(name)) delete env[name];
+                }
+              }
+              index++;
+              continue;
+            }
+            if (option.startsWith("--chdir=")) {
+              const directory = option.slice("--chdir=".length);
+              if (!directory) return { cwd: invocationCwd, env, ambiguous: true };
+              invocationCwd = isAbsolute(directory)
+                ? directory
+                : resolve(invocationCwd, directory);
+              index++;
+              continue;
+            }
+            if (option.startsWith("--argv0=")) {
+              if (option.length === "--argv0=".length) {
+                return { cwd: invocationCwd, env, ambiguous: true };
+              }
+              index++;
+              continue;
+            }
+            if (option === "-0" || option === "--null") {
+              index++;
+              continue;
+            }
+            if (
+              option === "-v" ||
+              option === "--debug" ||
+              option === "--list-signal-handling" ||
+              option === "--help" ||
+              option === "--version" ||
+              /^(?:--default-signal|--ignore-signal|--block-signal)(?:=.*)?$/.test(option)
+            ) {
+              index++;
+              continue;
+            }
+            if (!option.startsWith("-")) break;
+            return { cwd: invocationCwd, env, ambiguous: true };
+          }
+          continue;
+        }
+        const spec = simpleWrappers[wrapper];
+        if (spec) {
+          index++;
+          if (consumeWrapperOptions(spec)) {
+            return { cwd: invocationCwd, env, ambiguous: true };
+          }
+          continue;
+        }
+        if (wrapper === "timeout") {
+          index++;
+          if (
+            consumeWrapperOptions({
+              shortValues: ["-k", "-s"],
+              longValues: ["--kill-after", "--signal"],
+              longFlags: [
+                "--foreground",
+                "--preserve-status",
+                "--verbose",
+                "--help",
+                "--version",
+              ],
+            })
+          ) {
+            return { cwd: invocationCwd, env, ambiguous: true };
+          }
+          if (index < values.length) index++;
+          continue;
+        }
+        break;
+      }
+      if (shellExecutableName(values[index] ?? "") === "git") {
+        const gitArgs = values.slice(index + 1);
+        for (let i = 0; i < gitArgs.length; i++) {
+          const arg = gitArgs[i];
+          const configEnv =
+            arg === "--config-env"
+              ? gitArgs[++i] ?? ""
+              : arg.startsWith("--config-env=")
+                ? arg.slice("--config-env=".length)
+                : "";
+          const equals = configEnv.indexOf("=");
+          if (equals === -1) continue;
+          const variable = configEnv.slice(equals + 1);
+          if (!variable) continue;
+          deleteEnvironmentName(env, variable);
+          const value = environmentValue(commandEnv, variable);
+          if (value !== undefined) env[variable] = value;
+        }
+        return { cwd: invocationCwd, env, ambiguous: false };
+      }
+    }
+    return { cwd: invocationCwd, env, ambiguous: false };
+  }
+
+  interface GitAliasResolution {
+    disposition: "none" | "safe" | "unsafe";
+    command: string;
+  }
+
+  function gitPersistedAliasResolution(
+    args: readonly string[],
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): GitAliasResolution {
+    const invocation = gitInvocation(args);
+    let alias = invocation.subcommand;
+    if (!alias) return { disposition: "none", command: "" };
+    let resolvedAlias = false;
+    const visited = new Set<string>();
+    const readAlias = (name: string): string | null => {
+      const query = (command: string[]): string | null => {
+        const result = Bun.spawnSync(command, {
+          cwd,
+          env,
+          stdout: "pipe",
+          stderr: "ignore",
+        });
+        return result.exitCode === 0 ? result.stdout?.toString().trim() ?? "" : null;
+      };
+      const contextual = query([
+        "git",
+        ...invocation.prefix,
+        "config",
+        "--get",
+        `alias.${name}`,
+      ]);
+      if (contextual !== null) return contextual;
+      for (const file of [
+        env.GIT_CONFIG_GLOBAL,
+        env.HOME ? join(env.HOME, ".gitconfig") : undefined,
+        env.XDG_CONFIG_HOME ? join(env.XDG_CONFIG_HOME, "git", "config") : undefined,
+      ]) {
+        if (!file || !existsSync(file)) continue;
+        const expansion = query(["git", "config", "--file", file, "--get", `alias.${name}`]);
+        if (expansion !== null) return expansion;
+      }
+      return null;
+    };
+    for (let depth = 0; depth < 8; depth++) {
+      const folded = alias.toLowerCase();
+      if (visited.has(folded)) return { disposition: "unsafe", command: alias };
+      visited.add(folded);
+      const expansion = readAlias(alias);
+      if (expansion === null) {
+        return {
+          disposition: resolvedAlias ? "safe" : "none",
+          command: alias,
+        };
+      }
+      resolvedAlias = true;
+      if (!expansion || expansion.startsWith("!")) {
+        return { disposition: "unsafe", command: alias };
+      }
+      const parsed = shellWords(expansion);
+      if (parsed.ambiguous || parsed.words.length === 0) {
+        return { disposition: "unsafe", command: alias };
+      }
+      alias =
+        parsed.words[0].variants.find((variant) => variant.flavor === "posix")?.value ??
+        parsed.words[0].variants[0]?.value ??
+        "";
+      if (!alias) return { disposition: "unsafe", command: "" };
+    }
+    return { disposition: "unsafe", command: alias };
+  }
+
+  function gitPagerMode(
+    prefix: readonly string[],
+    env: Record<string, string | undefined>,
+  ): "default" | "disabled" | "enabled" {
+    const pager = (env.GIT_PAGER ?? env.PAGER ?? "").trim();
+    let mode: "default" | "disabled" | "enabled" =
+      pager.length === 0
+        ? "default"
+        : /^(?:cat|false)$/i.test(pager)
+          ? "disabled"
+          : "enabled";
+    for (const arg of prefix) {
+      if (arg === "--no-pager" || arg === "-P") mode = "disabled";
+      else if (arg === "--paginate" || arg === "-p") mode = "enabled";
+    }
+    return mode;
+  }
+
+  function gitStatusUsesExternalCommand(
+    args: readonly string[],
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): boolean {
+    const invocation = gitInvocation(args);
+    const prefix = invocation.prefix.filter((arg) => arg !== "--");
+    const pagerMode = gitPagerMode(prefix, env);
+    if (pagerMode === "enabled") return true;
+    const commandArgs = args.slice(invocation.subcommandIndex + 1);
+    const boundary = commandArgs.indexOf("--");
+    const optionArgs = boundary === -1 ? commandArgs : commandArgs.slice(0, boundary);
+    const positionalPathspecs = (): string[] => {
+      for (let i = 0; i < commandArgs.length; i++) {
+        const arg = commandArgs[i];
+        if (!arg.startsWith("-") || arg === "-") {
+          const pathspecs = commandArgs.slice(i);
+          return pathspecs.some((pathspec) => pathspec.startsWith("-"))
+            ? []
+            : pathspecs;
+        }
+        if (
+          /^-[vsbz]+$/.test(arg) ||
+          /^-u(?:all|normal|no)?$/.test(arg) ||
+          /^-M(?:\d+%?)?$/.test(arg) ||
+          /^--(?:no-)?(?:verbose|short|branch|show-stash|ahead-behind|porcelain|long|null|untracked-files|ignored|ignore-submodules|column)(?:=.*)?$/.test(
+            arg,
+          ) ||
+          arg === "--renames" ||
+          arg === "--no-renames" ||
+          /^--find-renames(?:=.*)?$/.test(arg)
+        ) {
+          continue;
+        }
+        return [];
+      }
+      return [];
+    };
+    const pathspecs =
+      boundary === -1 ? positionalPathspecs() : commandArgs.slice(boundary + 1);
+    const configuredCommand = (key: string, safeValues: RegExp): boolean => {
+      const result = Bun.spawnSync(
+        ["git", ...prefix, "config", "--get-all", key],
+        {
+          cwd,
+          env,
+          stdout: "pipe",
+          stderr: "ignore",
+        },
+      );
+      if (result.exitCode === 1) return false;
+      if (result.exitCode !== 0) return true;
+      return (result.stdout?.toString() ?? "")
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .some((value) => !safeValues.test(value.trim()));
+    };
+    if (configuredCommand("core.fsmonitor", /^(?:true|false)$/i)) return true;
+    if (
+      pagerMode !== "disabled" &&
+      (configuredCommand("core.pager", /^(?:cat|false)$/i) ||
+        configuredCommand("pager.status", /^(?:cat|false)$/i))
+    ) return true;
+    let submoduleMode: string | undefined;
+    for (const arg of optionArgs) {
+      if (arg === "--ignore-submodules") submoduleMode = "all";
+      else if (arg.startsWith("--ignore-submodules=")) {
+        submoduleMode = arg.slice("--ignore-submodules=".length).toLowerCase();
+      }
+    }
+    if (submoduleMode === "all") return false;
+
+    const rootResult = Bun.spawnSync(
+      ["git", ...prefix, "rev-parse", "--show-toplevel"],
+      {
+        cwd,
+        env,
+        stdout: "pipe",
+        stderr: "ignore",
+      },
+    );
+    if (rootResult.exitCode !== 0) return false;
+    const root = rootResult.stdout?.toString().trim();
+    if (!root) return true;
+    const visited = new Set<string>();
+    const childEnv: Record<string, string | undefined> = { ...env };
+    for (const name of [
+      "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+      "GIT_OBJECT_DIRECTORY",
+      "GIT_DIR",
+      "GIT_WORK_TREE",
+      "GIT_IMPLICIT_WORK_TREE",
+      "GIT_GRAFT_FILE",
+      "GIT_INDEX_FILE",
+      "GIT_NAMESPACE",
+      "GIT_PREFIX",
+      "GIT_INTERNAL_SUPER_PREFIX",
+      "GIT_QUARANTINE_PATH",
+      "GIT_REPLACE_REF_BASE",
+      "GIT_SHALLOW_FILE",
+      "GIT_COMMON_DIR",
+    ]) {
+      deleteEnvironmentName(childEnv, name);
+    }
+    const indexedGitlinks = (
+      repository: string,
+      repositoryEnv: Record<string, string | undefined>,
+      repositoryPathspecs: readonly string[] = [],
+      useRootInvocation = false,
+    ): string[] | null => {
+      const command = useRootInvocation
+        ? ["git", ...prefix, "ls-files", "--stage", "--full-name", "-z"]
+        : ["git", "-C", repository, "ls-files", "--stage", "--full-name", "-z"];
+      const result = Bun.spawnSync(
+        [
+          ...command,
+          ...(repositoryPathspecs.length > 0 ? ["--", ...repositoryPathspecs] : []),
+        ],
+        {
+          ...(useRootInvocation ? { cwd } : {}),
+          env: repositoryEnv,
+          stdout: "pipe",
+          stderr: "ignore",
+        },
+      );
+      if (result.exitCode !== 0) return null;
+      const paths: string[] = [];
+      for (const record of (result.stdout?.toString() ?? "").split("\0")) {
+        if (!record) continue;
+        const tab = record.indexOf("\t");
+        if (tab === -1 || !record.slice(0, tab).startsWith("160000 ")) continue;
+        const path = record.slice(tab + 1);
+        if (path) paths.push(path);
+      }
+      return paths;
+    };
+    const unsafeSubmodule = (repository: string, depth: number): boolean => {
+      if (depth > 16 || visited.size >= 64) return true;
+      let identity: string;
+      try {
+        identity = realpathSync.native(repository);
+      } catch {
+        return true;
+      }
+      if (visited.has(identity)) return false;
+      visited.add(identity);
+      const fsmonitor = Bun.spawnSync(
+        ["git", "-C", repository, "config", "--get-all", "core.fsmonitor"],
+        {
+          env: childEnv,
+          stdout: "pipe",
+          stderr: "ignore",
+        },
+      );
+      if (fsmonitor.exitCode !== 0 && fsmonitor.exitCode !== 1) return true;
+      if (
+        fsmonitor.exitCode === 0 &&
+        (fsmonitor.stdout?.toString() ?? "")
+          .split(/\r?\n/)
+          .filter(Boolean)
+          .some((value) => !/^(?:true|false)$/i.test(value.trim()))
+      ) {
+        return true;
+      }
+      const gitlinks = indexedGitlinks(repository, childEnv);
+      if (gitlinks === null) return true;
+      for (const path of gitlinks) {
+        const submodule = resolve(repository, path);
+        if (!existsSync(join(submodule, ".git"))) continue;
+        if (unsafeSubmodule(submodule, depth + 1)) return true;
+      }
+      return false;
+    };
+    const gitlinks = indexedGitlinks(root, env, pathspecs, true);
+    if (gitlinks === null) return true;
+    for (const path of gitlinks) {
+      const submodule = resolve(root, path);
+      if (!existsSync(join(submodule, ".git"))) continue;
+      if (unsafeSubmodule(submodule, 1)) return true;
+    }
+    return false;
+  }
+
+  function gitCommandIsUnsafe(
+    command: string,
+    args: readonly string[],
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): boolean {
+    if (!command) return false;
+    const result = Bun.spawnSync(["git", "--list-cmds=builtins"], {
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    if (result.exitCode !== 0) return true;
+    const builtins = new Set(
+      (result.stdout?.toString() ?? "")
+        .split(/\s+/)
+        .map((name) => name.trim().toLowerCase())
+        .filter(Boolean),
+    );
+    const folded = command.toLowerCase();
+    if (!builtins.has(folded)) return true;
+    if (folded === "config") {
+      const invocation = gitInvocation(args);
+      const configArgs = args.slice(invocation.subcommandIndex + 1);
+      const boundary = configArgs.indexOf("--");
+      const optionArgs = boundary === -1 ? configArgs : configArgs.slice(0, boundary);
+      return !optionArgs.some(
+        (arg) =>
+          arg === "--get" ||
+          arg === "--get-all" ||
+          arg === "--get-regexp" ||
+          arg === "--get-urlmatch" ||
+          arg === "--list" ||
+          arg === "-l",
+      );
+    }
+    const invocation = gitInvocation(args);
+    const commandArgs = args.slice(invocation.subcommandIndex + 1);
+    const boundary = commandArgs.indexOf("--");
+    const optionArgs = boundary === -1 ? commandArgs : commandArgs.slice(0, boundary);
+    const pagerDisabled = gitPagerMode(invocation.prefix, env) === "disabled";
+    if (folded === "branch") {
+      return !(pagerDisabled && optionArgs.includes("--list"));
+    }
+    if (folded === "tag") {
+      return !(
+        pagerDisabled &&
+        (optionArgs.includes("--list") || optionArgs.includes("-l"))
+      );
+    }
+    if (folded === "diff") {
+      let cached = false;
+      let externalDiff: boolean | undefined;
+      let textconv: boolean | undefined;
+      let submoduleMode: string | undefined;
+      for (const arg of optionArgs) {
+        if (arg === "--cached" || arg === "--staged") cached = true;
+        else if (arg === "--no-index") cached = false;
+        else if (arg === "--ext-diff") externalDiff = true;
+        else if (arg === "--no-ext-diff") externalDiff = false;
+        else if (arg === "--textconv") textconv = true;
+        else if (arg === "--no-textconv") textconv = false;
+        else if (arg === "--ignore-submodules") submoduleMode = "all";
+        else if (arg.startsWith("--ignore-submodules=")) {
+          submoduleMode = arg.slice("--ignore-submodules=".length).toLowerCase();
+        }
+      }
+      return !(
+        pagerDisabled &&
+        cached &&
+        externalDiff === false &&
+        textconv === false &&
+        submoduleMode === "all"
+      );
+    }
+    const safeBuiltins = new Set([
+      "status",
+      "rev-parse",
+      "show-ref",
+      "for-each-ref",
+      "ls-files",
+      "ls-tree",
+      "check-ignore",
+      "check-attr",
+      "check-mailmap",
+      "merge-base",
+      "name-rev",
+      "count-objects",
+      "version",
+    ]);
+    if (!safeBuiltins.has(folded)) return true;
+    return folded === "status" && gitStatusUsesExternalCommand(args, env, cwd);
+  }
+
+  function gitInvocationUsesDynamicEvaluation(
+    args: readonly string[],
+    command: string,
+    env: Record<string, string | undefined>,
+    cwd: string,
+  ): boolean {
+    if (gitUsesIndirectShellAlias(args, command)) return true;
+    const resolution = gitPersistedAliasResolution(args, env, cwd);
+    if (resolution.disposition === "unsafe") return true;
+    return gitCommandIsUnsafe(resolution.command, args, env, cwd);
+  }
+
+  async function shellInvokesDynamicEvaluation(
+    command: string,
+    cwd = projectDir,
+  ): Promise<boolean> {
     if (shellUsesDynamicExpansion(command)) return true;
+    if (shellUsesConstructedHostInvocation(command)) return true;
     const interpreter =
-      /^(?:ba|da|fi|k|z)?sh$|^(?:bun|bunx|deno|node|nodejs|npm|npx|pnpm|yarn|corepack|tsx|ts-node|python(?:\d+(?:\.\d+)*)?|ruby|perl|php|lua|luajit|raku|julia|java|js|qjs|osascript|powershell|pwsh)$/i;
+      /^(?:ba|da|fi|k|z)?sh$|^(?:bun|bunx|deno|node|nodejs|npm|npx|pnpm|yarn|corepack|tsx|ts-node|python(?:\d+(?:\.\d+)*)?|ruby|perl|php|lua|luajit|raku|julia|java|js|qjs|osascript|powershell|pwsh|cmd|cscript|wscript|mshta|awk|gawk|mawk|nawk)(?:\.(?:exe|com|cmd|bat))?$/i;
+    const directPowerShellHost =
+      /^(?:remove|clear|set|new|move|copy|rename)-item$|^(?:set|add|clear)-content$|^out-file$|^(?:ri|rm|rd|del|erase|rmdir|mi|mv|cp|cpi|ren|ni|sc|ac|clc)$/i;
+    const dynamicPowerShellHost =
+      /^(?:invoke-expression|iex|invoke-command|icm|invoke-item|ii|start-process|saps|start-job|sajb)$/i;
+    const isInterpreter = (name: string): boolean => {
+      const candidates = [name, posix.basename(name), win32.basename(name)];
+      if (candidates.some((candidate) => interpreter.test(candidate))) return true;
+      return /(?:powershell|pwsh|cmd|cscript|wscript|mshta|awk|gawk|mawk|nawk)(?:\.(?:exe|com|cmd|bat))?$/i.test(
+        name,
+      );
+    };
     try {
       const module = await loadReviewFreezeCommandModule();
       if (typeof module.shellCommandInvocations !== "function") return true;
-      return module.shellCommandInvocations(command).some(
-        (invocation) =>
-          interpreter.test(invocation.name) ||
-          invocation.name === "eval" ||
-          invocation.name === "source" ||
-          invocation.name === ".",
-      );
+      const hostExpression = shellUsesDirectHostExpression(command);
+      const flavor: PathFlavor =
+        process.platform === "win32" ? "win32" : "posix";
+      let states: ShellCwdState[] = [
+        { cwd, stack: [], status: "unknown", logicalAmbiguous: false },
+      ];
+      let operatorBefore: ShellCommandPart["operatorAfter"] = "";
+      for (const part of shellCommandParts(command)) {
+        const segment = part.text;
+        const parsed = shellWords(segment);
+        if (parsed.ambiguous) return true;
+        const activeStates: ShellCwdState[] = [];
+        const carriedStates: ShellCwdState[] = [];
+        for (const state of states) {
+          const active = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          const carried = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          if (operatorBefore === "&&") {
+            if (state.status !== "failure") activeStates.push(active);
+            if (state.status !== "success") carriedStates.push(carried);
+          } else if (operatorBefore === "||") {
+            if (state.status !== "success") activeStates.push(active);
+            if (state.status !== "failure") carriedStates.push(carried);
+          } else {
+            activeStates.push(active);
+          }
+        }
+
+        const invocations = module.shellCommandInvocations(segment);
+        for (const state of activeStates) {
+          const gitContext = gitCommandEnvironment(segment, state.cwd);
+          for (const invocation of invocations) {
+            const leaf = win32.basename(posix.basename(invocation.name));
+            if (
+              invocation.ambiguous ||
+              isInterpreter(invocation.name) ||
+              dynamicPowerShellHost.test(invocation.name) ||
+              (/^busybox(?:\.exe)?$/i.test(leaf) &&
+                isInterpreter(invocation.args[0] ?? "")) ||
+              (/^git(?:\.exe)?$/i.test(leaf) &&
+                (gitContext.ambiguous ||
+                  gitInvocationUsesDynamicEvaluation(
+                    invocation.args,
+                    segment,
+                    gitContext.env,
+                    gitContext.cwd,
+                  ))) ||
+              (hostExpression &&
+                directPowerShellHost.test(invocation.name)) ||
+              invocation.name === "eval" ||
+              invocation.name === "source" ||
+              invocation.name === "."
+            ) {
+              return true;
+            }
+          }
+        }
+
+        const isolatedSubshell = /^\s*\(.*\)\s*$/.test(segment);
+        const nonPersistent =
+          isolatedSubshell || ["|", "&"].includes(part.operatorAfter);
+        const controlAmbiguous =
+          /[{}]/.test(segment) ||
+          /\b(?:if|elif|else|while|until|case|for|select|function|then|do)\b/i.test(
+            segment,
+          );
+        const nextStates: ShellCwdState[] = [...carriedStates];
+        for (const state of activeStates) {
+          const original = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          const changed = {
+            cwd: state.cwd,
+            stack: [...state.stack],
+            status: state.status,
+            logicalAmbiguous: state.logicalAmbiguous,
+          };
+          const update = updateShellCwd(parsed.words, flavor, changed);
+          if (update === "ambiguous") return true;
+          if (update === "none") {
+            nextStates.push({ ...original, status: "unknown" });
+            continue;
+          }
+          let viable = false;
+          try {
+            viable = statSync(changed.cwd).isDirectory();
+          } catch {
+            // A literal directory change to a missing path cannot succeed.
+          }
+          if (!viable) {
+            nextStates.push({ ...original, status: "failure" });
+          } else if (nonPersistent) {
+            nextStates.push({ ...original, status: "success" });
+          } else if (controlAmbiguous) {
+            nextStates.push(
+              { ...original, status: "unknown" },
+              { ...changed, status: "unknown" },
+            );
+          } else {
+            nextStates.push({ ...changed, status: "success" });
+          }
+        }
+        const deduped = new Map<string, ShellCwdState>();
+        for (const state of nextStates) {
+          const key = shellCwdStateKey(state, flavor);
+          const existing = deduped.get(key);
+          if (!existing) {
+            deduped.set(key, state);
+            continue;
+          }
+          const sameLogicalState =
+            existing.cwd === state.cwd &&
+            existing.stack.length === state.stack.length &&
+            existing.stack.every(
+              (path, index) => path === state.stack[index],
+            );
+          existing.logicalAmbiguous ||=
+            state.logicalAmbiguous || !sameLogicalState;
+          if (state.cwd.length < existing.cwd.length) {
+            existing.cwd = state.cwd;
+            existing.stack = [...state.stack];
+          }
+        }
+        if (deduped.size > MAX_SHELL_CWD_STATES) return true;
+        states = [...deduped.values()];
+        operatorBefore = part.operatorAfter;
+      }
+      return false;
     } catch {
       return true;
     }
@@ -696,18 +2457,150 @@ export async function run(
     const cwd = effectiveCwd();
     const command = toolInput.command;
     if (toolName === "Bash" && typeof command === "string") {
-      if (
-        shellWords(command).some((word) =>
-          globPrefixTouchesProtected(word, cwd, protectedPaths) ||
-          concreteWordTouchesProtected(word, cwd, protectedPaths)
-        )
-      ) {
-        return true;
+      const states: Record<PathFlavor, ShellCwdState[]> = {
+        posix: [{ cwd, stack: [], status: "unknown", logicalAmbiguous: false }],
+        win32: [{ cwd, stack: [], status: "unknown", logicalAmbiguous: false }],
+      };
+      let operatorBefore: ShellCommandPart["operatorAfter"] = "";
+      for (const part of shellCommandParts(command)) {
+        const segment = part.text;
+        const parsed = shellWords(segment);
+        if (parsed.ambiguous) return true;
+        const activeStates: Record<PathFlavor, ShellCwdState[]> = {
+          posix: [],
+          win32: [],
+        };
+        const carriedStates: Record<PathFlavor, ShellCwdState[]> = {
+          posix: [],
+          win32: [],
+        };
+        for (const flavor of ["posix", "win32"] as const) {
+          for (const state of states[flavor]) {
+            const active = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            const carried = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            if (operatorBefore === "&&") {
+              if (state.status !== "failure") activeStates[flavor].push(active);
+              if (state.status !== "success") carriedStates[flavor].push(carried);
+            } else if (operatorBefore === "||") {
+              if (state.status !== "success") activeStates[flavor].push(active);
+              if (state.status !== "failure") carriedStates[flavor].push(carried);
+            } else {
+              activeStates[flavor].push(active);
+            }
+          }
+        }
+        if (
+          parsed.words.some(({ variants }) =>
+            variants.some(
+              ({ value, activeGlobIndexes, flavor }) =>
+                activeStates[flavor].some(
+                  (state) =>
+                    globPrefixTouchesProtected(
+                      value,
+                      state.cwd,
+                      protectedPaths,
+                      activeGlobIndexes[0] ?? -1,
+                      flavor,
+                    ) ||
+                    concreteWordTouchesProtected(
+                      value,
+                      state.cwd,
+                      protectedPaths,
+                      activeGlobIndexes.length > 0,
+                      flavor,
+                    ),
+                ),
+            )
+          )
+        ) {
+          return true;
+        }
+        const isolatedSubshell = /^\s*\(.*\)\s*$/.test(segment);
+        const nonPersistent =
+          isolatedSubshell || ["|", "&"].includes(part.operatorAfter);
+        const controlAmbiguous =
+          /[{}]/.test(segment) ||
+          /\b(?:if|elif|else|while|until|case|for|select|function|then|do)\b/i.test(
+            segment,
+          );
+        for (const flavor of ["posix", "win32"] as const) {
+          const nextStates: ShellCwdState[] = [...carriedStates[flavor]];
+          for (const state of activeStates[flavor]) {
+            const original = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            const changed = {
+              cwd: state.cwd,
+              stack: [...state.stack],
+              status: state.status,
+              logicalAmbiguous: state.logicalAmbiguous,
+            };
+            const update = updateShellCwd(parsed.words, flavor, changed);
+            if (update === "ambiguous") return true;
+            if (update === "none") {
+              nextStates.push({ ...original, status: "unknown" });
+              continue;
+            }
+            let viable = false;
+            try {
+              viable = statSync(changed.cwd).isDirectory();
+            } catch {
+              // A literal directory change to a missing path cannot succeed.
+            }
+            if (!viable) {
+              nextStates.push({ ...original, status: "failure" });
+            } else if (nonPersistent) {
+              nextStates.push({ ...original, status: "success" });
+            } else if (controlAmbiguous) {
+              nextStates.push(
+                { ...original, status: "unknown" },
+                { ...changed, status: "unknown" },
+              );
+            } else {
+              nextStates.push({ ...changed, status: "success" });
+            }
+          }
+          const deduped = new Map<string, ShellCwdState>();
+          for (const state of nextStates) {
+            const key = shellCwdStateKey(state, flavor);
+            const existing = deduped.get(key);
+            if (!existing) {
+              deduped.set(key, state);
+              continue;
+            }
+            const sameLogicalState =
+              existing.cwd === state.cwd &&
+              existing.stack.length === state.stack.length &&
+              existing.stack.every((path, index) => path === state.stack[index]);
+            existing.logicalAmbiguous ||=
+              state.logicalAmbiguous || !sameLogicalState;
+            if (state.cwd.length < existing.cwd.length) {
+              existing.cwd = state.cwd;
+              existing.stack = [...state.stack];
+            }
+          }
+          if (deduped.size > MAX_SHELL_CWD_STATES) return true;
+          states[flavor] = [...deduped.values()];
+        }
+        operatorBefore = part.operatorAfter;
       }
       const concrete = await reviewFreezeTargets();
       if (
         concrete?.some((path) =>
-          overlapsProtectedPath(path, protectedPaths)
+          overlapsProtectedPath(path, protectedPaths, cwd)
         )
       ) {
         return true;
@@ -718,10 +2611,7 @@ export async function run(
       (value) =>
         (globPrefixTouchesProtected(value, cwd, protectedPaths) ||
           (!/[\s*?[\]{}]/.test(value) &&
-            overlapsProtectedPath(
-              isAbsolute(value) ? value : resolve(cwd, value),
-              protectedPaths,
-            ))),
+            overlapsProtectedPath(value, protectedPaths, cwd))),
     );
   }
 
@@ -788,7 +2678,22 @@ export async function run(
                 "the live Task record was retired.",
             }),
           );
-          removeLedger(path);
+          retireSpawn(record);
+        }
+        for (const path of witnessFiles().sort()) {
+          const record = readRecord(path);
+          if (record?.parent !== cursor.conversation_id) continue;
+          runCore(
+            "aidlc-log-subagent.ts",
+            JSON.stringify({
+              hook_event_name: "SubagentStop",
+              agent_type: record.agent,
+              last_assistant_message:
+                "inferred: Cursor emitted sessionEnd after the primary Task ledger was lost; " +
+                "the independent delegation witness was retired.",
+            }),
+          );
+          retireSpawn(record);
         }
         removeLedger(mainFile(cursor.conversation_id));
       }
@@ -878,7 +2783,18 @@ export async function run(
           return 0;
         }
         const sub = cursor.tool_input?.subagent_type;
-        if (typeof sub === "string" && sub.length > 0) recordSpawn(sub);
+        if (
+          typeof sub === "string" &&
+          sub.length > 0 &&
+          !recordSpawn(sub)
+        ) {
+          process.stdout.write(`${JSON.stringify({
+            permission: "deny",
+            agent_message:
+              "AIDLC could not establish protected delegated-agent attribution, so the Task was not started.",
+          })}\n`);
+          return 0;
+        }
         writeAllow();
         return 0;
       }
@@ -888,15 +2804,14 @@ export async function run(
         agent &&
         toolName === "Bash" &&
         typeof command === "string" &&
-        (REVIEW_AGENT_RE.test(agent) || activeReviewerDispatch() !== null) &&
-        await shellInvokesDynamicEvaluation(command)
+        await shellInvokesDynamicEvaluation(command, effectiveCwd())
       ) {
         process.stdout.write(`${JSON.stringify({
           permission: "deny",
           agent_message:
             "AIDLC delegated agents cannot use general-purpose interpreters, shell parameter " +
-            "expansion, or dynamic command evaluation while reviewer attribution is active " +
-            "because those paths can bypass attribution-state protection. " +
+            "expansion, or dynamic command evaluation while delegated-agent attribution is active " +
+            "because those paths can invalidate protected attribution state. " +
             "Use Cursor's native read/search tools and have the parent conversation run executable probes.",
         })}\n`);
         return 0;
@@ -913,8 +2828,8 @@ export async function run(
         process.stdout.write(`${JSON.stringify({
           permission: "deny",
           agent_message:
-            "AIDLC reviewer identity is unavailable or ambiguous during an active review dispatch; " +
-            "the operation was denied rather than bypassing reviewer-scope enforcement.",
+            "AIDLC delegated-agent identity is unavailable or ambiguous while delegation state is active; " +
+            "the operation was denied rather than losing attribution enforcement.",
         })}\n`);
         return 0;
       }

--- a/harness/cursor/hooks/aidlc-cursor-adapter.ts
+++ b/harness/cursor/hooks/aidlc-cursor-adapter.ts
@@ -2353,6 +2353,10 @@ export async function run(
                   ))) ||
               (hostExpression &&
                 directPowerShellHost.test(invocation.name)) ||
+              (invocation.name === "find" &&
+                invocation.args.some((arg) =>
+                  ["-exec", "-execdir", "-ok", "-okdir"].includes(arg)
+                )) ||
               invocation.name === "eval" ||
               invocation.name === "source" ||
               invocation.name === "."

--- a/harness/cursor/hooks/aidlc-cursor-adapter.ts
+++ b/harness/cursor/hooks/aidlc-cursor-adapter.ts
@@ -700,6 +700,15 @@ export async function run(
   }
 
   interface ReviewFreezeCommandModule {
+    shellCommandInvocationDetails?: (
+      command: string,
+    ) => Array<{
+      name: string;
+      args: string[];
+      ambiguous?: boolean;
+      executable?: string;
+      launchers?: string[];
+    }>;
     shellCommandInvocations?: (
       command: string,
     ) => Array<{ name: string; args: string[]; ambiguous?: boolean }>;
@@ -2285,6 +2294,111 @@ export async function run(
       /^(?:remove|clear|set|new|move|copy|rename)-item$|^(?:set|add|clear)-content$|^out-file$|^(?:ri|rm|rd|del|erase|rmdir|mi|mv|cp|cpi|ren|ni|sc|ac|clc)$/i;
     const dynamicPowerShellHost =
       /^(?:invoke-expression|iex|invoke-command|icm|invoke-item|ii|start-process|saps|start-job|sajb)$/i;
+    const inspectableDelegatedCommands = new Set([
+      ":",
+      "[",
+      "ac",
+      "add-content",
+      "basename",
+      "cat",
+      "cd",
+      "chdir",
+      "clear-content",
+      "clear-item",
+      "clc",
+      "cli",
+      "cmp",
+      "copy",
+      "copy-item",
+      "cp",
+      "cpi",
+      "cut",
+      "dd",
+      "del",
+      "dir",
+      "dirname",
+      "echo",
+      "erase",
+      "exist",
+      "false",
+      "file",
+      "find",
+      "get-childitem",
+      "get-content",
+      "get-item",
+      "git",
+      "grep",
+      "head",
+      "join-path",
+      "jq",
+      "ls",
+      "md",
+      "mi",
+      "mkdir",
+      "move",
+      "move-item",
+      "mv",
+      "new-item",
+      "ni",
+      "out-file",
+      "pop-location",
+      "popd",
+      "printf",
+      "push-location",
+      "pushd",
+      "pwd",
+      "rd",
+      "readlink",
+      "realpath",
+      "remove-item",
+      "ren",
+      "rename",
+      "rename-item",
+      "resolve-path",
+      "rg",
+      "ri",
+      "rmdir",
+      "rm",
+      "rni",
+      "rsync",
+      "sc",
+      "select-string",
+      "set-content",
+      "set-item",
+      "set-location",
+      "sha1sum",
+      "sha256sum",
+      "sha512sum",
+      "shred",
+      "sl",
+      "sort",
+      "split-path",
+      "stat",
+      "tail",
+      "tee",
+      "test",
+      "test-path",
+      "touch",
+      "tr",
+      "true",
+      "truncate",
+      "type",
+      "uniq",
+      "unlink",
+      "wc",
+      "where",
+      "which",
+    ]);
+    const uninspectableExecutableToken = (value: string): boolean => {
+      const normalized = value.replaceAll("\\", "/");
+      return (
+        normalized.includes("/") ||
+        /^[A-Za-z]:/.test(normalized) ||
+        /\.(?:bat|cmd|ps1|psd1|psm1|sh|bash|dash|fish|ksh|zsh|cjs|js|mjs|cts|mts|ts|py|rb|pl|php|lua|jar|vbs|wsf|hta)$/i.test(
+          normalized,
+        )
+      );
+    };
     const isInterpreter = (name: string): boolean => {
       const candidates = [name, posix.basename(name), win32.basename(name)];
       if (candidates.some((candidate) => interpreter.test(candidate))) return true;
@@ -2294,7 +2408,7 @@ export async function run(
     };
     try {
       const module = await loadReviewFreezeCommandModule();
-      if (typeof module.shellCommandInvocations !== "function") return true;
+      if (typeof module.shellCommandInvocationDetails !== "function") return true;
       const hostExpression = shellUsesDirectHostExpression(command);
       const flavor: PathFlavor =
         process.platform === "win32" ? "win32" : "posix";
@@ -2332,17 +2446,27 @@ export async function run(
           }
         }
 
-        const invocations = module.shellCommandInvocations(segment);
+        const functionDefinition =
+          /^\s*(?:function\s+)?[A-Za-z_][A-Za-z0-9_]*\s*(?:\(\s*\))?\s*\{/.test(
+            segment,
+          );
+        const invocations = functionDefinition
+          ? []
+          : module.shellCommandInvocationDetails(segment);
         for (const state of activeStates) {
           const gitContext = gitCommandEnvironment(segment, state.cwd);
           for (const invocation of invocations) {
             const leaf = win32.basename(posix.basename(invocation.name));
             if (
               invocation.ambiguous ||
+              [invocation.executable, ...(invocation.launchers ?? [])].some(
+                (value) =>
+                  typeof value !== "string" ||
+                  value.length === 0 ||
+                  uninspectableExecutableToken(value),
+              ) ||
               isInterpreter(invocation.name) ||
               dynamicPowerShellHost.test(invocation.name) ||
-              (/^busybox(?:\.exe)?$/i.test(leaf) &&
-                isInterpreter(invocation.args[0] ?? "")) ||
               (/^git(?:\.exe)?$/i.test(leaf) &&
                 (gitContext.ambiguous ||
                   gitInvocationUsesDynamicEvaluation(
@@ -2359,7 +2483,8 @@ export async function run(
                 )) ||
               invocation.name === "eval" ||
               invocation.name === "source" ||
-              invocation.name === "."
+              invocation.name === "." ||
+              !inspectableDelegatedCommands.has(invocation.name)
             ) {
               return true;
             }

--- a/harness/cursor/hooks/aidlc-cursor-adapter.ts
+++ b/harness/cursor/hooks/aidlc-cursor-adapter.ts
@@ -700,6 +700,7 @@ export async function run(
   }
 
   interface ReviewFreezeCommandModule {
+    shellCommandAltersExecutableResolution?: (command: string) => boolean;
     shellCommandInvocationDetails?: (
       command: string,
     ) => Array<{
@@ -708,6 +709,8 @@ export async function run(
       ambiguous?: boolean;
       executable?: string;
       launchers?: string[];
+      dataDrivenMutation?: boolean;
+      executableResolutionChanged?: boolean;
     }>;
     shellCommandInvocations?: (
       command: string,
@@ -2408,7 +2411,13 @@ export async function run(
     };
     try {
       const module = await loadReviewFreezeCommandModule();
-      if (typeof module.shellCommandInvocationDetails !== "function") return true;
+      if (
+        typeof module.shellCommandAltersExecutableResolution !== "function" ||
+        typeof module.shellCommandInvocationDetails !== "function"
+      ) {
+        return true;
+      }
+      if (module.shellCommandAltersExecutableResolution(command)) return true;
       const hostExpression = shellUsesDirectHostExpression(command);
       const flavor: PathFlavor =
         process.platform === "win32" ? "win32" : "posix";
@@ -2459,6 +2468,7 @@ export async function run(
             const leaf = win32.basename(posix.basename(invocation.name));
             if (
               invocation.ambiguous ||
+              invocation.dataDrivenMutation ||
               [invocation.executable, ...(invocation.launchers ?? [])].some(
                 (value) =>
                   typeof value !== "string" ||

--- a/tests/unit/t157-workspace-shell-seed.test.ts
+++ b/tests/unit/t157-workspace-shell-seed.test.ts
@@ -264,6 +264,14 @@ describe("t157 seeded workspace shell + re-rooted .gitignore (SEED)", () => {
       expect(lines, `${h}: ignores engine-shaped sensor caches at any depth`).toContain(
         "**/aidlc/spaces/*/intents/**/.aidlc-sensors/",
       );
+      if (h === "cursor") {
+        expect(lines, "cursor: ignores the primary subagent ledger").toContain(
+          "aidlc/.aidlc-cursor-subagents/",
+        );
+        expect(lines, "cursor: ignores independent delegation witnesses").toContain(
+          "aidlc/.aidlc-cursor-subagent-*.json",
+        );
+      }
 
       const repo = mkdtempSync(join(tmpdir(), `aidlc-t157-gitignore-${h}-`));
       tempDirs.push(repo);

--- a/tests/unit/t264-review-freeze-hook.test.ts
+++ b/tests/unit/t264-review-freeze-hook.test.ts
@@ -47,6 +47,7 @@ import {
   judgeFreeze,
   REVIEW_FREEZE_FALLBACK_GUIDANCE,
   reviewFreezeRecoveryGuidance,
+  shellCommandInvocationDetails,
   shellCommandInvocations,
   writeTargets,
 } from "../../dist/claude/.claude/hooks/aidlc-review-freeze.ts";
@@ -145,6 +146,34 @@ test("builtin wrappers recursively expose evaluators", () => {
   }
   expect(shellCommandInvocations("builtin -p eval")).toEqual([
     { name: "", args: [], ambiguous: true },
+  ]);
+});
+
+test("inspection preserves executable provenance and unwraps multiplexer applets", () => {
+  expect(
+    shellCommandInvocationDetails(
+      "command ./scratch/echo.cmd harmless",
+    ),
+  ).toEqual([
+    {
+      name: "echo",
+      args: ["harmless"],
+      executable: "./scratch/echo.cmd",
+      launchers: ["command"],
+    },
+  ]);
+  expect(
+    shellCommandInvocationDetails("busybox env HOME=/tmp sh -c harmless"),
+  ).toEqual([
+    {
+      name: "sh",
+      args: ["-c", "harmless"],
+      executable: "sh",
+      launchers: ["busybox", "env"],
+    },
+  ]);
+  expect(shellCommandInvocations("toybox rm -rf aidlc")).toEqual([
+    { name: "rm", args: ["-rf", "aidlc"] },
   ]);
 });
 

--- a/tests/unit/t264-review-freeze-hook.test.ts
+++ b/tests/unit/t264-review-freeze-hook.test.ts
@@ -47,6 +47,7 @@ import {
   judgeFreeze,
   REVIEW_FREEZE_FALLBACK_GUIDANCE,
   reviewFreezeRecoveryGuidance,
+  shellCommandAltersExecutableResolution,
   shellCommandInvocationDetails,
   shellCommandInvocations,
   writeTargets,
@@ -174,6 +175,68 @@ test("inspection preserves executable provenance and unwraps multiplexer applets
   ]);
   expect(shellCommandInvocations("toybox rm -rf aidlc")).toEqual([
     { name: "rm", args: ["-rf", "aidlc"] },
+  ]);
+});
+
+test("inspection marks altered executable lookup and data-driven mutations", () => {
+  for (const command of [
+    "PATH=/tmp rg",
+    "env PATH=/tmp rg",
+    "env PaTh=/tmp rg",
+    "env PATHEXT=.CMD rg",
+    "env -uPATH rg",
+    "env --unset=PATH rg",
+    "env -i rg",
+    "env --ignore-environment rg",
+  ]) {
+    expect(shellCommandInvocationDetails(command), command).toEqual([
+      expect.objectContaining({
+        name: "rg",
+        executableResolutionChanged: true,
+      }),
+    ]);
+  }
+  for (const command of [
+    "PATH=/tmp; rg",
+    "env -S 'PATH=/tmp rg'",
+    "env --split-string='PATHEXT=.CMD rg'",
+  ]) {
+    expect(shellCommandAltersExecutableResolution(command), command).toBe(true);
+  }
+  for (const command of [
+    "HOME=/tmp rg",
+    "MYPATH=/tmp rg",
+    "echo PATH=/tmp",
+    "env --argv0 PATH rg",
+  ]) {
+    expect(shellCommandAltersExecutableResolution(command), command).toBe(false);
+  }
+  expect(shellCommandInvocationDetails("env HOME=/tmp rg")).toEqual([
+    {
+      name: "rg",
+      args: [],
+      executable: "rg",
+      launchers: ["env"],
+    },
+  ]);
+  expect(shellCommandInvocationDetails("xargs rm -rf")).toEqual([
+    {
+      name: "rm",
+      args: ["-rf"],
+      executable: "rm",
+      launchers: ["xargs"],
+      dataDriven: true,
+      dataDrivenMutation: true,
+    },
+  ]);
+  expect(shellCommandInvocationDetails("xargs printf '%s\\n'")).toEqual([
+    {
+      name: "printf",
+      args: ["%s\\n"],
+      executable: "printf",
+      launchers: ["xargs"],
+      dataDriven: true,
+    },
   ]);
 });
 

--- a/tests/unit/t264-review-freeze-hook.test.ts
+++ b/tests/unit/t264-review-freeze-hook.test.ts
@@ -47,6 +47,7 @@ import {
   judgeFreeze,
   REVIEW_FREEZE_FALLBACK_GUIDANCE,
   reviewFreezeRecoveryGuidance,
+  shellCommandInvocations,
   writeTargets,
 } from "../../dist/claude/.claude/hooks/aidlc-review-freeze.ts";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
@@ -88,6 +89,65 @@ const NFR = {
   reviewer: "aidlc-architecture-reviewer-agent",
   produces: ["nfr-requirements"],
 };
+
+test("wrapper value options retain the nested executable and arguments", () => {
+  for (const command of [
+    "env -a git HOME=/alternate git pwn",
+    "env --argv0 git HOME=/alternate git pwn",
+    "env --argv0=git HOME=/alternate git pwn",
+    "command env -a git HOME=/alternate git pwn",
+    "exec -a ignored env HOME=/alternate git pwn",
+    "command exec -a ignored env HOME=/alternate git pwn",
+    "xargs -d : env HOME=/alternate git pwn",
+    "xargs --delimiter : env HOME=/alternate git pwn",
+    "xargs --delimiter=: env HOME=/alternate git pwn",
+    "xargs --eof env HOME=/alternate git pwn",
+    "xargs --eof=STOP env HOME=/alternate git pwn",
+    "xargs --replace env HOME=/alternate git pwn",
+    "xargs --replace=TOKEN env HOME=/alternate git pwn",
+    "xargs --max-lines env HOME=/alternate git pwn",
+    "xargs --max-lines=1 env HOME=/alternate git pwn",
+    "xargs -L 1 env HOME=/alternate git pwn",
+    "xargs --process-slot-var SLOT env HOME=/alternate git pwn",
+    "xargs -J REPL env HOME=/alternate git pwn",
+    "xargs -rt --max-lines env HOME=/alternate git pwn",
+    "ENV.EXE HOME=/alternate GIT.EXE pwn",
+    "\"C:/Program Files/Git/usr/bin/env.exe\" HOME=/alternate \"C:/Program Files/Git/cmd/git.exe\" pwn",
+    String.raw`"C:\Program Files\Git\usr\bin\env.exe" HOME=/alternate "C:\Program Files\Git\cmd\git.exe" pwn`,
+    "env -uHOME HOME=/alternate git pwn",
+    "env -C/tmp git pwn",
+    "env -agit HOME=/alternate git pwn",
+    "env -i0 HOME=/alternate git pwn",
+  ]) {
+    expect(shellCommandInvocations(command), command).toEqual([
+      { name: "git", args: ["pwn"] },
+    ]);
+  }
+});
+
+test("unknown wrapper options remain explicitly ambiguous", () => {
+  expect(
+    shellCommandInvocations(
+      "xargs --future-value SLOT env HOME=/alternate git pwn",
+    ),
+  ).toEqual([{ name: "", args: [], ambiguous: true }]);
+});
+
+test("builtin wrappers recursively expose evaluators", () => {
+  for (const command of [
+    "builtin eval 'printf harmless'",
+    "builtin -- eval 'printf harmless'",
+    "builtin builtin -- eval 'printf harmless'",
+  ]) {
+    expect(shellCommandInvocations(command), command).toEqual([
+      { name: "eval", args: ["printf harmless"] },
+    ]);
+  }
+  expect(shellCommandInvocations("builtin -p eval")).toEqual([
+    { name: "", args: [], ambiguous: true },
+  ]);
+});
+
 const NONE: ReadonlySet<string> = new Set();
 const ready = { stageVerdict: "READY", unitVerdicts: new Map<string, string>() };
 const notReady = { stageVerdict: "NOT-READY", unitVerdicts: new Map<string, string>() };

--- a/tests/unit/t264-review-freeze-hook.test.ts
+++ b/tests/unit/t264-review-freeze-hook.test.ts
@@ -345,6 +345,39 @@ describe("t264 (a) judgeFreeze decision table", () => {
     expect(
       writeTargets("Bash", { command: "perl -pi -e 's/x/y/' /a/b.md /tmp/c.md" }),
     ).toEqual([hostPath("/a/b.md"), hostPath("/tmp/c.md")]);
+    expect(
+      writeTargets("Bash", { command: "find aidlc -depth -delete" }, "/p"),
+    ).toEqual([hostPath("/p/aidlc")]);
+    expect(
+      writeTargets("Bash", { command: "find -H -delete" }, "/p"),
+    ).toEqual([hostPath("/p")]);
+    expect(
+      writeTargets("Bash", { command: "find scratch -fprint /a/b.md" }, "/p"),
+    ).toEqual([hostPath("/a/b.md")]);
+    expect(
+      writeTargets("Bash", { command: "find scratch -fprintf /tmp/list '%p\\n'" }, "/p"),
+    ).toEqual([hostPath("/tmp/list")]);
+    expect(
+      writeTargets("Bash", { command: "find scratch -name '*.tmp'" }, "/p"),
+    ).toEqual([]);
+    expect(
+      writeTargets("Bash", { command: "Remove-Item aidlc -Recurse -Force" }, "/p"),
+    ).toContain(hostPath("/p/aidlc"));
+    expect(
+      writeTargets("Bash", { command: "Remove-Item -Path:aidlc -Recurse" }, "/p"),
+    ).toContain(hostPath("/p/aidlc"));
+    expect(
+      writeTargets("Bash", { command: "Move-Item aidlc scratch" }, "/p"),
+    ).toEqual(expect.arrayContaining([hostPath("/p/aidlc"), hostPath("/p/scratch")]));
+    expect(
+      writeTargets("Bash", { command: "rd /s /q aidlc" }, "/p"),
+    ).toContain(hostPath("/p/aidlc"));
+    expect(
+      writeTargets("Bash", { command: "rsync --delete scratch/ aidlc" }, "/p"),
+    ).toContain(hostPath("/p/aidlc"));
+    expect(
+      writeTargets("Bash", { command: "find aidlc -print0 | xargs -0 rm -rf" }, "/p"),
+    ).toContain(hostPath("/p"));
     expect(writeTargets("Bash", { command: "sed -n '1p' /a/b.md" })).toEqual([]);
     expect(
       writeTargets("Bash", { command: "sed --version; cat /a/b.md" }),

--- a/tests/unit/t276-cursor-adapter.test.ts
+++ b/tests/unit/t276-cursor-adapter.test.ts
@@ -28,11 +28,12 @@
 //   - malformed stdin denies guards and remains advisory (empty stdout)
 //     on every other target.
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   appendFileSync,
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -40,10 +41,11 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  symlinkSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join, sep } from "node:path";
+import { basename, dirname, join, relative, sep, win32 } from "node:path";
 import {
   createIntent,
   readAllAuditShards,
@@ -69,6 +71,8 @@ const PAYLOADS = JSON.parse(
 ) as Record<string, Record<string, unknown>>;
 
 const scratch: string[] = [];
+
+setDefaultTimeout(20_000);
 
 afterEach(() => {
   for (const dir of scratch.splice(0)) {
@@ -110,16 +114,53 @@ function ledgerFilesFor(projectDir: string, suffix = ".json"): string[] {
     .map((name) => join(dir, name));
 }
 
+function witnessFilesFor(projectDir: string): string[] {
+  const dir = join(projectDir, "aidlc");
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(
+      (name) =>
+        name.startsWith(".aidlc-cursor-subagent-") && name.endsWith(".json"),
+    )
+    .map((name) => join(dir, name));
+}
+
 function clearLedger(projectDir: string): void {
   rmSync(ledgerDirFor(projectDir), { recursive: true, force: true });
 }
 
+function withBackslashes(path: string): string {
+  return path.replaceAll("/", "\\");
+}
+
+function withMixedSeparators(path: string): string {
+  let useBackslash = true;
+  return path.replace(/[\\/]/g, () => {
+    useBackslash = !useBackslash;
+    return useBackslash ? "\\" : "/";
+  });
+}
+
 function payload(name: string, projectDir: string, extra: Record<string, unknown> = {}): string {
-  const raw = JSON.stringify(PAYLOADS[name]);
+  const replacePlaceholders = (value: unknown): unknown => {
+    if (typeof value === "string") {
+      return value
+        .replaceAll("{{PROJECT}}", projectDir)
+        .replaceAll("{{TRANSCRIPT}}", `${projectDir}/t.jsonl`);
+    }
+    if (Array.isArray(value)) return value.map(replacePlaceholders);
+    if (value && typeof value === "object") {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+          key,
+          replacePlaceholders(item),
+        ]),
+      );
+    }
+    return value;
+  };
   return JSON.stringify({
-    ...(JSON.parse(
-      raw.replaceAll("{{PROJECT}}", projectDir).replaceAll("{{TRANSCRIPT}}", `${projectDir}/t.jsonl`),
-    ) as Record<string, unknown>),
+    ...(replacePlaceholders(PAYLOADS[name]) as Record<string, unknown>),
     ...extra,
   });
 }
@@ -129,10 +170,12 @@ function runAdapter(
   target: string,
   stdin: string,
   options: {
+    adapterProjectDir?: string;
     cwd?: string;
     env?: Record<string, string | undefined>;
   } = {},
 ): { stdout: string; stderr: string; code: number } {
+  const adapterProjectDir = options.adapterProjectDir ?? projectDir;
   const env: Record<string, string | undefined> = {
     ...process.env,
     AIDLC_PROJECT_DIR: projectDir,
@@ -144,9 +187,9 @@ function runAdapter(
   }
   const r = spawnSync(
     "bun",
-    [join(projectDir, ".cursor", "hooks", "aidlc-cursor-adapter.ts"), target],
+    [join(adapterProjectDir, ".cursor", "hooks", "aidlc-cursor-adapter.ts"), target],
     {
-      cwd: options.cwd ?? projectDir,
+      cwd: options.cwd ?? adapterProjectDir,
       input: stdin,
       encoding: "utf-8",
       env: env as NodeJS.ProcessEnv,
@@ -179,6 +222,48 @@ function registerTaskParent(projectDir: string): void {
       session_id: conversation,
     }),
   );
+}
+
+function activateReviewer(project: string): { record: string; dispatch: string } {
+  seedStateFile(project, "state-construction.md");
+  const record = seededRecordDir(project);
+  clearLedger(project);
+  const dispatch = join(record, ".aidlc-reviewer-dispatch.json");
+  writeFileSync(
+    dispatch,
+    JSON.stringify({
+      reviewer: "aidlc-architecture-reviewer-agent",
+      stage: "functional-design",
+      unit: "unit-a",
+      exempt: [],
+    }),
+  );
+  registerTaskParent(project);
+  runAdapter(project, "guards", payload("preToolUseTask", project));
+  return { record, dispatch };
+}
+
+function windowsAdminUnc(path: string): string {
+  const normalized = win32.normalize(path);
+  const parsed = win32.parse(normalized);
+  if (!/^[A-Za-z]:\\$/.test(parsed.root)) {
+    throw new Error(`expected a drive-qualified Windows path, got: ${path}`);
+  }
+  return `\\\\localhost\\${parsed.root[0]}$\\${normalized.slice(parsed.root.length)}`;
+}
+
+function windowsGitBashPath(path: string): string {
+  const normalized = win32.normalize(path);
+  const parsed = win32.parse(normalized);
+  if (!/^[A-Za-z]:\\$/.test(parsed.root)) {
+    throw new Error(`expected a drive-qualified Windows path, got: ${path}`);
+  }
+  return `/${parsed.root[0].toLowerCase()}/${normalized.slice(parsed.root.length).replaceAll("\\", "/")}`;
+}
+
+function withMixedUncSeparators(path: string): string {
+  if (!path.startsWith("\\\\")) throw new Error(`expected UNC path, got: ${path}`);
+  return `\\\\${withMixedSeparators(path.slice(2))}`;
 }
 
 function projectWithReadyReview(): { project: string; artifact: string } {
@@ -777,7 +862,7 @@ describe("t276 cursor adapter payload conversion", () => {
     );
     expect(own.code).toBe(0);
     expectAllowJson(own);
-  });
+  }, 15_000);
 
   test("17: Delete keeps its real name for the state-transition guard", () => {
     const proj = installedProject();
@@ -918,7 +1003,7 @@ describe("t276 cursor adapter payload conversion", () => {
     expect(out.agent_message ?? "").toContain("aidlc-reviewer-scope.ts failed");
   });
 
-  test("22b: an unavailable shared freeze parser keeps the full guard fail-closed", () => {
+  test("22b: an unavailable shared freeze parser denies before the guard chain", () => {
     const proj = installedProject();
     seedStateFile(proj, "state-construction.md");
     registerTaskParent(proj);
@@ -950,7 +1035,9 @@ describe("t276 cursor adapter payload conversion", () => {
       agent_message?: string;
     };
     expect(out.permission).toBe("deny");
-    expect(out.agent_message ?? "").toContain("aidlc-review-freeze.ts failed");
+    expect(out.agent_message ?? "").toContain(
+      "general-purpose interpreters",
+    );
   });
 
   test("23: Shell working_directory and captured cwd feed reviewer-scope and review-freeze", () => {
@@ -1038,7 +1125,7 @@ describe("t276 cursor adapter payload conversion", () => {
       }),
     );
     expect(JSON.parse(wrappedWrite.stdout).permission).toBe("deny");
-  });
+  }, 15_000);
 
   test("23b: guards reuse freeze target classification without skipping real writes", () => {
     const proj = installedProject();
@@ -1396,6 +1483,79 @@ if (import.meta.main) {
     expect(out.agent_message ?? "").toContain("identity is unavailable or ambiguous");
   });
 
+  test("25b: non-reviewer attribution survives primary-ledger loss and still blocks nested Task", () => {
+    const proj = installedProject();
+    seedStateFile(proj, "state-construction.md");
+    clearLedger(proj);
+    registerTaskParent(proj);
+    const spawn = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseTask", proj, {
+        tool_input: {
+          description: "Developer probe",
+          prompt: "Implement the unit.",
+          subagent_type: "aidlc-developer-agent",
+        },
+      }),
+    );
+    expectAllowJson(spawn);
+    expect(ledgerFilesFor(proj)).toHaveLength(1);
+    expect(witnessFilesFor(proj)).toHaveLength(1);
+
+    const encodedRemoval = Buffer.from(
+      `require("node:fs").rmSync(${JSON.stringify(ledgerDirFor(proj))}, { recursive: true, force: true });`,
+      "utf-8",
+    ).toString("base64");
+    const dynamicRemoval = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "developer-child",
+        session_id: "developer-child",
+        tool_input: {
+          command: `node -e 'eval(Buffer.from("${encodedRemoval}", "base64").toString())'`,
+        },
+      }),
+    );
+    const dynamicOut = JSON.parse(dynamicRemoval.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(dynamicOut.permission).toBe("deny");
+    expect(dynamicOut.agent_message ?? "").toContain(
+      "general-purpose interpreters",
+    );
+
+    rmSync(ledgerDirFor(proj), { recursive: true, force: true });
+    expect(witnessFilesFor(proj)).toHaveLength(1);
+    const nested = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseTask", proj, {
+        conversation_id: "developer-child",
+        session_id: "developer-child",
+        generation_id: "nested-generation",
+        tool_use_id: "nested-tool-use",
+        tool_input: {
+          description: "Nested probe",
+          prompt: "Delegate again.",
+          subagent_type: "aidlc-quality-agent",
+        },
+      }),
+    );
+    const nestedOut = JSON.parse(nested.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(nestedOut.permission).toBe("deny");
+    expect(nestedOut.agent_message ?? "").toContain(
+      "nested delegation is not allowed",
+    );
+    expect(ledgerFilesFor(proj)).toHaveLength(0);
+    expect(witnessFilesFor(proj)).toHaveLength(1);
+  });
+
   test("26: an idle top-level conversation remains main until sessionEnd", () => {
     const proj = installedProject();
     seedStateFile(proj, "state-construction.md");
@@ -1442,5 +1602,1934 @@ if (import.meta.main) {
     );
     expect(resumed.code).toBe(0);
     expectAllowJson(resumed);
+  });
+
+  test("27: attribution protection parses Windows and mixed-separator shell paths", () => {
+    const proj = installedProject();
+    seedStateFile(proj, "state-construction.md");
+    const record = seededRecordDir(proj);
+    const dispatch = join(record, ".aidlc-reviewer-dispatch.json");
+    writeFileSync(
+      dispatch,
+      JSON.stringify({
+        reviewer: "aidlc-architecture-reviewer-agent",
+        stage: "functional-design",
+        unit: "unit-a",
+        exempt: [],
+      }),
+    );
+    registerTaskParent(proj);
+    runAdapter(proj, "guards", payload("preToolUseTask", proj));
+
+    for (const target of [
+      `${withBackslashes(dispatch.slice(0, -1))}*`,
+      `${withMixedSeparators(dispatch.slice(0, -1))}*`,
+    ]) {
+      const removal = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-windows-path-conversation",
+          session_id: "reviewer-windows-path-conversation",
+          tool_input: { command: `rm -f ${target}` },
+        }),
+      );
+      const out = JSON.parse(removal.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      if (process.platform === "win32") {
+        expect(out.permission, target).toBe("deny");
+        expect(out.agent_message ?? "", target).toContain("attribution state");
+      } else {
+        expectAllowJson(removal, target);
+      }
+    }
+
+    for (const target of [
+      withBackslashes(join(proj, "scratch", "ordinary.txt")),
+      `${withMixedSeparators(join(proj, "scratch", "ordinary"))}*`,
+    ]) {
+      const safe = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-windows-path-conversation",
+          session_id: "reviewer-safe-windows-path-conversation",
+          tool_input: { command: `rm -f ${target}` },
+        }),
+      );
+      expectAllowJson(safe, target);
+    }
+
+    const executableSafeCommand = "echo aidlc-safe-command";
+    const executableSafe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-executable-safe-path-conversation",
+        session_id: "reviewer-executable-safe-path-conversation",
+        tool_input: { command: executableSafeCommand },
+      }),
+    );
+    expectAllowJson(executableSafe, executableSafeCommand);
+    const executed =
+      process.platform === "win32"
+        ? spawnSync(process.env.ComSpec ?? "cmd.exe", ["/d", "/c", executableSafeCommand])
+        : spawnSync("sh", ["-c", executableSafeCommand]);
+    expect(executed.status, executableSafeCommand).toBe(0);
+    expect(executed.stdout.toString(), executableSafeCommand).toContain("aidlc-safe-command");
+  });
+
+  test("28: POSIX ordinary-character escapes retain shell meaning for non-allowlisted mutators", () => {
+    if (process.platform === "win32") return;
+    const proj = installedProject();
+    const { dispatch } = activateReviewer(proj);
+    const escapedDispatch = dispatch.replace("dispatch", "dispatc\\h");
+    expect(escapedDispatch).not.toContain(".aidlc-reviewer-dispatch.json");
+
+    const expanded = spawnSync("sh", ["-c", `printf '%s' ${escapedDispatch}`], {
+      encoding: "utf-8",
+    });
+    expect(expanded.status).toBe(0);
+    expect(expanded.stdout).toBe(dispatch);
+
+    const removal = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-posix-escape-conversation",
+        session_id: "reviewer-posix-escape-conversation",
+        tool_input: { command: `shred -u ${escapedDispatch}` },
+      }),
+    );
+    const out = JSON.parse(removal.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(out.permission).toBe("deny");
+    expect(out.agent_message ?? "").toContain("attribution state");
+
+    const harmless = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-harmless-posix-escape-conversation",
+        session_id: "reviewer-harmless-posix-escape-conversation",
+        tool_input: { command: "printf '%s\\n' harmless\\h" },
+      }),
+    );
+    expectAllowJson(harmless);
+  });
+
+  test("29: Windows evaluator variants and unresolved expansion remain fail-closed", () => {
+    const proj = installedProject();
+    const { dispatch } = activateReviewer(proj);
+    const externalGitDir = join(proj, "scratch", "git-exec-path");
+    mkdirSync(externalGitDir, { recursive: true });
+    const externalGitProgram = join(
+      externalGitDir,
+      process.platform === "win32" ? "git-externalpwn.cmd" : "git-externalpwn",
+    );
+    writeFileSync(
+      externalGitProgram,
+      process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n",
+    );
+    if (process.platform !== "win32") chmodSync(externalGitProgram, 0o755);
+    const hooksDir = join(proj, "scratch", "git-hooks");
+    mkdirSync(hooksDir, { recursive: true });
+    const preCommitHook = join(hooksDir, "pre-commit");
+    writeFileSync(preCommitHook, "#!/bin/sh\nexit 0\n");
+    if (process.platform !== "win32") chmodSync(preCommitHook, 0o755);
+    const encoded = Buffer.from("Remove-Item $env:AIDLC_REVIEW_TARGET", "utf16le").toString(
+      "base64",
+    );
+    const commands = [
+      "builtin eval \"printf harmless\"",
+      "builtin builtin -- eval \"printf harmless\"",
+      "Invoke-Expression \"'harmless'\"",
+      "iex \"'harmless'\"",
+      "Start-Process echo -ArgumentList harmless",
+      "Invoke-Command { 'harmless' }",
+      `powershell.exe -NoProfile -EncodedCommand ${encoded}`,
+      `"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -Command "'a' + 'b'"`,
+      `cmd.exe /d /c "echo %AIDLC_REVIEW_TARGET%"`,
+      "del /q %AIDLC_REVIEW_TARGET%",
+      `del /q ${dispatch.replace("dispatch", "dispatc^h")}`,
+      "Remove-Item -Path ('ordinary-' + 'name')",
+      "cscript.exe harmless.vbs",
+      "wscript.exe harmless.vbs",
+      "mshta.exe about:blank",
+      "awk 'BEGIN { print 1 }'",
+      "busybox awk 'BEGIN { print 1 }'",
+      "rd -Recurse -Force ('ordinary-' + 'name')",
+      "git -c alias.pwn='!echo harmless | sh' pwn",
+      `& ('Remove' + '-Item') -Force ('${dispatch.slice(0, -"-dispatch.json".length)}' + '-dispatch.json')`,
+      "& ('Remove-Item'.ToString()) ordinary",
+      "PWN='!echo harmless | sh' git --config-env=alias.pwn=PWN pwn",
+      `GIT_CONFIG_GLOBAL=${join(proj, "scratch", "gitconfig")} git pwn`,
+      `git --exec-path=${externalGitDir} externalpwn`,
+      `GIT_EXEC_PATH=${externalGitDir} git externalpwn`,
+      `env GIT_EXEC_PATH=${externalGitDir} git externalpwn`,
+      `git -c core.hooksPath=${hooksDir} -c user.name=x -c user.email=x@y commit --allow-empty -m x`,
+      `GIT_EDITOR=${externalGitProgram} git commit --allow-empty -m x`,
+      `git -c diff.external=${externalGitProgram} diff`,
+      `git bisect run ${externalGitProgram}`,
+      `git submodule foreach ${externalGitProgram}`,
+      `git -c core.fsmonitor=${externalGitProgram} status --short`,
+      `GIT_PAGER=${externalGitProgram} git status --short`,
+      "git --no-pager branch -- --list",
+      "git --no-pager tag -- --list",
+      `git -c diff.external=${externalGitProgram} --no-pager diff --cached -- scratch/ordinary --no-ext-diff --no-textconv --ignore-submodules=all`,
+      `git -c diff.external=${externalGitProgram} --no-pager diff --cached --no-ext-diff --ext-diff --no-textconv --ignore-submodules=all scratch/ordinary`,
+      `git --no-pager diff --cached --no-ext-diff --no-textconv --textconv --ignore-submodules=all scratch/ordinary`,
+      "git --no-pager --paginate branch --list",
+      "git config alias.pwn '!echo harmless | sh'",
+      "git config --global alias.pwn '!echo harmless | sh'",
+    ];
+    for (const command of commands) {
+      expect(command).not.toContain(".aidlc-reviewer-dispatch.json");
+      const evaluation = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-windows-evaluator-conversation",
+          session_id: "reviewer-windows-evaluator-conversation",
+          tool_input: { command },
+        }),
+      );
+      const out = JSON.parse(evaluation.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(out.permission, command).toBe("deny");
+      expect(out.agent_message ?? "", command).toContain("dynamic command evaluation");
+    }
+
+    const harmless = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-harmless-evaluator-text-conversation",
+        session_id: "reviewer-harmless-evaluator-text-conversation",
+        tool_input: {
+          command:
+            "printf '%s\\n' 'powershell.exe cmd.exe cscript.exe wscript.exe mshta.exe awk Remove-Item + %TARGET% ^'",
+        },
+      }),
+    );
+    expectAllowJson(harmless);
+
+    for (const command of [
+      `rm -f ${join(proj, "scratch", "report+backup.txt")}`,
+      "git -c core.quotePath=false status --short",
+      "PROXY=http://127.0.0.1 git --config-env=http.proxy=PROXY status --short",
+      "git config --get alias.pwn",
+      `git --exec-path=${externalGitDir} status --short`,
+      `GIT_EXEC_PATH=${externalGitDir} git status --short`,
+      "GIT_PAGER=cat git status --short",
+      "git -c core.fsmonitor=false status --short",
+      "git rev-parse --is-inside-work-tree",
+    ]) {
+      const safe = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-evaluator-boundary-conversation",
+          session_id: "reviewer-safe-evaluator-boundary-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safe, command);
+    }
+
+    const init = spawnSync("git", ["init"], { cwd: proj, encoding: "utf-8" });
+    expect(init.status).toBe(0);
+    const unsafeAlternateRepo = join(proj, "scratch", "unsafe-alternate-repo");
+    const safeAlternateRepo = join(proj, "scratch", "safe-alternate-repo");
+    mkdirSync(unsafeAlternateRepo, { recursive: true });
+    mkdirSync(safeAlternateRepo, { recursive: true });
+    expect(spawnSync("git", ["init"], { cwd: unsafeAlternateRepo }).status).toBe(0);
+    expect(spawnSync("git", ["init"], { cwd: safeAlternateRepo }).status).toBe(0);
+    expect(
+      spawnSync("git", ["config", "core.fsmonitor", externalGitProgram], {
+        cwd: unsafeAlternateRepo,
+      }).status,
+    ).toBe(0);
+    const unsafeGitDir = join(unsafeAlternateRepo, ".git").replaceAll("\\", "/");
+    const unsafeWorkTree = unsafeAlternateRepo.replaceAll("\\", "/");
+    const safeGitDir = join(safeAlternateRepo, ".git").replaceAll("\\", "/");
+    const safeWorkTree = safeAlternateRepo.replaceAll("\\", "/");
+    for (const command of [
+      `GIT_DIR=${unsafeGitDir} GIT_WORK_TREE=${unsafeWorkTree} git status --ignore-submodules=all`,
+      `env GIT_DIR=${unsafeGitDir} GIT_WORK_TREE=${unsafeWorkTree} git status --ignore-submodules=all`,
+      `GIT_COMMON_DIR=${unsafeGitDir} git status --ignore-submodules=all`,
+    ]) {
+      const unsafeRepository = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-unsafe-alternate-repository-conversation",
+          session_id: "reviewer-unsafe-alternate-repository-conversation",
+          tool_input: { command },
+        }),
+      );
+      const unsafeRepositoryOut = JSON.parse(unsafeRepository.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(unsafeRepositoryOut.permission, command).toBe("deny");
+      expect(unsafeRepositoryOut.agent_message ?? "", command).toContain(
+        "dynamic command evaluation",
+      );
+    }
+
+    for (const command of [
+      `GIT_DIR=${safeGitDir} GIT_WORK_TREE=${safeWorkTree} git status --ignore-submodules=all`,
+      `env GIT_DIR=${safeGitDir} GIT_WORK_TREE=${safeWorkTree} git status --ignore-submodules=all`,
+      `GIT_COMMON_DIR=${safeGitDir} git status --ignore-submodules=all`,
+      `GIT_NAMESPACE=review git status --ignore-submodules=all`,
+    ]) {
+      const safeRepository = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-alternate-repository-conversation",
+          session_id: "reviewer-safe-alternate-repository-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safeRepository, command);
+    }
+
+    const unsetRepositorySelectors =
+      "env -u GIT_DIR -u GIT_WORK_TREE git status --ignore-submodules=all";
+    const safeUnsetRepository = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-unset-alternate-repository-conversation",
+        session_id: "reviewer-unset-alternate-repository-conversation",
+        tool_input: { command: unsetRepositorySelectors },
+      }),
+      { env: { GIT_DIR: unsafeGitDir, GIT_WORK_TREE: unsafeWorkTree } },
+    );
+    expectAllowJson(safeUnsetRepository, unsetRepositorySelectors);
+
+    const resetRepositorySelectors =
+      `env -i GIT_DIR=${safeGitDir} GIT_WORK_TREE=${safeWorkTree} git status --ignore-submodules=all`;
+    const safeResetRepository = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-reset-alternate-repository-conversation",
+        session_id: "reviewer-reset-alternate-repository-conversation",
+        tool_input: { command: resetRepositorySelectors },
+      }),
+    );
+    expectAllowJson(safeResetRepository, resetRepositorySelectors);
+
+    const alternateChild = join(safeAlternateRepo, "child");
+    mkdirSync(alternateChild, { recursive: true });
+    expect(spawnSync("git", ["init"], { cwd: alternateChild }).status).toBe(0);
+    expect(
+      spawnSync("git", ["config", "user.name", "AIDLC Test"], {
+        cwd: alternateChild,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["config", "user.email", "aidlc@example.invalid"], {
+        cwd: alternateChild,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["commit", "--allow-empty", "-m", "fixture"], {
+        cwd: alternateChild,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["config", "core.fsmonitor", externalGitProgram], {
+        cwd: alternateChild,
+      }).status,
+    ).toBe(0);
+    const alternateChildHead = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: alternateChild,
+      encoding: "utf-8",
+    }).stdout.trim();
+    expect(
+      spawnSync(
+        "git",
+        ["update-index", "--add", "--cacheinfo", "160000", alternateChildHead, "child"],
+        { cwd: safeAlternateRepo },
+      ).status,
+    ).toBe(0);
+    writeFileSync(join(proj, "README.md"), "# Safe pathspec fixture\n");
+
+    for (const command of [
+      `GIT_DIR=${safeGitDir} GIT_WORK_TREE=${safeWorkTree} git status --ignore-submodules=none`,
+      `env GIT_DIR=${safeGitDir} GIT_WORK_TREE=${safeWorkTree} git status --ignore-submodules=none`,
+    ]) {
+      const unsafeAlternateChild = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-unsafe-alternate-submodule-conversation",
+          session_id: "reviewer-unsafe-alternate-submodule-conversation",
+          tool_input: { command },
+        }),
+      );
+      const unsafeAlternateChildOut = JSON.parse(unsafeAlternateChild.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(unsafeAlternateChildOut.permission, command).toBe("deny");
+      expect(unsafeAlternateChildOut.agent_message ?? "", command).toContain(
+        "dynamic command evaluation",
+      );
+    }
+
+    const safeAlternateChildCommand =
+      `GIT_DIR=${safeGitDir} GIT_WORK_TREE=${safeWorkTree} git status --ignore-submodules=all`;
+    const safeAlternateChild = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-alternate-submodule-conversation",
+        session_id: "reviewer-safe-alternate-submodule-conversation",
+        tool_input: { command: safeAlternateChildCommand },
+      }),
+    );
+    expectAllowJson(safeAlternateChild, safeAlternateChildCommand);
+
+    const shellAlias = spawnSync(
+      "git",
+      ["config", "alias.pwn", "!echo harmless | sh"],
+      { cwd: proj, encoding: "utf-8" },
+    );
+    expect(shellAlias.status).toBe(0);
+    const persisted = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-persisted-git-alias-conversation",
+        session_id: "reviewer-persisted-git-alias-conversation",
+        tool_input: { command: "git pwn" },
+      }),
+    );
+    const persistedOut = JSON.parse(persisted.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(persistedOut.permission).toBe("deny");
+    expect(persistedOut.agent_message ?? "").toContain("dynamic command evaluation");
+
+    const safeAlias = spawnSync(
+      "git",
+      ["config", "alias.st", "status --short"],
+      { cwd: proj, encoding: "utf-8" },
+    );
+    expect(safeAlias.status).toBe(0);
+    const externalAlias = spawnSync(
+      "git",
+      ["config", "alias.ext", "externalpwn"],
+      { cwd: proj, encoding: "utf-8" },
+    );
+    expect(externalAlias.status).toBe(0);
+
+    const externalAliasCommand = `git --exec-path=${externalGitDir} ext`;
+    const externalAliasResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-persisted-external-git-alias-conversation",
+        session_id: "reviewer-persisted-external-git-alias-conversation",
+        tool_input: { command: externalAliasCommand },
+      }),
+    );
+    const externalAliasOut = JSON.parse(externalAliasResult.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(externalAliasOut.permission).toBe("deny");
+    expect(externalAliasOut.agent_message ?? "").toContain("dynamic command evaluation");
+
+    const submoduleDir = join(proj, "scratch", "status-submodule");
+    mkdirSync(submoduleDir, { recursive: true });
+    expect(spawnSync("git", ["init"], { cwd: submoduleDir }).status).toBe(0);
+    expect(
+      spawnSync("git", ["config", "user.name", "AIDLC Test"], {
+        cwd: submoduleDir,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["config", "user.email", "aidlc@example.invalid"], {
+        cwd: submoduleDir,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["commit", "--allow-empty", "-m", "fixture"], {
+        cwd: submoduleDir,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["config", "core.fsmonitor", externalGitProgram], {
+        cwd: submoduleDir,
+      }).status,
+    ).toBe(0);
+    const submoduleHead = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: submoduleDir,
+      encoding: "utf-8",
+    }).stdout.trim();
+    const submodulePath = "scratch/status-submodule";
+    const unsafeAlternateIndex = join(proj, "scratch", "unsafe-alternate.index");
+    const safeAlternateIndex = join(proj, "scratch", "safe-alternate.index");
+    const unsafeIndexEnv = {
+      ...process.env,
+      GIT_INDEX_FILE: unsafeAlternateIndex,
+    };
+    const safeIndexEnv = {
+      ...process.env,
+      GIT_INDEX_FILE: safeAlternateIndex,
+    };
+    expect(
+      spawnSync("git", ["read-tree", "--empty"], {
+        cwd: proj,
+        env: unsafeIndexEnv,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync(
+        "git",
+        ["update-index", "--add", "--cacheinfo", "160000", submoduleHead, submodulePath],
+        { cwd: proj, env: unsafeIndexEnv },
+      ).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["read-tree", "--empty"], {
+        cwd: proj,
+        env: safeIndexEnv,
+      }).status,
+    ).toBe(0);
+    const unsafeIndexValue = unsafeAlternateIndex.replaceAll("\\", "/");
+    const safeIndexValue = safeAlternateIndex.replaceAll("\\", "/");
+    for (const command of [
+      `GIT_INDEX_FILE=${unsafeIndexValue} git status --ignore-submodules=none`,
+      `env GIT_INDEX_FILE=${unsafeIndexValue} git status --ignore-submodules=none`,
+    ]) {
+      const unsafeIndexStatus = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-unsafe-alternate-index-conversation",
+          session_id: "reviewer-unsafe-alternate-index-conversation",
+          tool_input: { command },
+        }),
+      );
+      const unsafeIndexOut = JSON.parse(unsafeIndexStatus.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(unsafeIndexOut.permission, command).toBe("deny");
+      expect(unsafeIndexOut.agent_message ?? "", command).toContain(
+        "dynamic command evaluation",
+      );
+    }
+
+    for (const command of [
+      `GIT_INDEX_FILE=${safeIndexValue} git status --ignore-submodules=none`,
+      `env GIT_INDEX_FILE=${safeIndexValue} git status --ignore-submodules=none`,
+    ]) {
+      const safeIndexStatus = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-alternate-index-conversation",
+          session_id: "reviewer-safe-alternate-index-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safeIndexStatus, command);
+    }
+
+    const unsetIndexCommand =
+      "env -u GIT_INDEX_FILE git status --ignore-submodules=none";
+    const unsetIndexStatus = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-unset-alternate-index-conversation",
+        session_id: "reviewer-unset-alternate-index-conversation",
+        tool_input: { command: unsetIndexCommand },
+      }),
+      { env: { GIT_INDEX_FILE: unsafeIndexValue } },
+    );
+    expectAllowJson(unsetIndexStatus, unsetIndexCommand);
+
+    const resetIndexCommand =
+      `env -i GIT_INDEX_FILE=${safeIndexValue} git status --ignore-submodules=none`;
+    const resetIndexStatus = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-reset-alternate-index-conversation",
+        session_id: "reviewer-reset-alternate-index-conversation",
+        tool_input: { command: resetIndexCommand },
+      }),
+    );
+    expectAllowJson(resetIndexStatus, resetIndexCommand);
+
+
+    for (const command of [
+      "git --no-pager branch --list",
+      "git --no-pager tag --list",
+      "git --no-pager diff --cached --no-ext-diff --no-textconv --ignore-submodules=all",
+      "git --paginate --no-pager branch --list",
+      `git -c diff.external=${externalGitProgram} --no-pager diff --cached --ext-diff --no-ext-diff --textconv --no-textconv --ignore-submodules=none --ignore-submodules=all scratch/ordinary`,
+    ]) {
+      const safeInspection = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-git-inspection-conversation",
+          session_id: "reviewer-safe-git-inspection-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safeInspection, command);
+    }
+
+    const safePersisted = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-persisted-git-alias-conversation",
+        session_id: "reviewer-safe-persisted-git-alias-conversation",
+        tool_input: { command: "git st" },
+      }),
+    );
+    expectAllowJson(safePersisted, "git st");
+
+    const safePersistedWithExecPath = `git --exec-path=${externalGitDir} st`;
+    const safePersistedExecPath = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-persisted-git-exec-path-conversation",
+        session_id: "reviewer-safe-persisted-git-exec-path-conversation",
+        tool_input: { command: safePersistedWithExecPath },
+      }),
+    );
+    expectAllowJson(safePersistedExecPath, safePersistedWithExecPath);
+
+    const nestedRepo = join(proj, "scratch", "nested-repo");
+    mkdirSync(nestedRepo, { recursive: true });
+    expect(spawnSync("git", ["init"], { cwd: nestedRepo }).status).toBe(0);
+    expect(
+      spawnSync("git", ["config", "alias.pwn", "!echo harmless | sh"], {
+        cwd: nestedRepo,
+      }).status,
+    ).toBe(0);
+    expect(
+      spawnSync("git", ["config", "alias.st", "status --short"], {
+        cwd: nestedRepo,
+      }).status,
+    ).toBe(0);
+    const nestedRelative = relative(proj, nestedRepo).replaceAll("\\", "/");
+    for (const command of [
+      `git -C ${nestedRelative} pwn`,
+      `git --git-dir=${nestedRelative}/.git --work-tree=${nestedRelative} pwn`,
+      `env -C ${nestedRelative} git pwn`,
+      `env --chdir=${nestedRelative} git pwn`,
+    ]) {
+      const nestedAlias = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-nested-persisted-git-alias-conversation",
+          session_id: "reviewer-nested-persisted-git-alias-conversation",
+          tool_input: { command },
+        }),
+      );
+      const nestedOut = JSON.parse(nestedAlias.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(nestedOut.permission, command).toBe("deny");
+      expect(nestedOut.agent_message ?? "", command).toContain("dynamic command evaluation");
+    }
+    for (const command of [
+      `git -C ${nestedRelative} st`,
+      `env --chdir=${nestedRelative} git st`,
+    ]) {
+      const safeNestedAlias = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-nested-persisted-git-alias-conversation",
+          session_id: "reviewer-safe-nested-persisted-git-alias-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safeNestedAlias, command);
+    }
+
+    if (process.platform !== "win32") {
+      const alternateHome = join(proj, "scratch", "alternate-home");
+      mkdirSync(alternateHome, { recursive: true });
+      writeFileSync(
+        join(alternateHome, ".gitconfig"),
+        "[alias]\n  homepwn = !echo harmless | sh\n  homest = status --short\n",
+      );
+      const xdgHome = join(proj, "scratch", "xdg-home");
+      mkdirSync(join(xdgHome, "git"), { recursive: true });
+      writeFileSync(
+        join(xdgHome, "git", "config"),
+        "[alias]\n  xdgpwn = !echo harmless | sh\n",
+      );
+      const safeHome = join(proj, "scratch", "safe-home");
+      mkdirSync(safeHome, { recursive: true });
+      writeFileSync(
+        join(safeHome, ".gitconfig"),
+        "[alias]\n  homest = status --short\n",
+      );
+      for (const command of [
+        `HOME=${alternateHome} git homepwn`,
+        `XDG_CONFIG_HOME=${xdgHome} git xdgpwn`,
+        `env HOME=${alternateHome} git homepwn`,
+        `env XDG_CONFIG_HOME=${xdgHome} git xdgpwn`,
+        `env -S 'HOME=${alternateHome} git homepwn'`,
+        `env --split-string='XDG_CONFIG_HOME=${xdgHome} git xdgpwn'`,
+        `command env HOME=${alternateHome} git homepwn`,
+        `nice -n 5 env HOME=${alternateHome} git homepwn`,
+        `timeout 5 env HOME=${alternateHome} git homepwn`,
+        `env -a git HOME=${alternateHome} git homepwn`,
+        `env --argv0 git HOME=${alternateHome} git homepwn`,
+        `env --argv0=git HOME=${alternateHome} git homepwn`,
+        `command env -a git HOME=${alternateHome} git homepwn`,
+        `exec -a ignored env HOME=${alternateHome} git homepwn`,
+        `command exec -a ignored env HOME=${alternateHome} git homepwn`,
+        `printf 'x:' | xargs -d : env HOME=${alternateHome} git homepwn`,
+        `xargs --delimiter : env HOME=${alternateHome} git homepwn`,
+        `xargs --delimiter=: env HOME=${alternateHome} git homepwn`,
+        `xargs --eof env HOME=${alternateHome} git homepwn`,
+        `xargs --eof=STOP env HOME=${alternateHome} git homepwn`,
+        `xargs --replace env HOME=${alternateHome} git homepwn`,
+        `xargs --replace=TOKEN env HOME=${alternateHome} git homepwn`,
+        `xargs --max-lines env HOME=${alternateHome} git homepwn`,
+        `xargs --max-lines=1 env HOME=${alternateHome} git homepwn`,
+        `xargs -L 1 env HOME=${alternateHome} git homepwn`,
+        `xargs --process-slot-var SLOT env HOME=${alternateHome} git homepwn`,
+        `xargs -J REPL env HOME=${alternateHome} git homepwn`,
+        `ENV.EXE HOME=${alternateHome} GIT.EXE homepwn`,
+        `"C:/Program Files/Git/usr/bin/ENV.EXE" HOME=${alternateHome} "C:/Program Files/Git/cmd/GIT.EXE" homepwn`,
+        `env -uHOME HOME=${alternateHome} git homepwn`,
+        `env -C${proj} HOME=${alternateHome} git homepwn`,
+        `env -agit HOME=${alternateHome} git homepwn`,
+        `env -i0 HOME=${alternateHome} git homepwn`,
+        `HOME=${safeHome} git homest; HOME=${alternateHome} git homepwn`,
+      ]) {
+        const alternateAlias = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: "reviewer-command-local-git-alias-conversation",
+            session_id: "reviewer-command-local-git-alias-conversation",
+            tool_input: { command },
+          }),
+        );
+        const alternateOut = JSON.parse(alternateAlias.stdout) as {
+          permission?: string;
+          agent_message?: string;
+        };
+        expect(alternateOut.permission, command).toBe("deny");
+        expect(alternateOut.agent_message ?? "", command).toContain(
+          "dynamic command evaluation",
+        );
+      }
+
+      const ambiguousWrapperCommand =
+        `xargs --future-value SLOT env HOME=${alternateHome} git homepwn`;
+      const ambiguousWrapper = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-ambiguous-wrapper-conversation",
+          session_id: "reviewer-ambiguous-wrapper-conversation",
+          tool_input: { command: ambiguousWrapperCommand },
+        }),
+      );
+      const ambiguousWrapperOut = JSON.parse(ambiguousWrapper.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(ambiguousWrapperOut.permission).toBe("deny");
+      expect(ambiguousWrapperOut.agent_message ?? "").toContain("attribution state");
+      const safeAlternateCommand = `HOME=${alternateHome} git homest`;
+      const safeAlternate = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-command-local-git-alias-conversation",
+          session_id: "reviewer-safe-command-local-git-alias-conversation",
+          tool_input: { command: safeAlternateCommand },
+        }),
+      );
+      expectAllowJson(safeAlternate, safeAlternateCommand);
+
+      const safeEnvCommand = `env HOME=${alternateHome} git homest`;
+      const safeEnv = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-env-git-alias-conversation",
+          session_id: "reviewer-safe-env-git-alias-conversation",
+          tool_input: { command: safeEnvCommand },
+        }),
+      );
+      expectAllowJson(safeEnv, safeEnvCommand);
+
+      const safeSplitCommand = `env -S 'HOME=${safeHome} git homest'`;
+      const safeSplit = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-split-env-git-alias-conversation",
+          session_id: "reviewer-safe-split-env-git-alias-conversation",
+          tool_input: { command: safeSplitCommand },
+        }),
+      );
+      expectAllowJson(safeSplit, safeSplitCommand);
+
+      for (const { command, env } of [
+        {
+          command: "env -u HOME git status --short",
+          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
+        },
+        {
+          command: "env --unset=HOME git status --short",
+          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
+        },
+        {
+          command: "env -uHOME git status --short",
+          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
+        },
+        {
+          command: "env -u XDG_CONFIG_HOME git status --short",
+          env: { HOME: undefined, XDG_CONFIG_HOME: xdgHome },
+        },
+        {
+          command: "env -i git status --short",
+          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
+        },
+        {
+          command: "env --ignore-environment git status --short",
+          env: { HOME: undefined, XDG_CONFIG_HOME: xdgHome },
+        },
+        {
+          command: "command env -u HOME git status --short",
+          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
+        },
+        {
+          command: "nice env -i git status --short",
+          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
+        },
+      ]) {
+        const clearedAlias = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: "reviewer-cleared-git-environment-conversation",
+            session_id: "reviewer-cleared-git-environment-conversation",
+            tool_input: { command },
+          }),
+          { env },
+        );
+        expectAllowJson(clearedAlias, command);
+      }
+
+      for (const command of [
+        `env -u HOME HOME=${alternateHome} git homepwn`,
+        `env -i HOME=${alternateHome} git homepwn`,
+        `env -uHOME HOME=${alternateHome} git homepwn`,
+        `env -i0 HOME=${alternateHome} git homepwn`,
+      ]) {
+        const restoredAlias = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: "reviewer-restored-git-environment-conversation",
+            session_id: "reviewer-restored-git-environment-conversation",
+            tool_input: { command },
+          }),
+        );
+        const restoredOut = JSON.parse(restoredAlias.stdout) as {
+          permission?: string;
+          agent_message?: string;
+        };
+        expect(restoredOut.permission, command).toBe("deny");
+        expect(restoredOut.agent_message ?? "", command).toContain(
+          "dynamic command evaluation",
+        );
+      }
+
+      for (const command of [
+        `command env HOME=${alternateHome} git homest`,
+        `nice env HOME=${alternateHome} git homest`,
+        `timeout 5 env HOME=${alternateHome} git homest`,
+      ]) {
+        const safeWrappedAlias = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: "reviewer-safe-wrapped-git-environment-conversation",
+            session_id: "reviewer-safe-wrapped-git-environment-conversation",
+            tool_input: { command },
+          }),
+        );
+        expectAllowJson(safeWrappedAlias, command);
+      }
+
+      const mainConversation = PAYLOADS.preToolUseTask.conversation_id;
+      if (typeof mainConversation !== "string") {
+        throw new Error("preToolUseTask fixture is missing conversation_id");
+      }
+      const safeClusterCommand = "env -i0 git status --short";
+      const safeCluster = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: mainConversation,
+          session_id: mainConversation,
+          tool_input: { command: safeClusterCommand },
+        }),
+        { env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined } },
+      );
+      expectAllowJson(safeCluster, safeClusterCommand);
+
+      for (const command of [
+        `env -a git HOME=${alternateHome} git homest`,
+        `env --argv0 git HOME=${alternateHome} git homest`,
+        `env --argv0=git HOME=${alternateHome} git homest`,
+        `exec -a ignored env HOME=${alternateHome} git homest`,
+        `command exec -a ignored env HOME=${alternateHome} git homest`,
+        `xargs -d : env HOME=${alternateHome} git homest`,
+        `xargs --delimiter : env HOME=${alternateHome} git homest`,
+        `xargs --delimiter=: env HOME=${alternateHome} git homest`,
+        `xargs --eof env HOME=${alternateHome} git homest`,
+        `xargs --eof=STOP env HOME=${alternateHome} git homest`,
+        `xargs --replace env HOME=${alternateHome} git homest`,
+        `xargs --replace=TOKEN env HOME=${alternateHome} git homest`,
+        `xargs --max-lines env HOME=${alternateHome} git homest`,
+        `xargs --max-lines=1 env HOME=${alternateHome} git homest`,
+        `xargs -L 1 env HOME=${alternateHome} git homest`,
+        `xargs --process-slot-var SLOT env HOME=${alternateHome} git homest`,
+        `xargs -J REPL env HOME=${alternateHome} git homest`,
+        `xargs -rt --max-lines env HOME=${alternateHome} git homest`,
+        `ENV.EXE HOME=${alternateHome} GIT.EXE homest`,
+        `"C:/Program Files/Git/usr/bin/ENV.EXE" HOME=${alternateHome} "C:/Program Files/Git/cmd/GIT.EXE" homest`,
+        `env -C/tmp HOME=${alternateHome} git homest`,
+        `env -agit HOME=${alternateHome} git homest`,
+        `env -i0 HOME=${alternateHome} git homest`,
+      ]) {
+        const safeArgv0Alias = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: mainConversation,
+            session_id: mainConversation,
+            tool_input: { command },
+          }),
+        );
+        expectAllowJson(safeArgv0Alias, command);
+      }
+    } else {
+      const envExe = "C:\\Program Files\\Git\\usr\\bin\\env.exe";
+      const gitExe = "C:\\Program Files\\Git\\cmd\\git.exe";
+      expect(existsSync(envExe)).toBe(true);
+      expect(existsSync(gitExe)).toBe(true);
+      const alternateHome = join(proj, "scratch", "windows-alternate-home");
+      mkdirSync(alternateHome, { recursive: true });
+      writeFileSync(
+        join(alternateHome, ".gitconfig"),
+        "[alias]\n  homepwn = !echo harmless | sh\n  homest = status --short\n",
+      );
+      const homeValue = alternateHome.replaceAll("\\", "/");
+      for (const command of [
+        `ENV.EXE HOME=${homeValue} GIT.EXE homepwn`,
+        `"${envExe}" HOME=${homeValue} "${gitExe}" homepwn`,
+      ]) {
+        const dangerousExeWrapper = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: "reviewer-windows-exe-wrapper-conversation",
+            session_id: "reviewer-windows-exe-wrapper-conversation",
+            tool_input: { command },
+          }),
+        );
+        const dangerousOut = JSON.parse(dangerousExeWrapper.stdout) as {
+          permission?: string;
+          agent_message?: string;
+        };
+        expect(dangerousOut.permission, command).toBe("deny");
+        expect(dangerousOut.agent_message ?? "", command).toContain(
+          "dynamic command evaluation",
+        );
+      }
+
+      const mainConversation = PAYLOADS.preToolUseTask.conversation_id;
+      if (typeof mainConversation !== "string") {
+        throw new Error("preToolUseTask fixture is missing conversation_id");
+      }
+      for (const command of [
+        `ENV.EXE HOME=${homeValue} GIT.EXE homest`,
+        `"${envExe}" HOME=${homeValue} "${gitExe}" homest`,
+      ]) {
+        const safeExeWrapper = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: mainConversation,
+            session_id: mainConversation,
+            tool_input: { command },
+          }),
+        );
+        expectAllowJson(safeExeWrapper, command);
+      }
+    }
+
+    writeFileSync(
+      join(proj, ".gitmodules"),
+      `[submodule "status-fixture"]\n  path = ${submodulePath}\n  url = ./status-submodule\n`,
+    );
+    expect(
+      spawnSync(
+        "git",
+        ["update-index", "--add", "--cacheinfo", "160000", submoduleHead, submodulePath],
+        { cwd: proj },
+      ).status,
+    ).toBe(0);
+
+    const recursiveStatusCommand = "git status --short --ignore-submodules=none";
+    const recursiveStatus = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-submodule-status-conversation",
+        session_id: "reviewer-submodule-status-conversation",
+        tool_input: { command: recursiveStatusCommand },
+      }),
+    );
+    const recursiveStatusOut = JSON.parse(recursiveStatus.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(recursiveStatusOut.permission).toBe("deny");
+    expect(recursiveStatusOut.agent_message ?? "").toContain("dynamic command evaluation");
+
+    const safeRestrictedStatus = "git status --short -- README.md";
+    const safeRestrictedResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-restricted-status-conversation",
+        session_id: "reviewer-safe-restricted-status-conversation",
+        tool_input: { command: safeRestrictedStatus },
+      }),
+    );
+    expectAllowJson(safeRestrictedResult, safeRestrictedStatus);
+
+    for (const command of [
+      "git status --short README.md",
+      "git status --short --untracked-files=no README.md",
+      "git -C scratch status ordinary.txt",
+    ]) {
+      const safePositionalStatus = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-positional-status-conversation",
+          session_id: "reviewer-safe-positional-status-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safePositionalStatus, command);
+    }
+
+    const unsafeRestrictedStatus =
+      `git status --short -- ${submodulePath}`;
+    const unsafeRestrictedResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-unsafe-restricted-status-conversation",
+        session_id: "reviewer-unsafe-restricted-status-conversation",
+        tool_input: { command: unsafeRestrictedStatus },
+      }),
+    );
+    const unsafeRestrictedOut = JSON.parse(unsafeRestrictedResult.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(unsafeRestrictedOut.permission).toBe("deny");
+    expect(unsafeRestrictedOut.agent_message ?? "").toContain(
+      "dynamic command evaluation",
+    );
+
+    for (const command of [
+      `git status --short ${submodulePath}`,
+      "git -C scratch status status-submodule",
+    ]) {
+      const unsafePositionalStatus = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-unsafe-positional-status-conversation",
+          session_id: "reviewer-unsafe-positional-status-conversation",
+          tool_input: { command },
+        }),
+      );
+      const unsafePositionalOut = JSON.parse(unsafePositionalStatus.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(unsafePositionalOut.permission, command).toBe("deny");
+      expect(unsafePositionalOut.agent_message ?? "", command).toContain(
+        "dynamic command evaluation",
+      );
+    }
+
+    writeFileSync(join(proj, "scratch", "ordinary.txt"), "safe\n");
+    const nestedCwdStatus = "git -C scratch status -- status-submodule";
+    const nestedCwdResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-nested-cwd-status-conversation",
+        session_id: "reviewer-nested-cwd-status-conversation",
+        tool_input: { command: nestedCwdStatus },
+      }),
+    );
+    const nestedCwdOut = JSON.parse(nestedCwdResult.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(nestedCwdOut.permission).toBe("deny");
+    expect(nestedCwdOut.agent_message ?? "").toContain("dynamic command evaluation");
+
+    for (const command of [
+      "git -C scratch status -- ordinary.txt",
+      "git -C scratch status -- ':(top)README.md'",
+    ]) {
+      const safeNestedCwd = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-nested-cwd-status-conversation",
+          session_id: "reviewer-safe-nested-cwd-status-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safeNestedCwd, command);
+    }
+
+    const workingDirectoryStatus = "git status -- status-submodule";
+    const workingDirectoryResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-working-directory-status-conversation",
+        session_id: "reviewer-working-directory-status-conversation",
+        tool_input: {
+          command: workingDirectoryStatus,
+          working_directory: join(proj, "scratch"),
+        },
+      }),
+    );
+    const workingDirectoryOut = JSON.parse(workingDirectoryResult.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(workingDirectoryOut.permission).toBe("deny");
+    expect(workingDirectoryOut.agent_message ?? "").toContain(
+      "dynamic command evaluation",
+    );
+
+    const safeWorkingDirectoryStatus = "git status -- ordinary.txt";
+    const safeWorkingDirectoryResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-working-directory-status-conversation",
+        session_id: "reviewer-safe-working-directory-status-conversation",
+        tool_input: {
+          command: safeWorkingDirectoryStatus,
+          working_directory: join(proj, "scratch"),
+        },
+      }),
+    );
+    expectAllowJson(safeWorkingDirectoryResult, safeWorkingDirectoryStatus);
+
+    const conflictingStatusCommand =
+      "git status --short --ignore-submodules=all --ignore-submodules=none";
+    const conflictingStatus = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-conflicting-submodule-status-conversation",
+        session_id: "reviewer-conflicting-submodule-status-conversation",
+        tool_input: { command: conflictingStatusCommand },
+      }),
+    );
+    const conflictingStatusOut = JSON.parse(conflictingStatus.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(conflictingStatusOut.permission).toBe("deny");
+    expect(conflictingStatusOut.agent_message ?? "").toContain("dynamic command evaluation");
+
+    const disguisedStatusCommand =
+      "git status --short -- scratch --ignore-submodules=all";
+    const disguisedStatus = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-disguised-submodule-status-conversation",
+        session_id: "reviewer-disguised-submodule-status-conversation",
+        tool_input: { command: disguisedStatusCommand },
+      }),
+    );
+    const disguisedStatusOut = JSON.parse(disguisedStatus.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(disguisedStatusOut.permission).toBe("deny");
+    expect(disguisedStatusOut.agent_message ?? "").toContain("dynamic command evaluation");
+
+    const ignoredSubmoduleStatus =
+      "git status --short --ignore-submodules=all";
+    const safeIgnoredStatus = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-submodule-status-conversation",
+        session_id: "reviewer-safe-submodule-status-conversation",
+        tool_input: { command: ignoredSubmoduleStatus },
+      }),
+    );
+    expectAllowJson(safeIgnoredStatus, ignoredSubmoduleStatus);
+
+    const safeConflictingStatus =
+      "git status --short --ignore-submodules=none --ignore-submodules=all";
+    const safeEffectiveStatus = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-effective-submodule-status-conversation",
+        session_id: "reviewer-safe-effective-submodule-status-conversation",
+        tool_input: { command: safeConflictingStatus },
+      }),
+    );
+    expectAllowJson(safeEffectiveStatus, safeConflictingStatus);
+
+    rmSync(join(proj, ".gitmodules"), { force: true });
+    const manifestlessStatus =
+      "git status --short --ignore-submodules=none";
+    const manifestlessResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-manifestless-gitlink-status-conversation",
+        session_id: "reviewer-manifestless-gitlink-status-conversation",
+        tool_input: { command: manifestlessStatus },
+      }),
+    );
+    const manifestlessOut = JSON.parse(manifestlessResult.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(manifestlessOut.permission).toBe("deny");
+    expect(manifestlessOut.agent_message ?? "").toContain("dynamic command evaluation");
+
+    expect(
+      spawnSync("git", ["update-index", "--force-remove", submodulePath], {
+        cwd: proj,
+      }).status,
+    ).toBe(0);
+    writeFileSync(
+      join(proj, ".gitmodules"),
+      `[submodule "stale-status-fixture"]\n  path = ${submodulePath}\n  url = ./status-submodule\n`,
+    );
+    const staleManifestStatus =
+      "git status --short --ignore-submodules=none";
+    const staleManifestResult = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-stale-submodule-manifest-conversation",
+        session_id: "reviewer-stale-submodule-manifest-conversation",
+        tool_input: { command: staleManifestStatus },
+      }),
+    );
+    expectAllowJson(staleManifestResult, staleManifestStatus);
+  }, 55_000);
+
+  test("30: existing symlink or junction aliases cannot hide protected attribution paths", () => {
+    const proj = installedProject();
+    const { record } = activateReviewer(proj);
+    const protectedAlias = join(proj, "protected-review-alias");
+    symlinkSync(record, protectedAlias, process.platform === "win32" ? "junction" : "dir");
+    const aliasedRemoval =
+      `shred -u ${join(protectedAlias, ".aidlc-reviewer-dispatch.jso")}*`;
+    const removal = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-path-alias-conversation",
+        session_id: "reviewer-path-alias-conversation",
+        tool_input: { command: aliasedRemoval },
+      }),
+    );
+    const out = JSON.parse(removal.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(out.permission).toBe("deny");
+    expect(out.agent_message ?? "").toContain("attribution state");
+
+    const safeDir = join(proj, "scratch", "safe-target");
+    mkdirSync(safeDir, { recursive: true });
+    const safeAlias = join(proj, "safe-review-alias");
+    symlinkSync(safeDir, safeAlias, process.platform === "win32" ? "junction" : "dir");
+    const safe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-path-alias-conversation",
+        session_id: "reviewer-safe-path-alias-conversation",
+        tool_input: { command: `shred -u ${join(safeAlias, "ordinary")}*` },
+      }),
+    );
+    expectAllowJson(safe);
+  });
+
+  test("31: Windows device, 8.3, trailing-alias, and Git-Bash paths are canonicalized", () => {
+    if (process.platform !== "win32") return;
+    const proj = installedProject();
+    const { dispatch } = activateReviewer(proj);
+    const short = spawnSync(
+      process.env.ComSpec ?? "cmd.exe",
+      ["/d", "/c", `for %I in ("${dirname(dispatch)}") do @echo %~sI`],
+      { encoding: "utf-8" },
+    );
+    expect(short.status).toBe(0);
+    const shortDir = short.stdout.trim();
+    expect(shortDir.length).toBeGreaterThan(0);
+    expect(shortDir.toLowerCase()).not.toBe(dirname(dispatch).toLowerCase());
+    const shortFileResult = spawnSync(
+      process.env.ComSpec ?? "cmd.exe",
+      ["/d", "/c", `for %I in ("${dispatch}") do @echo %~sI`],
+      { encoding: "utf-8" },
+    );
+    expect(shortFileResult.status).toBe(0);
+    const shortFile = shortFileResult.stdout.trim();
+    expect(shortFile.length).toBeGreaterThan(0);
+    expect(basename(shortFile).toLowerCase()).not.toBe(basename(dispatch).toLowerCase());
+    const nativeProject = win32.normalize(proj);
+    const projectParent = dirname(nativeProject);
+    const wildcardProject =
+      `${basename(nativeProject).replace(/^[ .]+/, "").replace(/[ .]/g, "").slice(0, 6).toUpperCase()}~?`;
+
+    const protectedTargets = [
+      `${windowsGitBashPath(dispatch.slice(0, -1))}*`,
+      `\\\\?\\${dispatch.slice(0, -1)}*`,
+      join(dirname(dispatch), ".AIDLC-REVIEWER-DISPATCH.JSON. "),
+      `${join(shortDir, basename(dispatch).slice(0, -1))}*`,
+      `${shortFile.slice(0, -1)}*`,
+      join(
+        projectParent,
+        wildcardProject,
+        `${relative(proj, dispatch).slice(0, -1)}*`,
+      ),
+    ];
+    for (const target of protectedTargets) {
+      const removal = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-windows-alias-conversation",
+          session_id: "reviewer-windows-alias-conversation",
+          tool_input: { command: `del /q ${target}` },
+        }),
+      );
+      const out = JSON.parse(removal.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(out.permission, target).toBe("deny");
+      expect(out.agent_message ?? "", target).toContain("attribution state");
+    }
+
+    const safePath = join(proj, "scratch", "native-safe.txt");
+    mkdirSync(dirname(safePath), { recursive: true });
+    writeFileSync(safePath, "safe\n");
+    const safeCommand = `del /q ${safePath}`;
+    const safe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-native-safe-path-conversation",
+        session_id: "reviewer-native-safe-path-conversation",
+        tool_input: { command: safeCommand },
+      }),
+    );
+    expectAllowJson(safe, safeCommand);
+    const executed = spawnSync(
+      process.env.ComSpec ?? "cmd.exe",
+      ["/d", "/c", safeCommand],
+      { encoding: "utf-8" },
+    );
+    expect(executed.status, executed.stderr).toBe(0);
+    expect(existsSync(safePath)).toBe(false);
+
+    const safeDirectory = join(proj, "scratch", "quoted-safe-directory");
+    mkdirSync(safeDirectory, { recursive: true });
+    for (const command of [
+      `dir ${safeDirectory}\\`,
+      `dir "${safeDirectory}\\"`,
+    ]) {
+      const directoryRead = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-trailing-directory-conversation",
+          session_id: "reviewer-safe-trailing-directory-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(directoryRead, command);
+    }
+
+    const safeShortGlob = join(proj, "ORDINA~1.*");
+    const safeShortRemoval = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-short-name-conversation",
+        session_id: "reviewer-safe-short-name-conversation",
+        tool_input: { command: `del /q ${safeShortGlob}` },
+      }),
+    );
+    expectAllowJson(safeShortRemoval, safeShortGlob);
+
+    const safeAncestorGlob = join(projectParent, "ORDINA~?", "ordinary.txt");
+    const safeAncestorRemoval = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-short-ancestor-conversation",
+        session_id: "reviewer-safe-short-ancestor-conversation",
+        tool_input: { command: `del /q ${safeAncestorGlob}` },
+      }),
+    );
+    expectAllowJson(safeAncestorRemoval, safeAncestorGlob);
+  }, 20_000);
+
+  test("32: native and mixed UNC wildcard paths retain their protected root", () => {
+    if (process.platform !== "win32") return;
+    const localProject = installedProject();
+    const project = windowsAdminUnc(localProject);
+    expect(existsSync(project)).toBe(true);
+    seedStateFile(project, "state-construction.md");
+    const record = seededRecordDir(project);
+    const dispatch = join(record, ".aidlc-reviewer-dispatch.json");
+    writeFileSync(
+      dispatch,
+      JSON.stringify({
+        reviewer: "aidlc-architecture-reviewer-agent",
+        stage: "functional-design",
+        unit: "unit-a",
+        exempt: [],
+      }),
+    );
+    mkdirSync(ledgerDirFor(project), { recursive: true });
+    writeFileSync(
+      join(ledgerDirFor(project), "spawn-unc-reviewer.json"),
+      JSON.stringify({
+        agent: "aidlc-architecture-reviewer-agent",
+        parent: "unc-parent",
+        task: "unc-review",
+      }),
+    );
+    for (const target of [
+      `${dispatch.slice(0, -1)}*`,
+      `${withMixedUncSeparators(dispatch.slice(0, -1))}*`,
+    ]) {
+      const removal = runAdapter(
+        project,
+        "guards",
+        payload("preToolUseShell", project, {
+          conversation_id: "reviewer-unc-path-conversation",
+          session_id: "reviewer-unc-path-conversation",
+          tool_input: { command: `del /q ${target}` },
+        }),
+        { adapterProjectDir: localProject, cwd: localProject },
+      );
+      const out = JSON.parse(removal.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(out.permission, target).toBe("deny");
+      expect(out.agent_message ?? "", target).toContain("attribution state");
+    }
+  }, 20_000);
+
+  test("33: POSIX and PowerShell home aliases resolve before protected-path comparison", () => {
+    const proj = installedProject();
+    const { dispatch } = activateReviewer(proj);
+    const relative = dispatch.slice(proj.length + 1);
+    const protectedTarget =
+      process.platform === "win32"
+        ? `~\\${relative.replaceAll("/", "\\").slice(0, -1)}*`
+        : `~/${relative.slice(0, -1)}*`;
+    const command =
+      process.platform === "win32"
+        ? `Remove-Item ${protectedTarget}`
+        : `shred -u ${protectedTarget}`;
+    const removal = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-home-alias-conversation",
+        session_id: "reviewer-home-alias-conversation",
+        tool_input: { command },
+      }),
+      {
+        env: {
+          HOME: proj,
+          USERPROFILE: proj,
+        },
+      },
+    );
+    const out = JSON.parse(removal.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(out.permission).toBe("deny");
+    expect(out.agent_message ?? "").toContain("attribution state");
+
+    if (process.platform !== "win32") {
+      for (const currentTargetCommand of [
+        `shred -u ~+/${relative.slice(0, -1)}*`,
+        "find ~+/aidlc/.aidlc-cursor-subagent* -depth -delete",
+        `shred -u ~-/${relative.slice(0, -1)}*`,
+        "find ~-/aidlc/.aidlc-cursor-subagent* -depth -delete",
+      ]) {
+        const currentTarget = runAdapter(
+          proj,
+          "guards",
+          payload("preToolUseShell", proj, {
+            conversation_id: "reviewer-current-directory-alias-conversation",
+            session_id: "reviewer-current-directory-alias-conversation",
+            tool_input: { command: currentTargetCommand },
+          }),
+          {
+            env: {
+              HOME: proj,
+              OLDPWD: proj,
+              USERPROFILE: proj,
+            },
+          },
+        );
+        const currentOut = JSON.parse(currentTarget.stdout) as {
+          permission?: string;
+          agent_message?: string;
+        };
+        expect(currentOut.permission, currentTargetCommand).toBe("deny");
+        expect(currentOut.agent_message ?? "", currentTargetCommand).toContain(
+          "attribution state",
+        );
+      }
+    }
+
+    const safeTarget =
+      process.platform === "win32" ? "~\\scratch\\ordinary*" : "~/scratch/ordinary*";
+    const safeCommand =
+      process.platform === "win32" ? `Remove-Item ${safeTarget}` : `shred -u ${safeTarget}`;
+    const safe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-home-alias-conversation",
+        session_id: "reviewer-safe-home-alias-conversation",
+        tool_input: { command: safeCommand },
+      }),
+      {
+        env: {
+          HOME: proj,
+          USERPROFILE: proj,
+        },
+      },
+    );
+    expectAllowJson(safe, safeCommand);
+
+    if (process.platform !== "win32") {
+      const safeCurrentCommand = "shred -u ~+/scratch/ordinary*";
+      const safeCurrent = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-current-directory-alias-conversation",
+          session_id: "reviewer-safe-current-directory-alias-conversation",
+          tool_input: { command: safeCurrentCommand },
+        }),
+      );
+      expectAllowJson(safeCurrent, safeCurrentCommand);
+
+      const safeOldCommand = "shred -u ~-/scratch/ordinary*";
+      const safeOld = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-old-directory-alias-conversation",
+          session_id: "reviewer-safe-old-directory-alias-conversation",
+          tool_input: { command: safeOldCommand },
+        }),
+        { env: { OLDPWD: proj } },
+      );
+      expectAllowJson(safeOld, safeOldCommand);
+
+      const username = process.env.USER ?? process.env.LOGNAME;
+      const actualHome = process.env.HOME;
+      expect(username).toBeTruthy();
+      expect(actualHome).toBeTruthy();
+      const namedAlias = join(
+        actualHome ?? "",
+        `aidlc-t276-named-${basename(proj)}`,
+      );
+      symlinkSync(proj, namedAlias, "dir");
+      scratch.push(namedAlias);
+      const namedProtected =
+        `shred -u ~${username}/${basename(namedAlias)}/${relative.slice(0, -1)}*`;
+      const namedRemoval = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-named-home-alias-conversation",
+          session_id: "reviewer-named-home-alias-conversation",
+          tool_input: { command: namedProtected },
+        }),
+      );
+      const namedOut = JSON.parse(namedRemoval.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(namedOut.permission).toBe("deny");
+      expect(namedOut.agent_message ?? "").toContain("attribution state");
+
+      const namedSafe =
+        `shred -u ~${username}/${basename(namedAlias)}/scratch/ordinary*`;
+      const safeNamedRemoval = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-named-home-alias-conversation",
+          session_id: "reviewer-safe-named-home-alias-conversation",
+          tool_input: { command: namedSafe },
+        }),
+      );
+      expectAllowJson(safeNamedRemoval, namedSafe);
+    }
+  });
+
+  test("34: shell-internal directory changes rebase later path operands", () => {
+    const proj = installedProject();
+    const { dispatch } = activateReviewer(proj);
+    const aidlcDir = join(proj, "aidlc");
+    const relativeDispatch = relative(aidlcDir, dispatch);
+    const projectRelativeDispatch = relative(proj, dispatch);
+    const commands =
+      process.platform === "win32"
+        ? [
+            `cd /d aidlc && del /q ${relativeDispatch.slice(0, -1)}*`,
+            "pushd aidlc && del /q .aidlc-cursor-subagent*",
+            `Set-Location aidlc; Remove-Item ${relativeDispatch.slice(0, -1)}*`,
+            `cd /d no-such-dir || del /q ${projectRelativeDispatch.slice(0, -1)}*`,
+            `cd /d aidlc || echo unchanged\ndel /q ${relativeDispatch.slice(0, -1)}*`,
+            `cd /d aidlc || cd /d scratch\ndel /q ${relativeDispatch.slice(0, -1)}*`,
+            `cd /d aidlc | del /q ${projectRelativeDispatch.slice(0, -1)}*`,
+            `(cd /d scratch) & del /q ${projectRelativeDispatch.slice(0, -1)}*`,
+            `if (Test-Path aidlc) { Set-Location aidlc }; Remove-Item ${relativeDispatch.slice(0, -1)}*`,
+          ]
+        : [
+            `cd aidlc; shred -u ${relativeDispatch.slice(0, -1)}*`,
+            "pushd aidlc; find .aidlc-cursor-subagent* -depth -delete",
+            `cd no-such-dir || shred -u ${projectRelativeDispatch.slice(0, -1)}*`,
+            `cd aidlc || true; shred -u ${relativeDispatch.slice(0, -1)}*`,
+            `cd aidlc || cd scratch; shred -u ${relativeDispatch.slice(0, -1)}*`,
+            `cd aidlc | shred -u ${projectRelativeDispatch.slice(0, -1)}*`,
+            `(cd scratch); shred -u ${projectRelativeDispatch.slice(0, -1)}*`,
+            `if cd aidlc; then shred -u ${relativeDispatch.slice(0, -1)}*; fi`,
+            `if true; then cd aidlc; fi; shred -u ${relativeDispatch.slice(0, -1)}*`,
+            `case x in x) cd aidlc;; esac; shred -u ${relativeDispatch.slice(0, -1)}*`,
+            `f(){ cd aidlc; }; f; shred -u ${relativeDispatch.slice(0, -1)}*`,
+            `builtin cd aidlc; shred -u ${relativeDispatch.slice(0, -1)}*`,
+            "builtin -- pushd aidlc; find .aidlc-cursor-subagent* -depth -delete",
+          ];
+    for (const command of commands) {
+      const removal = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-shell-cwd-conversation",
+          session_id: "reviewer-shell-cwd-conversation",
+          tool_input: { command },
+        }),
+      );
+      const out = JSON.parse(removal.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(out.permission, command).toBe("deny");
+      expect(out.agent_message ?? "", command).toContain("attribution state");
+    }
+
+    const scratchDir = join(proj, "scratch");
+    mkdirSync(scratchDir, { recursive: true });
+    const safeCommand =
+      process.platform === "win32"
+        ? "cd /d scratch && del /q ordinary.txt"
+        : "cd scratch; rm -f ordinary.txt";
+    const safe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-shell-cwd-conversation",
+        session_id: "reviewer-safe-shell-cwd-conversation",
+        tool_input: { command: safeCommand },
+      }),
+    );
+    expectAllowJson(safe, safeCommand);
+
+    const safeFailedCommand =
+      process.platform === "win32"
+        ? "cd /d no-such-dir || del /q scratch\\ordinary.txt"
+        : "cd no-such-dir || rm -f scratch/ordinary.txt";
+    const safeFailed = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-failed-shell-cwd-conversation",
+        session_id: "reviewer-safe-failed-shell-cwd-conversation",
+        tool_input: { command: safeFailedCommand },
+      }),
+    );
+    expectAllowJson(safeFailed, safeFailedCommand);
+
+    for (const command of process.platform === "win32"
+      ? [
+          "cd /d scratch || echo unchanged\ndel /q ordinary.txt",
+          "cd /d no-such-dir || cd /d scratch\ndel /q ordinary.txt",
+        ]
+      : [
+          "cd scratch || true; rm -f ordinary.txt",
+          "cd no-such-dir || cd scratch; rm -f ordinary.txt",
+        ]) {
+      const safeConditional = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-conditional-shell-cwd-conversation",
+          session_id: "reviewer-safe-conditional-shell-cwd-conversation",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safeConditional, command);
+    }
+
+    const branchPrefix = Array.from({ length: 25 }, (_, index) =>
+      process.platform === "win32"
+        ? `cd /d missing-${index}`
+        : `cd missing-${index}`
+    ).join("; ");
+    const branchedSafeCommand =
+      process.platform === "win32"
+        ? `${branchPrefix}; del /q scratch\\ordinary.txt`
+        : `${branchPrefix}; rm -f scratch/ordinary.txt`;
+    const branchedSafe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-branched-shell-cwd-conversation",
+        session_id: "reviewer-safe-branched-shell-cwd-conversation",
+        tool_input: { command: branchedSafeCommand },
+      }),
+    );
+    expectAllowJson(branchedSafe, branchedSafeCommand);
+
+    const successfulDirs = Array.from({ length: 25 }, (_, index) =>
+      join(proj, "scratch", `existing-${index}`)
+    );
+    for (const dir of successfulDirs) mkdirSync(dir, { recursive: true });
+    const successfulPrefix = successfulDirs
+      .map((dir) =>
+        process.platform === "win32"
+          ? `cd /d ${dir}`
+          : `cd ${dir}`
+      )
+      .join("; ");
+    const successfulSafeCommand =
+      process.platform === "win32"
+        ? `${successfulPrefix}; del /q ${join(proj, "scratch", "ordinary.txt")}`
+        : `${successfulPrefix}; rm -f ${join(proj, "scratch", "ordinary.txt")}`;
+    const successfulSafe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-successful-cwd-chain-conversation",
+        session_id: "reviewer-safe-successful-cwd-chain-conversation",
+        tool_input: { command: successfulSafeCommand },
+      }),
+    );
+    expectAllowJson(successfulSafe, successfulSafeCommand);
+
+    const hubAliases = Array.from({ length: 25 }, (_, index) => `cwd-hub-${index}`);
+    for (const alias of hubAliases) {
+      symlinkSync(
+        process.platform === "win32" ? proj : ".",
+        join(proj, alias),
+        process.platform === "win32" ? "junction" : "dir",
+      );
+    }
+    const hubPrefix =
+      process.platform === "win32"
+        ? hubAliases.map((alias) => `if exist ${alias} cd /d ${alias}`).join("\n")
+        : hubAliases.map((alias) => `if true; then cd ${alias}; fi`).join("; ");
+    const hubSafeCommand =
+      process.platform === "win32"
+        ? `${hubPrefix}\ndel /q scratch\\ordinary.txt`
+        : `${hubPrefix}; rm -f scratch/ordinary.txt`;
+    const hubStartedAt = Date.now();
+    const hubSafe = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "reviewer-safe-symlink-cwd-hub-conversation",
+        session_id: "reviewer-safe-symlink-cwd-hub-conversation",
+        tool_input: { command: hubSafeCommand },
+      }),
+    );
+    expectAllowJson(hubSafe, hubSafeCommand);
+    expect(Date.now() - hubStartedAt).toBeLessThan(5_000);
+
+    if (process.platform !== "win32") {
+      const safeFunctionCommand = "f(){ cd aidlc; }; rm -f scratch/ordinary.txt";
+      const safeFunction = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-function-cwd-conversation",
+          session_id: "reviewer-safe-function-cwd-conversation",
+          tool_input: { command: safeFunctionCommand },
+        }),
+      );
+      expectAllowJson(safeFunction, safeFunctionCommand);
+
+      const safeBuiltinCommand = "builtin cd scratch; rm -f ordinary.txt";
+      const safeBuiltin = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-builtin-cwd-conversation",
+          session_id: "reviewer-safe-builtin-cwd-conversation",
+          tool_input: { command: safeBuiltinCommand },
+        }),
+      );
+      expectAllowJson(safeBuiltin, safeBuiltinCommand);
+    }
+  }, 15_000);
+
+  test("35: Git inspection follows reachable compound-command cwd state", () => {
+    const proj = installedProject();
+    activateReviewer(proj);
+    const unsafe = join(proj, "scratch", "unsafe-git-cwd");
+    mkdirSync(unsafe, { recursive: true });
+    expect(spawnSync("git", ["init"], { cwd: unsafe }).status).toBe(0);
+    const helper = join(
+      proj,
+      "scratch",
+      process.platform === "win32" ? "fsmonitor-helper.cmd" : "fsmonitor-helper",
+    );
+    writeFileSync(
+      helper,
+      process.platform === "win32"
+        ? "@echo off\r\nexit /b 0\r\n"
+        : "#!/bin/sh\nexit 0\n",
+    );
+    if (process.platform !== "win32") chmodSync(helper, 0o755);
+    expect(
+      spawnSync("git", ["config", "core.fsmonitor", helper], {
+        cwd: unsafe,
+      }).status,
+    ).toBe(0);
+
+    const relativeUnsafe = relative(proj, unsafe);
+    const denied =
+      process.platform === "win32"
+        ? [
+            `cd /d ${JSON.stringify(relativeUnsafe)} && git status --short`,
+            `Set-Location ${JSON.stringify(relativeUnsafe)}; git status --short`,
+            `if (Test-Path ${JSON.stringify(relativeUnsafe)}) { Set-Location ${JSON.stringify(relativeUnsafe)} }; git status --short`,
+          ]
+        : [
+            `cd ${JSON.stringify(relativeUnsafe)}; git status --short`,
+            `cd ${JSON.stringify(relativeUnsafe)} && git status --short`,
+            `builtin cd ${JSON.stringify(relativeUnsafe)}; git status --short`,
+            `if true; then cd ${JSON.stringify(relativeUnsafe)}; fi; git status --short`,
+          ];
+    for (const command of denied) {
+      const result = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-compound-git-cwd",
+          session_id: "reviewer-compound-git-cwd",
+          tool_input: { command },
+        }),
+      );
+      const out = JSON.parse(result.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(out.permission, command).toBe("deny");
+      expect(out.agent_message ?? "", command).toContain(
+        "dynamic command evaluation",
+      );
+    }
+
+    const allowed =
+      process.platform === "win32"
+        ? [
+            "cd /d no-such-dir && git status --short",
+            "cd /d no-such-dir || git status --short",
+          ]
+        : [
+            "cd no-such-dir && git status --short",
+            "cd no-such-dir || git status --short",
+            `cd ${JSON.stringify(relativeUnsafe)} | git status --short`,
+            `(cd ${JSON.stringify(relativeUnsafe)}); git status --short`,
+          ];
+    for (const command of allowed) {
+      const result = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "reviewer-safe-compound-git-cwd",
+          session_id: "reviewer-safe-compound-git-cwd",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(result, command);
+    }
   });
 });

--- a/tests/unit/t276-cursor-adapter.test.ts
+++ b/tests/unit/t276-cursor-adapter.test.ts
@@ -1918,7 +1918,7 @@ if (import.meta.main) {
 
     const resetRepositorySelectors =
       `env -i GIT_DIR=${safeGitDir} GIT_WORK_TREE=${safeWorkTree} git status --ignore-submodules=all`;
-    const safeResetRepository = runAdapter(
+    const resetRepository = runAdapter(
       proj,
       "guards",
       payload("preToolUseShell", proj, {
@@ -1927,7 +1927,14 @@ if (import.meta.main) {
         tool_input: { command: resetRepositorySelectors },
       }),
     );
-    expectAllowJson(safeResetRepository, resetRepositorySelectors);
+    const resetRepositoryOut = JSON.parse(resetRepository.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(resetRepositoryOut.permission).toBe("deny");
+    expect(resetRepositoryOut.agent_message ?? "").toContain(
+      "dynamic command evaluation",
+    );
 
     const alternateChild = join(safeAlternateRepo, "child");
     mkdirSync(alternateChild, { recursive: true });
@@ -2176,7 +2183,14 @@ if (import.meta.main) {
         tool_input: { command: resetIndexCommand },
       }),
     );
-    expectAllowJson(resetIndexStatus, resetIndexCommand);
+    const resetIndexOut = JSON.parse(resetIndexStatus.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(resetIndexOut.permission).toBe("deny");
+    expect(resetIndexOut.agent_message ?? "").toContain(
+      "dynamic command evaluation",
+    );
 
 
     for (const command of [
@@ -2418,19 +2432,7 @@ if (import.meta.main) {
           env: { HOME: undefined, XDG_CONFIG_HOME: xdgHome },
         },
         {
-          command: "env -i git status --short",
-          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
-        },
-        {
-          command: "env --ignore-environment git status --short",
-          env: { HOME: undefined, XDG_CONFIG_HOME: xdgHome },
-        },
-        {
           command: "command env -u HOME git status --short",
-          env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
-        },
-        {
-          command: "nice env -i git status --short",
           env: { HOME: alternateHome, XDG_CONFIG_HOME: undefined },
         },
       ]) {
@@ -3627,7 +3629,7 @@ if (import.meta.main) {
     );
   });
 
-  test("37: delegated project executables cannot erase attribution stores", () => {
+  test("37: delegated executable lookup and data-driven mutators cannot erase attribution stores", () => {
     const proj = installedProject();
     seedStateFile(proj, "state-construction.md");
     clearLedger(proj);
@@ -3654,12 +3656,11 @@ if (import.meta.main) {
       scriptDir,
       process.platform === "win32" ? "wipe-attribution.cmd" : "wipe-attribution",
     );
-    writeFileSync(
-      script,
+    const destructiveBody =
       process.platform === "win32"
         ? `@echo off\r\nrmdir /s /q "${ledgerDirFor(proj)}"\r\ndel /q "${witness}"\r\n`
-        : `#!/bin/sh\nrm -rf ${JSON.stringify(ledgerDirFor(proj))}\nrm -f ${JSON.stringify(witness)}\n`,
-    );
+        : `#!/bin/sh\n/bin/rm -rf ${JSON.stringify(ledgerDirFor(proj))}\n/bin/rm -f ${JSON.stringify(witness)}\n`;
+    writeFileSync(script, destructiveBody);
     if (process.platform !== "win32") chmodSync(script, 0o755);
 
     const command =
@@ -3701,6 +3702,121 @@ if (import.meta.main) {
     );
     expect(ledgerFilesFor(proj)).toHaveLength(1);
     expect(witnessFilesFor(proj)).toHaveLength(1);
+
+    const shadowedRg = join(
+      scriptDir,
+      process.platform === "win32" ? "rg.cmd" : "rg",
+    );
+    writeFileSync(shadowedRg, destructiveBody);
+    if (process.platform !== "win32") chmodSync(shadowedRg, 0o755);
+    const resolutionCommands = [
+      `env PATH=${JSON.stringify(scriptDir)} rg`,
+      `PATH=${JSON.stringify(scriptDir)} rg`,
+      `PATH=${JSON.stringify(scriptDir)}; rg`,
+      `env PaTh=${JSON.stringify(scriptDir)} rg`,
+      "env PATHEXT=.CMD rg",
+      "env -uPATH rg",
+      "env --unset=PATH rg",
+      "env -i rg",
+      "env -i0 rg",
+      "env --ignore-environment rg",
+      "nice env -i rg",
+    ];
+    for (const [index, unsafeCommand] of resolutionCommands.entries()) {
+      const denied = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "developer-project-executable-child",
+          session_id: "developer-project-executable-child",
+          tool_input: { command: unsafeCommand },
+        }),
+      );
+      const deniedOut = JSON.parse(denied.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      if (deniedOut.permission === "allow" && index === 0) {
+        const result =
+          process.platform === "win32"
+            ? spawnSync(
+                process.env.ComSpec ?? "cmd.exe",
+                ["/d", "/s", "/c", "rg"],
+                {
+                  cwd: proj,
+                  encoding: "utf-8",
+                  env: {
+                    ...process.env,
+                    PATH: scriptDir,
+                    PATHEXT: ".CMD",
+                  },
+                },
+              )
+            : spawnSync("rg", [], {
+                cwd: proj,
+                encoding: "utf-8",
+                env: { ...process.env, PATH: scriptDir },
+              });
+        expect(result.status, result.stderr).toBe(0);
+      }
+      expect(deniedOut.permission, unsafeCommand).toBe("deny");
+      expect(ledgerFilesFor(proj), unsafeCommand).toHaveLength(1);
+      expect(witnessFilesFor(proj), unsafeCommand).toHaveLength(1);
+    }
+
+    const safeEnvironment = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "developer-project-executable-child",
+        session_id: "developer-project-executable-child",
+        tool_input: { command: "env HOME=scratch rg --version" },
+      }),
+    );
+    expectAllowJson(safeEnvironment);
+
+    const targets = join(scriptDir, "targets.txt");
+    writeFileSync(targets, "../aidlc\n");
+    const dataDrivenCommand = "xargs rm -rf < targets.txt";
+    const dataDriven = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "developer-project-executable-child",
+        session_id: "developer-project-executable-child",
+        cwd: scriptDir,
+        tool_input: { command: dataDrivenCommand, cwd: scriptDir },
+      }),
+    );
+    const dataDrivenOut = JSON.parse(dataDriven.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    if (dataDrivenOut.permission === "allow" && process.platform !== "win32") {
+      const result = spawnSync("sh", ["-c", dataDrivenCommand], {
+        cwd: scriptDir,
+        encoding: "utf-8",
+      });
+      expect(result.status, result.stderr).toBe(0);
+    }
+    expect(dataDrivenOut.permission).toBe("deny");
+    expect(ledgerFilesFor(proj)).toHaveLength(1);
+    expect(witnessFilesFor(proj)).toHaveLength(1);
+
+    const safeDataDriven = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "developer-project-executable-child",
+        session_id: "developer-project-executable-child",
+        cwd: scriptDir,
+        tool_input: {
+          command: "xargs printf < targets.txt",
+          cwd: scriptDir,
+        },
+      }),
+    );
+    expectAllowJson(safeDataDriven);
 
     for (const unsafeCommand of [
       process.platform === "win32"

--- a/tests/unit/t276-cursor-adapter.test.ts
+++ b/tests/unit/t276-cursor-adapter.test.ts
@@ -3626,4 +3626,146 @@ if (import.meta.main) {
       "nested delegation is not allowed",
     );
   });
+
+  test("37: delegated project executables cannot erase attribution stores", () => {
+    const proj = installedProject();
+    seedStateFile(proj, "state-construction.md");
+    clearLedger(proj);
+    registerTaskParent(proj);
+    const spawn = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseTask", proj, {
+        tool_input: {
+          description: "Developer probe",
+          prompt: "Implement the unit.",
+          subagent_type: "aidlc-developer-agent",
+        },
+      }),
+    );
+    expectAllowJson(spawn);
+    const [witness] = witnessFilesFor(proj);
+    expect(ledgerFilesFor(proj)).toHaveLength(1);
+    expect(witness).toBeDefined();
+
+    const scriptDir = join(proj, "scratch");
+    mkdirSync(scriptDir, { recursive: true });
+    const script = join(
+      scriptDir,
+      process.platform === "win32" ? "wipe-attribution.cmd" : "wipe-attribution",
+    );
+    writeFileSync(
+      script,
+      process.platform === "win32"
+        ? `@echo off\r\nrmdir /s /q "${ledgerDirFor(proj)}"\r\ndel /q "${witness}"\r\n`
+        : `#!/bin/sh\nrm -rf ${JSON.stringify(ledgerDirFor(proj))}\nrm -f ${JSON.stringify(witness)}\n`,
+    );
+    if (process.platform !== "win32") chmodSync(script, 0o755);
+
+    const command =
+      process.platform === "win32"
+        ? "scratch\\wipe-attribution.cmd"
+        : "./scratch/wipe-attribution";
+    const execution = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseShell", proj, {
+        conversation_id: "developer-project-executable-child",
+        session_id: "developer-project-executable-child",
+        tool_input: { command },
+      }),
+    );
+    const executionOut = JSON.parse(execution.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    if (executionOut.permission === "allow") {
+      const result =
+        process.platform === "win32"
+          ? spawnSync(
+              process.env.ComSpec ?? "cmd.exe",
+              [
+                "/d",
+                "/s",
+                "/c",
+                `"${script}"`,
+              ],
+              { encoding: "utf-8" },
+            )
+          : spawnSync(script, [], { encoding: "utf-8" });
+      expect(result.status, result.stderr).toBe(0);
+    }
+    expect(executionOut.permission).toBe("deny");
+    expect(executionOut.agent_message ?? "").toContain(
+      "general-purpose interpreters",
+    );
+    expect(ledgerFilesFor(proj)).toHaveLength(1);
+    expect(witnessFilesFor(proj)).toHaveLength(1);
+
+    for (const unsafeCommand of [
+      process.platform === "win32"
+        ? "scratch\\echo.cmd harmless"
+        : "./scratch/printf.sh harmless",
+      "busybox rm -rf aidlc",
+      "toybox rm -rf aidlc",
+    ]) {
+      const denied = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "developer-project-executable-child",
+          session_id: "developer-project-executable-child",
+          tool_input: { command: unsafeCommand },
+        }),
+      );
+      const deniedOut = JSON.parse(denied.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(deniedOut.permission, unsafeCommand).toBe("deny");
+      expect(ledgerFilesFor(proj), unsafeCommand).toHaveLength(1);
+      expect(witnessFilesFor(proj), unsafeCommand).toHaveLength(1);
+    }
+
+    for (const safeCommand of [
+      "printf '%s\\n' harmless",
+      "busybox printf '%s\\n' harmless",
+      "toybox printf '%s\\n' harmless",
+    ]) {
+      const allowed = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "developer-project-executable-child",
+          session_id: "developer-project-executable-child",
+          tool_input: { command: safeCommand },
+        }),
+      );
+      expectAllowJson(allowed, safeCommand);
+    }
+
+    const nested = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseTask", proj, {
+        conversation_id: "developer-project-executable-child",
+        session_id: "developer-project-executable-child",
+        generation_id: "project-executable-nested-generation",
+        tool_use_id: "project-executable-nested-tool-use",
+        tool_input: {
+          description: "Nested probe",
+          prompt: "Delegate again.",
+          subagent_type: "aidlc-quality-agent",
+        },
+      }),
+    );
+    const nestedOut = JSON.parse(nested.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(nestedOut.permission).toBe("deny");
+    expect(nestedOut.agent_message ?? "").toContain(
+      "nested delegation is not allowed",
+    );
+  });
 });

--- a/tests/unit/t276-cursor-adapter.test.ts
+++ b/tests/unit/t276-cursor-adapter.test.ts
@@ -3532,4 +3532,98 @@ if (import.meta.main) {
       expectAllowJson(result, command);
     }
   });
+
+  test("36: find traversal cannot erase delegated-agent attribution stores", () => {
+    const proj = installedProject();
+    seedStateFile(proj, "state-construction.md");
+    clearLedger(proj);
+    registerTaskParent(proj);
+    const spawn = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseTask", proj, {
+        tool_input: {
+          description: "Developer probe",
+          prompt: "Implement the unit.",
+          subagent_type: "aidlc-developer-agent",
+        },
+      }),
+    );
+    expectAllowJson(spawn);
+    expect(ledgerFilesFor(proj)).toHaveLength(1);
+    expect(witnessFilesFor(proj)).toHaveLength(1);
+
+    for (const command of [
+      "find aidlc -depth -delete",
+      "find aidlc -exec rm -rf {} +",
+      "find aidlc -execdir rm -rf {} +",
+      "find aidlc -print0 | xargs -0 rm -rf",
+      "Remove-Item aidlc -Recurse -Force",
+      "Remove-Item -Path:aidlc -Recurse -Force",
+      "Move-Item aidlc scratch",
+      "rd /s /q aidlc",
+      "rsync --delete scratch/ aidlc",
+    ]) {
+      const removal = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "developer-find-child",
+          session_id: "developer-find-child",
+          tool_input: { command },
+        }),
+      );
+      const out = JSON.parse(removal.stdout) as {
+        permission?: string;
+        agent_message?: string;
+      };
+      expect(out.permission, command).toBe("deny");
+      expect(out.agent_message ?? "", command).toContain("attribution state");
+      expect(ledgerFilesFor(proj), command).toHaveLength(1);
+      expect(witnessFilesFor(proj), command).toHaveLength(1);
+    }
+
+    mkdirSync(join(proj, "scratch"), { recursive: true });
+    for (const command of [
+      "find scratch -depth -delete",
+      "Remove-Item scratch -Recurse -Force",
+      "Move-Item scratch ordinary",
+      "rsync --delete scratch/ ordinary",
+    ]) {
+      const safe = runAdapter(
+        proj,
+        "guards",
+        payload("preToolUseShell", proj, {
+          conversation_id: "developer-find-child",
+          session_id: "developer-find-child",
+          tool_input: { command },
+        }),
+      );
+      expectAllowJson(safe, command);
+    }
+
+    const nested = runAdapter(
+      proj,
+      "guards",
+      payload("preToolUseTask", proj, {
+        conversation_id: "developer-find-child",
+        session_id: "developer-find-child",
+        generation_id: "find-nested-generation",
+        tool_use_id: "find-nested-tool-use",
+        tool_input: {
+          description: "Nested probe",
+          prompt: "Delegate again.",
+          subagent_type: "aidlc-quality-agent",
+        },
+      }),
+    );
+    const nestedOut = JSON.parse(nested.stdout) as {
+      permission?: string;
+      agent_message?: string;
+    };
+    expect(nestedOut.permission).toBe("deny");
+    expect(nestedOut.agent_message ?? "").toContain(
+      "nested delegation is not allowed",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- interpret delegated shell words under both POSIX escape and Windows separator semantics while preserving active wildcard meaning and UNC roots
- canonicalize symlink, junction, device, trailing-dot/space, Git-Bash, home, current-directory, and wildcarded 8.3 aliases before comparing reviewer-attribution paths
- reject direct and nested PowerShell/cmd/script-host evaluators, dynamic expressions, Git aliases/config sources, wrapper-provided environments, and ambiguous mutation paths while reviewer attribution is active
- track `cd`/`pushd`/`popd` and PowerShell location changes across compounds, conditionals, loops, functions, pipelines, backgrounds, and subshells
- inspect Git status/submodule execution with option, cwd, `-C`, pathspec, environment, and repository-context semantics while continuing to allow ordinary safe commands
- preserve safe quoted/trailing-separator paths and fail closed only when a protected identity cannot be resolved unambiguously

## Verification

- final local `t276-cursor-adapter`: passed
- final native Windows `t276-cursor-adapter`: 34 passed, 0 failed, no skips
- affected Cursor/reviewer boundary tests
- adapter and test TypeScript checks
- focused Biome check
- `bun scripts/package.ts --check`
- packaging parity test
- `git diff --check`

## Notes

- no full-suite run was performed; verification was limited to Cursor dispatch, reviewer freeze, path/evaluator parsing, packaging, and native Windows behavior
- final adversarial closure review reported no findings and `MERGEABLE`
