### PR TITLE
test: harden Windows TUI process cleanup

### DIFF
--- a/tests/e2e/t-tui-compose-front.serial.test.ts
+++ b/tests/e2e/t-tui-compose-front.serial.test.ts
@@ -25,7 +25,10 @@ import { readdirSync, readFileSync } from "node:fs";
 import * as os from "node:os";
 import { join } from "node:path";
 import { stateFilePathFor } from "../harness/sdk-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const IS_WIN = os.platform() === "win32";
@@ -133,8 +136,11 @@ describe("t-tui compose front journey (live claude TUI)", () => {
         const stateMd = readFileSync(stateFilePathFor(sandbox), "utf8");
         expect(stateMd).toContain(`- **Scope**: ${composed}`);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-custom-harness.serial.test.ts
+++ b/tests/e2e/t-tui-custom-harness.serial.test.ts
@@ -136,6 +136,7 @@ import { driveAidlc, recordDirFor, stateFilePathFor } from "../harness/sdk-drive
 import { resolveWinNode } from "../harness/tui-drive.ts";
 import {
   cleanupTuiProject,
+  cleanupTuiProjectAfterKill,
   compileTuiRuntimeGraph,
   setupTuiProject,
 } from "../harness/tui-fixtures.ts";
@@ -317,8 +318,11 @@ describe("t-tui-custom-harness (the {sdk,tui} two-driver journey)", () => {
         expect(pane).toContain(`> ${SNAPSHOT_STAGE_SLUG}`);
         expect(pane).toContain(`-- ${CUSTOM_AGENT_DISPLAY}`);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     90_000,
@@ -592,8 +596,11 @@ describe("t-tui-custom-harness (the {sdk,tui} two-driver journey)", () => {
         const tailKnowledge = readFileSync(tailArtifact, "utf8").includes(CUSTOM_KNOWLEDGE_MARKER);
         expect(headKnowledge || tailKnowledge).toBe(true);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(tuiProj);
+        cleanupTuiProjectAfterKill(
+          tuiProj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-journey-orientation.serial.test.ts
+++ b/tests/e2e/t-tui-journey-orientation.serial.test.ts
@@ -186,10 +186,15 @@ function captureOrientationStatusline(sampleIndex: number): OrientationSample {
     String(PROCESS_EXIT_TIMEOUT_MS),
   ]);
   let fixtureCleanupError: unknown;
-  try {
-    cleanupTuiProject(sandbox);
-  } catch (error) {
-    fixtureCleanupError = error;
+  if (killed.rc === 0 && dead.rc === 0) {
+    try {
+      cleanupTuiProject(sandbox);
+    } catch (error) {
+      fixtureCleanupError = error;
+    }
+  } else {
+    fixtureCleanupError =
+      `skipped because process teardown failed; workspace preserved at ${sandbox}`;
   }
 
   if (killed.rc !== 0 || dead.rc !== 0 || fixtureCleanupError !== undefined) {

--- a/tests/e2e/t-tui-kiro-bugfix-scope.serial.test.ts
+++ b/tests/e2e/t-tui-kiro-bugfix-scope.serial.test.ts
@@ -34,7 +34,7 @@ import { join } from "node:path";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { recordDirFor, stateFilePathFor } from "../harness/sdk-drive.ts";
 import {
-  cleanupTuiProject,
+  cleanupTuiProjectAfterKill,
   createKiroNumberedProseAnswerState,
   KIRO_SRC,
   markdownH2Section,
@@ -209,8 +209,11 @@ describe("t-tui-kiro-bugfix-scope (brownfield bugfix journey, numbered-prose gat
         expect(questionAnsweredAt).toBeGreaterThan(-1);
         expect(gateOpenedAt).toBeGreaterThan(questionAnsweredAt);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-kiro-intent-capture.serial.test.ts
+++ b/tests/e2e/t-tui-kiro-intent-capture.serial.test.ts
@@ -61,7 +61,7 @@ import { join } from "node:path";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { seededRecordDir, seededStateFile } from "../harness/fixtures.ts";
 import {
-  cleanupTuiProject,
+  cleanupTuiProjectAfterKill,
   createKiroNumberedProseAnswerState,
   KIRO_SRC,
   markdownH2Section,
@@ -322,8 +322,11 @@ describe("t-tui-kiro-intent-capture (numbered-prose gates on the shipped dist/ki
         expect(questionAnsweredAt).toBeGreaterThan(summaryConfirmedAt);
         expect(gateOpenedAt).toBeGreaterThan(questionAnsweredAt);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-kiro-status.serial.test.ts
+++ b/tests/e2e/t-tui-kiro-status.serial.test.ts
@@ -25,7 +25,11 @@ import { existsSync, readFileSync } from "node:fs";
 import * as os from "node:os";
 import { join } from "node:path";
 import { seededStateFile } from "../harness/fixtures.ts";
-import { cleanupTuiProject, KIRO_SRC, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  KIRO_SRC,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const IS_WIN = os.platform() === "win32";
@@ -126,8 +130,11 @@ describe("t-tui-kiro-status (read-only status through the Kiro print-directive a
         // Read-only contract: the state file is byte-identical afterwards.
         expect(readFileSync(statePath, "utf8")).toBe(stateBefore);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,
@@ -149,8 +156,11 @@ describe("t-tui-kiro-status (read-only status through the Kiro print-directive a
         // per-intent state file the seeded record would hold never appears.
         expect(existsSync(seededStateFile(sandbox))).toBe(false);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-preflight.serial.test.ts
+++ b/tests/e2e/t-tui-preflight.serial.test.ts
@@ -57,6 +57,10 @@ import {
   WIN_KILL_TIMEOUT_MS,
   winSessionDir,
 } from "../harness/tui-drive.ts";
+import {
+  assertTuiDriveKill,
+  cleanupTuiProjectAfterKill,
+} from "../harness/tui-fixtures.ts";
 
 // ---------------------------------------------------------------------------
 // Locate the driver + pick the runtime per platform (§2.1, D-TUI-7).
@@ -118,6 +122,20 @@ function drive(args: string[]): Run {
     env: process.env,
   });
   return { rc: res.status ?? -1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+function recordSessionKill(
+  session: string,
+  errors: unknown[],
+): void {
+  try {
+    assertTuiDriveKill(
+      drive(["kill", "--session", session]),
+      session,
+    );
+  } catch (error) {
+    errors.push(error);
+  }
 }
 
 async function waitUntil(
@@ -365,6 +383,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
     () => {
       const session = `aidlc_tui_preflight_${process.pid}`;
       const sandbox = mkdtempSync(join(tmpdir(), "aidlc-tui-preflight-"));
+      let runError: unknown;
       try {
         // 1) start the known-answer target in a fixed-size session.
         const started = drive([
@@ -421,10 +440,29 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
         expect(captured.rc).toBe(0);
         expect(captured.stdout).toContain(GLYPH_SENTINEL);
         expect(captured.stdout).not.toContain("\x1b[");
-      } finally {
-        drive(["kill", "--session", session]);
-        if (existsSync(sandbox)) rmSync(sandbox, { recursive: true, force: true });
+      } catch (error) {
+        runError = error;
       }
+      let cleanupError: unknown;
+      try {
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
+      } catch (error) {
+        cleanupError = error;
+      }
+      if (cleanupError !== undefined) {
+        if (runError === undefined) throw cleanupError;
+        throw new Error(
+          `TUI preflight and cleanup both failed.\n` +
+            `original test error: ${String(runError)}\n` +
+            `cleanup error: ${String(cleanupError)}`,
+          { cause: runError },
+        );
+      }
+      if (runError !== undefined) throw runError;
     },
     20_000,
   );
@@ -443,7 +481,15 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
       const cmdShim = join(sandbox, "claude shim.cmd");
       const legacyDaemonScript = join(sandbox, "legacy-tui-drive.ts");
       const sessions: string[] = [];
-
+      const cleanupErrors: unknown[] = [];
+      const throwRecordedCleanupErrors = (): void => {
+        if (cleanupErrors.length === 0) return;
+        const recorded = cleanupErrors.splice(0);
+        throw new Error(
+          `Windows TUI case cleanup failed:\n${recorded.map(String).join("\n")}`,
+          { cause: recorded[0] },
+        );
+      };
       writeFileSync(
         childScript,
         [
@@ -719,7 +765,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
           ).toBe(true);
           expect(liveRecordedIdentities(recorded)).toEqual([]);
         } finally {
-          drive(["kill", "--session", session]);
+          recordSessionKill(session, cleanupErrors);
         }
       };
 
@@ -822,7 +868,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
           ).toBe(true);
           expect(liveRecordedIdentities(recorded)).toEqual([]);
         } finally {
-          drive(["kill", "--session", session]);
+          recordSessionKill(session, cleanupErrors);
         }
       };
 
@@ -922,7 +968,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
           } else {
             process.env.AIDLC_TUI_CIM_TRACE_FILE = priorTrace;
           }
-          drive(["kill", "--session", session]);
+          recordSessionKill(session, cleanupErrors);
         }
       };
 
@@ -1003,7 +1049,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
           ).toBe(true);
           expect(liveRecordedIdentities(recorded)).toEqual([]);
         } finally {
-          drive(["kill", "--session", session]);
+          recordSessionKill(session, cleanupErrors);
         }
       };
 
@@ -1120,8 +1166,8 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
             ),
           ).toBe(true);
         } finally {
-          drive(["kill", "--session", staleSession]);
-          drive(["kill", "--session", actualSession]);
+          recordSessionKill(staleSession, cleanupErrors);
+          recordSessionKill(actualSession, cleanupErrors);
         }
       };
 
@@ -1266,8 +1312,8 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
             ),
           ).toBe(true);
         } finally {
-          drive(["kill", "--session", sessionA]);
-          drive(["kill", "--session", sessionB]);
+          recordSessionKill(sessionA, cleanupErrors);
+          recordSessionKill(sessionB, cleanupErrors);
         }
       };
 
