### PR TITLE
fix: doctor detects a dead hook seam when the health dir is empty after a stage ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.90] - 2026-08-25
+
+`/aidlc --doctor` now distinguishes hook directories that have not had a chance to populate from dead hook seams after a workflow stage ran. **Upgrade:** refresh your `dist/<harness>/` shell so doctor can detect this condition.
+
+* When `.aidlc-hooks-health/` exists without any `.last` files and the active audit ledger contains `STAGE_STARTED`, doctor reports `Hook heartbeat data` and exits 1; CI jobs that gate on doctor will now fail for this broken hook state.
+* Missing, pre-created, and debug-only health directories still report the existing not-yet-fired pass row before any stage starts, while real heartbeat files continue to report their last-fired timestamps.
+
 ## [2.6.89] - 2026-08-25
 
 The conductor no longer parks a workflow because context *feels* heavy. The orchestrator skill previously licensed parking when context seemed low even though the conductor cannot measure its own usage, causing unnecessary park/resume interruptions while most of the window remained free. **Upgrade:** refresh your `dist/<harness>/` shell to install the bounded parking guidance.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.89-blue)
+![version](https://img.shields.io/badge/version-2.6.90-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/dist/copilot/.aidlc/tools/aidlc-utility.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/dist/cursor/.cursor/tools/aidlc-utility.ts
+++ b/dist/cursor/.cursor/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/dist/opencode/.aidlc/tools/aidlc-utility.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-utility.ts
@@ -2581,24 +2581,27 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
     }
   }
 
+  // Read across every per-clone audit shard (single shard in the common case).
+  // Both hook-health and state-drift checks use the same intent-scoped ledger.
+  const auditAllShards = readAllAuditShards(projectDir);
+  const auditShardEvents = readAuditShardEvents(projectDir);
+
   // 6. Hook heartbeats
-  // Three states:
-  //   (a) .aidlc-hooks-health/ missing entirely → fresh install, hooks haven't
-  //       had a chance to fire yet. Pass with advisory label — not drift.
-  //   (b) Directory exists but no .last files → hooks registered but have
-  //       never fired. Genuine drift; fail.
-  //   (c) Directory has .last files → hooks are working; pass with timestamps.
+  // Three states, discriminated by health-dir presence, readable heartbeats,
+  // and evidence that a workflow stage ran in the same intent-scoped ledger:
+  //   (a) .aidlc-hooks-health/ missing entirely, or present without .last files
+  //       before STAGE_STARTED → hooks have not had a chance to fire. Pass.
+  //       This preserves debug-only dirs and ignores doctor's HEALTH_CHECKED.
+  //   (b) Directory exists without .last files after STAGE_STARTED, or .last
+  //       files exist but are all unreadable → hooks should have fired. Fail.
+  //   (c) Directory has readable .last files → hooks are working; pass with
+  //       timestamps.
   const healthDir = hooksHealthDir(projectDir);
   const heartbeatEntries: string[] = [];
   const heartbeatDirExists = existsSync(healthDir);
-  // A health dir that exists but carries NO hook-fired content is equivalent to
-  // "not yet fired" (state a), not drift (state b). Besides the `.last`
-  // heartbeats, the dir may hold purely-diagnostic files that no hook firing
-  // produced: `hook-debug.log` (written by hookDebug under AIDLC_HOOK_DEBUG) and
-  // `.first-fired` (the run-sensors banner marker). If ONLY those exist, treat
-  // it as fresh — otherwise enabling AIDLC_HOOK_DEBUG on a fresh install would
-  // flip this check from PASS to a false drift FAIL for exactly the user trying
-  // to diagnose hooks.
+  const workflowStageStarted = auditAllShards.includes("**Event**: STAGE_STARTED");
+  // Track .last presence separately from readable entries so an unreadable
+  // heartbeat file remains a failure instead of looking like a fresh install.
   let hasHookFiredContent = false;
   if (heartbeatDirExists) {
     try {
@@ -2623,19 +2626,23 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
       pass: true,
       label: `Hooks last fired: ${heartbeatEntries.join(", ")}`,
     });
-  } else if (!heartbeatDirExists || !hasHookFiredContent) {
-    // (a) fresh install (dir absent) OR a debug-only dir with no heartbeats yet
-    // — nothing to verify. Not drift.
+  } else if (
+    !heartbeatDirExists ||
+    (!hasHookFiredContent && !workflowStageStarted)
+  ) {
+    // (a) fresh install, pre-created dir, or debug-only dir before a stage ran.
     results.push({
       pass: true,
       label: "Hook heartbeats: not yet fired (first workflow stage will populate)",
     });
   } else {
-    // (b) registered but never fired — genuine drift
+    // (b) a stage ran without any heartbeat, or heartbeat files are unreadable.
     results.push({
       pass: false,
       label: "Hook heartbeat data",
-      fix: "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
+      fix: !hasHookFiredContent && workflowStageStarted
+        ? "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired — verify hooks are registered in settings.json"
+        : "health dir exists but no hooks have fired — verify hooks are registered in settings.json",
     });
   }
 
@@ -2717,9 +2724,6 @@ function handleDoctor(projectDir: string, flags: Record<string, string> = {}): v
   // verify the state actually matches. Covers the rare case where audit-first
   // succeeded but the state write failed (disk full, permission lost mid-run).
   const stateMdPath = stateFilePath(projectDir);
