### PR TITLE
fix: kind-vacuous units no longer deadlock per-unit summary-confirmation routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.103] - 2026-08-26
+
+Kind-vacuous Construction units no longer deadlock summary-confirmation routing when their unit kind excludes every output of a per-unit stage. **Upgrade:** refresh your `dist/<harness>/` shell so unit-major routing and per-unit approval skip confirmation evidence that an inapplicable unit cannot produce.
+
+* Unit-major iteration now advances past kind-vacuous units to the next applicable stage and unit instead of emitting `Refusing to complete`.
+* Stage-major per-unit approval now presents the normal gate when all units are kind-vacuous, without requiring nonexistent questions or summary confirmation.
+
 ## [2.6.102] - 2026-08-26
 
 Rule files can now carry validated lifecycle metadata, and doctor separates stale team/project overlaps from live contradiction-review candidates without changing runtime rule delivery. **Upgrade:** refresh your `dist/<harness>/` shell; add lifecycle fields only where you want file-level drift triage.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.102-blue)
+![version](https://img.shields.io/badge/version-2.6.103-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/dist/claude/.claude/tools/aidlc-orchestrate.ts
+++ b/dist/claude/.claude/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/dist/codex/.codex/tools/aidlc-orchestrate.ts
+++ b/dist/codex/.codex/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
+++ b/dist/cursor/.cursor/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
+++ b/dist/kiro/.kiro/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-orchestrate.ts
@@ -3939,6 +3939,13 @@ function unitLedgerFor(projectDir: string, slug: string): UnitLedger {
   };
 }
 
+function kindVacuous(node: GraphStage, unitKind: string | null): boolean {
+  return (
+    (node.produces ?? []).length > 0 &&
+    applicableProduceNames(node, unitKind, false).length === 0
+  );
+}
+
 // A unit is SETTLED when its artifacts exist AND, when the receipt ledger is
 // in use, a current-attempt UNIT_COMPLETED receipt names it. Kind-vacuous
 // units (required set filters to empty — the stage does not apply) never
