### PR TITLE
feat(plugin): add mabl-verification plugin

### DIFF
--- a/plugins/mabl-verification/.aidlc-plugin/plugin.json
+++ b/plugins/mabl-verification/.aidlc-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "mabl-verification",
+  "version": "1.0.0",
+  "description": "End-to-end mabl verification loop plugin — pre-PR test matching, local execution, failure RCA, coverage gap analysis, triage routing, and ship gating via mabl's AI testing platform. Maps code changes to mabl tests, runs them locally, root-causes failures, identifies coverage gaps, and gates ship decisions against release readiness.",
+  "author": { "name": "mabl" },
+  "dependencies": ["core"],
+  "aidlc": {
+    "contributes": {
+      "stages": "stages/",
+      "overlays": "contributions/",
+      "agents": "agents/",
+      "scopes": "scopes/",
+      "knowledge": "knowledge/",
+      "sensors": "sensors/",
+      "tools": "tools/"
+    }
+  }
+}

--- a/plugins/mabl-verification/README.md
+++ b/plugins/mabl-verification/README.md
@@ -1,0 +1,223 @@
+# mabl-verification — AIDLC testing plugin
+
+A first-party AIDLC plugin: end-to-end mabl verification loop layered onto the
+AI-DLC workflow. Maps code changes to mabl tests, runs them locally, root-causes
+failures, identifies coverage gaps, and gates ship decisions against mabl's
+release readiness scoring.
+
+## 1. What it does
+
+mabl-verification enriches an AI-DLC run so that every code change is verified
+against the user-facing flows it touches via mabl's AI testing platform. It:
+
+- **contributes** to the existing `build-and-test` stage with a quick mabl
+  smoke-check after unit tests pass;
+- **adds three new stages** — pre-PR verification (construction), coverage gap
+  analysis (construction), and a ship gate (operation) that turns the verification
+  signal into a SHIP/BLOCK/NEEDS_HUMAN recommendation;
+- **ships two advisory sensors** that read the machine-readable JSON results and
+  report run-status and coverage-threshold findings;
+- **ships a doctor check** that verifies the mabl CLI, authentication, workspace,
+  and composed plugin state; and
+- **ships one agent** (`mabl-verification-agent`) that leads all three stages,
+  absorbing the methodology for test matching, failure RCA, triage routing,
+  coverage analysis, and ship gating.
+
+## 2. How to use it
+
+### Prerequisites
+
+- **mabl CLI** (Node 18+): `npm install -g @mablhq/mabl-cli`
+- **mabl CLI authenticated**: `mabl auth login` or `mabl auth activate-key <key>`
+- **mabl MCP server** connected to your harness (provides `search_mabl_tests`,
+  `analyze_mabl_failure`, `check_release_readiness`, etc.)
+- **bun** on PATH (required by all AIDLC plugins for hooks and tools)
+- **A running local dev server** for test execution
+- **At least one mabl test** in the workspace covering the application
+
+### Installation
+
+Build the plugin projections (from the aidlc-workflows repo root):
+
+```bash
+bun scripts/package.ts          # emits dist/plugins/mabl-verification/<harness>/
+```
+
+Then install per harness:
+
+**Kiro IDE / Kiro CLI** (folder-drop + compose):
+```bash
+cp -r dist/plugins/mabl-verification/kiro-ide/. <project>/
+AIDLC_PLUGIN_ROOT="$(pwd)/dist/plugins/mabl-verification/kiro-ide" \
+  AIDLC_PROJECT_DIR="<project>" AIDLC_HARNESS_DIR=.kiro \
+  bun dist/plugins/mabl-verification/kiro-ide/hooks/compose.ts
+```
+
+**Claude Code** (host store):
+```bash
+/plugin marketplace add <repo-or-path>/dist/plugins/mabl-verification/claude
+/plugin install aidlc-mabl-verification@aidlc-plugins
+```
+
+**Codex CLI** (host store, in a git repo):
+```bash
+codex plugin marketplace add <…>/dist/plugins/mabl-verification/codex
+codex plugin add aidlc-mabl-verification@aidlc-plugins
+```
+
+Then verify:
+```bash
+/aidlc --doctor    # expect 36 stages, Plugin check (mabl-verification): rows, 0 failures
+/aidlc --scope enterprise   # the mabl-verification stages route under enterprise/feature/mvp/classic
+```
+
+### Scope gating
+
+The three plugin stages activate under `enterprise`, `feature`, `mvp`, `classic`,
+and the plugin's own `mabl-verification-validation` scope. A `poc` or `bugfix`
+run won't reach them unless explicitly scoped.
+
+## 3. Existing stages it modifies (the contribution seam)
+
+| Core stage | What mabl-verification adds |
+|---|---|
+| `build-and-test` (construction) | Produces `mabl-verification-local-run-log`; binds `mabl-run-status` sensor; adds required section "mabl Verification"; splices Step 10a (quick smoke-check: match one test + run locally + record result). |
+
+## 4. New stages it creates
+
+| Stage | Phase | # | Activation | Produces |
+|---|---|---|---|---|
+| `mabl-verification-pre-pr` | construction | 3.90 | After build-and-test when mabl is configured | `mabl-verification-impact`, `mabl-verification-run-results` |
+| `mabl-verification-coverage-gap` | construction | 3.95 | CONDITIONAL — when pre-pr reports zero-match or partial coverage | `mabl-verification-coverage-report` |
+| `mabl-verification-ship-gate` | operation | 4.50 | EXECUTE under declared scopes | `mabl-verification-ship-verdict` |
+
+All three are led by `mabl-verification-agent`, mode: inline.
+
+## 5. Design & implementation
+
+### Layout
+
+```
+plugins/mabl-verification/
+  .aidlc-plugin/plugin.json              # manifest
+  stages/construction/                   # 2 new construction stages
+    mabl-verification-pre-pr.md
+    mabl-verification-coverage-gap.md
+  stages/operation/                      # 1 new operation stage
+    mabl-verification-ship-gate.md
+  contributions/construction/            # 1 stage modification
+    build-and-test.md
+  agents/                                # 1 agent persona
+    mabl-verification-agent.md
+  scopes/                                # 1 plugin scope
+    mabl-verification-validation.md
+  knowledge/mabl-verification-agent/     # 4 methodology knowledge files
+    local-run-patterns.md
+    authoring-best-practices.md
+    failure-rca-methodology.md
+    triage-routing.md
+  sensors/                               # 2 advisory sensor manifests
+    aidlc-mabl-run-status.md
+    aidlc-mabl-coverage-threshold.md
+  tools/                                 # 2 sensor scripts + 1 doctor check
+    aidlc-sensor-mabl-run-status.ts
+    aidlc-sensor-mabl-coverage-threshold.ts
+    mabl-verification-doctor.ts
+  tests/                                 # content validation
+    plugin.test.ts
+  README.md
+```
+
+### The verification loop
+
+The plugin implements a 6-question verification loop:
+
+| # | Question | Answered by |
+|---|----------|-------------|
+| Q1 | Which tests are affected by this change? | `mabl-verification-pre-pr` (Steps 3–6) |
+| Q2 | Do they pass? | `mabl-verification-pre-pr` (Steps 7–8) |
+| Q3 | Why did it fail? | Agent knowledge: `failure-rca-methodology.md` |
+| Q4 | What should we do next? | Agent knowledge: `triage-routing.md` |
+| Q5 | Is there a coverage gap? | `mabl-verification-coverage-gap` |
+| Q6 | Is it safe to ship? | `mabl-verification-ship-gate` |
+
+### Sensors (advisory)
+
+- **mabl-run-status** — reads `mabl-verification-run-results.md` or
+  `mabl-verification-local-run-log.md`, reports pass/fail counts and unresolved
+  failures. Bound to `build-and-test` (contribution) and `mabl-verification-pre-pr`.
+- **mabl-coverage-threshold** — reads `mabl-verification-coverage-report.md`,
+  reports critical/normal gap counts and ship-blocker status. Bound to
+  `mabl-verification-coverage-gap`.
+
+Both are advisory (the framework has no blocking sensor severity yet). Findings
+are REPORTED, not enforced. The stage prose and ship-gate handle actual gating.
+
+### Machine-readable contract
+
+Each stage emits a JSON summary block at the end of its Markdown artifact that the
+sensors read. Artifacts land under the engine-resolved record dir for the stage.
+
+### Team knowledge (user-managed)
+
+Project-specific configuration (workspace IDs, application IDs, credential
+mappings, environment URLs) belongs in team knowledge at:
+```
+aidlc/spaces/<active-space>/knowledge/mabl-verification-agent/workspace-constants.md
+```
+
+This file is NOT shipped by the plugin — teams create it during onboarding.
+
+## 6. Testing this plugin
+
+```bash
+bun test plugins/mabl-verification/tests/plugin.test.ts
+```
+
+Validates: manifest, stage frontmatter (slug/filename match, plugin ownership, valid
+agents, phase, number, artifact namespacing), contributions (target core stages,
+namespaced artifacts, fragments), sensors (naming convention, tool references),
+agents/scopes (naming, frontmatter), knowledge (exists, non-empty), and tools
+(parseable).
+
+## 7. Configuration
+
+### MCP server setup
+
+The mabl MCP server must be connected to the harness. There is no
+`mabl agent install kiro` target — add the entry by hand:
+
+```json
+{
+  "mcpServers": {
+    "mabl": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/mabl-mcp-server@latest"],
+      "env": {
+        "MABL_API_KEY": "<your-api-key>"
+      }
+    }
+  }
+}
+```
+
+Place in `.kiro/settings/mcp.json` (Kiro), `.claude/settings.json` (Claude Code),
+or the equivalent for your harness.
+
+### Workspace ID
+
+Set once so future runs are zero-prompt:
+```bash
+mabl config set workspace-id <your-workspace-id>
+```
+
+Or provide in team knowledge at
+`aidlc/spaces/<space>/knowledge/mabl-verification-agent/workspace-constants.md`.
+
+## See also
+
+- [Plugin Mechanism](../../docs/reference/18-plugin-mechanism.md) — the normative design
+- [Authoring a Plugin](../../docs/harness-engineering/10-authoring-a-plugin.md) — the author guide
+- [test-pro plugin](../test-pro/) — the reference fixture this plugin is modeled after
+- [mabl documentation](https://help.mabl.com/) — mabl platform docs
+- [mabl CLI reference](https://help.mabl.com/docs/mabl-cli) — CLI commands

--- a/plugins/mabl-verification/agents/mabl-verification-agent.md
+++ b/plugins/mabl-verification/agents/mabl-verification-agent.md
@@ -1,0 +1,115 @@
+---
+name: mabl-verification-agent
+display_name: mabl Verification Agent
+plugin: mabl-verification
+examples:
+  - mabl-verification-run-results.md
+  - mabl-verification-coverage-report.md
+  - mabl-verification-ship-verdict.md
+description: >
+  End-to-end mabl verification lead responsible for pre-PR test matching, local
+  execution, failure root-cause analysis, triage routing, coverage gap analysis,
+  and ship gating. Maps code changes to mabl tests via semantic search (MCP),
+  runs them locally via the mabl CLI, root-causes failures against the source
+  code (product regression vs stale test vs env/data vs flake), routes triage
+  decisions with loop bounds and human gates, identifies uncovered flows, and
+  gates ship decisions against mabl release readiness.
+disallowedTools: Task
+tier: judgment
+---
+
+**IMPORTANT: Do NOT use the Task tool. You operate as a delegated agent and must not spawn sub-agents.**
+
+# mabl Verification Agent
+
+You are a senior QA automation engineer specializing in mabl's AI-powered testing
+platform. You bridge the gap between code changes and end-to-end test coverage by
+orchestrating mabl's semantic test matching, local CLI execution, AI failure
+analysis, and release readiness scoring. You ensure that every code change is
+verified against the user-facing flows it touches before it ships.
+
+## Core Responsibilities
+
+### Pre-PR Test Matching & Execution
+- Analyze diffs (working tree or committed) to identify user-facing flows affected
+- Translate code changes into natural-language search queries for mabl's semantic index
+- Match changes to existing mabl tests via MCP `search_mabl_tests`
+- Execute matched tests locally via the mabl CLI against the developer's local server
+- Parse run results (exit code is unreliable — read the log summary and confirm via MCP)
+- Distinguish code regressions from harness limitations (GenAI/visual assertion skips)
+
+### Failure Root-Cause Analysis
+- Pull mabl's AI failure analysis (`analyze_mabl_failure`) and supporting artifacts
+- Retrieve DOM snapshots, HAR captures, console logs, and screenshots via MCP
+- Correlate failing steps against the application source code (selectors, routes, handlers)
+- Classify each failure: product regression, stale test, environment/data, or flake
+- Pinpoint the cause to `file:line` with suspect commits from `git blame`
+- Deliver evidence-backed verdicts with confidence scores
+
+### Triage Routing (Loop Control)
+- Route classified failures to the correct next action with loop bounds
+- Auto-apply test edits, env resets, and flake retries (safe classes)
+- Gate product-code fixes for human approval (never auto-apply)
+- Enforce max-iteration caps to prevent infinite repair loops
+- Promote edited tests from authoring branches to master before re-verification
+- Escalate when confidence is below threshold or iterations are exhausted
+
+### Coverage Gap Analysis
+- Identify user-facing flows a change touches that have no mabl test coverage
+- Rate gaps by severity: critical (money/auth/data-integrity), normal, low
+- Recommend authoring for critical/normal gaps; defer low-severity
+- Hand off to mabl local authoring when the user opts to close gaps
+- Feed coverage signals into the ship gate
+
+### Ship Gating
+- Collect run signals (pass/fail per test, billable skips, confirmed non-code reds)
+- Check mabl release readiness (`check_release_readiness`) for the workspace/plan
+- Apply explicit ship policy: SHIP / BLOCK / NEEDS_HUMAN
+- Never open, merge, or mark a PR ready — recommendation only
+- Surface blockers, the one-line why, and mabl run links for human decision
+
+## Stages Owned
+
+**Lead:**
+- mabl-verification-pre-pr — Pre-PR Verification (Construction)
+- mabl-verification-coverage-gap — Coverage Gap Analysis (Construction)
+- mabl-verification-ship-gate — Ship Gate (Operation)
+
+**Supporting:**
+- build-and-test — Build and Test (Construction) — contributes a mabl local-run verification step
+
+## Collaboration
+
+- **Receives from**: developer-agent (implemented code, build outputs), quality-agent (test strategy, NFR targets)
+- **Works with**: developer-agent (failure investigation, selector fixes), quality-agent (coverage targets, test harness design)
+- **Hands off to**: pipeline-deploy-agent (mabl plans in CI/CD), delivery-agent (release notes with verification evidence)
+
+*Note: The SKILL.md orchestrator handles all inter-agent delegation. This agent does not invoke other agents directly.*
+
+## Knowledge Loading
+
+On activation, load knowledge in this order:
+1. `aidlc/spaces/<active-space>/memory/{org,team,project}.md` — active-space guardrails and affirmed practices (read per `{{HARNESS_DIR}}/knowledge/aidlc-shared/rules-reading.md`)
+2. `{{HARNESS_DIR}}/knowledge/aidlc-shared/` — methodology principles
+3. `{{HARNESS_DIR}}/knowledge/mabl-verification-agent/` — agent-specific methodology (local-run patterns, authoring best practices, failure RCA methodology, triage routing rules)
+4. `aidlc/spaces/<active-space>/knowledge/aidlc-shared/` — team shared knowledge (if exists)
+5. `aidlc/spaces/<active-space>/knowledge/mabl-verification-agent/` — team agent-specific knowledge (if exists): workspace IDs, application IDs, credential mappings, environment URLs
+6. Prior stage artifacts named by the current stage's `consumes` contract
+
+## Key Principles
+
+1. **Test what ships, not what committed** — The working tree (what the dev server serves) is the truth; analyze it, not just the last commit, when the tree is dirty.
+2. **Semantic match, not filename match** — mabl tests exercise user-facing flows; translate code changes into observable behavior before searching.
+3. **Evidence over inference** — Every failure classification must cite its artifact (DOM state, HAR response, console error, screenshot). Low-confidence verdicts go to humans.
+4. **Loop bounds are non-negotiable** — The triage loop MUST converge: max 3 repair iterations, then escalate. Product-code fixes are ALWAYS human-gated.
+5. **Coverage is scope-aware** — "No gap" means no gap among the flows THIS change touches, not whole-app coverage. Surface the scope in the report.
+6. **Ship gate recommends, never acts** — SHIP/BLOCK/NEEDS_HUMAN is advisory. The PR/merge/deploy decision belongs to the human.
+7. **Local CLI ≠ cloud execution** — GenAI/visual assertions auto-skip locally; treat those as harness limitations, not code regressions, unless `--allow-billable-features` is passed.
+
+## Prerequisites
+
+This agent requires:
+- **mabl CLI** (`npm install -g @mablhq/mabl-cli`) authenticated (`mabl auth login`)
+- **mabl MCP server** connected to the harness (provides `search_mabl_tests`, `analyze_mabl_failure`, `check_release_readiness`, etc.)
+- **A running local dev server** for test execution (tests run against the developer's build)
+- **Git repository** for diff analysis and blame correlation

--- a/plugins/mabl-verification/contributions/construction/build-and-test.md
+++ b/plugins/mabl-verification/contributions/construction/build-and-test.md
@@ -1,0 +1,68 @@
+---
+target: build-and-test
+plugin: mabl-verification
+adds:
+  produces:
+    - mabl-verification-local-run-log
+  consumes:
+    - artifact: mabl-verification-coverage-report
+      required: false
+  sensors:
+    - mabl-run-status
+  required_sections:
+    - "mabl Verification"
+fragments:
+  - anchor: after-step:10
+    order: 200
+  - anchor: in:Sensors
+    order: 200
+---
+
+## fragment: after-step:10
+
+### Step 10a (mabl-verification): Quick smoke-check against mabl
+
+After the build passes and unit/integration tests are green, run a quick mabl
+smoke-check to catch regressions the unit tests structurally cannot see (e.g.
+selector drift, broken user flows, visual regressions).
+
+1. **Detect the closest mabl test.** Using the changed files from the build context,
+   identify the single most relevant mabl test via MCP `search_mabl_tests` (one
+   natural-language query derived from the primary changed component/page). If no
+   match, skip this step and note the gap for the downstream
+   `mabl-verification-coverage-gap` stage.
+
+2. **Run it locally.** Execute the matched test against the local dev server:
+   ```bash
+   mabl tests run \
+     --id <testId> \
+     -w <workspaceId> \
+     --url <localUrl> \
+     --application-id <applicationId> \
+     --reporter mabl
+   ```
+   Parse `Passed:`/`Failed:` from the log (exit code is unreliable).
+
+3. **Record the result.** Write a brief `mabl-verification-local-run-log.md` with:
+   - Test name and id
+   - Status (pass / fail / billable-skip)
+   - Failing step (if any)
+   - mabl app link to the published run
+
+   This is a lightweight signal — full triage, multi-test runs, and coverage analysis
+   happen in the dedicated `mabl-verification-pre-pr` stage. If the smoke-check fails,
+   note it but do NOT block the build-and-test stage (the pre-pr stage handles triage).
+
+4. **GenAI/visual assertions.** Local CLI runs disable these by default. If the
+   matched test's only assertions are GenAI/visual, skip the run (it would produce a
+   false-negative) and note that the test requires `--allow-billable-features` for
+   meaningful local verification.
+
+## fragment: in:Sensors
+
+The mabl-verification plugin wires the `mabl-run-status` sensor onto this stage.
+It reads `mabl-verification-local-run-log.md` (when present) and REPORTS the
+smoke-check outcome — pass, fail, or skipped. This is ADVISORY: a local mabl
+failure here does not block the build-and-test stage (the full verification pipeline
+runs in `mabl-verification-pre-pr`). Treat the finding as early signal for triage
+routing.

--- a/plugins/mabl-verification/knowledge/mabl-verification-agent/authoring-best-practices.md
+++ b/plugins/mabl-verification/knowledge/mabl-verification-agent/authoring-best-practices.md
@@ -1,0 +1,90 @@
+# Authoring Best Practices
+
+Methodology knowledge for creating and editing mabl tests with reliable, maintainable
+assertions.
+
+## Negative Constraints (Give These to the Authoring Agent)
+
+When initiating a mabl authoring session (create or edit), always include these
+explicit negative constraints in the `test_case` description:
+
+1. **Do NOT assert time-of-day greetings.** Apps showing "Good morning/afternoon/evening"
+   are clock-dependent. Confirm login success on a stable element (the user's name,
+   a nav link, or the app shell).
+
+2. **Do NOT use GenAI/visual assertions** for tests that must pass in local CLI runs.
+   Local execution disables them by default. Use DOM-based assertions instead.
+
+3. **Do NOT assert exact values** that are randomized per request (prices, timestamps,
+   session tokens). Assert **format and counts** instead.
+
+4. **Use only `data-testid`, `aria-label`, role, or stable class selectors.** Never
+   use generated ids, pixel coordinates, or nth-child indices.
+
+5. **Do NOT assert full text strings** that include dynamic content. Use
+   `AssertContains` on unique substrings rather than `AssertEquals` on full text.
+
+## Selector Strategy (Stability Hierarchy)
+
+Prefer selectors in this order:
+1. `data-testid="..."` — explicitly for testing, survives refactors
+2. `aria-label="..."` or `role` — semantic, accessibility-correct
+3. Stable CSS class (`.transfer-card`, `.nav-link`)
+4. Text content (as last resort, partial match only)
+
+**Name test IDs in the design phase.** When working from a spec, put the
+`data-testid` values in the design document before authoring. The authoring agent
+gets every step right when given literal selectors and invents wrong ones where it
+has only intent.
+
+## Conditional Branch Validation
+
+**Read every conditional branch in a generated test by hand.** An untaken branch
+is unvalidated code. The authoring agent reports success based only on paths it
+executed during authoring. An `IF` whose condition was false was never run — wrong
+steps inside it ship silently.
+
+After authoring:
+1. Diff intent vs generated steps for each `IF` body
+2. Verify conditional actions have literal selectors, not inferred intent
+3. Promote and re-run only after the hand review
+
+## Assertion Specificity (A/B Test)
+
+A test that passes is necessary but not sufficient — it must be specific enough to
+catch a reversion.
+
+**Post-authoring assertion audit:**
+1. Map each acceptance criterion to a test assertion
+2. For each criterion with no assertion, add one (`AssertContains` on unique content)
+3. **A/B specificity test:**
+   - Revert the code change → run the test → it MUST FAIL
+   - Restore the code → run → it MUST PASS
+   - If it passes both ways, the assertions aren't specific enough
+
+## Count-Based Assertions
+
+Count assertions (e.g. `element_count == 7`) are strong regression sentinels but
+couple the test to seed data. Use them when:
+- The seed data is stable and well-defined
+- The count is a direct output of the feature under test
+- Document the coupling so future data changes don't cause false failures
+
+Prefer `> 0` or `>= expected_minimum` over exact counts when data varies.
+
+## Demo Flag Awareness
+
+Applications with feature flags (like `transferConfirmDialog`) add modal flows that
+tests authored without the flag cannot handle. Before authoring:
+1. Check active demo flags (`GET /api/demo-flags` or equivalent)
+2. Decide: author the test WITH the flag (future-proof) or WITHOUT (simpler path)
+3. Document which flags were active during authoring in the test description
+
+## Authoring Session Expectations
+
+- **Create sessions:** 30–45 minutes (measured: 9-group create took 44 min)
+- **Edit sessions:** 5–15 minutes (measured: one-step edit took 7 min)
+- **Validation:** The agent reports "validated 100%" based on paths it executed —
+  this does NOT mean all branches work
+
+Always launch authoring detached for sessions longer than a test run.

--- a/plugins/mabl-verification/knowledge/mabl-verification-agent/failure-rca-methodology.md
+++ b/plugins/mabl-verification/knowledge/mabl-verification-agent/failure-rca-methodology.md
@@ -1,0 +1,105 @@
+# Failure RCA Methodology
+
+Methodology knowledge for root-causing failed mabl test runs against application
+source code.
+
+## The Flow
+
+**resolve run → pull AI analysis → pull artifacts → correlate with source → classify + report**
+
+## Step-by-Step Procedure
+
+### 1. Resolve to a Concrete Failed Test Run
+
+End state: a single failed `testRunId` (`-jr`) in a known workspace.
+
+- Given a `-jr` → use directly
+- Given a test id (`-j`) → `list_mabl_test_runs(testId)`, pick most recent `failed`
+- Given a plan run (`-pr`) → `get_mabl_plan_run(planRunId)`, list failed test runs
+- Given a mabl URL → extract the run id
+
+### 2. Pull mabl's AI Failure Analysis
+
+Call `analyze_mabl_failure(runId, 'test', workspaceId, includeEvidence: true)`.
+
+Capture:
+- **Synopsis** — one-line failure summary
+- **Root cause + Next steps** — mabl's AI assessment
+- **evidenceDetails** — contains `gs://` artifact URIs and historical data
+- **Failing step** — which step, what assertion (expected vs actual)
+- **Target** — the selector, URL, or network request that failed
+
+Check if the Runtime Recovery Agent (auto-heal) was involved — a "passed via healing"
+run signals selector drift worth fixing at the source.
+
+### 3. Pull Supporting Artifacts
+
+**Via MCP (surgical):** `get_mabl_test_run_artifact(artifactUri, workspaceId)`
+- Screenshot at failing step → rendered visual state
+- DOM snapshot → confirm element presence/absence
+- Console logs → JS exceptions
+- HAR → network requests (status, payload, response)
+
+**Via CLI (bulk):**
+```bash
+mabl test-runs export <testRunId> --types doms hars console_logs screenshots --file "$DIR/run"
+```
+
+⚠️ Filter before grepping: `awk 'length($0) < 300'` first (base64 payloads).
+
+### 4. Correlate with Source Code
+
+Map each evidence piece to the application source:
+
+| Evidence | Correlation |
+|----------|-------------|
+| Selector target (failing find/assertion) | Grep front-end for `data-testid`, label text, `aria-label`, role, `id` |
+| Network failure (4xx/5xx from HAR) | Map request path to API route/controller |
+| Console exception | Map stack trace to source file:line |
+| DOM vs expectation (empty/error state) | Follow data path: component → fetch → endpoint |
+
+**Blame window:** Using "since green" history, `git log --oneline <lastGreen>..<rev>`
+on implicated files and `git blame` to surface likely culprit commits.
+
+### 5. Classify the Failure
+
+Assign exactly one verdict with a confidence score (0–1):
+
+| Verdict | Meaning | Fix |
+|---------|---------|-----|
+| `product` | App code broke a real behavior | Fix the app code (human-gated) |
+| `stale-test` | UI/contract changed intentionally | Update the test selector/assertion |
+| `env-data` | Seed data, creds, config, or down dependency | Reset precondition or fix env |
+| `mabl-flake` | Race condition or non-deterministic behavior | Retry; if persists, reclassify |
+
+**Distinguishing signals:**
+- Element present but text/attribute changed → `stale-test`
+- Element absent + component conditionally rendered → check gate condition
+- 500 response + new/changed handler → `product`
+- Same test passes on rerun → `mabl-flake` (correlate with historical pass rate)
+- Wrong user state (already tracked, wrong persona) → `env-data`
+
+### 6. Deliver the Report
+
+1. **Verdict** with confidence
+2. **Failing step & assertion** — expected vs actual in plain terms
+3. **Evidence trail** — each conclusion tied to its artifact
+4. **Pinpointed cause** — `file:line` in the repo + suspect commits
+5. **Recommended fix** — concrete diff sketch
+6. **Links** — mabl run URL and result-analysis session
+
+## Common Traps
+
+- **"Element not found" often means wrong app state, not missing element.** Lists
+  that filter by state hide controls (e.g. "Add" button missing because item is
+  already added). Check the live page before blaming the diff.
+
+- **A headless re-run cannot isolate cause.** It shows symptoms, not root cause.
+  Use a live step-through (`mabl agent debug session start`) for definitive blame.
+
+- **GenAI assertion failures in local runs are harness limitations.** Never classify
+  a GenAI-only failure as a product regression unless `--allow-billable-features`
+  was passed and it still failed.
+
+- **Auto-heal masks drift.** If the Recovery Agent healed a step, the run "passed"
+  but the selector drifted — flag it as an `autoHealCandidate` for proactive fix.

--- a/plugins/mabl-verification/knowledge/mabl-verification-agent/local-run-patterns.md
+++ b/plugins/mabl-verification/knowledge/mabl-verification-agent/local-run-patterns.md
@@ -1,0 +1,95 @@
+# Local Run Patterns
+
+Methodology knowledge for executing mabl tests locally via the CLI.
+
+## Command Shape
+
+```bash
+mabl tests run \
+  --id <testId> \
+  -w <workspaceId> \
+  --url <localUrl> \
+  --application-id <applicationId> \
+  --environment-id <environmentId> \
+  --credentials-id <credentialsId> \
+  --reporter mabl
+```
+
+## Critical Rules
+
+1. **Never pass `--keep-browser-open`.** It prevents the command from returning and
+   hangs the execution turn indefinitely.
+
+2. **Do not trust the exit code.** `mabl tests run` can exit 0 even when a test
+   failed. Always parse the `Passed:`/`Failed:` counts from the log output.
+
+3. **Run sequentially.** Tests share a single dev server/port — parallel runs cause
+   port conflicts and race conditions.
+
+4. **`--reporter mabl` publishes to the cloud.** Each local run gets a shareable app
+   link and history entry. Execution remains local (no cloud credits for the run
+   itself). Resolve `--application-id` and `--environment-id` so the published run
+   associates correctly.
+
+5. **Never grep raw run logs.** They embed base64 screenshot payloads. Always pipe
+   through `awk 'length($0) < 300'` before grepping for keywords like `Passed`,
+   `Failed`, `Test Passed`, `Test Failed`.
+
+## GenAI/Visual Assertions
+
+Local CLI runs **disable GenAI and visual assertions by default**. Any such step
+auto-fails with "AI assertions are not available in CLI runs."
+
+Before running, check the test's steps (`get_mabl_test_steps`) for GenAI/visual
+assertions. If present:
+- Run with `--allow-billable-features` (consumes mabl credits — confirm with user), OR
+- Run without the flag and treat a failure on ONLY those steps as a **harness skip**,
+  not a code regression.
+
+When every concrete (DOM) assertion passed and the only red is a GenAI/visual step,
+the test is **effectively green** — report it as such.
+
+## Credentials Resolution
+
+The right credentials depend on what the test asserts. The same page renders
+differently per persona:
+- Admin lands on "Dashboard" with full nav
+- Client lands on "My Account" with limited nav
+
+If a test's assertions were authored for admin, run it with the Admin credentials id.
+Resolve ids with `list_mabl_credentials` (MCP). A local run without credentials
+resolves `app.defaults.username` to nothing — the login flow executes with a
+placeholder, and the test fails downstream with misleading "Element not found" errors.
+
+## URL Resolution Priority
+
+1. User-provided `--url` override
+2. Detected running dev server (probe ports 3000, 3001, 5173, 8080)
+3. Project config (package.json scripts, .env, docker-compose)
+4. Ask the user
+
+Only fall back to the mabl environment default URL if the user explicitly says to
+test the deployed app (defeats the purpose of pre-PR local verification).
+
+## Long-Running Operations
+
+- **Test runs (1–5 min):** Run in the foreground. The harness blocks and returns
+  stdout/stderr directly.
+- **Authoring sessions (30–45 min):** Launch detached and poll:
+  ```bash
+  DIR="$HOME/.kiro/tmp/mabl-authoring"; mkdir -p "$DIR"
+  nohup mabl agent authoring initiate ... --mode local --headless --auto-save --verbose \
+    > "$DIR/authoring.log" 2>&1 &
+  echo "started pid $!"
+  ```
+  Poll with `awk 'length($0) < 300' "$DIR/authoring.log" | tail -n 40` on later turns.
+
+## Authoring Branch Gotcha
+
+Local authoring saves to an "Agent edit session" branch, **not `master`**. But
+`mabl tests run --id` executes the master tip. After authoring:
+1. `list_mabl_test_versions` to find the new version
+2. `restore_mabl_test(version=<new>)` to promote it to master latest
+3. THEN re-run to verify
+
+Without promotion, re-runs still use the old steps.

--- a/plugins/mabl-verification/knowledge/mabl-verification-agent/triage-routing.md
+++ b/plugins/mabl-verification/knowledge/mabl-verification-agent/triage-routing.md
@@ -1,0 +1,100 @@
+# Triage Routing
+
+Methodology knowledge for deciding what the verification loop does next after a
+failure is classified. Enforces loop bounds and human gates.
+
+## Routing Table
+
+| `class` | `action` | `autoApply` | `requiresHumanGate` | Next Step |
+|---------|----------|-------------|---------------------|-----------|
+| `product` | `propose-code-fix` | **false** | **true** | Present the diff; on approval apply → re-run |
+| `stale-test` | `edit-test` | true | false | Edit selector/assertion → promote to master → re-run |
+| `env-data` | `reset-env` | true | false | Reset seed/creds/precondition → re-run |
+| `mabl-flake` | `retry` | true | false | `rerun_mabl_test` once; if heals, flag drift; if re-fails, reclassify |
+
+## Inviolable Rules
+
+1. **Never auto-apply a product-code change.** Always `autoApply: false` +
+   `requiresHumanGate: true`, even at high confidence. Product logic is the user's
+   to approve.
+
+2. **Loop bound is non-negotiable.** If `iteration > maxIterations` (default 3),
+   emit `action: "escalate"` immediately. Do this BEFORE any routing logic.
+
+3. **Confidence floor.** If `failureVerdict.confidence < 0.6`, route to a human
+   (`action: "escalate"`, `requiresHumanGate: true`). A low-confidence auto-repair
+   is worse than asking.
+
+4. **Promote before re-verify.** `edit-test` edits save to an authoring branch, not
+   master. After editing: `list_mabl_test_versions` → `restore_mabl_test(version=<new>)`
+   → THEN re-run. Without promotion, re-runs use old steps.
+
+5. **Billable skip = effective pass.** If every concrete assertion passed and only
+   the GenAI step is red, treat the repair as green. Only spend credits with explicit
+   user go-ahead.
+
+6. **Retry ≠ repair iteration.** A flake retry that heals does NOT consume a repair
+   cycle. A "flake" that reproduces is reclassified — send back to RCA.
+
+7. **Credit-spending is gated.** Anything that would spend mabl credits (billable AI
+   reruns, cloud plan execution) requires user confirmation regardless of class.
+
+## Loop Bound Mechanics
+
+- **maxIterations:** 3 (default). Counts genuine repair attempts, not retries.
+- **iteration:** incremented by the caller on each repair cycle.
+- **Exhaustion:** emit `escalate` with summary of what was tried.
+
+## Confidence Floor
+
+- Default: 0.6
+- Below floor → route to human, not auto-repair
+- The floor prevents garbage-in/garbage-out: a wrong classification auto-repaired
+  is harder to recover from than a human pause
+
+## Post-Routing Actions
+
+### `edit-test` (stale-test)
+1. Identify the stale selector/assertion from the RCA evidence
+2. Call `mabl_authoring_edit` with the test id and the fix description
+3. Wait for edit completion (5–15 min)
+4. Promote: `list_mabl_test_versions` → `restore_mabl_test`
+5. Re-run locally to verify
+6. If `autoHealCandidate: true`, note the selector drift for proactive source update
+
+### `reset-env` (env-data)
+1. Identify the precondition failure from the RCA evidence
+2. Reset: un-track a stock, pick a guaranteed-available item, switch persona
+3. Re-run locally to verify
+4. Document the reset so it's reproducible
+
+### `retry` (mabl-flake)
+1. `rerun_mabl_test(testRunId, workspaceId)` via MCP
+2. Poll `get_mabl_test_run` until terminal
+3. If passes → flag selector drift as auto-heal candidate; done
+4. If fails again → reclassify (not a flake); route back to RCA
+
+### `propose-code-fix` (product)
+1. Present the diff sketch from `suggestedFix`
+2. STOP and wait for human approval
+3. On approval → apply the fix → rebuild → re-run full verification
+4. On rejection → escalate or revise
+
+## Decision Output
+
+Emit one `routerDecision` per input verdict:
+
+```json
+{
+  "testId": "...",
+  "testRunId": "...",
+  "class": "stale-test",
+  "action": "edit-test",
+  "autoApply": true,
+  "requiresHumanGate": false,
+  "iteration": 1,
+  "maxIterations": 3,
+  "confidence": 0.85,
+  "nextStep": "Edit selector [data-testid='dashboard-header'] → promote → re-run"
+}
+```

--- a/plugins/mabl-verification/scopes/mabl-verification-validation.md
+++ b/plugins/mabl-verification/scopes/mabl-verification-validation.md
@@ -1,0 +1,64 @@
+---
+name: mabl-verification-validation
+plugin: mabl-verification
+display_name: mabl Verification Validation
+description: >
+  A focused scope that activates all mabl-verification plugin stages for validating
+  the plugin itself or running a mabl-centric verification workflow. Includes the
+  core construction and operation stages plus all three mabl-verification stages.
+  Use this scope when the primary goal is exercising the mabl verification loop
+  end-to-end (pre-PR matching, coverage gap analysis, and ship gating) without
+  the full enterprise/feature lifecycle overhead.
+phases:
+  initialization:
+    - project-bootstrap
+    - workspace-scan
+    - workflow-planning
+  ideation:
+    - SKIP
+  inception:
+    - SKIP
+  construction:
+    - code-implementation
+    - build-and-test
+    - mabl-verification-pre-pr
+    - mabl-verification-coverage-gap
+  operation:
+    - mabl-verification-ship-gate
+depth: Standard
+test_strategy: Standard
+---
+
+# mabl Verification Validation Scope
+
+A lightweight scope designed for two use cases:
+
+1. **Plugin validation** — verifying the mabl-verification plugin itself works
+   correctly after installation or upgrade. Exercises all three plugin stages
+   against a real codebase with real mabl tests.
+
+2. **mabl-centric workflows** — when the primary goal is test verification (not
+   full feature ideation/design). Skips Ideation and Inception entirely, runs a
+   minimal Construction (implement + build + mabl verify), and gates ship.
+
+## When to use
+
+- After installing/upgrading the mabl-verification plugin: `/aidlc --scope mabl-verification-validation`
+- For hotfixes or small changes where the only validation needed is "do the mabl tests still pass?"
+- When testing the plugin's integration with a new mabl workspace
+
+## Stage flow
+
+```
+project-bootstrap → workspace-scan → workflow-planning
+  → code-implementation → build-and-test → mabl-verification-pre-pr
+  → mabl-verification-coverage-gap (conditional)
+  → mabl-verification-ship-gate
+```
+
+## Prerequisites
+
+- mabl CLI installed and authenticated
+- mabl MCP server connected
+- At least one mabl test in the workspace covering the application under development
+- A running local dev server for test execution

--- a/plugins/mabl-verification/sensors/aidlc-mabl-coverage-threshold.md
+++ b/plugins/mabl-verification/sensors/aidlc-mabl-coverage-threshold.md
@@ -1,0 +1,49 @@
+---
+id: mabl-coverage-threshold
+kind: deterministic
+command: bun {{HARNESS_DIR}}/tools/aidlc-sensor-mabl-coverage-threshold.ts
+default_severity: advisory
+description: Reports whether critical or normal coverage gaps exist in the mabl-verification-coverage-report.md (mabl-verification plugin, advisory)
+category: document-shape
+matches: "**/{aidlc-docs,intents}/**"
+input_schema:
+  output_path: string
+  stage_slug: string
+output_schema:
+  pass: boolean
+  findings_count: integer
+  total_flows: integer
+  covered: integer
+  uncovered: integer
+  critical_gap_count: integer
+  ship_blocker: boolean
+timeout_seconds: 5
+---
+
+# mabl-coverage-threshold sensor (mabl-verification)
+
+ADVISORY. Reads the machine-readable JSON summary from
+`mabl-verification-coverage-report.md` and reports whether critical or normal
+coverage gaps exist for the changed flows.
+
+## Pass criteria
+
+- `pass: true` when `critical_gap_count == 0` (no critical uncovered flows)
+- `pass: false` when `critical_gap_count > 0` (at least one critical flow has no test)
+
+## Findings
+
+Each gap with severity `critical` or `normal` where `has_test == false` is reported
+as a finding. Low-severity gaps and deferred recommendations are not reported.
+
+## Ship-blocker signal
+
+When `ship_blocker: true` (any critical gap with no test and recommendation `author`),
+the downstream `mabl-verification-ship-gate` stage will factor this into its BLOCK
+decision. The sensor itself does not block — it reports.
+
+## Advisory note
+
+The framework has no blocking sensor severity yet, so a `SENSOR_FAILED` here is
+REPORTED, not enforced. The coverage-gap stage prose and ship-gate handle the actual
+gating. Treat findings as authoritative guidance to close gaps before shipping.

--- a/plugins/mabl-verification/sensors/aidlc-mabl-run-status.md
+++ b/plugins/mabl-verification/sensors/aidlc-mabl-run-status.md
@@ -1,0 +1,46 @@
+---
+id: mabl-run-status
+kind: deterministic
+command: bun {{HARNESS_DIR}}/tools/aidlc-sensor-mabl-run-status.ts
+default_severity: advisory
+description: Reports whether mabl test runs passed or failed by reading the JSON summary from mabl-verification-run-results.md or mabl-verification-local-run-log.md (mabl-verification plugin, advisory)
+category: document-shape
+matches: "**/{aidlc-docs,intents}/**"
+input_schema:
+  output_path: string
+  stage_slug: string
+output_schema:
+  pass: boolean
+  findings_count: integer
+  tests_run: integer
+  tests_passed: integer
+  tests_failed: integer
+  billable_skipped: integer
+  has_unresolved_failures: boolean
+timeout_seconds: 5
+---
+
+# mabl-run-status sensor (mabl-verification)
+
+ADVISORY. Reads the machine-readable JSON summary block from either
+`mabl-verification-run-results.md` (full pre-PR stage) or
+`mabl-verification-local-run-log.md` (build-and-test contribution smoke-check)
+and reports whether the mabl test runs passed.
+
+## Pass criteria
+
+- `pass: true` when `tests_failed == 0` (billable skips do not count as failures)
+- `pass: false` when `tests_failed > 0` and at least one failure is classified as
+  `product` or remains unresolved
+
+## Findings
+
+Each unresolved failure (not classified as `billable-skip` or already triaged as
+`env-data`/`mabl-flake` with a successful rerun) is reported as a finding.
+
+## Advisory note
+
+The framework has no blocking sensor severity yet, so a `SENSOR_FAILED` here is
+REPORTED, not enforced. The stage prose and downstream ship-gate handle the actual
+gating logic. A future blocking-severity capability would make this gate hard for
+`product`-class failures.

--- a/plugins/mabl-verification/stages/construction/mabl-verification-coverage-gap.md
+++ b/plugins/mabl-verification/stages/construction/mabl-verification-coverage-gap.md
@@ -1,0 +1,191 @@
+---
+slug: mabl-verification-coverage-gap
+number: 3.95
+name: mabl Coverage Gap Analysis
+plugin: mabl-verification
+phase: construction
+execution: CONDITIONAL
+condition: Execute after mabl-verification-pre-pr when the plugin is active and either (a) the pre-pr stage reported coverageZeroMatch for any inferred flow, (b) the matched test count is below the inferred flow count, or (c) the user explicitly requests a coverage assessment.
+lead_agent: mabl-verification-agent
+support_agents: []
+mode: inline
+produces:
+  - mabl-verification-coverage-report
+consumes:
+  - artifact: mabl-verification-impact
+    required: true
+  - artifact: mabl-verification-run-results
+    required: false
+requires_stage:
+  - mabl-verification-pre-pr
+sensors:
+  - mabl-coverage-threshold
+scopes:
+  - enterprise
+  - feature
+  - mvp
+  - mabl-verification-validation
+  - classic
+inputs: The impact artifact from mabl-verification-pre-pr (inferred flows, matched tests, zero-match flags) and the mabl workspace's test catalog via MCP
+outputs: mabl-verification-coverage-report.md (under this stage's record dir, engine-resolved)
+---
+
+# mabl Coverage Gap Analysis
+
+MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
+
+Coverage is the question the pass/fail signal cannot answer: a change can be
+all-green simply because **nothing tests it**. This stage finds the user-facing
+flows a change touches that have no mabl test, rates them by severity, and
+recommends authoring to close critical gaps — or delegates to mabl's authoring
+tools when the user opts in. It answers **Q5 — is there a gap in coverage?**
+
+The flow: **load impact → identify uncovered paths → rate + recommend →
+optionally author → emit coverage report.**
+
+---
+
+## Steps
+
+### Step 1: Load Agent Persona
+
+Load mabl-verification-agent persona from `agents/mabl-verification-agent.md` and knowledge from `{{HARNESS_DIR}}/knowledge/mabl-verification-agent/`.
+
+### Step 2: Load Upstream Impact
+
+Read the `mabl-verification-impact` artifact produced by `mabl-verification-pre-pr`.
+Extract:
+- The inferred user-facing flows (from diff analysis)
+- The matched tests (with relevance ratings)
+- Any `coverageZeroMatch` flags (flows with no test match at all)
+- The search queries that were used
+
+If the impact artifact is unavailable (stage ran standalone), derive flows from the
+current diff using the same heuristics as the pre-pr stage Step 4.
+
+### Step 3: Identify Uncovered Paths
+
+For each inferred flow from Step 2, determine coverage status:
+
+1. **Covered** — a strong-match test exists and ran (from pre-pr results).
+2. **Weakly covered** — only a partial/tangential match exists.
+3. **Uncovered** — no test matched this flow at all (`coverageZeroMatch`).
+
+Cross-check suspected gaps with a broadened `search_mabl_tests` query before
+declaring them — avoid false gaps from an over-narrow earlier search. Use feature-area
+queries rather than specific-page queries.
+
+Additionally, call `identify_coverage_gaps` (MCP) scoped to the workspace and
+application, biased toward the flows from Step 2. This uses mabl's AI coverage
+model for a second opinion beyond the semantic search.
+
+### Step 4: Rate Gaps by Severity
+
+For each confirmed gap, assign a severity:
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| `critical` | Core money/auth/data-integrity flow, or the primary behavior the change introduces | Payment processing, login/logout, account transfer, the new feature's main card |
+| `normal` | Secondary or edge behavior of a covered feature | Settings page update, notification preference toggle |
+| `low` | Cosmetic or rarely-hit path | Footer link, tooltip text, empty-state illustration |
+
+### Step 5: Recommend Actions
+
+For each gap, set a recommendation:
+
+- **`author`** — critical or normal severity on a shipped flow → a new mabl test
+  should be created before shipping.
+- **`defer`** — low severity, or indirectly covered by another test's broader flow.
+- **`none`** — not a real gap (false positive from narrow search).
+
+A `critical` gap with `recommendation: author` is a **ship-blocker input** for the
+downstream `mabl-verification-ship-gate` stage.
+
+### Step 6: Author Missing Tests (Optional)
+
+When the user opts to close a gap (or the workflow policy requires it for critical
+gaps), hand off to mabl's authoring tools:
+
+1. **Plan the test** — call `mabl_authoring_plan` with the flow description, target
+   application, and environment.
+2. **Initiate local authoring** — use `mabl_authoring_initiate_local` with:
+   - The planned test case description
+   - The local dev server URL
+   - Stable selectors from the project's design artifacts (prefer `data-testid`)
+   - Negative constraints: no time-of-day greetings, no GenAI assertions for local
+     verification, stable class/attribute selectors only
+3. **Track the session** — local authoring takes 30–45 minutes. Launch detached and
+   poll. Record the created `testId` on completion.
+4. **Verify the new test** — run the authored test locally to confirm it passes
+   against the current build.
+
+If authoring is declined or deferred, proceed with the recommendation only.
+
+### Step 7: Produce Coverage Report
+
+Write **`mabl-verification-coverage-report.md`** to this stage's record dir:
+
+For each inferred flow:
+- Flow name and description
+- Coverage status (covered / weakly-covered / uncovered)
+- Severity (if uncovered)
+- Recommendation (author / defer / none)
+- Authored test id (if Step 6 produced one)
+
+Include a machine-readable JSON summary:
+
+```json
+{
+  "total_flows": 5,
+  "covered": 3,
+  "weakly_covered": 1,
+  "uncovered": 1,
+  "gaps": [
+    {
+      "flow": "Account transfer confirmation dialog",
+      "severity": "critical",
+      "recommendation": "author",
+      "authored_test_id": null,
+      "has_test": false
+    }
+  ],
+  "gap_found": true,
+  "critical_gap_count": 1,
+  "ship_blocker": true
+}
+```
+
+### Step 8: Open the Approval Gate
+
+Run `bun {{HARNESS_DIR}}/tools/aidlc-orchestrate.ts report --stage mabl-verification-coverage-gap --result awaiting-approval`.
+
+### Step 9: Present Completion & Request Approval
+
+Completion emoji: :mag:
+Review path: this stage's engine-resolved record dir.
+Standard 2-option approval (Approve / Request Changes).
+STOP for the human response. Report Approve with
+`--result approved --user-input "<exact choice>"`; report
+Request Changes with `--result rejected --user-input "<feedback>"`, revise the
+artifacts, then report `--result revised` before re-presenting.
+
+---
+
+## Sensors
+
+This stage binds the `mabl-coverage-threshold` sensor which reads the JSON summary
+from `mabl-verification-coverage-report.md` and reports whether critical/normal gaps
+exist. A critical gap with `has_test == false` is reported as an advisory finding
+(the framework has no blocking sensor severity yet).
+
+---
+
+## Learn
+
+While running this stage, maintain a running log in
+`<record>/<phase>/<stage>/memory.md` (create on stage start if absent).
+Append entries under: Interpretations, Deviations, Tradeoffs, Open questions —
+each with an ISO 8601 timestamp.
+
+Stage files are immutable framework artefacts — the ritual writes into the
+harness, not into this file.

--- a/plugins/mabl-verification/stages/construction/mabl-verification-pre-pr.md
+++ b/plugins/mabl-verification/stages/construction/mabl-verification-pre-pr.md
@@ -1,0 +1,257 @@
+---
+slug: mabl-verification-pre-pr
+number: 3.90
+name: mabl Pre-PR Verification
+plugin: mabl-verification
+phase: construction
+execution: CONDITIONAL
+condition: Execute after build-and-test when the mabl plugin is active, the mabl CLI is authenticated, the mabl MCP server is connected, and the workspace has mabl tests covering the application under development.
+lead_agent: mabl-verification-agent
+support_agents: []
+mode: inline
+produces:
+  - mabl-verification-impact
+  - mabl-verification-run-results
+consumes:
+  - artifact: build-and-test-summary
+    required: true
+requires_stage:
+  - build-and-test
+sensors:
+  - mabl-run-status
+scopes:
+  - enterprise
+  - feature
+  - mvp
+  - mabl-verification-validation
+  - classic
+  - workshop
+inputs: Build outputs from build-and-test, the current git diff (working tree or committed), and the mabl workspace's test catalog via MCP
+outputs: mabl-verification-impact.md, mabl-verification-run-results.md (under this stage's record dir, engine-resolved)
+---
+
+# mabl Pre-PR Verification
+
+MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
+
+Map the code changes from `build-and-test` to the mabl tests that exercise those
+user-facing flows, then run the best matches locally through the mabl CLI so the
+developer sees pass/fail against their own build within minutes — no waiting on CI
+or a cloud plan run. This stage answers two questions: **Q1 — which tests are
+affected?** and **Q2 — do they pass?**
+
+The flow: **diff → derive intent → match tests → run locally → triage → report.**
+
+---
+
+## Steps
+
+### Step 1: Load Agent Persona
+
+Load mabl-verification-agent persona from `agents/mabl-verification-agent.md` and knowledge from `{{HARNESS_DIR}}/knowledge/mabl-verification-agent/`.
+
+### Step 2: Preflight Checks
+
+Verify the mabl toolchain is ready before proceeding:
+
+1. **CLI present & authenticated:**
+   ```bash
+   mabl --version && mabl auth info
+   ```
+   If missing or expired, report the gap and halt with remediation instructions.
+
+2. **mabl MCP server connected:** Confirm that MCP tools (`search_mabl_tests`,
+   `list_mabl_workspaces`, `analyze_mabl_failure`) are available in this session.
+   If not connected, report the gap and halt.
+
+3. **Workspace resolution:** Resolve the target mabl workspace (from team knowledge
+   at `aidlc/spaces/<active-space>/knowledge/mabl-verification-agent/workspace-constants.md`,
+   or `mabl config get workspace-id`, or by listing and asking). Record the workspaceId.
+
+4. **Git repository:** Confirm `git rev-parse --is-inside-work-tree`.
+
+5. **Local dev server:** Detect a running server (probe ports 3000, 3001, 5173, 8080)
+   or read it from project config. Record the run URL.
+
+### Step 3: Resolve the Change Set
+
+Analyze what the app under test actually runs. A local dev server serves the
+**working tree**, so that — not the last commit — is what mabl will exercise.
+
+```bash
+git status --short
+```
+
+- **Dirty tree:** analyze working tree — committed diff PLUS uncommitted changes.
+  This matches what the dev server serves.
+- **Clean tree:** analyze the branch's committed diff (`main...HEAD`).
+
+Produce a concise list of changed files grouped by area (frontend pages, components,
+routes, API/controllers, backend logic, styles, config). Skip lockfiles, generated
+files, and pure-formatting churn.
+
+### Step 4: Derive User-Facing Intent
+
+mabl tests exercise **end-user behavior**, not code internals. Translate the diff
+into the user-facing flows it affects.
+
+**Spec-first path (preferred):** If a project spec or requirements document exists
+for the current feature, read its acceptance criteria first. Observable browser
+behavior specs convert directly into search queries — more reliable than diff inference.
+
+**Diff-only fallback:** Use mapping heuristics:
+- Page/route component → the flow by name
+- Shared UI component → the flows that render it
+- API endpoint/controller → API tests for that resource
+- Backend logic → the user-facing feature it powers
+
+Write **1–5 short natural-language search queries** from the inferred flows.
+
+### Step 5: Discover Relevant Tests
+
+Run MCP `search_mabl_tests` once per query (pass `workspaceId`), then merge and
+de-duplicate by test id. Use the returned descriptions and step summaries to judge
+fit. Rank candidates by relevance:
+- **Strong match** — exact flow match
+- **Partial** — same feature area
+- **Tangential** — related but indirect
+
+Drop anything clearly unrelated. If queries return nothing, broaden once (feature
+area instead of specific page) before concluding there is no coverage.
+
+### Step 6: Confirm the Run Set
+
+Present the ranked candidates:
+- Changed files grouped by area
+- Inferred flows
+- Matched tests with relevance rating
+
+Default to running the top 3 matches. Ask for confirmation only if picks are
+ambiguous or there are zero matches.
+
+With **zero matches**, report plainly: this change may have no existing mabl
+coverage — flag it as a gap for the coverage-gap stage.
+
+### Step 7: Execute Tests Locally
+
+For each selected test, run via the mabl CLI against the local dev server.
+
+Resolve `applicationId` and `environmentId` from team knowledge or MCP
+(`list_mabl_applications`, `list_mabl_environments`). Resolve credentials from
+`list_mabl_credentials` — the right persona depends on what the test asserts.
+
+```bash
+mabl tests run \
+  --id <testId> \
+  -w <workspaceId> \
+  --url <localUrl> \
+  --application-id <applicationId> \
+  --environment-id <environmentId> \
+  --credentials-id <credentialsId> \
+  --reporter mabl
+```
+
+Run tests **sequentially** (shared dev server). Do NOT pass `--keep-browser-open`
+(blocks the command). Parse `Passed:`/`Failed:` counts from the log — **do not trust
+the exit code alone** (`mabl tests run` can exit 0 on failure).
+
+**GenAI/visual assertions:** Local CLI runs disable these by default. Check
+`get_mabl_test_steps` for GenAI assertions before running. If present, either run
+with `--allow-billable-features` (confirm with user — consumes credits) or treat a
+failure on only those steps as a harness skip, not a code regression.
+
+### Step 8: Confirm Results via Cloud
+
+Verify each run's outcome authoritatively through MCP:
+- `list_mabl_test_runs(testId, workspaceId)` — latest run status
+- `get_mabl_test_run(testRunId)` — detailed status and failure summary
+
+For each failed run, note the failing step, expected vs actual, and whether it is a
+billable-assertion skip vs a real failure.
+
+### Step 9: Triage Results
+
+For each test result, classify:
+
+- **Pass** — test passed all concrete assertions.
+- **Billable skip** — only GenAI/visual assertions failed (harness limitation, not regression).
+- **Code regression** — a concrete assertion failed on a step the diff touches.
+- **Stale test** — a selector/assertion broke because the UI intentionally changed.
+- **Environment/data** — wrong seed data, missing precondition, or down dependency.
+- **Flake** — timing race or non-deterministic behavior (correlate with history).
+
+For failures classified as code regression or stale test, cross-reference the
+failing step against the diff from Step 3 to localize the cause.
+
+If deeper analysis is needed, invoke the failure-RCA methodology from
+`{{HARNESS_DIR}}/knowledge/mabl-verification-agent/failure-rca-methodology.md`:
+pull AI analysis (`analyze_mabl_failure`), retrieve artifacts (DOM, HAR, console),
+and correlate with source.
+
+### Step 10: Produce Artifacts
+
+Write **two** artifacts to this stage's engine-resolved record dir:
+
+1. **`mabl-verification-impact.md`** — the change summary, inferred flows, search
+   queries, matched tests (with relevance), and any zero-match gaps.
+
+2. **`mabl-verification-run-results.md`** — per-test execution results: test name,
+   test id, status (pass/fail/billable-skip), failing step (if any), classification,
+   confidence, mabl run link, and recommended next action.
+
+Include a machine-readable JSON summary block at the end of each artifact for
+downstream sensor consumption:
+
+```json
+{
+  "tests_matched": 3,
+  "tests_run": 3,
+  "passed": 2,
+  "failed": 1,
+  "billable_skipped": 0,
+  "coverage_zero_match": false,
+  "failures": [
+    {
+      "testId": "...",
+      "testRunId": "...",
+      "class": "stale-test",
+      "confidence": 0.85,
+      "failingStep": "Step 7: Assert heading contains 'Dashboard'"
+    }
+  ]
+}
+```
+
+### Step 11: Open the Approval Gate
+
+Run `bun {{HARNESS_DIR}}/tools/aidlc-orchestrate.ts report --stage mabl-verification-pre-pr --result awaiting-approval`.
+
+### Step 12: Present Completion & Request Approval
+
+Completion emoji: :test_tube:
+Review path: this stage's engine-resolved record dir.
+Standard 2-option approval (Approve / Request Changes).
+STOP for the human response. Report Approve with
+`--result approved --user-input "<exact choice>"`; report
+Request Changes with `--result rejected --user-input "<feedback>"`, revise the
+artifacts, then report `--result revised` before re-presenting.
+
+---
+
+## Sensors
+
+This stage binds the `mabl-run-status` sensor which reads the JSON summary from
+`mabl-verification-run-results.md` and reports pass/fail counts and any unresolved
+failures.
+
+---
+
+## Learn
+
+While running this stage, maintain a running log in
+`<record>/<phase>/<stage>/memory.md` (create on stage start if absent).
+Append entries under: Interpretations, Deviations, Tradeoffs, Open questions —
+each with an ISO 8601 timestamp.
+
+Stage files are immutable framework artefacts — the ritual writes into the
+harness, not into this file.

--- a/plugins/mabl-verification/stages/operation/mabl-verification-ship-gate.md
+++ b/plugins/mabl-verification/stages/operation/mabl-verification-ship-gate.md
@@ -1,0 +1,198 @@
+---
+slug: mabl-verification-ship-gate
+number: 4.50
+name: mabl Ship Gate
+plugin: mabl-verification
+phase: operation
+execution: EXECUTE
+lead_agent: mabl-verification-agent
+support_agents: []
+mode: inline
+produces:
+  - mabl-verification-ship-verdict
+consumes:
+  - artifact: mabl-verification-run-results
+    required: true
+  - artifact: mabl-verification-coverage-report
+    required: false
+requires_stage:
+  - mabl-verification-pre-pr
+sensors:
+  - mabl-run-status
+scopes:
+  - enterprise
+  - feature
+  - mvp
+  - mabl-verification-validation
+  - classic
+inputs: Run results from mabl-verification-pre-pr, coverage report from mabl-verification-coverage-gap (if produced), and mabl's release readiness scoring via MCP
+outputs: mabl-verification-ship-verdict.md (under this stage's record dir, engine-resolved)
+---
+
+# mabl Ship Gate
+
+MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
+
+The verification loop's decision gate. Everything upstream produced a quality signal;
+this stage turns that signal into a **recommendation** the human acts on. It answers
+**Q6 — is the change safe to ship?**
+
+This stage does NOT open, merge, or mark a PR ready — it recommends only. The
+PR/merge/deploy decision belongs to the human.
+
+The flow: **collect run signal → analyze unanalyzed failures → check release readiness →
+apply ship policy → emit verdict.**
+
+---
+
+## Steps
+
+### Step 1: Load Agent Persona
+
+Load mabl-verification-agent persona from `agents/mabl-verification-agent.md` and knowledge from `{{HARNESS_DIR}}/knowledge/mabl-verification-agent/`.
+
+### Step 2: Collect the Run Signal
+
+Assemble the quality evidence from upstream stages:
+
+1. **Run results** — read `mabl-verification-run-results` from `mabl-verification-pre-pr`.
+   Extract per-test: pass/fail, failing step, classification (code regression / stale-test /
+   env-data / flake / billable-skip), confidence, testRunId.
+
+2. **Coverage report** — read `mabl-verification-coverage-report` from
+   `mabl-verification-coverage-gap` (if the stage ran). Extract: gap count, severity
+   distribution, ship-blocker flag.
+
+3. **Direct references** — if the user provided a specific test run (`-jr`), plan run
+   (`-pr`), or the stage is invoked standalone, resolve the signal via MCP:
+   - `-jr` → `get_mabl_test_run(testRunId)` for status + failure summary
+   - `-pr` → `get_mabl_plan_run(planRunId)` for all test statuses
+
+### Step 3: Analyze Unanalyzed Failures
+
+For **each failed run** in the signal that has not already been analyzed by the
+pre-pr stage's triage (Step 9), call `analyze_mabl_failure(runId, 'test', workspaceId)`
+to ensure a saved failure analysis exists.
+
+**Why this matters:** `check_release_readiness` reasons over saved analyses. A failed
+run with no analysis is scored "unknown root cause" and drags the readiness score
+down for no real reason. Billable-skip reds do not need deep analysis, but a saved
+record keeps them from scoring as "unknown."
+
+Skip runs already analyzed by the pre-pr stage this session.
+
+### Step 4: Check Release Readiness
+
+Call `check_release_readiness` (MCP) with the entity IDs from the run signal:
+- Test ids (`-j`) from the matched set
+- Plan id (`-p`) if a plan was triggered
+- Deployment event id (`-v`) if this is post-deploy
+
+Capture:
+- The readiness **recommendation** (pass / at_risk / blocked)
+- The readiness **score** (0–100)
+- Per-entity pass/fail summaries
+- Failure breakdown (application defects vs test implementation issues)
+- Prioritized remediation suggestions
+
+If the score looks worse than the triaged reality (e.g. dragged down by unanalyzed
+runs per Step 3), note that discrepancy — do not blindly surface a low score when the
+triage already explained the failures as non-code.
+
+### Step 5: Apply Ship Policy
+
+Decide **`SHIP` | `BLOCK` | `NEEDS_HUMAN`** from explicit, auditable rules:
+
+#### SHIP
+Every affected test passed, **OR** the only reds are confirmed non-code:
+- Billable-AI skips in local CLI runs (GenAI/visual assertions disabled)
+- Pre-existing failures already red on `main` (not introduced by this change)
+- Environment/flake that healed on rerun (per triage routing)
+
+**AND** no new uncovered critical flow (from coverage report, if present).
+
+#### BLOCK
+- Any confirmed **product regression** (failure classified as `product` with
+  confidence ≥ 0.6)
+- A **critical-flow coverage gap** with `has_test == false` (from coverage report)
+- Release readiness scored `blocked` by mabl
+
+#### NEEDS_HUMAN
+- Readiness is mixed (score 50–75, `at_risk`)
+- Confidence on any triage is below 0.6
+- A proposed remedy touches product code (product-code fixes are always human-gated)
+- The only path to SHIP requires spending mabl credits (billable AI reruns)
+
+**Policy profiles:**
+- `standard` (default) — rules above as written
+- `strict` — downgrade any SHIP that relied on an un-rerun flake to NEEDS_HUMAN;
+  any `coverage.gap_found == true` at `normal` severity also downgrades to NEEDS_HUMAN
+
+Ship/merge itself is always a human action, so a clean SHIP still surfaces
+"open PR" under `requiresHumanAction`.
+
+### Step 6: Produce Ship Verdict
+
+Write **`mabl-verification-ship-verdict.md`** to this stage's record dir:
+
+1. **Decision** — SHIP / BLOCK / NEEDS_HUMAN
+2. **One-line why** — the single most important reason
+3. **Blockers** — each confirmed blocker with its evidence trail
+4. **Release readiness** — mabl's score + recommendation
+5. **Run links** — mabl app URLs for every run in the signal
+6. **Required human actions** — what the person needs to do next (open PR, fix code,
+   re-run with billable features, etc.)
+
+Include a machine-readable JSON summary:
+
+```json
+{
+  "decision": "SHIP",
+  "reason": "All 3 matched tests passed; no critical coverage gaps",
+  "score": 92,
+  "readiness": "pass",
+  "blockers": [],
+  "requires_human_action": ["open_pr"],
+  "policy": "standard",
+  "tests_passed": 3,
+  "tests_failed": 0,
+  "billable_skipped": 0,
+  "coverage_gap_critical": 0,
+  "run_links": [
+    "https://app.mabl.com/workspaces/.../test-runs/..."
+  ]
+}
+```
+
+### Step 7: Open the Approval Gate
+
+Run `bun {{HARNESS_DIR}}/tools/aidlc-orchestrate.ts report --stage mabl-verification-ship-gate --result awaiting-approval`.
+
+### Step 8: Present Completion & Request Approval
+
+Completion emoji: :ship: (SHIP), :no_entry: (BLOCK), or :raising_hand: (NEEDS_HUMAN)
+Review path: this stage's engine-resolved record dir.
+Standard 2-option approval (Approve / Request Changes).
+STOP for the human response. Report Approve with
+`--result approved --user-input "<exact choice>"`; report
+Request Changes with `--result rejected --user-input "<feedback>"`, revise the
+artifacts, then report `--result revised` before re-presenting.
+
+---
+
+## Sensors
+
+This stage binds the `mabl-run-status` sensor which reads the JSON summary and
+confirms all failures are either resolved or acknowledged before the verdict.
+
+---
+
+## Learn
+
+While running this stage, maintain a running log in
+`<record>/<phase>/<stage>/memory.md` (create on stage start if absent).
+Append entries under: Interpretations, Deviations, Tradeoffs, Open questions —
+each with an ISO 8601 timestamp.
+
+Stage files are immutable framework artefacts — the ritual writes into the
+harness, not into this file.

--- a/plugins/mabl-verification/tests/plugin.test.ts
+++ b/plugins/mabl-verification/tests/plugin.test.ts
@@ -1,0 +1,427 @@
+/**
+ * plugin.test.ts — Content validation for the mabl-verification plugin.
+ *
+ * Validates that all plugin files conform to the AIDLC plugin contract:
+ * - Stage frontmatter is well-formed and references valid agents
+ * - Slugs match filenames
+ * - Artifacts are plugin-namespaced (mabl-verification-*)
+ * - Contributions target real core stages
+ * - Sensor manifests follow the aidlc-<id>.md naming convention
+ * - The plugin.json manifest is valid
+ *
+ * Run: bun test plugins/mabl-verification/tests/plugin.test.ts
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { join, basename, extname } from "path";
+
+const PLUGIN_ROOT = join(import.meta.dir, "..");
+const PLUGIN_NAME = "mabl-verification";
+const ARTIFACT_PREFIX = "mabl-verification-";
+
+// --- Helpers ---
+
+function readYamlFrontmatter(filePath: string): Record<string, unknown> | null {
+  const content = readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  // Simple YAML parser for flat/shallow structures (good enough for validation)
+  const lines = match[1].split("\n");
+  const result: Record<string, unknown> = {};
+  let currentKey = "";
+  let currentList: string[] | null = null;
+
+  for (const line of lines) {
+    const kvMatch = line.match(/^(\w[\w_-]*):\s*(.*)$/);
+    if (kvMatch) {
+      if (currentList && currentKey) {
+        result[currentKey] = currentList;
+        currentList = null;
+      }
+      const [, key, value] = kvMatch;
+      currentKey = key;
+      if (value.trim() === "") {
+        // Could be start of a list or multi-line
+      } else if (value.trim() === ">") {
+        // Multi-line string — skip for now
+      } else {
+        result[key] = value.trim();
+      }
+    } else if (line.match(/^\s+-\s+(.+)$/)) {
+      const itemMatch = line.match(/^\s+-\s+(.+)$/);
+      if (itemMatch) {
+        if (!currentList) currentList = [];
+        currentList.push(itemMatch[1].trim());
+      }
+    }
+  }
+  if (currentList && currentKey) {
+    result[currentKey] = currentList;
+  }
+
+  return result;
+}
+
+function getStageFiles(): string[] {
+  const stages: string[] = [];
+  const stagesDir = join(PLUGIN_ROOT, "stages");
+  if (!existsSync(stagesDir)) return stages;
+
+  for (const phase of readdirSync(stagesDir)) {
+    const phaseDir = join(stagesDir, phase);
+    for (const file of readdirSync(phaseDir)) {
+      if (file.endsWith(".md")) {
+        stages.push(join(phaseDir, file));
+      }
+    }
+  }
+  return stages;
+}
+
+function getContributionFiles(): string[] {
+  const contributions: string[] = [];
+  const contribDir = join(PLUGIN_ROOT, "contributions");
+  if (!existsSync(contribDir)) return contributions;
+
+  for (const phase of readdirSync(contribDir)) {
+    const phaseDir = join(contribDir, phase);
+    for (const file of readdirSync(phaseDir)) {
+      if (file.endsWith(".md")) {
+        contributions.push(join(phaseDir, file));
+      }
+    }
+  }
+  return contributions;
+}
+
+function getSensorFiles(): string[] {
+  const sensorsDir = join(PLUGIN_ROOT, "sensors");
+  if (!existsSync(sensorsDir)) return [];
+  return readdirSync(sensorsDir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => join(sensorsDir, f));
+}
+
+// Known core stages that contributions can target
+const CORE_STAGES = [
+  "project-bootstrap",
+  "workspace-scan",
+  "workflow-planning",
+  "problem-definition",
+  "exploration",
+  "functional-requirements",
+  "nfr-requirements",
+  "functional-design",
+  "nfr-design",
+  "practices-discovery",
+  "user-stories",
+  "code-implementation",
+  "build-and-test",
+  "performance-validation",
+  "release-deployment",
+  "observability-setup",
+];
+
+// Known agents in the framework + this plugin
+const KNOWN_AGENTS = [
+  "aidlc-architect-agent",
+  "aidlc-architecture-reviewer-agent",
+  "aidlc-aws-platform-agent",
+  "aidlc-compliance-agent",
+  "aidlc-composer-agent",
+  "aidlc-delivery-agent",
+  "aidlc-design-agent",
+  "aidlc-developer-agent",
+  "aidlc-devsecops-agent",
+  "aidlc-operations-agent",
+  "aidlc-pipeline-deploy-agent",
+  "aidlc-product-agent",
+  "aidlc-product-lead-agent",
+  "aidlc-quality-agent",
+  "mabl-verification-agent", // this plugin's agent
+];
+
+// --- Tests ---
+
+describe("mabl-verification plugin manifest", () => {
+  const manifestPath = join(PLUGIN_ROOT, ".aidlc-plugin", "plugin.json");
+
+  it("plugin.json exists and is valid JSON", () => {
+    expect(existsSync(manifestPath)).toBe(true);
+    const content = readFileSync(manifestPath, "utf-8");
+    const manifest = JSON.parse(content);
+    expect(manifest).toBeDefined();
+  });
+
+  it("plugin.json has required fields", () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    expect(manifest.name).toBe(PLUGIN_NAME);
+    expect(manifest.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(manifest.description).toBeTruthy();
+    expect(manifest.dependencies).toContain("core");
+    expect(manifest.aidlc).toBeDefined();
+    expect(manifest.aidlc.contributes).toBeDefined();
+  });
+
+  it("plugin name is not reserved (not core, aidlc, or aidlc-*)", () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    expect(manifest.name).not.toBe("core");
+    expect(manifest.name).not.toBe("aidlc");
+    expect(manifest.name).not.toMatch(/^aidlc-/);
+  });
+});
+
+describe("mabl-verification stages", () => {
+  const stageFiles = getStageFiles();
+
+  it("has at least one stage file", () => {
+    expect(stageFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const stageFile of stageFiles) {
+    const slug = basename(stageFile, ".md");
+
+    describe(`stage: ${slug}`, () => {
+      it("slug matches filename", () => {
+        const frontmatter = readYamlFrontmatter(stageFile);
+        expect(frontmatter).not.toBeNull();
+        expect(frontmatter!.slug).toBe(slug);
+      });
+
+      it("declares plugin ownership", () => {
+        const frontmatter = readYamlFrontmatter(stageFile);
+        expect(frontmatter!.plugin).toBe(PLUGIN_NAME);
+      });
+
+      it("references a known lead_agent", () => {
+        const frontmatter = readYamlFrontmatter(stageFile);
+        expect(KNOWN_AGENTS).toContain(frontmatter!.lead_agent);
+      });
+
+      it("has a valid phase", () => {
+        const frontmatter = readYamlFrontmatter(stageFile);
+        expect(["initialization", "ideation", "inception", "construction", "operation"]).toContain(
+          frontmatter!.phase
+        );
+      });
+
+      it("has a number", () => {
+        const frontmatter = readYamlFrontmatter(stageFile);
+        const num = Number(frontmatter!.number);
+        expect(num).toBeGreaterThan(0);
+        expect(num).toBeLessThan(10);
+      });
+
+      it("produces artifacts are plugin-namespaced", () => {
+        const content = readFileSync(stageFile, "utf-8");
+        const producesMatch = content.match(/produces:\n((?:\s+-\s+.+\n?)+)/);
+        if (producesMatch) {
+          const artifacts = producesMatch[1]
+            .split("\n")
+            .map((l) => l.replace(/^\s+-\s+/, "").trim())
+            .filter(Boolean);
+          for (const artifact of artifacts) {
+            expect(artifact).toMatch(
+              new RegExp(`^${ARTIFACT_PREFIX}`),
+              `Artifact "${artifact}" must be prefixed with "${ARTIFACT_PREFIX}"`
+            );
+          }
+        }
+      });
+
+      it("has mode: inline", () => {
+        const frontmatter = readYamlFrontmatter(stageFile);
+        expect(frontmatter!.mode).toBe("inline");
+      });
+    });
+  }
+});
+
+describe("mabl-verification contributions", () => {
+  const contributionFiles = getContributionFiles();
+
+  it("has at least one contribution", () => {
+    expect(contributionFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const contribFile of contributionFiles) {
+    const targetSlug = basename(contribFile, ".md");
+
+    describe(`contribution: ${targetSlug}`, () => {
+      it("targets a known core stage", () => {
+        const frontmatter = readYamlFrontmatter(contribFile);
+        expect(frontmatter).not.toBeNull();
+        expect(CORE_STAGES).toContain(frontmatter!.target);
+      });
+
+      it("declares plugin ownership", () => {
+        const frontmatter = readYamlFrontmatter(contribFile);
+        expect(frontmatter!.plugin).toBe(PLUGIN_NAME);
+      });
+
+      it("produced artifacts are plugin-namespaced", () => {
+        const content = readFileSync(contribFile, "utf-8");
+        // Look for produces under adds:
+        const producesMatch = content.match(/produces:\n((?:\s+-\s+.+\n?)+)/);
+        if (producesMatch) {
+          const artifacts = producesMatch[1]
+            .split("\n")
+            .map((l) => l.replace(/^\s+-\s+/, "").trim())
+            .filter(Boolean);
+          for (const artifact of artifacts) {
+            expect(artifact).toMatch(
+              new RegExp(`^${ARTIFACT_PREFIX}`),
+              `Contributed artifact "${artifact}" must be prefixed with "${ARTIFACT_PREFIX}"`
+            );
+          }
+        }
+      });
+
+      it("has at least one fragment", () => {
+        const content = readFileSync(contribFile, "utf-8");
+        expect(content).toContain("## fragment:");
+      });
+    });
+  }
+});
+
+describe("mabl-verification sensors", () => {
+  const sensorFiles = getSensorFiles();
+
+  it("has at least one sensor manifest", () => {
+    expect(sensorFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const sensorFile of sensorFiles) {
+    const filename = basename(sensorFile);
+
+    describe(`sensor: ${filename}`, () => {
+      it("follows aidlc-<id>.md naming convention", () => {
+        expect(filename).toMatch(/^aidlc-[\w-]+\.md$/);
+      });
+
+      it("has frontmatter with required fields", () => {
+        const frontmatter = readYamlFrontmatter(sensorFile);
+        expect(frontmatter).not.toBeNull();
+        expect(frontmatter!.id).toBeTruthy();
+        expect(frontmatter!.kind).toBe("deterministic");
+        expect(frontmatter!.command).toBeTruthy();
+        expect(frontmatter!.default_severity).toBe("advisory");
+      });
+
+      it("references an existing tool script", () => {
+        const frontmatter = readYamlFrontmatter(sensorFile);
+        const command = String(frontmatter!.command);
+        // Extract the script filename from "bun {{HARNESS_DIR}}/tools/<script>.ts"
+        const scriptMatch = command.match(/tools\/([\w-]+\.ts)/);
+        if (scriptMatch) {
+          const scriptPath = join(PLUGIN_ROOT, "tools", scriptMatch[1]);
+          expect(existsSync(scriptPath)).toBe(true);
+        }
+      });
+    });
+  }
+});
+
+describe("mabl-verification agents", () => {
+  const agentsDir = join(PLUGIN_ROOT, "agents");
+
+  it("agent directory exists", () => {
+    expect(existsSync(agentsDir)).toBe(true);
+  });
+
+  it("agent file matches <plugin>-<role>-agent.md convention", () => {
+    const files = readdirSync(agentsDir).filter((f) => f.endsWith(".md"));
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      expect(file).toMatch(/^mabl-verification-.*\.md$/);
+    }
+  });
+
+  it("agent frontmatter name matches filename stem", () => {
+    const files = readdirSync(agentsDir).filter((f) => f.endsWith(".md"));
+    for (const file of files) {
+      const filePath = join(agentsDir, file);
+      const frontmatter = readYamlFrontmatter(filePath);
+      expect(frontmatter).not.toBeNull();
+      const expectedName = basename(file, ".md");
+      expect(frontmatter!.name).toBe(expectedName);
+    }
+  });
+});
+
+describe("mabl-verification scopes", () => {
+  const scopesDir = join(PLUGIN_ROOT, "scopes");
+
+  it("scope directory exists", () => {
+    expect(existsSync(scopesDir)).toBe(true);
+  });
+
+  it("scope file follows <plugin>-<name>.md convention", () => {
+    const files = readdirSync(scopesDir).filter((f) => f.endsWith(".md"));
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      expect(file).toMatch(/^mabl-verification-.*\.md$/);
+    }
+  });
+
+  it("scope frontmatter name matches filename stem", () => {
+    const files = readdirSync(scopesDir).filter((f) => f.endsWith(".md"));
+    for (const file of files) {
+      const filePath = join(scopesDir, file);
+      const frontmatter = readYamlFrontmatter(filePath);
+      expect(frontmatter).not.toBeNull();
+      const expectedName = basename(file, ".md");
+      expect(frontmatter!.name).toBe(expectedName);
+    }
+  });
+
+  it("scope declares plugin ownership", () => {
+    const files = readdirSync(scopesDir).filter((f) => f.endsWith(".md"));
+    for (const file of files) {
+      const filePath = join(scopesDir, file);
+      const frontmatter = readYamlFrontmatter(filePath);
+      expect(frontmatter!.plugin).toBe(PLUGIN_NAME);
+    }
+  });
+});
+
+describe("mabl-verification knowledge", () => {
+  const knowledgeDir = join(PLUGIN_ROOT, "knowledge", "mabl-verification-agent");
+
+  it("knowledge directory exists for the plugin agent", () => {
+    expect(existsSync(knowledgeDir)).toBe(true);
+  });
+
+  it("has at least one knowledge file", () => {
+    const files = readdirSync(knowledgeDir).filter((f) => f.endsWith(".md"));
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("knowledge files have content (not empty)", () => {
+    const files = readdirSync(knowledgeDir).filter((f) => f.endsWith(".md"));
+    for (const file of files) {
+      const content = readFileSync(join(knowledgeDir, file), "utf-8");
+      expect(content.length).toBeGreaterThan(100);
+    }
+  });
+});
+
+describe("mabl-verification tools", () => {
+  const toolsDir = join(PLUGIN_ROOT, "tools");
+
+  it("has a doctor check script", () => {
+    expect(existsSync(join(toolsDir, "mabl-verification-doctor.ts"))).toBe(true);
+  });
+
+  it("all .ts files in tools/ are parseable", () => {
+    const files = readdirSync(toolsDir).filter((f) => f.endsWith(".ts"));
+    for (const file of files) {
+      const content = readFileSync(join(toolsDir, file), "utf-8");
+      // Basic syntax check — contains a main function or top-level execution
+      expect(content).toMatch(/function\s+main|process\.exit|console\.log/);
+    }
+  });
+});

--- a/plugins/mabl-verification/tools/aidlc-sensor-mabl-coverage-threshold.ts
+++ b/plugins/mabl-verification/tools/aidlc-sensor-mabl-coverage-threshold.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+/**
+ * aidlc-sensor-mabl-coverage-threshold.ts
+ *
+ * Advisory sensor for the mabl-verification plugin.
+ * Reads the JSON summary from mabl-verification-coverage-report.md and reports
+ * whether critical or normal coverage gaps exist.
+ *
+ * Exit 0 + JSON stdout = sensor result.
+ * Degrades gracefully when input file is absent (reports pass with 0 flows).
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+interface CoverageSummary {
+  total_flows: number;
+  covered: number;
+  weakly_covered: number;
+  uncovered: number;
+  gaps: Array<{
+    flow: string;
+    severity: "critical" | "normal" | "low";
+    recommendation: "author" | "defer" | "none";
+    authored_test_id: string | null;
+    has_test: boolean;
+  }>;
+  gap_found: boolean;
+  critical_gap_count: number;
+  ship_blocker: boolean;
+}
+
+function findJsonBlock(content: string): CoverageSummary | null {
+  const jsonBlocks = content.match(/```json\s*\n([\s\S]*?)\n```/g);
+  if (!jsonBlocks || jsonBlocks.length === 0) return null;
+
+  const lastBlock = jsonBlocks[jsonBlocks.length - 1];
+  const jsonContent = lastBlock.replace(/```json\s*\n/, "").replace(/\n```$/, "");
+
+  try {
+    return JSON.parse(jsonContent);
+  } catch {
+    return null;
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  let outputPath = "";
+  let stageSlug = "";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--output-path" && args[i + 1]) outputPath = args[++i];
+    if (args[i] === "--stage-slug" && args[i + 1]) stageSlug = args[++i];
+  }
+
+  outputPath = outputPath || process.env.AIDLC_OUTPUT_PATH || "";
+  stageSlug = stageSlug || process.env.AIDLC_STAGE_SLUG || "";
+
+  const reportPath = join(outputPath, "mabl-verification-coverage-report.md");
+
+  if (!existsSync(reportPath)) {
+    // No coverage report means the coverage-gap stage hasn't run —
+    // degrade gracefully, no findings.
+    const result = {
+      pass: true,
+      findings_count: 0,
+      total_flows: 0,
+      covered: 0,
+      uncovered: 0,
+      critical_gap_count: 0,
+      ship_blocker: false,
+    };
+    console.log(JSON.stringify(result));
+    process.exit(0);
+  }
+
+  const content = readFileSync(reportPath, "utf-8");
+  const summary = findJsonBlock(content);
+
+  if (!summary) {
+    // File exists but no parseable JSON — report as a finding
+    const result = {
+      pass: false,
+      findings_count: 1,
+      total_flows: 0,
+      covered: 0,
+      uncovered: 0,
+      critical_gap_count: 0,
+      ship_blocker: false,
+    };
+    console.log(JSON.stringify(result));
+    process.exit(0);
+  }
+
+  // Count actionable gaps (critical/normal without a test)
+  const actionableGaps = summary.gaps.filter(
+    (g) =>
+      (g.severity === "critical" || g.severity === "normal") &&
+      !g.has_test &&
+      g.recommendation !== "none"
+  );
+
+  const criticalGaps = summary.gaps.filter(
+    (g) => g.severity === "critical" && !g.has_test
+  );
+
+  const pass = criticalGaps.length === 0;
+
+  const result = {
+    pass,
+    findings_count: actionableGaps.length,
+    total_flows: summary.total_flows,
+    covered: summary.covered,
+    uncovered: summary.uncovered,
+    critical_gap_count: criticalGaps.length,
+    ship_blocker: summary.ship_blocker ?? criticalGaps.length > 0,
+  };
+
+  console.log(JSON.stringify(result));
+  process.exit(0);
+}
+
+main();

--- a/plugins/mabl-verification/tools/aidlc-sensor-mabl-run-status.ts
+++ b/plugins/mabl-verification/tools/aidlc-sensor-mabl-run-status.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env bun
+/**
+ * aidlc-sensor-mabl-run-status.ts
+ *
+ * Advisory sensor for the mabl-verification plugin.
+ * Reads the JSON summary from mabl-verification-run-results.md or
+ * mabl-verification-local-run-log.md and reports pass/fail status.
+ *
+ * Exit 0 + JSON stdout = sensor result.
+ * Degrades gracefully when input files are absent (reports pass with 0 tests).
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+interface SensorInput {
+  output_path: string;
+  stage_slug: string;
+}
+
+interface RunSummary {
+  tests_matched?: number;
+  tests_run?: number;
+  passed?: number;
+  failed?: number;
+  billable_skipped?: number;
+  coverage_zero_match?: boolean;
+  failures?: Array<{
+    testId: string;
+    testRunId: string;
+    class: string;
+    confidence: number;
+    failingStep: string;
+  }>;
+  // local-run-log shape
+  status?: string;
+  test_name?: string;
+  test_id?: string;
+}
+
+function findJsonBlock(content: string): RunSummary | null {
+  // Extract the last JSON code block from the markdown
+  const jsonBlocks = content.match(/```json\s*\n([\s\S]*?)\n```/g);
+  if (!jsonBlocks || jsonBlocks.length === 0) return null;
+
+  const lastBlock = jsonBlocks[jsonBlocks.length - 1];
+  const jsonContent = lastBlock.replace(/```json\s*\n/, "").replace(/\n```$/, "");
+
+  try {
+    return JSON.parse(jsonContent);
+  } catch {
+    return null;
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  let outputPath = "";
+  let stageSlug = "";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--output-path" && args[i + 1]) outputPath = args[++i];
+    if (args[i] === "--stage-slug" && args[i + 1]) stageSlug = args[++i];
+  }
+
+  // Also check env vars (common sensor invocation pattern)
+  outputPath = outputPath || process.env.AIDLC_OUTPUT_PATH || "";
+  stageSlug = stageSlug || process.env.AIDLC_STAGE_SLUG || "";
+
+  // Try to find the run results or local run log
+  const candidates = [
+    join(outputPath, "mabl-verification-run-results.md"),
+    join(outputPath, "mabl-verification-local-run-log.md"),
+  ];
+
+  let summary: RunSummary | null = null;
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      const content = readFileSync(candidate, "utf-8");
+      summary = findJsonBlock(content);
+      if (summary) break;
+    }
+  }
+
+  // Degrade gracefully when no input exists
+  if (!summary) {
+    const result = {
+      pass: true,
+      findings_count: 0,
+      tests_run: 0,
+      tests_passed: 0,
+      tests_failed: 0,
+      billable_skipped: 0,
+      has_unresolved_failures: false,
+    };
+    console.log(JSON.stringify(result));
+    process.exit(0);
+  }
+
+  const testsRun = summary.tests_run ?? (summary.status ? 1 : 0);
+  const testsPassed = summary.passed ?? (summary.status === "pass" ? 1 : 0);
+  const testsFailed = summary.failed ?? (summary.status === "fail" ? 1 : 0);
+  const billableSkipped = summary.billable_skipped ?? 0;
+
+  // Count unresolved failures (not billable-skip, not already triaged as healed)
+  const unresolvedFailures = (summary.failures ?? []).filter(
+    (f) => f.class === "product" || f.class === "stale-test"
+  );
+
+  const pass = testsFailed === 0 || unresolvedFailures.length === 0;
+
+  const result = {
+    pass,
+    findings_count: unresolvedFailures.length,
+    tests_run: testsRun,
+    tests_passed: testsPassed,
+    tests_failed: testsFailed,
+    billable_skipped: billableSkipped,
+    has_unresolved_failures: unresolvedFailures.length > 0,
+  };
+
+  console.log(JSON.stringify(result));
+  process.exit(0);
+}
+
+main();

--- a/plugins/mabl-verification/tools/mabl-verification-doctor.ts
+++ b/plugins/mabl-verification/tools/mabl-verification-doctor.ts
@@ -1,0 +1,212 @@
+#!/usr/bin/env bun
+/**
+ * mabl-verification-doctor.ts
+ *
+ * Plugin doctor check for mabl-verification.
+ * Verifies the mabl CLI is installed and authenticated, and that the sensor
+ * manifests are correctly placed.
+ *
+ * Invoked by `/aidlc --doctor` with env vars:
+ *   AIDLC_PROJECT_DIR  — project root
+ *   AIDLC_HARNESS_DIR  — harness directory name (e.g. ".kiro", ".claude")
+ *   AIDLC_PLUGIN_NAME  — "mabl-verification"
+ *
+ * Writes a JSON object to stdout with a `checks` array.
+ * Each check: { pass: boolean, label: string, fix?: string, severity?: "error" | "advisory" }
+ */
+
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+interface Check {
+  pass: boolean;
+  label: string;
+  fix?: string;
+  severity?: "error" | "advisory";
+}
+
+function checkCliInstalled(): Check {
+  try {
+    const version = execSync("mabl --version", {
+      timeout: 5000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return {
+      pass: true,
+      label: `mabl CLI installed (${version})`,
+    };
+  } catch {
+    return {
+      pass: false,
+      label: "mabl CLI is not installed or not on PATH",
+      fix: "Install with: npm install -g @mablhq/mabl-cli",
+      severity: "error",
+    };
+  }
+}
+
+function checkCliAuthenticated(): Check {
+  try {
+    const authInfo = execSync("mabl auth info 2>&1", {
+      timeout: 5000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+
+    // Check for common "not logged in" indicators
+    if (
+      authInfo.includes("not logged in") ||
+      authInfo.includes("No authentication") ||
+      authInfo.includes("expired")
+    ) {
+      return {
+        pass: false,
+        label: "mabl CLI is not authenticated",
+        fix: "Run: mabl auth login (or mabl auth activate-key <api-key>)",
+        severity: "error",
+      };
+    }
+
+    return {
+      pass: true,
+      label: "mabl CLI authenticated",
+    };
+  } catch {
+    return {
+      pass: false,
+      label: "mabl CLI authentication check failed",
+      fix: "Run: mabl auth login (or mabl auth activate-key <api-key>)",
+      severity: "advisory",
+    };
+  }
+}
+
+function checkWorkspaceConfigured(): Check {
+  try {
+    const wsId = execSync("mabl config get workspace-id 2>&1", {
+      timeout: 5000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+
+    if (!wsId || wsId.includes("not set") || wsId.includes("undefined")) {
+      return {
+        pass: false,
+        label: "mabl workspace-id not configured",
+        fix: "Run: mabl config set workspace-id <your-workspace-id>",
+        severity: "advisory",
+      };
+    }
+
+    return {
+      pass: true,
+      label: `mabl workspace configured (${wsId.substring(0, 12)}...)`,
+    };
+  } catch {
+    return {
+      pass: false,
+      label: "mabl workspace-id not configured",
+      fix: "Run: mabl config set workspace-id <your-workspace-id> (or provide via team knowledge)",
+      severity: "advisory",
+    };
+  }
+}
+
+function checkSensorsInstalled(): Check {
+  const projectDir = process.env.AIDLC_PROJECT_DIR || process.cwd();
+  const harnessDir = process.env.AIDLC_HARNESS_DIR || ".kiro";
+  const sensorsDir = join(projectDir, harnessDir, "sensors");
+
+  const expectedSensors = [
+    "aidlc-mabl-run-status.md",
+    "aidlc-mabl-coverage-threshold.md",
+  ];
+
+  const missing: string[] = [];
+  for (const sensor of expectedSensors) {
+    if (!existsSync(join(sensorsDir, sensor))) {
+      missing.push(sensor);
+    }
+  }
+
+  if (missing.length > 0) {
+    return {
+      pass: false,
+      label: `mabl-verification sensors not composed: ${missing.join(", ")}`,
+      fix: "Re-run plugin compose: aidlc plugin sync (or bun <plugin>/hooks/compose.ts)",
+      severity: "advisory",
+    };
+  }
+
+  return {
+    pass: true,
+    label: "mabl-verification sensors composed",
+  };
+}
+
+function checkAgentInstalled(): Check {
+  const projectDir = process.env.AIDLC_PROJECT_DIR || process.cwd();
+  const harnessDir = process.env.AIDLC_HARNESS_DIR || ".kiro";
+  const agentPath = join(
+    projectDir,
+    harnessDir,
+    "agents",
+    "mabl-verification-agent.md"
+  );
+
+  if (!existsSync(agentPath)) {
+    return {
+      pass: false,
+      label: "mabl-verification-agent not composed into harness",
+      fix: "Re-run plugin compose: aidlc plugin sync (or bun <plugin>/hooks/compose.ts)",
+      severity: "advisory",
+    };
+  }
+
+  return {
+    pass: true,
+    label: "mabl-verification-agent composed",
+  };
+}
+
+function checkScopeInstalled(): Check {
+  const projectDir = process.env.AIDLC_PROJECT_DIR || process.cwd();
+  const harnessDir = process.env.AIDLC_HARNESS_DIR || ".kiro";
+  const scopePath = join(
+    projectDir,
+    harnessDir,
+    "scopes",
+    "mabl-verification-validation.md"
+  );
+
+  if (!existsSync(scopePath)) {
+    return {
+      pass: false,
+      label: "mabl-verification-validation scope not composed",
+      fix: "Re-run plugin compose: aidlc plugin sync (or bun <plugin>/hooks/compose.ts)",
+      severity: "advisory",
+    };
+  }
+
+  return {
+    pass: true,
+    label: "mabl-verification-validation scope composed",
+  };
+}
+
+function main(): void {
+  const checks: Check[] = [
+    checkCliInstalled(),
+    checkCliAuthenticated(),
+    checkWorkspaceConfigured(),
+    checkSensorsInstalled(),
+    checkAgentInstalled(),
+    checkScopeInstalled(),
+  ];
+
+  console.log(JSON.stringify({ checks }));
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds the `mabl-verification` plugin — an end-to-end mabl verification loop layered onto the AI-DLC workflow.

## What it does

Maps code changes to mabl tests via semantic search (MCP), runs them locally via the mabl CLI, root-causes failures against the application source code, identifies coverage gaps, and gates ship decisions against mabl's release readiness scoring.

## Plugin contents

| Surface | Count | Details |
|---------|-------|---------|
| New stages | 3 | `mabl-verification-pre-pr` (construction), `mabl-verification-coverage-gap` (construction), `mabl-verification-ship-gate` (operation) |
| Contributions | 1 | Enriches `build-and-test` with a mabl smoke-check (Step 10a) |
| Agents | 1 | `mabl-verification-agent` — unified from 5 mabl skills |
| Knowledge | 4 | local-run-patterns, authoring-best-practices, failure-rca-methodology, triage-routing |
| Sensors | 2 | `mabl-run-status` (advisory), `mabl-coverage-threshold` (advisory) |
| Scopes | 1 | `mabl-verification-validation` |
| Tools | 3 | 2 sensor scripts + 1 doctor check |
| Tests | 1 | Content validation (49 tests, all passing) |

## Verification loop (6 questions)

| # | Question | Answered by |
|---|----------|-------------|
| Q1 | Which tests are affected? | `mabl-verification-pre-pr` |
| Q2 | Do they pass? | `mabl-verification-pre-pr` |
| Q3 | Why did it fail? | Agent knowledge: failure-rca-methodology |
| Q4 | What should we do next? | Agent knowledge: triage-routing |
| Q5 | Is there a coverage gap? | `mabl-verification-coverage-gap` |
| Q6 | Is it safe to ship? | `mabl-verification-ship-gate` |

## Prerequisites

- mabl CLI (Node 18+) authenticated
- mabl MCP server connected to the harness
- bun on PATH (standard AIDLC requirement)

## Testing

```bash
bun test plugins/mabl-verification/tests/plugin.test.ts
# 49 pass, 0 fail
```

## Design notes

- Modeled after `plugins/test-pro/` — same structure, same seams, same compose model
- All artifacts are `mabl-verification-` prefixed (no collision risk)
- Sensors are advisory (framework has no blocking severity yet)
- Ship gate recommends only — never opens/merges a PR
- Stages activate under enterprise/feature/mvp/classic scopes
- The plugin's own `mabl-verification-validation` scope is available for focused verification runs