-  // Read across every per-clone audit shard (single shard in the common case).
-  const auditAllShards = readAllAuditShards(projectDir);
-  const auditShardEvents = readAuditShardEvents(projectDir);
   if (existsSync(stateMdPath) && auditAllShards.length > 0) {
     try {
       const auditContent = auditAllShards;

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.89";
+export const AIDLC_VERSION = "2.6.90";

--- a/tests/unit/t37.test.ts
+++ b/tests/unit/t37.test.ts
@@ -63,7 +63,8 @@
 //   - .sh 15 keyword sad (two scopes share a kw) -> grep -E "Keyword overlap:
 //       [0-9]* conflict" -> Test 15 (+ status 1 STRONGER).
 //   - .sh 16 heartbeat advisory on fresh install -> grep "Hook heartbeats: not
-//       yet fired" -> Test 16.
+//       yet fired" -> Test 16. Tests 16b-16e extend the process contract across
+//       empty, debug-only, and populated health dirs with stage-start evidence.
 //   - .sh 17 full happy path (setupIntegrationProject) -> doctor exits 0
 //       -> Test 17: status===0 (same observable: the exit code).
 //   - .sh 18 findAllEvents shape (chronological + slug filter + empty miss)
@@ -183,6 +184,24 @@ const WORKFLOW_COMPLETED_BLOCK = `
 
 ---
 `;
+
+const STAGE_STARTED_BLOCK = `
+## Stage Started
+**Timestamp**: 2026-05-03T00:00:00Z
+**Event**: STAGE_STARTED
+**Stage**: workspace-detection
+
+---
+`;
+
+function appendStageStartedAudit(p: string): void {
+  const auditPath = seededAuditShard(p);
+  writeFileSync(
+    auditPath,
+    `${readFileSync(auditPath, "utf-8")}${STAGE_STARTED_BLOCK}`,
+    "utf-8",
+  );
+}
 
 // ============================================================
 // State / audit drift checks (covers: subcommand:aidlc-utility:doctor)
@@ -471,6 +490,78 @@ describe("t37 aidlc-utility doctor — graph-level checks", () => {
     // No .aidlc-hooks-health/ dir -> fresh-install advisory branch.
     const r = doctor(p);
     expect(r.out).toContain("Hook heartbeats: not yet fired");
+  });
+
+  test("16b: empty health dir before STAGE_STARTED -> 'not yet fired' pass row", () => {
+    const p = track(setupIntegrationProject({
+      withState: STATE_MID_IDEATION,
+      withAudit: true,
+    }));
+    // audit-sample.md intentionally has no STAGE_STARTED.
+    mkdirSync(hooksHealthDir(p), { recursive: true });
+    const r = doctor(p);
+    expect(r.out).toContain("✓  Hook heartbeats: not yet fired");
+    expect(r.status).toBe(0);
+  });
+
+  test("16c: empty health dir after STAGE_STARTED -> heartbeat failure, exit 1", () => {
+    const p = track(setupIntegrationProject({
+      withState: STATE_MID_IDEATION,
+      withAudit: true,
+    }));
+    appendStageStartedAudit(p);
+    mkdirSync(hooksHealthDir(p), { recursive: true });
+    const r = doctor(p);
+    expect(r.out).toContain("✗  Hook heartbeat data");
+    expect(r.out).toContain(
+      "health dir exists and the ledger shows STAGE_STARTED, but no hook has ever fired",
+    );
+    expect(r.status).toBe(1);
+  });
+
+  test("16d: debug-only health dir passes before STAGE_STARTED and fails after it", () => {
+    const before = track(setupIntegrationProject({
+      withState: STATE_MID_IDEATION,
+      withAudit: true,
+    }));
+    const beforeHealthDir = hooksHealthDir(before);
+    mkdirSync(beforeHealthDir, { recursive: true });
+    writeFileSync(join(beforeHealthDir, "hook-debug.log"), "debug enabled\n", "utf-8");
+    const beforeResult = doctor(before);
+    expect(beforeResult.out).toContain("✓  Hook heartbeats: not yet fired");
+    expect(beforeResult.status).toBe(0);
+
+    const after = track(setupIntegrationProject({
+      withState: STATE_MID_IDEATION,
+      withAudit: true,
+    }));
+    appendStageStartedAudit(after);
+    const afterHealthDir = hooksHealthDir(after);
+    mkdirSync(afterHealthDir, { recursive: true });
+    writeFileSync(join(afterHealthDir, "hook-debug.log"), "debug enabled\n", "utf-8");
+    const afterResult = doctor(after);
+    expect(afterResult.out).toContain("✗  Hook heartbeat data");
+    expect(afterResult.status).toBe(1);
+  });
+
+  test("16e: real heartbeat after STAGE_STARTED -> last-fired pass row", () => {
+    const p = track(setupIntegrationProject({
+      withState: STATE_MID_IDEATION,
+      withAudit: true,
+    }));
+    appendStageStartedAudit(p);
+    const healthDir = hooksHealthDir(p);
+    mkdirSync(healthDir, { recursive: true });
+    writeFileSync(
+      join(healthDir, "continue-workflow.last"),
+      "2026-05-03T00:01:00Z\n",
+      "utf-8",
+    );
+    const r = doctor(p);
+    expect(r.out).toContain(
+      "✓  Hooks last fired: continue-workflow 2026-05-03T00:01:00Z",
+    );
+    expect(r.status).toBe(0);
   });
 
   test("17: full happy path -> doctor exits 0 on full-scaffold project", () => {


### PR DESCRIPTION
Doctor documented a fail state for a health dir with no .last heartbeats but the branch was unreachable, so an install whose hooks never fire (which permanently parks every human gate) passed section 6. The check now fails with exit 1 when the same-scope ledger contains STAGE_STARTED and no hook ever wrote a heartbeat, while fresh installs, pre-created empty dirs, debug-only dirs, and fresh clones still pass; covered by new t37 cases 16b-16e and shipped as 2.6.71. Note: v2's CHANGELOG head has since moved past 2.6.71 (currently 2.6.74), so the version slot re-bumps at landing per the changelog conflict policy. Closes #861