@@ -3955,8 +3962,7 @@ function unitSettled(
 ): boolean {
   if (!unitCovered(projectDir, node, unit, recordPrefix, codekbCtx, unitKind)) return false;
   if (!ledger.inUse) return true;
-  const names = node.produces ?? [];
-  if (names.length > 0 && applicableProduceNames(node, unitKind, false).length === 0) {
+  if (kindVacuous(node, unitKind)) {
     return true; // vacuous for this kind — no directive, no receipt to earn
   }
   return ledger.receipts.has(unit);
@@ -3997,6 +4003,9 @@ function nextUncoveredUnit(
       uncovered.push(unit);
       continue;
     }
+    // A kind-vacuous unit settles with no directive and owes no questions or
+    // summary confirmation.
+    if (kindVacuous(node, kinds?.get(unit) ?? null)) continue;
     const confirmation = checkSummaryConfirmationEvidence(projectDir, node, {
       stateContent,
       unit,
@@ -4617,6 +4626,7 @@ function emitUnitMajorRunStage(
         emit(directive);
         return;
       }
+      if (kindVacuous(k, kinds?.get(u) ?? null)) continue;
       const confirmation = checkSummaryConfirmationEvidence(projectDir, k, {
         stateContent,
         unit: u,

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.102";
+export const AIDLC_VERSION = "2.6.103";

--- a/tests/unit/t208-unit-kind-pruning.test.ts
+++ b/tests/unit/t208-unit-kind-pruning.test.ts
@@ -132,8 +132,17 @@ function envNoScope(): NodeJS.ProcessEnv {
   return e;
 }
 
-function runNext(proj: string): Directive {
-  const r = runOrchestrateNext(ORCH, proj, [], { env: envNoScope() });
+function runNext(
+  proj: string,
+  enforceSummaryConfirmationGuard = false,
+): Directive {
+  const env = envNoScope();
+  if (enforceSummaryConfirmationGuard) {
+    delete env.AIDLC_SKIP_SUMMARY_CONFIRMATION_GUARD;
+    env.AIDLC_SKIP_ARTIFACT_GUARD = "1";
+    env.AIDLC_SKIP_HUMAN_PRESENCE_GUARD = "1";
+  }
+  const r = runOrchestrateNext(ORCH, proj, [], { env });
   if (r.directive === null) {
     throw new Error(`runNext no JSON. status=${r.status}\n${r.stdout}\n${r.stderr}`);
   }
@@ -329,7 +338,8 @@ describe("t208 engine unit-kind pruning", () => {
   test("4: a packaging unit on functional-design is vacuously covered", () => {
     const proj = seedProject("functional-design");
     seedBoltDag(proj, [{ name: "pack", kind: "packaging" }]);
-    const d = runNext(proj);
+    const d = runNext(proj, true);
+    expect(d.kind).toBe("run-stage");
     expect(d.stage).toBe("functional-design");
     // pack owes nothing; every unit is covered -> the all-covered re-entry
     // presents the real gate (true) on the last unit with an empty produces set.

--- a/tests/unit/t209-unit-major-iteration.test.ts
+++ b/tests/unit/t209-unit-major-iteration.test.ts
@@ -145,6 +145,7 @@ interface Directive {
 function constructionState(opts: {
   skeletonStance?: string;
   iteration?: string;
+  designBlockAction?: "EXECUTE" | "SKIP";
 }): string {
   const stanceLine = opts.skeletonStance
     ? `- **Skeleton Stance**: ${opts.skeletonStance}\n`
@@ -155,6 +156,7 @@ function constructionState(opts: {
   const iterationLine = opts.iteration
     ? `- **Construction Iteration**: ${opts.iteration}\n`
     : "";
+  const designBlockAction = opts.designBlockAction ?? "EXECUTE";
   return `# AI-DLC State Tracking
 
 ## Project Information
@@ -176,10 +178,10 @@ ${iterationLine}
 
 ### CONSTRUCTION PHASE
 - [-] functional-design — EXECUTE
-- [ ] nfr-requirements — EXECUTE
-- [ ] nfr-design — EXECUTE
-- [ ] infrastructure-design — EXECUTE
-- [ ] code-generation — EXECUTE
+- [ ] nfr-requirements — ${designBlockAction}
+- [ ] nfr-design — ${designBlockAction}
+- [ ] infrastructure-design — ${designBlockAction}
+- [ ] code-generation — ${designBlockAction}
 - [ ] build-and-test — EXECUTE
 
 ### INCEPTION PHASE
@@ -207,13 +209,16 @@ function coverFullGrid(proj: string, units: string[]): void {
 }
 
 /** Seed a fresh unit-major Construction project. Returns the proj dir. */
-function seedProject(iteration?: string): string {
+function seedProject(
+  iteration?: string,
+  designBlockAction?: "EXECUTE" | "SKIP",
+): string {
   const proj = createTestProject();
   tempDirs.push(proj);
   seedAidlcMemory(proj);
   writeFileSync(
     seededStateFile(proj),
-    constructionState({ skeletonStance: "on", iteration }),
+    constructionState({ skeletonStance: "on", iteration, designBlockAction }),
   );
   return proj;
 }
@@ -224,9 +229,17 @@ interface NextRun {
 }
 
 /** Run `aidlc-orchestrate.ts next`, capturing both its directive and diagnostics. */
-function runNextWithStderr(proj: string): NextRun {
+function runNextWithStderr(
+  proj: string,
+  enforceSummaryConfirmationGuard = false,
+): NextRun {
   const env = { ...process.env };
   delete env.AWS_AIDLC_DEFAULT_SCOPE;
+  if (enforceSummaryConfirmationGuard) {
+    delete env.AIDLC_SKIP_SUMMARY_CONFIRMATION_GUARD;
+    env.AIDLC_SKIP_ARTIFACT_GUARD = "1";
+    env.AIDLC_SKIP_HUMAN_PRESENCE_GUARD = "1";
+  }
   const r = runOrchestrateNext(ORCH, proj, [], { env });
   if (r.directive === null) {
     throw new Error(
@@ -356,6 +369,20 @@ describe("t209 opt-in unit-major construction design iteration", () => {
     expect(d.stage).toBe("functional-design");
     expect(d.unit).toBe("alpha");
     expect(d.gate).toBe(false);
+  }, 30000);
+
+  test("1b: a kind-vacuous unit does not block the next applicable unit", () => {
+    // Isolate the active stage: packaging is applicable to later unit-major
+    // stages, while this regression targets functional-design's vacuous guard.
+    const proj = seedProject("unit-major", "SKIP");
+    seedBoltDag(proj, [
+      { name: "pkg", kind: "packaging" },
+      { name: "alpha", kind: "library", depends_on: ["pkg"] },
+    ]);
+    const d = runNextWithStderr(proj, true).directive;
+    expect(d.kind).toBe("run-stage");
+    expect(d.stage).toBe("functional-design");
+    expect(d.unit).toBe("alpha");
   }, 30000);
 
   // 2: THE PIVOTAL ORDERING ASSERTION. With functional-design/alpha covered, the


### PR DESCRIPTION
In unit-major Construction (and stage-major per-unit approval), a unit whose kind excludes every required produce of the active stage hit the per-unit summary-confirmation guard and returned a hard "Refusing to complete" error that pre-empted routing of the genuinely-next unit, deadlocking the workflow. This applies the kind-applicability filter the guard's stage-level path and the wave path already use at the two per-unit call sites (nextUncoveredUnit, emitUnitMajorRunStage), via a shared kindVacuous predicate also reused by unitSettled, with guard-live regressions in t208/t209.

Note: the committed version slot is 2.6.72; upstream v2's CHANGELOG head has since moved to 2.6.74, so the slot re-bumps at landing per the changelog conflict policy (version trio only — the code merges cleanly).

Closes #864
