### PR TITLE
fix(knowledge): make duplicate-record recovery fail closed (#895)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.100] - 2026-08-26
+
+Knowledge index recovery now selects duplicate records against the live managed source even when the project path traverses a symlink, and refuses present sources that cannot be safely read. **Upgrade:** refresh your `dist/<harness>/` shell to receive the corrected recovery behavior.
+
+* `aidlc-knowledge sync` rebuilds a missing `index.json` using digest matching through symlinked project paths, preventing a newer stale duplicate record from surviving recovery.
+* When duplicate records require a digest tie-break, a present-but-refused managed source, including a dangling symlink, now stops the rebuild with the source path and refusal reason; only a genuinely absent source retains the deterministic newest-`indexed_at` fallback.
+
 ## [2.6.99] - 2026-08-26
 
 Audit and usage-ledger read-modify-write transactions now remain serialized during Windows lock handoff instead of allowing retirement or stale recovery to displace a successor. **Upgrade:** re-copy `dist/<harness>/` so all state, audit, active-directive, and usage writers receive the generation-bound lock protocol.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.99-blue)
+![version](https://img.shields.io/badge/version-2.6.100-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-knowledge.ts
+++ b/core/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/dist/claude/.claude/tools/aidlc-knowledge.ts
+++ b/dist/claude/.claude/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/dist/codex/.codex/tools/aidlc-knowledge.ts
+++ b/dist/codex/.codex/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/dist/copilot/.aidlc/tools/aidlc-knowledge.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/dist/cursor/.cursor/tools/aidlc-knowledge.ts
+++ b/dist/cursor/.cursor/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/dist/kiro-ide/.kiro/tools/aidlc-knowledge.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/dist/kiro/.kiro/tools/aidlc-knowledge.ts
+++ b/dist/kiro/.kiro/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/dist/opencode/.aidlc/tools/aidlc-knowledge.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-knowledge.ts
@@ -3876,11 +3876,25 @@ export function rebuildIndex(projectDir: string, space: string): DocumentIndex {
   for (const [sourcePath, rows] of liveByPath) {
     if (rows.length < 2) continue;
     let currentDigest: string | null = null;
-    if (docsReal !== null && rows.some((row) => row.source.kind === "managed")) {
+    if (
+      docsReal !== null &&
+      rows.some((row) => row.source.kind === "managed") &&
+      sourcePath.startsWith("documents/")
+    ) {
+      const abs = join(
+        docsReal,
+        sourcePath.slice("documents/".length).split("/").join(sep),
+      );
       try {
-        const abs = join(knowledgeDir(projectDir, space), sourcePath.split("/").join(sep));
         currentDigest = sha256Hex(readCandidate(docsReal, abs));
-      } catch { /* absent/refused source gives no preferred digest */ }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw new Error(
+            `cannot choose among duplicate records for ${sourcePath} while rebuilding the index: ` +
+              errorMessage(e),
+          );
+        }
+      }
     }
     rows.sort((a, b) => {
       const aMatches = currentDigest !== null && a.sha256 === currentDigest;

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.99";
+export const AIDLC_VERSION = "2.6.100";

--- a/tests/unit/t298-knowledge-transaction.test.ts
+++ b/tests/unit/t298-knowledge-transaction.test.ts
@@ -69,6 +69,7 @@ import {
   onboard,
   readIndex,
   rebindDocument,
+  rebuildIndex,
   setIntentAssociation,
   sha256Hex,
   spaceAuditShardPath,
@@ -99,21 +100,26 @@ const MIN_HOLD_MS = 300;
 const HOLD_CAP_MS = 15_000;
 
 let proj: string | undefined;
+let projectLink: string | undefined;
 
 /** A project WITH AN ACTIVE INTENT. The intent is not incidental: the shard bug
  *  this file guards is invisible in a space with no intents, because that is the
  *  one case where the buggy call happens to return the right path. */
-function projectWithIntent(): string {
-  proj = mkdtempSync(join(tmpdir(), "t298-"));
+function initializeProjectWithIntent(projectDir: string): string {
   const r = spawnSync(
     "bun",
     [join(AIDLC_TOOLS, "aidlc-utility.ts"), "intent-create", "--label", "probe",
-     "--project-dir", proj],
+     "--project-dir", projectDir],
     { encoding: "utf-8", env: CHILD_ENV },
   );
   expect(r.status, `intent-create failed: ${r.stderr}`).toBe(0);
-  mkdirSync(documentsDir(proj, SPACE), { recursive: true });
-  return proj;
+  mkdirSync(documentsDir(projectDir, SPACE), { recursive: true });
+  return projectDir;
+}
+
+function projectWithIntent(): string {
+  proj = mkdtempSync(join(tmpdir(), "t298-"));
+  return initializeProjectWithIntent(proj);
 }
 
 function doc(p: string, name: string, body = "text\n"): string {
@@ -128,6 +134,36 @@ function intentUuid(p: string): string {
     "utf-8",
   )) as { uuid: string }[];
   return rows[0].uuid;
+}
+
+function plantDuplicatePolicy(p: string): {
+  source: string;
+  indexedId: string;
+  duplicateId: string;
+} {
+  const source = doc(p, "policy.md", "current policy\n");
+  const indexed = onboard(p, SPACE, source, NOW).indexed[0];
+  const winnerDir = join(documentkbDir(p, SPACE), indexed.id);
+  const winnerMeta = JSON.parse(
+    readFileSync(join(winnerDir, "metadata.json"), "utf-8"),
+  ) as Record<string, unknown>;
+  const duplicateId = "019fda80-8f8d-7bfa-b56c-983cf0353fab";
+  const duplicateDir = join(documentkbDir(p, SPACE), duplicateId);
+  mkdirSync(duplicateDir, { recursive: true });
+  writeFileSync(
+    join(duplicateDir, "metadata.json"),
+    `${JSON.stringify({
+      ...winnerMeta,
+      id: duplicateId,
+      sha256: sha256Hex(Buffer.from("stale policy\n")),
+      bytes: Buffer.byteLength("stale policy\n"),
+      indexed_at: "2026-08-08T00:00:00Z",
+      extraction: { state: "unsupported_type", detectedType: "text/plain" },
+      content: undefined,
+      content_sha256: undefined,
+    }, null, 2)}\n`,
+  );
+  return { source, indexedId: indexed.id, duplicateId };
 }
 
 function runOnboard(p: string, args: string[] = []): { status: number; out: string } {
@@ -210,6 +246,10 @@ function auditShards(p: string): { path: string; body: string }[] {
 }
 
 afterEach(() => {
+  if (projectLink !== undefined) {
+    rmSync(projectLink, { recursive: true, force: true });
+    projectLink = undefined;
+  }
   if (proj !== undefined) {
     rmSync(proj, { recursive: true, force: true });
     proj = undefined;
@@ -1517,28 +1557,7 @@ describe("t298 commit-time reconciliation and idempotent recovery", () => {
 
   test("rebuild keeps the duplicate live row whose digest matches the source", () => {
     const p = projectWithIntent();
-    const source = doc(p, "policy.md", "current policy\n");
-    const indexed = onboard(p, SPACE, source, NOW).indexed[0];
-    const winnerDir = join(documentkbDir(p, SPACE), indexed.id);
-    const winnerMeta = JSON.parse(
-      readFileSync(join(winnerDir, "metadata.json"), "utf-8"),
-    ) as Record<string, unknown>;
-    const loserId = "019fda80-8f8d-7bfa-b56c-983cf0353fab";
-    const loserDir = join(documentkbDir(p, SPACE), loserId);
-    mkdirSync(loserDir, { recursive: true });
-    writeFileSync(
-      join(loserDir, "metadata.json"),
-      `${JSON.stringify({
-        ...winnerMeta,
-        id: loserId,
-        sha256: sha256Hex(Buffer.from("stale policy\n")),
-        bytes: Buffer.byteLength("stale policy\n"),
-        indexed_at: "2026-08-08T00:00:00Z",
-        extraction: { state: "unsupported_type", detectedType: "text/plain" },
-        content: undefined,
-        content_sha256: undefined,
-      }, null, 2)}\n`,
-    );
+    const { source, indexedId } = plantDuplicatePolicy(p);
     rmSync(indexPath(p, SPACE));
 
     syncDocuments(p, SPACE, "2026-08-09T00:00:00Z");
@@ -1546,8 +1565,66 @@ describe("t298 commit-time reconciliation and idempotent recovery", () => {
       (row) => !row.removed_at && row.source.path === "documents/policy.md",
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].id).toBe(indexed.id);
+    expect(rows[0].id).toBe(indexedId);
     expect(rows[0].sha256).toBe(sha256Hex(readFileSync(source)));
+  });
+
+  test("rebuild resolves duplicate source digests through a symlinked project path", () => {
+    proj = mkdtempSync(join(tmpdir(), "t298-real-"));
+    projectLink = `${proj}-link`;
+    symlinkSync(proj, projectLink, "dir");
+    const p = initializeProjectWithIntent(projectLink);
+    const { source, indexedId } = plantDuplicatePolicy(p);
+    rmSync(indexPath(p, SPACE));
+
+    syncDocuments(p, SPACE, "2026-08-09T00:00:00Z");
+    const rows = readIndex(p, SPACE).documents.filter(
+      (row) => !row.removed_at && row.source.path === "documents/policy.md",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(indexedId);
+    expect(rows[0].sha256).toBe(sha256Hex(readFileSync(source)));
+  });
+
+  test("rebuild refuses a present duplicate source that cannot be read", () => {
+    const p = projectWithIntent();
+    const { source } = plantDuplicatePolicy(p);
+    rmSync(indexPath(p, SPACE));
+    rmSync(source);
+    mkdirSync(source);
+
+    expect(() => rebuildIndex(p, SPACE)).toThrow(
+      /documents\/policy\.md.*policy\.md is a directory/,
+    );
+  });
+
+  test("rebuild refuses a dangling duplicate source symlink", () => {
+    const p = projectWithIntent();
+    const { source } = plantDuplicatePolicy(p);
+    rmSync(indexPath(p, SPACE));
+    rmSync(source);
+    try {
+      symlinkSync("missing-policy.md", source);
+    } catch {
+      return; // Windows without symlink privilege.
+    }
+
+    expect(() => rebuildIndex(p, SPACE)).toThrow(
+      /documents\/policy\.md.*policy\.md is a symlink/i,
+    );
+  });
+
+  test("rebuild with an absent duplicate source keeps the newest indexed row", () => {
+    const p = projectWithIntent();
+    const { source, duplicateId } = plantDuplicatePolicy(p);
+    rmSync(indexPath(p, SPACE));
+    rmSync(source);
+
+    const rows = rebuildIndex(p, SPACE).documents.filter(
+      (row) => !row.removed_at && row.source.path === "documents/policy.md",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(duplicateId);
   });
 
   test("a successful edited onboard event carries its source path", () => {


### PR DESCRIPTION
rebuildIndex resolved the documents/ anchor with realpathSync but built the digest candidate from the unresolved project path, so on a symlinked project path the containment check refused the read and the duplicate-record tie-break silently degraded to newest indexed_at — letting a stale row survive index recovery as a spliced record. The candidate is now derived from the resolved documents/ root, an absent source keeps the documented indexed_at fallback, and a present-but-refused source now stops the rebuild with the source path and reason; three new t298 tests pin the symlinked-path regression on Linux CI plus the refused and absent branches.

Note on the version slot: this branch carries 2.6.77 (committed when v2 was at 2.6.69); v2 has since advanced to 2.6.74. Per the changelog conflict policy the slot re-bumps at landing if taken by then.

Closes #895