@@ -1341,7 +1387,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
             ),
           ).toBe(true);
         } finally {
-          drive(["kill", "--session", session]);
+          recordSessionKill(session, cleanupErrors);
         }
       };
 
@@ -1444,7 +1490,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
           } else {
             process.env.AIDLC_TUI_CIM_FAIL_CONTEXTS = prior;
           }
-          drive(["kill", "--session", session]);
+          recordSessionKill(session, cleanupErrors);
         }
       };
 
@@ -1506,7 +1552,7 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
           } else {
             process.env.AIDLC_TUI_CIM_FAIL_CONTEXTS = prior;
           }
-          drive(["kill", "--session", session]);
+          recordSessionKill(session, cleanupErrors);
         }
       };
 
@@ -1608,53 +1654,77 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
             } else {
               process.env.AIDLC_TUI_CIM_TRACE_FILE = priorTrace;
             }
-            drive(["kill", "--session", session]);
+            recordSessionKill(session, cleanupErrors);
           }
         };
 
+      let runError: unknown;
       try {
         await runShimCase("cmd");
+        throwRecordedCleanupErrors();
         await runShimCase("ps1");
+        throwRecordedCleanupErrors();
         await runMissingTargetIdentityFastExit();
+        throwRecordedCleanupErrors();
         await runCase("posix", () => "signals/*/done.txt", true);
+        throwRecordedCleanupErrors();
         await runCase("native", () => "signals\\*\\done.txt", true, true);
+        throwRecordedCleanupErrors();
         await runCase(
           "drive",
           (caseDir) => join(caseDir, "signals", "*", "done.txt"),
           true,
         );
+        throwRecordedCleanupErrors();
         await runCase(
           "gitbash",
           (caseDir) => gitBashPath(join(caseDir, "signals", "*", "done.txt")),
           true,
         );
+        throwRecordedCleanupErrors();
         await runCase(
           "unc",
           (caseDir) =>
             uncLocalhostPath(join(caseDir, "signals", "*", "done.txt")),
           true,
         );
+        throwRecordedCleanupErrors();
         await runCase(
           "mixed",
           (caseDir) =>
             mixedDrivePath(join(caseDir, "signals", "*", "done.txt")),
           true,
         );
+        throwRecordedCleanupErrors();
         await runCase("timeout", () => "signals\\*\\missing.txt", false);
+        throwRecordedCleanupErrors();
         await runParentFirstExit();
+        throwRecordedCleanupErrors();
         await runStalePidOwnership();
+        throwRecordedCleanupErrors();
         await runTokenlessLegacyOwnership();
+        throwRecordedCleanupErrors();
         await runPreUpgradeLegacySession();
+        throwRecordedCleanupErrors();
         await runCollidingSessions();
+        throwRecordedCleanupErrors();
         await runOrdinaryCimFailure();
+        throwRecordedCleanupErrors();
         await runParentFirstCimFailure();
+        throwRecordedCleanupErrors();
         await runChildIdentityRetry();
+        throwRecordedCleanupErrors();
         await runPersistentNonRootVerificationFailure();
-      } finally {
-        for (const session of sessions) {
-          drive(["kill", "--session", session]);
-        }
-        if (existsSync(sandbox)) {
+        throwRecordedCleanupErrors();
+      } catch (error) {
+        runError = error;
+      }
+
+      for (const session of sessions) {
+        recordSessionKill(session, cleanupErrors);
+      }
+      if (cleanupErrors.length === 0 && existsSync(sandbox)) {
+        try {
           const removed = await removeTreeWithRetry(sandbox, 5_000);
           if (!removed) {
             process.stderr.write(
@@ -1662,7 +1732,20 @@ describe("t-tui-preflight (terminal substrate capability gate)", () => {
                 `preserved for delayed cleanup: ${sandbox}\n`,
             );
           }
+        } catch (error) {
+          cleanupErrors.push(error);
         }
+      }
+      if (cleanupErrors.length > 0) {
+        throw new Error(
+          `Windows TUI preflight cleanup failed; workspace preserved at ${sandbox}\n` +
+            `original test error: ${String(runError ?? "none")}\n` +
+            `cleanup errors:\n${cleanupErrors.map(String).join("\n")}`,
+          { cause: runError ?? cleanupErrors[0] },
+        );
+      }
+      if (runError !== undefined) {
+        throw runError;
       }
     },
     300_000,

--- a/tests/e2e/t-tui-render-colour.serial.test.ts
+++ b/tests/e2e/t-tui-render-colour.serial.test.ts
@@ -45,7 +45,10 @@ import { existsSync, readFileSync } from "node:fs";
 import * as os from "node:os";
 import { join } from "node:path";
 import { resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -194,8 +197,11 @@ describe("t-tui-render statusline COLOUR branch (live turn populates ctx:%, macO
           expect(ansi).toMatch(new RegExp(`${ESC}\\[32m\\s*ctx:\\d`));
         }
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-render-complete.serial.test.ts
+++ b/tests/e2e/t-tui-render-complete.serial.test.ts
@@ -30,7 +30,10 @@ import { existsSync, readFileSync } from "node:fs";
 import * as os from "node:os";
 import { join } from "node:path";
 import { resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -143,8 +146,11 @@ describe("t-tui-render statusline COMPLETE sentinel (seeded completed, no tokens
           "[AIDLC] fixture · COMPLETE [▓▓▓▓▓▓▓▓▓▓]",
         );
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     90_000,

--- a/tests/e2e/t-tui-render-statusline.serial.test.ts
+++ b/tests/e2e/t-tui-render-statusline.serial.test.ts
@@ -54,7 +54,10 @@ import { existsSync, readFileSync } from "node:fs";
 import * as os from "node:os";
 import { join } from "node:path";
 import { resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -176,8 +179,11 @@ function captureWorkflowStatusline(): string {
     }
     return pane;
   } finally {
-    drive(["kill", "--session", session]);
-    cleanupTuiProject(sandbox);
+    cleanupTuiProjectAfterKill(
+      sandbox,
+      session,
+      drive(["kill", "--session", session]),
+    );
   }
 }
 

--- a/tests/e2e/t-tui-statusline.serial.test.ts
+++ b/tests/e2e/t-tui-statusline.serial.test.ts
@@ -29,11 +29,12 @@
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
 import * as os from "node:os";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveWinNode } from "../harness/tui-drive.ts";
+import { cleanupTuiProjectAfterKill } from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -193,8 +194,11 @@ describe("t-tui-statusline (statusline renders in a real terminal)", () => {
           "Enter to set as default · s to use this session only · Esc to cancel",
         );
       } finally {
-        drive(["kill", "--session", session]);
-        if (existsSync(sandbox)) rmSync(sandbox, { recursive: true, force: true });
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     90_000,

--- a/tests/e2e/t-tui-t101-memory-lifecycle.serial.test.ts
+++ b/tests/e2e/t-tui-t101-memory-lifecycle.serial.test.ts
@@ -55,7 +55,10 @@ import { join } from "node:path";
 import { parseMemoryHeadings } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { seededRecordDir, seededStateFile } from "../harness/fixtures.ts";
 import { resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -278,8 +281,11 @@ describe("t-tui-t101 (memory.md start→approval lifecycle through a driven gate
         // The captured numbered choices above prove the real approval gate
         // rendered and remained unanswered.
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t139-revision-loop-idempotency.serial.test.ts
+++ b/tests/e2e/t-tui-t139-revision-loop-idempotency.serial.test.ts
@@ -77,7 +77,12 @@ import * as os from "node:os";
 import { join } from "node:path";
 import { stateFilePathFor } from "../harness/sdk-drive.ts";
 import { gridHasMenu, resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  assertTuiDriveKill,
+  cleanupTuiProject,
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -320,7 +325,10 @@ describe("t-tui-t139 revision-loop idempotency (reject->approve == clean approve
         );
         expect(cleanRc).toBe(0);
         const clean = readTerminal(cleanSandbox);
-        drive(["kill", "--session", cleanSession]);
+        assertTuiDriveKill(
+          drive(["kill", "--session", cleanSession]),
+          cleanSession,
+        );
 
         // CLEAN sanity: it reached the milestone with NO rejection.
         expect(clean.scope).toMatch(/bugfix/i);
@@ -404,11 +412,19 @@ describe("t-tui-t139 revision-loop idempotency (reject->approve == clean approve
           expect(revised.revisionCount).toBeGreaterThan(clean.revisionCount);
         } finally {
           if (pollTimer) clearInterval(pollTimer);
-          if (revisedSession) drive(["kill", "--session", revisedSession]);
+          if (revisedSession) {
+            assertTuiDriveKill(
+              drive(["kill", "--session", revisedSession]),
+              revisedSession,
+            );
+          }
         }
       } finally {
-        drive(["kill", "--session", cleanSession]);
-        cleanupTuiProject(cleanSandbox);
+        cleanupTuiProjectAfterKill(
+          cleanSandbox,
+          cleanSession,
+          drive(["kill", "--session", cleanSession]),
+        );
         if (revisedSandbox) cleanupTuiProject(revisedSandbox);
       }
     },

--- a/tests/e2e/t-tui-t24-stage-jump.serial.test.ts
+++ b/tests/e2e/t-tui-t24-stage-jump.serial.test.ts
@@ -93,7 +93,10 @@ import { join } from "node:path";
 import { resolveWinNode } from "../harness/tui-drive.ts";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { seededStateFile } from "../harness/fixtures.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -305,8 +308,11 @@ describe("t-tui-t24 stage-jump (forward --stage lands on disk + re-renders statu
         // writes "**Timestamp**: <ts>".
         expect(auditMd).toMatch(/\*\*Timestamp\*\*:.*\d[0-9T:Z-]/);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t27-depth-override.serial.test.ts
+++ b/tests/e2e/t-tui-t27-depth-override.serial.test.ts
@@ -85,7 +85,10 @@ import { join } from "node:path";
 import { resolveWinNode } from "../harness/tui-drive.ts";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { seededAuditDir, seededStateFile } from "../harness/fixtures.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -293,8 +296,11 @@ describe("t-tui-t27 depth override (config-change lands + renders)", () => {
         // what the headless SDK path could not see, asserted without grepping prose.
         expect(pane).toContain("· IDEATION");
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,
@@ -332,8 +338,11 @@ describe("t-tui-t27 depth override (config-change lands + renders)", () => {
         expect(after).toBe(before);
         expect(readAllAuditShards(proj)).not.toMatch(/^\*\*Event\*\*: DEPTH_CHANGED$/m);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t29-env-scope.serial.test.ts
+++ b/tests/e2e/t-tui-t29-env-scope.serial.test.ts
@@ -86,7 +86,10 @@ import { join } from "node:path";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { stateFilePathFor } from "../harness/sdk-drive.ts";
 import { resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -295,8 +298,11 @@ describe("t-tui-t29 env-scope (AWS_AIDLC_DEFAULT_SCOPE seeds new-workflow scope 
         // never-created flat fallback path).
         expect(existsSync(stateFilePathFor(proj))).toBe(false);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,
@@ -353,8 +359,11 @@ describe("t-tui-t29 env-scope (AWS_AIDLC_DEFAULT_SCOPE seeds new-workflow scope 
         const wiIdx = auditMd.indexOf("WORKSPACE_INITIALISED");
         expect(auditMd.slice(wiIdx, wiIdx + 500)).toMatch(/Scope.*:\s*feature/);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,
@@ -390,8 +399,11 @@ describe("t-tui-t29 env-scope (AWS_AIDLC_DEFAULT_SCOPE seeds new-workflow scope 
         expect(stateMd).toMatch(/^- \*\*Scope\*\*: feature$/m);
         expect(stateMd).not.toMatch(/^- \*\*Scope\*\*: classic$/m);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,
@@ -427,8 +439,11 @@ describe("t-tui-t29 env-scope (AWS_AIDLC_DEFAULT_SCOPE seeds new-workflow scope 
         // state file; stateFilePathFor falls to the never-created flat fallback).
         expect(existsSync(stateFilePathFor(proj))).toBe(false);
       } finally {
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t50-bugfix-scope.serial.test.ts
+++ b/tests/e2e/t-tui-t50-bugfix-scope.serial.test.ts
@@ -101,7 +101,10 @@ import {
   stateFilePathFor,
 } from "../harness/sdk-drive.ts";
 import { gridHasMenu, resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 import { activeSpace } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 
 // The space-level per-repo codekb dir the RE stage writes into
@@ -408,8 +411,11 @@ describe("t-tui-t50-bugfix-scope (answering gates advances bugfix lifecycle on d
         expect(sawMenu).toBe(true);
       } finally {
         if (pollTimer) clearInterval(pollTimer);
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t51-poc-scope.serial.test.ts
+++ b/tests/e2e/t-tui-t51-poc-scope.serial.test.ts
@@ -69,7 +69,10 @@ import * as os from "node:os";
 import { join } from "node:path";
 import { auditFilePathFor, recordDirFor, stateFilePathFor } from "../harness/sdk-drive.ts";
 import { gridHasMenu, resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -356,8 +359,11 @@ describe("t-tui-t51-poc-scope (answering gates advances poc Ideation on disk)", 
         expect(sawMenu).toBe(true);
       } finally {
         if (pollTimer) clearInterval(pollTimer);
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t58-workshop-scope.serial.test.ts
+++ b/tests/e2e/t-tui-t58-workshop-scope.serial.test.ts
@@ -96,7 +96,10 @@ import { join } from "node:path";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { recordDirFor, stateFilePathFor } from "../harness/sdk-drive.ts";
 import { resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -412,8 +415,11 @@ describe("t-tui-t58 workshop-scope (skips Ideation, runs Inception+ at Standard/
         expect(sawMenu).toBe(true);
       } finally {
         if (pollTimer) clearInterval(pollTimer);
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(proj);
+        cleanupTuiProjectAfterKill(
+          proj,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t73-intent-capture.serial.test.ts
+++ b/tests/e2e/t-tui-t73-intent-capture.serial.test.ts
@@ -78,7 +78,7 @@ import { resolveWinNode } from "../harness/tui-drive.ts";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { seededRecordDir, seededStateFile } from "../harness/fixtures.ts";
 import {
-  cleanupTuiProject,
+  cleanupTuiProjectAfterKill,
   markdownH2Section,
   setupTuiProject,
 } from "../harness/tui-fixtures.ts";
@@ -442,8 +442,11 @@ describe("t-tui-t73-intent-capture (answering the stage gate produces artifacts 
         expect(sawSelectFooter || sawSubmitStrip).toBe(true);
       } finally {
         if (pollTimer) clearInterval(pollTimer);
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-t74-requirements-analysis.serial.test.ts
+++ b/tests/e2e/t-tui-t74-requirements-analysis.serial.test.ts
@@ -94,7 +94,10 @@ import {
   seededRecordDir,
   seededStateFile,
 } from "../harness/fixtures.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -421,8 +424,11 @@ describe("t-tui-t74-requirements-analysis (answering AUQ gates commits the requi
         expect(sawSelectFooter).toBe(true);
       } finally {
         if (pollTimer) clearInterval(pollTimer);
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/e2e/t-tui-windows-user-settings-isolation.serial.test.ts
+++ b/tests/e2e/t-tui-windows-user-settings-isolation.serial.test.ts
@@ -17,7 +17,6 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import * as os from "node:os";
@@ -25,8 +24,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveWinNode } from "../harness/tui-drive.ts";
 import {
+  assertTuiDriveKill,
+  cleanupTuiProject,
   completedClaudeTurnPattern,
   isolatedTuiUserProfileEnv,
+  removeTuiProjectTreeWithRetry,
 } from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
@@ -53,6 +55,10 @@ interface TraceRecord {
   noEnter?: boolean;
   pattern?: string;
   stableMs?: number;
+}
+
+interface ProbeCleanupState {
+  allKillsSucceeded: boolean;
 }
 
 function drive(args: string[], env: NodeJS.ProcessEnv): Run {
@@ -198,6 +204,7 @@ function runProbe(
   tracePath: string,
   settingArgs: string[],
   expectedMarker: string,
+  cleanupState: ProbeCleanupState,
 ): { pane: string; trace: TraceRecord[] } {
   const env = { ...baseEnv, AIDLC_TUI_TRACE_FILE: tracePath };
   try {
@@ -292,7 +299,9 @@ function runProbe(
     expect(completionWait.stableMs).toBe(600);
     return { pane, trace };
   } finally {
-    drive(["kill", "--session", session], env);
+    const killed = drive(["kill", "--session", session], env);
+    if (killed.rc !== 0) cleanupState.allKillsSucceeded = false;
+    assertTuiDriveKill(killed, session);
   }
 }
 
@@ -336,6 +345,7 @@ describe("Windows Claude TUI user-settings isolation", () => {
       );
       expect(probeEnv.CLAUDE_CONFIG_DIR).toBeUndefined();
       expect(probeEnv.AIDLC_TUI_SETTING_SOURCES).toBeUndefined();
+      const cleanupState: ProbeCleanupState = { allKillsSucceeded: true };
 
       try {
         const traceDir = process.env.AIDLC_TEST_LOG_DIR ?? sandbox;
@@ -350,6 +360,7 @@ describe("Windows Claude TUI user-settings isolation", () => {
           explicitTrace,
           ["--setting-sources", "user,project"],
           USER_SENTINEL,
+          cleanupState,
         );
         expect(explicit.pane).toContain(USER_SENTINEL);
         expect(explicit.pane).toContain(PROJECT_SENTINEL);
@@ -371,6 +382,7 @@ describe("Windows Claude TUI user-settings isolation", () => {
           isolatedTrace,
           [],
           PROJECT_SENTINEL,
+          cleanupState,
         );
         expect(isolated.pane).toContain(PROJECT_SENTINEL);
         expect(isolated.pane).not.toContain(USER_SENTINEL);
@@ -385,8 +397,14 @@ describe("Windows Claude TUI user-settings isolation", () => {
           "--dangerously-skip-permissions",
         ]);
       } finally {
-        if (existsSync(sandbox)) {
-          rmSync(sandbox, { recursive: true, force: true });
+        if (cleanupState.allKillsSucceeded) {
+          cleanupTuiProject(project);
+          if (existsSync(sandbox)) removeTuiProjectTreeWithRetry(sandbox);
+        } else {
+          process.stderr.write(
+            `[t-tui-windows-user-settings-isolation] kill failed; ` +
+              `workspace preserved at ${sandbox}\n`,
+          );
         }
       }
     },

--- a/tests/e2e/t-tui-workshop.serial.test.ts
+++ b/tests/e2e/t-tui-workshop.serial.test.ts
@@ -38,7 +38,10 @@ import { join } from "node:path";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { stateFilePathFor } from "../harness/sdk-drive.ts";
 import { resolveWinNode } from "../harness/tui-drive.ts";
-import { cleanupTuiProject, setupTuiProject } from "../harness/tui-fixtures.ts";
+import {
+  cleanupTuiProjectAfterKill,
+  setupTuiProject,
+} from "../harness/tui-fixtures.ts";
 
 const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const AIDLC_SRC = join(import.meta.dir, "..", "..", "dist", "claude", ".claude");
@@ -267,8 +270,11 @@ describe("t-tui-workshop (answering AUQ gates advances disk state)", () => {
         expect(sawSelectFooter).toBe(true);
       } finally {
         if (pollTimer) clearInterval(pollTimer);
-        drive(["kill", "--session", session]);
-        cleanupTuiProject(sandbox);
+        cleanupTuiProjectAfterKill(
+          sandbox,
+          session,
+          drive(["kill", "--session", session]),
+        );
       }
     },
     TEST_TIMEOUT_MS,

--- a/tests/harness/tui-drive.ts
+++ b/tests/harness/tui-drive.ts
@@ -155,6 +155,9 @@ export const WIN_KILL_TIMEOUT_MS = 8_000;
 const WIN_PROCESS_QUERY_TIMEOUT_MS = 750;
 const WIN_TASKKILL_TIMEOUT_MS = 750;
 const WIN_CONSOLE_LIST_TIMEOUT_MS = 5_000;
+const WINDOWS_SESSION_CLEANUP_ATTEMPTS = 20;
+const WINDOWS_SESSION_CLEANUP_WAIT_MS = 100;
+const RETRYABLE_WINDOWS_RM_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"]);
 
 type Args = {
   positionals: string[];
@@ -410,6 +413,41 @@ function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
+export interface WindowsSessionCleanupOptions {
+  attempts?: number;
+  waitMs?: number;
+  remove?: (path: string) => void;
+  sleep?: (ms: number) => void;
+}
+
+export function removeWindowsSessionDirWithRetry(
+  path: string,
+  options: WindowsSessionCleanupOptions = {},
+): void {
+  const attempts = options.attempts ?? WINDOWS_SESSION_CLEANUP_ATTEMPTS;
+  const waitMs = options.waitMs ?? WINDOWS_SESSION_CLEANUP_WAIT_MS;
+  const remove = options.remove ??
+    ((target: string) => rmSync(target, { recursive: true, force: true }));
+  const wait = options.sleep ?? sleepSync;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      remove(path);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (
+        typeof code !== "string" ||
+        !RETRYABLE_WINDOWS_RM_CODES.has(code) ||
+        attempt >= attempts
+      ) {
+        throw error;
+      }
+      wait(waitMs);
+    }
+  }
+}
+
 function processIsAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -489,6 +527,31 @@ function forceKillWindowsTree(
   );
 }
 
+export interface WindowsForcedTerminationOptions {
+  now?: () => number;
+  terminate?: (pid: number, timeoutMs: number) => void;
+  maxAttemptMs?: number;
+}
+
+export function forceKillWindowsProcessesWithinDeadline(
+  processes: Array<{ pid: number }>,
+  deadline: number,
+  options: WindowsForcedTerminationOptions = {},
+): void {
+  const now = options.now ?? Date.now;
+  const terminate = options.terminate ??
+    ((pid: number, timeoutMs: number) => {
+      forceKillWindowsTree(pid, timeoutMs);
+    });
+  const maxAttemptMs = options.maxAttemptMs ?? WIN_TASKKILL_TIMEOUT_MS;
+
+  for (const processInfo of processes) {
+    const budget = Math.min(maxAttemptMs, Math.max(0, deadline - now()));
+    if (budget <= 0) break;
+    terminate(processInfo.pid, budget);
+  }
+}
+
 export type WindowsProcessIdentity = {
   pid: number;
   parentPid: number;
@@ -511,6 +574,7 @@ type WindowsSessionMeta = {
   rows: number;
   session?: string;
   ownerToken?: string;
+  cwd?: string;
 };
 
 type WindowsSessionOwnership = {
@@ -589,6 +653,11 @@ function readJsonFileWithRetry<T>(
   return readJsonFile<T>(path);
 }
 
+export function parsePowerShellBase64Json<T>(raw: string): T {
+  const encoded = raw.replace(/^\uFEFF/, "").trim();
+  return JSON.parse(Buffer.from(encoded, "base64").toString("utf8")) as T;
+}
+
 function windowsProcessQuery(
   pid: number,
   timeoutMs = WIN_PROCESS_QUERY_TIMEOUT_MS,
@@ -610,7 +679,8 @@ function windowsProcessQuery(
     '  creationDate = $p.CreationDate.ToUniversalTime().ToString("o")',
     "  commandLine = [string]$p.CommandLine",
     "}",
-    "$out | ConvertTo-Json -Compress",
+    "$json = $out | ConvertTo-Json -Compress",
+    "[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))",
   ].join("\n");
   const result = runBoundedCommand(
     "powershell.exe",
@@ -631,7 +701,7 @@ function windowsProcessQuery(
   try {
     return {
       status: "ok",
-      value: JSON.parse(result.stdout.trim()) as WindowsProcessIdentity,
+      value: parsePowerShellBase64Json<WindowsProcessIdentity>(result.stdout),
     };
   } catch {
     return {
@@ -662,7 +732,8 @@ function windowsProcessFallbackQuery(
     '  creationDate = $p.StartTime.ToUniversalTime().ToString("o")',
     "  commandLine = ''",
     "}",
-    "$out | ConvertTo-Json -Compress",
+    "$json = $out | ConvertTo-Json -Compress",
+    "[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))",
   ].join("\n");
   const result = runBoundedCommand(
     "powershell.exe",
@@ -679,7 +750,7 @@ function windowsProcessFallbackQuery(
   try {
     return {
       status: "ok",
-      value: JSON.parse(result.stdout.trim()) as WindowsProcessIdentity,
+      value: parsePowerShellBase64Json<WindowsProcessIdentity>(result.stdout),
     };
   } catch {
     return {
@@ -718,7 +789,8 @@ function windowsDirectChildrenQuery(
     "  currentRoot = Convert-Identity $root",
     "  children = $children",
     "}",
-    "ConvertTo-Json -InputObject $out -Depth 4 -Compress",
+    "$json = ConvertTo-Json -InputObject $out -Depth 4 -Compress",
+    "[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))",
   ].join("\n");
   const result = runBoundedCommand(
     "powershell.exe",
@@ -736,9 +808,9 @@ function windowsDirectChildrenQuery(
     };
   }
   try {
-    const parsed = JSON.parse(
-      result.stdout.trim(),
-    ) as WindowsDescendantSnapshot;
+    const parsed = parsePowerShellBase64Json<WindowsDescendantSnapshot>(
+      result.stdout,
+    );
     return {
       status: "ok",
       value: {
@@ -1055,7 +1127,16 @@ function mergeWindowsProcessIdentities(
 }
 
 function clearWindowsSessionAuthority(dir: string): void {
-  for (const name of ["pid", "child.pid", "meta.json", "ownership.json"]) {
+  for (
+    const name of [
+      "pid",
+      "child.pid",
+      "meta.json",
+      "ownership.json",
+      "target-spawn.json",
+      "target-exit.json",
+    ]
+  ) {
     rmSync(join(dir, name), { force: true });
   }
 }
@@ -1191,7 +1272,7 @@ const tmuxBackend: Backend = {
 //   <dir>/cmd.log   — append-only command log the daemon tails (send/kill).
 //   <dir>/grid.txt  — the latest reconstructed grid the daemon snapshots; the
 //                     capture/wait clients read it.
-//   <dir>/meta.json — { cols, rows, ownerToken } for diagnostics + PID authority.
+//   <dir>/meta.json — { cols, rows, ownerToken, cwd } for diagnostics + PID authority.
 //   <dir>/pid       — the daemon pid, for kill's force-terminate backstop.
 //   <dir>/child.pid — the node-pty child pid.
 //   <dir>/tree.pids — the daemon's kill-time process-tree snapshot.
@@ -1238,7 +1319,7 @@ function killLegacyWindowsSession(session: string, dir: string): void {
   );
   if (daemonQuery.status !== "ok") {
     if (daemonQuery.status === "absent") {
-      rmSync(dir, { recursive: true, force: true });
+      removeWindowsSessionDirWithRetry(dir);
       return;
     }
     fail(`cannot verify legacy Windows session '${session}': ${daemonQuery.message}`, 1);
@@ -1294,7 +1375,7 @@ function killLegacyWindowsSession(session: string, dir: string): void {
       1,
     );
   }
-  rmSync(dir, { recursive: true, force: true });
+  removeWindowsSessionDirWithRetry(dir);
 }
 
 const win32Backend: Backend = {
@@ -1318,12 +1399,12 @@ const win32Backend: Backend = {
         1,
       );
     }
-    rmSync(dir, { recursive: true, force: true });
+    removeWindowsSessionDirWithRetry(dir);
     mkdirSync(dir, { recursive: true });
     const ownerToken = randomUUID();
     writeFileSync(
       join(dir, "meta.json"),
-      JSON.stringify({ cols: width, rows: height, session, ownerToken }),
+      JSON.stringify({ cols: width, rows: height, session, ownerToken, cwd }),
     );
 
     // Fork the daemon UNDER NODE (never bun — node-pty input wedges under bun,
@@ -1804,11 +1885,7 @@ const win32Backend: Backend = {
     let survivors =
       liveQuery.status === "ok" ? liveQuery.value : [];
     while (survivors.length > 0 && remaining() > 0) {
-      for (const process of survivors) {
-        const budget = Math.min(WIN_TASKKILL_TIMEOUT_MS, remaining());
-        if (budget <= 0) break;
-        forceKillWindowsTree(process.pid, budget);
-      }
+      forceKillWindowsProcessesWithinDeadline(survivors, deadline);
       if (remaining() > 0) sleepSync(Math.min(100, remaining()));
       liveQuery = liveOwnedWindowsProcesses(
         survivors,
@@ -1914,12 +1991,11 @@ async function runWinChildWrapper(a: Args): Promise<void> {
   const exitFile = requireFlag(a, "exit-file");
   if (a.rest.length === 0) process.exit(2);
   while (!existsSync(releaseFile)) await sleep(25);
-  const codePage = runBoundedCommand(
-    "chcp.com",
-    ["65001"],
-    DEFAULT_PROCESS_SNAPSHOT_TIMEOUT_MS,
-    "ignore",
-  );
+  const codePage = spawnSync("chcp.com", ["65001"], {
+    stdio: "ignore",
+    windowsHide: false,
+    timeout: DEFAULT_PROCESS_SNAPSHOT_TIMEOUT_MS,
+  });
   if (codePage.status !== 0) {
     process.stderr.write("tui-drive child launch failed: unable to select UTF-8 console mode\n");
     process.exit(127);

--- a/tests/harness/tui-fixtures.ts
+++ b/tests/harness/tui-fixtures.ts
@@ -67,6 +67,9 @@ const FIXTURES_DIR = join(REPO_ROOT, "tests", "fixtures");
 const CLAUDE_MEMORY_SRC = join(REPO_ROOT, "dist", "claude", "aidlc");
 const KIRO_MEMORY_SRC = join(REPO_ROOT, "dist", "kiro", "aidlc");
 const KIRO_IDE_MEMORY_SRC = join(REPO_ROOT, "dist", "kiro-ide", "aidlc");
+const RETRYABLE_TUI_CLEANUP_CODES = new Set(["EBUSY", "ENOTEMPTY", "EPERM"]);
+const WINDOWS_TUI_CLEANUP_ATTEMPTS = 20;
+const WINDOWS_TUI_CLEANUP_WAIT_MS = 250;
 
 /** Build a disposable Windows user-profile environment for a Claude TUI probe.
  * CLAUDE_CONFIG_DIR overrides the normal home-based user config lookup, so it
@@ -701,10 +704,173 @@ function copyDirContents(src: string, dest: string): void {
  *  mkdtemp name, cleaned in `finally`), so a debugging run sets this to keep the
  *  seeded .claude/, the written artefacts, the audit, and the sensor detail dir
  *  for post-mortem. Green CI never sets it, so normal runs still clean up. */
+export interface TuiProjectCleanupOptions {
+  attempts?: number;
+  waitMs?: number;
+  remove?: (path: string) => void;
+  sleep?: (ms: number) => void;
+  diagnostics?: (path: string) => string;
+}
+
+export interface TuiDriveRunResult {
+  rc: number;
+  stdout?: string;
+  stderr?: string;
+}
+
+export interface PendingTuiSession {
+  name: string;
+  recordedPid?: number;
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function sameWindowsPath(a: string, b: string): boolean {
+  const normalize = (value: string): string =>
+    value.replaceAll("\\", "/").replace(/\/+$/, "").toLowerCase();
+  return normalize(a) === normalize(b);
+}
+
+export function pendingTuiSessionsForProject(
+  proj: string,
+  sessionsRoot = join(tmpdir(), "tui-drive"),
+): PendingTuiSession[] {
+  const sessions: PendingTuiSession[] = [];
+  try {
+    for (const name of existsSync(sessionsRoot) ? readdirSync(sessionsRoot) : []) {
+      const dir = join(sessionsRoot, name);
+      const metaPath = join(dir, "meta.json");
+      const pidPath = join(dir, "pid");
+      if (!existsSync(metaPath)) continue;
+      try {
+        const meta = JSON.parse(readFileSync(metaPath, "utf8")) as {
+          cwd?: string;
+          session?: string;
+        };
+        if (!meta.cwd || !sameWindowsPath(meta.cwd, proj)) continue;
+        let recordedPid: number | undefined;
+        try {
+          const raw = readFileSync(pidPath, "utf8").trim();
+          if (/^[1-9]\d*$/.test(raw)) recordedPid = Number(raw);
+        } catch {
+          // Missing/corrupt PID metadata is part of the pending-session evidence.
+        }
+        sessions.push({
+          name: meta.session ?? name,
+          recordedPid,
+        });
+      } catch {
+        // A concurrently closing session can remove or truncate its metadata.
+      }
+    }
+  } catch (error) {
+    throw new Error(
+      `could not inspect tui-drive sessions: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+  return sessions;
+}
+
+function windowsTuiCleanupDiagnostics(
+  proj: string,
+  sessionsRoot?: string,
+): string {
+  let sessions: PendingTuiSession[];
+  try {
+    sessions = pendingTuiSessionsForProject(proj, sessionsRoot);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  if (sessions.length === 0) {
+    return "no matching tui-drive session metadata remained";
+  }
+  return [
+    `matching sessions: ${sessions.map((session) =>
+      `${session.name}=${session.recordedPid ?? "missing-pid"}`
+    ).join(", ")}`,
+  ].join("\n");
+}
+
+export function assertNoPendingTuiSessionsForProject(
+  proj: string,
+  sessionsRoot?: string,
+): void {
+  const sessions = pendingTuiSessionsForProject(proj, sessionsRoot);
+  if (sessions.length === 0) return;
+  throw new Error(
+    `cleanupTuiProject refusing to remove ${proj}: tui-drive teardown did not ` +
+      `complete for ${sessions.map((session) => session.name).join(", ")}\n` +
+      `session diagnostics:\n${windowsTuiCleanupDiagnostics(proj, sessionsRoot)}`,
+  );
+}
+
+export function removeTuiProjectTreeWithRetry(
+  proj: string,
+  options: TuiProjectCleanupOptions = {},
+): void {
+  const attempts = options.attempts ??
+    (process.platform === "win32" ? WINDOWS_TUI_CLEANUP_ATTEMPTS : 1);
+  const waitMs = options.waitMs ?? WINDOWS_TUI_CLEANUP_WAIT_MS;
+  const remove = options.remove ??
+    ((path: string) => rmSync(path, { recursive: true, force: true }));
+  const wait = options.sleep ?? sleepSync;
+  const diagnostics = options.diagnostics ?? windowsTuiCleanupDiagnostics;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      remove(proj);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const retryable =
+        typeof code === "string" && RETRYABLE_TUI_CLEANUP_CODES.has(code);
+      if (!retryable) throw error;
+      if (attempt >= attempts) {
+        const detail = error instanceof Error ? error.message : String(error);
+        const wrapped = new Error(
+          `cleanupTuiProject exhausted ${attempts} attempt(s) removing ${proj}: ` +
+            `${code}: ${detail}\nprocess diagnostics:\n${diagnostics(proj)}`,
+          { cause: error },
+        ) as NodeJS.ErrnoException;
+        wrapped.code = code;
+        throw wrapped;
+      }
+      wait(waitMs);
+    }
+  }
+}
+
 export function cleanupTuiProject(proj: string): void {
   if (process.env.AIDLC_KEEP_TEMP === "1") {
     if (proj) process.stderr.write(`[tui-fixtures] AIDLC_KEEP_TEMP=1 — preserved ${proj}\n`);
     return;
   }
-  if (proj && existsSync(proj)) rmSync(proj, { recursive: true, force: true });
+  if (proj) assertNoPendingTuiSessionsForProject(proj);
+  if (proj && existsSync(proj)) removeTuiProjectTreeWithRetry(proj);
+}
+
+export function assertTuiDriveKill(
+  result: TuiDriveRunResult,
+  session: string,
+): void {
+  if (result.rc === 0) return;
+  const stderr = result.stderr?.trim() ?? "";
+  throw new Error(
+    `tui-drive kill failed for session '${session}' (rc=${result.rc})` +
+      `${stderr ? `\n${stderr}` : ""}`,
+  );
+}
+
+export function cleanupTuiProjectAfterKill(
+  proj: string,
+  session: string,
+  result: TuiDriveRunResult,
+): void {
+  assertTuiDriveKill(result, session);
+  cleanupTuiProject(proj);
 }

--- a/tests/unit/t142-tui-drive-setting-sources.test.ts
+++ b/tests/unit/t142-tui-drive-setting-sources.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -31,23 +32,30 @@ import {
   filterConsoleOwnedWindowsProcesses,
   filterOwnedWindowsDescendants,
   filterSpawnOwnedWindowsDescendants,
+  forceKillWindowsProcessesWithinDeadline,
   gridHasOption,
   gridIsApprovalGate,
   normalizeTuiCommand,
   newConsoleProcessIds,
+  parsePowerShellBase64Json,
   parsePortablePath,
   pickRevisionOption,
   pickRevisionTypeSomethingOption,
   resolvePortablePathPattern,
+  removeWindowsSessionDirWithRetry,
   runBoundedCommand,
   shouldForceKillWindowsChildRoot,
   winSessionDir,
 } from "../harness/tui-drive.ts";
 import {
+  assertNoPendingTuiSessionsForProject,
   cleanupTuiProject,
+  cleanupTuiProjectAfterKill,
   compileTuiRuntimeGraph,
   createKiroNumberedProseAnswerState,
   nextKiroNumberedProseAnswer,
+  pendingTuiSessionsForProject,
+  removeTuiProjectTreeWithRetry,
   setupTuiProject,
 } from "../harness/tui-fixtures.ts";
 import { seededRecordDir } from "../harness/fixtures.ts";
@@ -561,6 +569,139 @@ describe("tui-drive bounded Windows subprocesses", () => {
     expect(
       shouldForceKillWindowsChildRoot(undefined, recorded, recycled),
     ).toBe(false);
+  });
+});
+
+describe("TUI cleanup hardening", () => {
+  test("PowerShell process metadata preserves Unicode through ASCII transport", () => {
+    const identity = {
+      pid: 6001,
+      parentPid: 6000,
+      creationDate: "2026-08-26T00:00:00.000Z",
+      commandLine: "node -e \"←→ ▓░ ✓✔ ❯☐☒ —\"",
+    };
+    const encoded = Buffer.from(
+      JSON.stringify(identity),
+      "utf8",
+    ).toString("base64");
+
+    expect(
+      parsePowerShellBase64Json<typeof identity>(`\uFEFF${encoded}\r\n`),
+    ).toEqual(identity);
+  });
+
+  test("one forced-termination deadline bounds a multi-process batch", () => {
+    let now = 0;
+    const attempts: Array<{ pid: number; timeoutMs: number }> = [];
+
+    forceKillWindowsProcessesWithinDeadline(
+      [{ pid: 6101 }, { pid: 6102 }, { pid: 6103 }],
+      5_000,
+      {
+        now: () => now,
+        maxAttemptMs: 5_000,
+        terminate: (pid, timeoutMs) => {
+          attempts.push({ pid, timeoutMs });
+          now += timeoutMs;
+        },
+      },
+    );
+
+    expect(attempts).toEqual([{ pid: 6101, timeoutMs: 5_000 }]);
+    expect(now).toBe(5_000);
+  });
+
+  test("retries transient Windows session-directory cleanup", () => {
+    let removeCalls = 0;
+    const waits: number[] = [];
+
+    removeWindowsSessionDirWithRetry("C:\\temp\\tui-session", {
+      attempts: 4,
+      waitMs: 25,
+      remove: () => {
+        removeCalls++;
+        if (removeCalls < 3) {
+          const error = new Error("locked") as NodeJS.ErrnoException;
+          error.code = "EBUSY";
+          throw error;
+        }
+      },
+      sleep: (ms) => waits.push(ms),
+    });
+
+    expect(removeCalls).toBe(3);
+    expect(waits).toEqual([25, 25]);
+  });
+
+  test("retries transient workspace cleanup", () => {
+    let removeCalls = 0;
+    const waits: number[] = [];
+
+    removeTuiProjectTreeWithRetry("C:\\temp\\project", {
+      attempts: 4,
+      waitMs: 20,
+      remove: () => {
+        removeCalls++;
+        if (removeCalls < 2) {
+          const error = new Error("busy") as NodeJS.ErrnoException;
+          error.code = "EPERM";
+          throw error;
+        }
+      },
+      sleep: (ms) => waits.push(ms),
+    });
+
+    expect(removeCalls).toBe(2);
+    expect(waits).toEqual([20]);
+  });
+
+  test("cwd metadata associates a pending session with its workspace", () => {
+    const project = mkdtempSync(join(tmpdir(), "aidlc-session-project-"));
+    const sessionsRoot = mkdtempSync(join(tmpdir(), "aidlc-session-root-"));
+    const session = "pending-session";
+    const sessionDir = join(sessionsRoot, "hashed-channel");
+    mkdirSync(sessionDir);
+    writeFileSync(
+      join(sessionDir, "meta.json"),
+      JSON.stringify({
+        cols: 120,
+        rows: 40,
+        session,
+        ownerToken: "owner-token",
+        cwd: project,
+      }),
+    );
+    writeFileSync(join(sessionDir, "pid"), "6201");
+
+    try {
+      expect(pendingTuiSessionsForProject(project, sessionsRoot)).toEqual([
+        { name: session, recordedPid: 6201 },
+      ]);
+      expect(() =>
+        assertNoPendingTuiSessionsForProject(project, sessionsRoot)
+      ).toThrow(/pending-session/);
+      expect(existsSync(project)).toBe(true);
+    } finally {
+      rmSync(sessionsRoot, { recursive: true, force: true });
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  test("a failed kill leaves the workspace intact", () => {
+    const project = mkdtempSync(join(tmpdir(), "aidlc-kill-failure-"));
+    try {
+      expect(() =>
+        cleanupTuiProjectAfterKill(project, "failed-session", {
+          rc: 9,
+          stderr: "verified process survived",
+        })
+      ).toThrow(
+        /kill failed for session 'failed-session' \(rc=9\)[\s\S]*verified process survived/,
+      );
+      expect(existsSync(project)).toBe(true);
+    } finally {
+      rmSync(project, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/unit/t152-windows-portability.test.ts
+++ b/tests/unit/t152-windows-portability.test.ts
@@ -5,7 +5,7 @@
 // every platform by checking the files that make that run repeatable.
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { REPO_ROOT } from "../harness/fixtures.ts";
 
@@ -134,5 +134,42 @@ describe("t152 Windows portability guard", () => {
     expect(typeCheck).toContain('`${result.stdout ?? ""}${result.stderr ?? ""}`');
     expect(typeCheck).toContain("stdout.split(/\\r?\\n/)");
     expect(typeCheck).toContain("parseTscOutput(output)");
+  });
+
+  test("Windows forced termination uses one shared deadline", () => {
+    const driver = read("tests/harness/tui-drive.ts");
+    expect(driver).toContain("forceKillWindowsProcessesWithinDeadline");
+    expect(driver).toContain("deadline - now()");
+    expect(driver).toContain(
+      "forceKillWindowsProcessesWithinDeadline(survivors, deadline)",
+    );
+  });
+
+  test("Windows ConPTY and process metadata keep UTF-8 boundaries explicit", () => {
+    const driver = read("tests/harness/tui-drive.ts");
+    expect(driver).toContain('"chcp.com", ["65001"]');
+    expect(driver).toContain("windowsHide: false");
+    expect(
+      driver.match(
+        /\[Convert\]::ToBase64String\(\[Text\.Encoding\]::UTF8\.GetBytes\(\$json\)\)/g,
+      ),
+    ).toHaveLength(3);
+    expect(driver).toContain("parsePowerShellBase64Json");
+    expect(driver).toContain('"target-spawn.json",');
+    expect(driver).toContain('"target-exit.json",');
+  });
+
+  test("TUI journeys do not silently ignore kill failures", () => {
+    const e2eDir = join(TESTS, "e2e");
+    const files = readdirSync(e2eDir)
+      .filter((name) => /^t-tui.*\.test\.ts$/.test(name))
+      .sort();
+    expect(files.length).toBeGreaterThan(0);
+    for (const name of files) {
+      const body = readFileSync(join(e2eDir, name), "utf8");
+      expect(body, name).not.toMatch(
+        /^\s*drive\(\["kill"[^\n]*\]\);\s*$/m,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Identify Windows TUI daemons and descendants by session token and process creation identity, preventing stale or reused PIDs from authorizing unrelated `taskkill` targets.
- Await the complete ConPTY process tree with bounded graceful and forced teardown, preserving diagnostics for surviving or ambiguous processes.
- Retry transient Windows workspace and session-directory locks while keeping genuine teardown leaks visible.
- Route every TUI e2e cleanup through helpers that propagate kill failures instead of reporting a false green or cleanup-only failure.

This is test infrastructure only, so it does not bump the framework version.

## Testing

- Focused Linux tests: 59 pass, 0 fail.
- Focused native Windows tests: 59 pass, 0 fail.
- Native Windows orientation journey repeated twice: 2 pass, no residual test-owned processes.
- Focused typecheck, TUI lint, and package drift checks passed.
- Codex implementer/reviewer loop reached `MERGEABLE` on review cycle 4.

No full TUI or repository test suite was run.
