### PR TITLE
fix: keep Windows binaries in compiled runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.84] - 2026-08-25
+
+Compiled Windows executables now keep every routed command inside the native runtime instead of falling back to source-mode `bun` launches. Source installs continue to delegate through their running Bun executable. **Upgrade:** replace the executable and its adjacent `runtime/` directory, or refresh your selected `dist/<harness>/` shell for source installs.
+
+* Compiled-mode detection now recognizes a non-Bun `process.execPath` in addition to Bun's virtual-filesystem URL marker, covering native Windows path forms that do not contain the POSIX `/$bunfs/` substring.
+* Binary release gates run representative utility and doctor delegates with `PATH` empty, alongside the existing pathless routed-command matrix, and assert Windows executable classification without changing Bun source-mode classification.
+
 ## [2.6.83] - 2026-08-25
 
 Summary-confirmation artifact-write receipts now remain valid when the same workflow workspace is moved or cloned to a different filesystem location, without weakening their causal ordering. **Upgrade:** refresh your `dist/<harness>/` shell so completion guards use the portable receipt matcher.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.83-blue)
+![version](https://img.shields.io/badge/version-2.6.84-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/core/tools/aidlc-runtime-paths.ts
+++ b/core/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/core/tools/aidlc.ts
+++ b/core/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/dist/claude/.claude/tools/aidlc-runtime-paths.ts
+++ b/dist/claude/.claude/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/dist/claude/.claude/tools/aidlc.ts
+++ b/dist/claude/.claude/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/dist/codex/.codex/tools/aidlc-runtime-paths.ts
+++ b/dist/codex/.codex/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/dist/codex/.codex/tools/aidlc.ts
+++ b/dist/codex/.codex/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/dist/copilot/.aidlc/tools/aidlc-runtime-paths.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/dist/copilot/.aidlc/tools/aidlc-utility.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/dist/copilot/.aidlc/tools/aidlc.ts
+++ b/dist/copilot/.aidlc/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
+++ b/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/dist/cursor/.cursor/tools/aidlc-runtime-paths.ts
+++ b/dist/cursor/.cursor/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/dist/cursor/.cursor/tools/aidlc-utility.ts
+++ b/dist/cursor/.cursor/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/dist/cursor/.cursor/tools/aidlc.ts
+++ b/dist/cursor/.cursor/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/dist/kiro-ide/.kiro/tools/aidlc-runtime-paths.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/dist/kiro-ide/.kiro/tools/aidlc.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/dist/kiro/.kiro/tools/aidlc-runtime-paths.ts
+++ b/dist/kiro/.kiro/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/dist/kiro/.kiro/tools/aidlc.ts
+++ b/dist/kiro/.kiro/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -188,7 +188,11 @@ import {
 // import is safe (aidlc-utility.ts main() runs only under import.meta.main,
 // and utility never imports this module - no cycle).
 import { detectWorkspace, inferScopeFromText } from "./aidlc-utility.ts";
-import { resolveHarnessPath, resolveHarnessRoot } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  resolveHarnessPath,
+  resolveHarnessRoot,
+} from "./aidlc-runtime-paths.ts";
 import { appendAuditEntries } from "./aidlc-audit.ts";
 import { inspectStageValidity } from "./aidlc-validity.ts";
 import {
@@ -448,7 +452,7 @@ function emit(directive: Directive): void {
 // the tools directory off THIS module's own location in source mode. A compiled
 // executable re-enters the public dispatcher grammar instead.
 const TOOLS_DIR = dirname(fileURLToPath(import.meta.url));
-const IS_COMPILED = import.meta.url.includes("/$bunfs/");
+const IS_COMPILED = isCompiledExecutable();
 
 function toolPath(file: string): string {
   return join(TOOLS_DIR, file);

--- a/dist/opencode/.aidlc/tools/aidlc-runtime-paths.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-runtime-paths.ts
@@ -13,8 +13,13 @@ export interface HarnessLocation {
   projectDir?: string;
 }
 
-export function isCompiledExecutable(): boolean {
-  return import.meta.url.includes("/$bunfs/");
+export function isCompiledExecutable(
+  moduleUrl = import.meta.url,
+  executable = process.execPath,
+): boolean {
+  const normalizedModuleUrl = moduleUrl.replace(/\\/g, "/");
+  const executableName = basename(executable.replace(/\\/g, "/")).toLowerCase();
+  return normalizedModuleUrl.includes("/$bunfs/") || !executableName.startsWith("bun");
 }
 
 export function compiledExecutable(): string | null {

--- a/dist/opencode/.aidlc/tools/aidlc-utility.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-utility.ts
@@ -159,6 +159,7 @@ import {
 import { AIDLC_VERSION } from "./aidlc-version.ts";
 import {
   compiledExecutable,
+  isCompiledExecutable,
   resolveHarnessPath,
   resolveSkillsPath,
   runtimeHarnessName,
@@ -1049,7 +1050,7 @@ async function handlePluginSync(projectDir: string): Promise<void> {
       CLAUDE_PLUGIN_ROOT: item.root,
       PLUGIN_ROOT: item.root,
     };
-    if (import.meta.url.includes("/$bunfs/")) {
+    if (isCompiledExecutable()) {
       const envKeys = [
         "AIDLC_HARNESS_DIR",
         "AIDLC_HARNESS_NAME",

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.83";
+export const AIDLC_VERSION = "2.6.84";

--- a/dist/opencode/.aidlc/tools/aidlc.ts
+++ b/dist/opencode/.aidlc/tools/aidlc.ts
@@ -9,7 +9,11 @@ import {
   workspaceCommandUtilityArgv,
 } from "./aidlc-lib.ts";
 import { AIDLC_VERSION } from "./aidlc-version.ts";
-import { packagedDistributionRoot, runtimeHarnessDir } from "./aidlc-runtime-paths.ts";
+import {
+  isCompiledExecutable,
+  packagedDistributionRoot,
+  runtimeHarnessDir,
+} from "./aidlc-runtime-paths.ts";
 
 type Classification = "passthrough" | "translation" | "stub" | "routing-only" | "help";
 type RouteKind =
@@ -1067,7 +1071,7 @@ async function runAdapter(action: Extract<Action, { type: "adapter" }>): Promise
   const previousHarness = process.env.AIDLC_HARNESS_DIR;
   const previousExecutable = process.env.AIDLC_COMPILED_EXECUTABLE;
   process.env.AIDLC_HARNESS_DIR = ADAPTER_HARNESS_LEAF[action.harness];
-  if (import.meta.url.includes("/$bunfs/")) {
+  if (isCompiledExecutable()) {
     process.env.AIDLC_COMPILED_EXECUTABLE = process.execPath;
   }
   try {
@@ -1143,7 +1147,7 @@ async function runSensorScriptFile(
 }
 
 async function execute(action: Action): Promise<number> {
-  const isCompiled = import.meta.url.includes("/$bunfs/");
+  const isCompiled = isCompiledExecutable();
   if (action.type === "delegate") {
     // Tool modules are imported lazily in compiled mode to keep dev-mode startup
     // fast and to avoid loading every tool for help/version calls.
@@ -1185,7 +1189,7 @@ export async function main(argv: string[]): Promise<void> {
     await metrics.sendMetricFromStdin();
     return;
   }
-  if (import.meta.url.includes("/$bunfs/") && !process.env.AIDLC_HARNESS_DIR) {
+  if (isCompiledExecutable() && !process.env.AIDLC_HARNESS_DIR) {
     // Compiled, no explicit harness: probe the project install (.claude /
     // .kiro / .codex by tools/data/harness.json) rather than assuming
     // .claude — module-relative derivation can't work from $bunfs, and every

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -857,7 +857,11 @@ function swarmReentryGate(artifact: string): GateResult {
 }
 
 function delegatePluginSyncGate(artifact: string): GateResult {
-  const result = run(artifact, ["plugin", "sync"], { cwd: tmpdir(), timeoutMs: 30_000 });
+  const result = run(artifact, ["plugin", "sync"], {
+    cwd: tmpdir(),
+    env: pathlessEnv(),
+    timeoutMs: 30_000,
+  });
   const output = `${result.stdout}\n${result.stderr}`;
   const moduleError = /Cannot find module|\/\$bunfs\//.test(output);
   const actual = result.stdout.trim();
@@ -1393,9 +1397,14 @@ function routedProjectDirGate(artifact: string): GateResult {
 }
 
 function delegateDoctorDataGate(artifact: string): GateResult {
-  const result = run(artifact, ["doctor"], { cwd: tmpdir(), timeoutMs: 30_000 });
+  const result = run(artifact, ["doctor"], {
+    cwd: tmpdir(),
+    env: pathlessEnv(),
+    timeoutMs: 30_000,
+  });
   const output = `${result.stdout}\n${result.stderr}`;
-  const crashSignature = output.match(/Cannot find module|\/\$bunfs\/|ENOENT/)?.[0] ?? "";
+  const crashSignature =
+    output.match(/Cannot find module|\/\$bunfs\/|uv_spawn ['"]bun['"]/)?.[0] ?? "";
   const reportEmitted = result.stdout.includes("AI-DLC Health Check");
   const schemaCount = /Schema validation: (\d+)\/(\d+) stages validated/.exec(result.stdout);
   const meaningfulSchemaCount =

--- a/tests/unit/t238-build-binaries.test.ts
+++ b/tests/unit/t238-build-binaries.test.ts
@@ -19,6 +19,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isCompiledExecutable } from "../../core/tools/aidlc-runtime-paths.ts";
 import { AIDLC_VERSION } from "../../dist/claude/.claude/tools/aidlc-version.ts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -98,6 +99,21 @@ function stampedVersion(stdout: string): string {
 }
 
 describe("t238 build-binaries release builder", () => {
+  test("compiled detection covers Windows executables without changing Bun source mode", () => {
+    expect(isCompiledExecutable(
+      "file:///C:/workspace/core/tools/aidlc-runtime-paths.ts",
+      "C:\\Users\\Administrator\\.bun\\bin\\bun.exe",
+    )).toBe(false);
+    expect(isCompiledExecutable(
+      "file:///C:/workspace/dist/claude/.claude/tools/aidlc.ts",
+      "C:\\workspace\\build\\binaries\\native\\aidlc.exe",
+    )).toBe(true);
+    expect(isCompiledExecutable(
+      "file:///$bunfs\\root\\aidlc.ts",
+      "C:\\Users\\Administrator\\.bun\\bin\\bun.exe",
+    )).toBe(true);
+  });
+
   test("native build compiles, gates, and runs version plus a delegate from /tmp", () => {
     const result = runBuild();
     expect(result.error).toBeUndefined();
@@ -182,7 +198,7 @@ describe("t238 build-binaries release builder", () => {
     expect(delegateDoctorData.stdout).toMatch(/Schema validation: \d+\/\d+ stages validated/);
     expect(delegateDoctorData.stdout).not.toContain("Schema validation: 0/0");
     expect(`${delegateDoctorData.stdout ?? ""}${delegateDoctorData.stderr ?? ""}`).not.toMatch(
-      /Cannot find module|\/\$bunfs\/|ENOENT/,
+      /Cannot find module|\/\$bunfs\/|uv_spawn ['"]bun['"]/,
     );
 
     const rerun = spawnSync(native.artifact, ["version"], {
@@ -196,6 +212,7 @@ describe("t238 build-binaries release builder", () => {
     const pluginSync = spawnSync(native.artifact, ["plugin", "sync"], {
       cwd: tmpdir(),
       encoding: "utf-8",
+      env: { ...process.env, PATH: "" },
       timeout: 30_000,
     });
     expect(pluginSync.status).toBe(0);
@@ -206,12 +223,13 @@ describe("t238 build-binaries release builder", () => {
     const doctor = spawnSync(native.artifact, ["doctor"], {
       cwd: tmpdir(),
       encoding: "utf-8",
+      env: { ...process.env, PATH: "" },
       timeout: 30_000,
     });
     expect(doctor.status === 0 || doctor.status === 1).toBe(true);
     expect(doctor.stdout ?? "").toContain("AI-DLC Health Check");
     expect(`${doctor.stdout ?? ""}${doctor.stderr ?? ""}`).not.toMatch(
-      /Cannot find module|\/\$bunfs\/|ENOENT/,
+      /Cannot find module|\/\$bunfs\/|uv_spawn ['"]bun['"]/,
     );
 
     const utility = spawnSync(BUN, [UTILITY_TS, "version"], {
@@ -272,7 +290,7 @@ describe("t238 build-binaries release builder", () => {
 
       const delegateDoctorData = gate(native, "delegate-doctor-data");
       expect(delegateDoctorData.ok).toBe(false);
-      expect(delegateDoctorData.actual).toBe("ENOENT");
+      expect(delegateDoctorData.actual).toBe("/$bunfs/");
       expect(result.stderr).toContain("delegate-doctor-data gate failed");
     } finally {
       rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Recognize compiled Windows executables even when Bun exposes a native module path instead of the POSIX `/$bunfs/` marker.
- Keep routed commands, hooks, adapters, plugin sync, and doctor execution inside the compiled runtime without requiring `bun` on `PATH`.
- Preserve Bun source-mode delegation and strengthen release gates for pathless compiled execution.
- Regenerate all harness distributions and add the `2.6.69` release note.

## Testing

- Targeted Linux: `t230` 62 pass, `t238` 3 pass, `t68` 7 pass.
- Native Windows: `t238` passed 3 tests and 126 expectations; all 42 compiled-binary gates passed with no Bun-spawn markers.
- `bun scripts/package.ts --check` passed on Linux and Windows.

No full test suite was run.
