### PR TITLE
fix: keep type-check sensor cache in the project record, not per-package tsconfig dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.96] - 2026-08-26
+
+Type-check sensor incremental state now stays in the project record and uses a distinct cache per tsconfig, preventing package-local `aidlc/` trees in monorepos. **Upgrade:** refresh your `dist/<harness>/` shell and drop any user-side workaround ignore rules; legacy package-local cache directories may be removed individually after confirming they contain only sensor cache data.
+
+* Type-check keeps `--project` and the tsconfig-directory working directory while writing `.tsbuildinfo-<sha256>` files under the project record's `.aidlc-sensors/` directory, keyed by the project-relative tsconfig path.
+* Every harness now ignores the full engine-shaped sensor-cache path at any depth, covering legacy package-local trees without ignoring unrelated `.aidlc-sensors` directories.
+
 ## [2.6.95] - 2026-08-25
 
 `/aidlc --doctor` now reports consumed artifacts with multiple loaded producers before runtime silently selects the first producer by graph load order. **Upgrade:** refresh your `dist/<harness>/` shell to install the new advisory check; no workflow migration is required.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.95-blue)
+![version](https://img.shields.io/badge/version-2.6.96-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/templates/onboarding.md
+++ b/core/templates/onboarding.md
@@ -62,6 +62,7 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)
 {{SLOT:gitignore_extra}}

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/core/tools/aidlc-sensor-type-check.ts
+++ b/core/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/claude/.claude/CLAUDE.md
+++ b/dist/claude/.claude/CLAUDE.md
@@ -79,6 +79,7 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)
 - `.claude/settings.local.json`

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/claude/.claude/tools/aidlc-sensor-type-check.ts
+++ b/dist/claude/.claude/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/claude/.gitignore
+++ b/dist/claude/.gitignore
@@ -44,6 +44,9 @@ aidlc/.aidlc-active-space-*.tmp
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/codex/.codex/tools/aidlc-sensor-type-check.ts
+++ b/dist/codex/.codex/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/codex/.gitignore
+++ b/dist/codex/.gitignore
@@ -44,6 +44,9 @@ aidlc/.aidlc-active-space-*.tmp
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/dist/codex/AGENTS.md
+++ b/dist/codex/AGENTS.md
@@ -88,5 +88,6 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)

--- a/dist/copilot/.aidlc/tools/aidlc-lib.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/copilot/.aidlc/tools/aidlc-lib.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/copilot/.aidlc/tools/aidlc-sensor-type-check.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/copilot/.gitignore
+++ b/dist/copilot/.gitignore
@@ -43,6 +43,9 @@ aidlc/.aidlc-clone-id
 # state keyed by the harness session id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/dist/copilot/AGENTS.md
+++ b/dist/copilot/AGENTS.md
@@ -92,5 +92,6 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)

--- a/dist/cursor/.cursor/tools/aidlc-lib.ts
+++ b/dist/cursor/.cursor/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/cursor/.cursor/tools/aidlc-lib.ts
+++ b/dist/cursor/.cursor/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/cursor/.cursor/tools/aidlc-sensor-type-check.ts
+++ b/dist/cursor/.cursor/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/cursor/.gitignore
+++ b/dist/cursor/.gitignore
@@ -46,6 +46,9 @@ aidlc/.aidlc-cursor-subagents/
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/dist/cursor/AGENTS.md
+++ b/dist/cursor/AGENTS.md
@@ -78,5 +78,6 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)

--- a/dist/kiro-ide/.gitignore
+++ b/dist/kiro-ide/.gitignore
@@ -50,6 +50,9 @@ aidlc/.aidlc-readonly-latch
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/kiro-ide/.kiro/tools/aidlc-sensor-type-check.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/kiro-ide/AGENTS.md
+++ b/dist/kiro-ide/AGENTS.md
@@ -74,5 +74,6 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)

--- a/dist/kiro/.gitignore
+++ b/dist/kiro/.gitignore
@@ -49,6 +49,9 @@ aidlc/.aidlc-readonly-latch
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/kiro/.kiro/tools/aidlc-sensor-type-check.ts
+++ b/dist/kiro/.kiro/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/kiro/AGENTS.md
+++ b/dist/kiro/AGENTS.md
@@ -74,5 +74,6 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -9504,9 +9504,10 @@ export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
 // `baseDir` is the project dir for current dispatcher and type-check callers;
 // callers append a stage slug as needed. Before 2.6.94, type-check passed a
-// tsconfig directory instead, creating legacy package-local record trees. A
-// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
-// context is supplied.
+// tsconfig directory instead, creating legacy package-local record trees. With
+// no explicit intent/space, `docsRoot` follows the active-intent cursor (or lone
+// record) when one resolves, so caches and failure details share the manifest's
+// per-intent location; only pre-intent does it fall back to the flat space root.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -7421,11 +7421,12 @@ export function repoDir(projectDir: string, repoName: string): string {
 // pathspec a directory match, so a root FILE named `aidlc` stays in the walk.
 const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 
-// The sensor cache is the one member of the family that is NOT root-anchored:
-// the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the tsconfig
-// dir (core/tools/aidlc-sensor-type-check.ts's `sensorsDir`), which a
-// monorepo's per-package tsconfig can put anywhere under repoDir. So this one
-// needs a depth-tolerant pathspec while the shell names stay root-anchored.
+// The sensor-cache exclusion remains depth-tolerant for legacy and worktree
+// paths. Before 2.6.94, the type-check sensor anchored
+// `.aidlc-sensors/.tsbuildinfo` at the nearest tsconfig directory, so monorepo
+// package caches could appear anywhere under repoDir. Those stray trees persist
+// in upgraded repositories, and Bolt worktree record mirrors can also sit below
+// the workspace roof, while the shell names stay root-anchored.
 //
 // #646 review - the shell/any-depth split is deliberate, not an oversight: an
 // earlier fix applied `**/<name>/**` to ALL four names to close a *reported*
@@ -7445,10 +7446,10 @@ const AIDLC_SHELL_DIR_NAMES = ["aidlc/", ".aidlc/"];
 // engine actually writes instead of by its leaf. Every writer resolves through
 // `sensorsDir()` -> `docsRoot()` -> `intentsDir()` -> `workspaceRoot()`, so the
 // cache is always `<anchor>/aidlc/spaces/<space>/intents[/<record>]/
-// .aidlc-sensors/` - the `<anchor>` is what varies (roof, Bolt worktree, or a
-// monorepo package's tsconfig dir), which is exactly what the leading `**/`
-// absorbs. The inner `/**/` also matches zero directories, covering the flat
-// (no active record) form the type-check anchor produces.
+// .aidlc-sensors/`. The `<anchor>` can be the roof, a Bolt worktree, or a
+// legacy pre-2.6.94 monorepo package tsconfig directory, which is exactly what
+// the leading `**/` absorbs. The inner `/**/` also matches zero directories,
+// covering the flat (no active record) form.
 const AIDLC_SENSOR_CACHE_GLOBS = [
   ":(glob)**/aidlc/spaces/*/intents/**/.aidlc-sensors/**",
 ];
@@ -9501,11 +9502,11 @@ export function composeMarkerPath(projectDir: string): string {
 export const COMPOSE_MARKER_TTL_MS = 24 * 60 * 60 * 1000;
 
 // `<baseDir>/.aidlc-sensors` — the sensor detail-output / tsbuildinfo directory.
-// `baseDir` is the project dir for the dispatcher, or a tsconfig anchor for the
-// type-check sensor; callers append a stage slug as needed. The tsconfig-anchor
-// caller passes a non-projectDir base, so the record-dir resolution is OPT-OUT:
-// only resolve per-intent when the caller passes intent/space context; a bare
-// baseDir keeps the flat `.aidlc-sensors` leaf for the type-check anchor case.
+// `baseDir` is the project dir for current dispatcher and type-check callers;
+// callers append a stage slug as needed. Before 2.6.94, type-check passed a
+// tsconfig directory instead, creating legacy package-local record trees. A
+// bare baseDir still keeps the flat `.aidlc-sensors` leaf when no intent/space
+// context is supplied.
 export function sensorsDir(baseDir: string, intent?: string, space?: string): string {
   if (intent === undefined && space === undefined) {
     return join(docsRoot(baseDir), ".aidlc-sensors");

--- a/dist/opencode/.aidlc/tools/aidlc-sensor-type-check.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-sensor-type-check.ts
@@ -1,11 +1,11 @@
 // aidlc-sensor-type-check.ts — per-sensor script for the `type-check` sensor.
 //
 // Owns the type-check itself; the dispatcher (aidlc-sensor.ts) routes a
-// SENSOR fire to this script via the manifest's `command:` field. Self-
-// contained: no imports from sibling tools. Wraps `bunx tsc --project
-// <tsconfig> --noEmit --pretty false --incremental --tsBuildInfoFile
-// <path under the active record's .aidlc-sensors/>` and prints the locked stdout
-// JSON shape:
+// SENSOR fire to this script via the manifest's `command:` field. It uses the
+// shared project resolver to keep incremental state under the active record,
+// then wraps `bunx tsc --project <tsconfig> --noEmit --pretty false
+// --incremental --tsBuildInfoFile <record cache path>` and prints the locked
+// stdout JSON shape:
 //
 //   {"pass": <bool>, "errors": [{file, line, column, message}, ...]}
 //
@@ -30,11 +30,11 @@
 //   via stdout-line count, not exit code.
 //
 // * Why --incremental --tsBuildInfoFile: persist compile state across
-//   fires under the active record's .aidlc-sensors/.tsbuildinfo (gitignored by
-//   the framework). Subsequent fires re-check only changed files
-//   instead of the entire project. Doesn't fix cross-file attribution
-//   but cuts re-reporting noise — same un-introduced error doesn't spam
-//   SENSOR_FAILED on every Write.
+//   fires under the active record's .aidlc-sensors/.tsbuildinfo-<sha256>.
+//   The hash is derived from the project-relative tsconfig path, so monorepo
+//   package configs do not overwrite one shared cache. Subsequent fires
+//   re-check only changed files instead of the entire project. This doesn't
+//   fix cross-file attribution, but it cuts re-reporting noise.
 //
 // * Tool-unavailable detection: probe `bunx tsc --version` once at
 //   startup. `bunx <tool>` returns non-127 codes for several failure
@@ -70,9 +70,10 @@
 //   127 tsc unresolvable
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { sensorsDir } from "./aidlc-lib.ts";
+import { dirname, isAbsolute, join, posix, relative, resolve } from "node:path";
+import { resolveProjectDir, sensorsDir } from "./aidlc-lib.ts";
 
 interface ParsedError {
 	file: string;
@@ -263,18 +264,24 @@ export function main(argv: string[]): void {
 	}
 	const tsconfigDir = dirname(tsconfigPath);
 
-		// Use the tsconfig directory as the project anchor for resolving the
-		// active record's .aidlc-sensors/.tsbuildinfo. The .aidlc-sensors/
-		// directory is gitignored, so the tsbuildinfo never pollutes commits.
-	const sensorsBaseDir = sensorsDir(tsconfigDir);
+	// Keep every package's incremental state in the project record tree. Hashing
+	// the portable project-relative tsconfig path isolates monorepo caches while
+	// preserving the tsconfig directory as tsc's cwd below.
+	const projectDir = resolveProjectDir();
+	const relativeTsconfigPath = posix.normalize(
+		relative(projectDir, tsconfigPath).replaceAll("\\", "/"),
+	);
+	const tsconfigHash = createHash("sha256")
+		.update(relativeTsconfigPath, "utf-8")
+		.digest("hex");
+	const sensorsBaseDir = sensorsDir(projectDir);
 	try {
 		mkdirSync(sensorsBaseDir, { recursive: true });
 	} catch {
-		// If we can't mkdir (read-only fs etc.), proceed without
-		// --tsBuildInfoFile by pointing at a tmp path. tsc still works,
-		// just non-incremental on next run.
+		// Leave the requested cache path in place. tsc will report an unwritable
+		// path through the ordinary script-error status gate.
 	}
-	const tsBuildInfoFile = join(sensorsBaseDir, ".tsbuildinfo");
+	const tsBuildInfoFile = join(sensorsBaseDir, `.tsbuildinfo-${tsconfigHash}`);
 
 	// Probe tsc availability first. cwd doesn't matter for --version.
 	probeTscAvailable(tsconfigDir);

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.95";
+export const AIDLC_VERSION = "2.6.96";

--- a/dist/opencode/.gitignore
+++ b/dist/opencode/.gitignore
@@ -44,6 +44,9 @@ aidlc/.aidlc-active-space-*.tmp
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/dist/opencode/AGENTS.md
+++ b/dist/opencode/AGENTS.md
@@ -77,5 +77,6 @@ Commit the `aidlc/` workspace tree — the record (state, the per-clone audit sh
 - `aidlc/active-space` and `aidlc/spaces/*/intents/active-intent` (per-user cursors)
 - `aidlc/.aidlc-clone-id` (per-clone audit-shard token) and `aidlc/.aidlc-sessions/`
 - `aidlc/spaces/*/intents/.aidlc-*` (pre-intent hooks-health scratch)
+- `**/aidlc/spaces/*/intents/**/.aidlc-sensors/` (engine-shaped sensor caches at any depth, including legacy package-local trees)
 - `aidlc/spaces/*/intents/*/runtime-graph.json` (also covers per-Bolt worktree fragments by relative-path glob)
 - `aidlc/spaces/*/intents/*/.aidlc-*` (recovery, hooks-health, sensors scratch)

--- a/harness/claude/dot-gitignore
+++ b/harness/claude/dot-gitignore
@@ -44,6 +44,9 @@ aidlc/.aidlc-active-space-*.tmp
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/harness/codex/dot-gitignore
+++ b/harness/codex/dot-gitignore
@@ -44,6 +44,9 @@ aidlc/.aidlc-active-space-*.tmp
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/harness/copilot/dot-gitignore
+++ b/harness/copilot/dot-gitignore
@@ -43,6 +43,9 @@ aidlc/.aidlc-clone-id
 # state keyed by the harness session id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/harness/cursor/dot-gitignore
+++ b/harness/cursor/dot-gitignore
@@ -46,6 +46,9 @@ aidlc/.aidlc-cursor-subagents/
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/harness/kiro-ide/dot-gitignore
+++ b/harness/kiro-ide/dot-gitignore
@@ -50,6 +50,9 @@ aidlc/.aidlc-readonly-latch
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/harness/kiro/dot-gitignore
+++ b/harness/kiro/dot-gitignore
@@ -49,6 +49,9 @@ aidlc/.aidlc-readonly-latch
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/harness/opencode/dot-gitignore
+++ b/harness/opencode/dot-gitignore
@@ -44,6 +44,9 @@ aidlc/.aidlc-active-space-*.tmp
 # state keyed by Claude Code session_id, never shared truth.
 aidlc/.aidlc-sessions/
 aidlc/spaces/*/intents/.aidlc-*
+# Engine-shaped sensor caches at any depth, mirroring the #646 fingerprint glob;
+# also covers legacy pre-2.6.94 trees without ignoring every .aidlc-sensors leaf.
+**/aidlc/spaces/*/intents/**/.aidlc-sensors/
 # DocumentKB staged-transaction scratch: `onboard` stages a document into
 # `.journal/<txn-id>/` and renames it into place under the audit lock. Per-clone
 # and transient -- a committed journal would be a merge conflict on every

--- a/tests/integration/t92.test.ts
+++ b/tests/integration/t92.test.ts
@@ -11,19 +11,20 @@
 // in-process handleFire() twin would lose the exit-code half AND the
 // process.exit(0) / lock-orphan-recovery behaviour the .sh relies on.
 //
-// SPAWN vs IN-PROCESS split: ALL 47 cases are spawn-based. There is
+// SPAWN vs IN-PROCESS split: ALL 48 cases are spawn-based. There is
 // no pure-function arm — every behaviour (argv validation exit codes,
 // truth-table branches, audit emission, concurrency, lock-orphan
 // recovery) is observed through the real CLI subprocess + the audit.md it
-// writes. So spawnCount = 45-worth-of-cases, inProcessCount = 0.
+// writes. So spawnCount = 46-worth-of-cases, inProcessCount = 0.
 //
-// Tests 44-45 (Groups N + O) are additions beyond the original .sh's
+// Tests 44-46 (Groups N + O + P) are additions beyond the original .sh's
 // plan-43, guarding the type-check status gate: test 44 covers the
 // config-load failure (tsc non-zero + zero parseable diagnostics ->
 // script-error: exit-<n>, not a false PASS); test 45 covers the cross-file
 // edge (tsc non-zero with diagnostics for OTHER files but none for the
 // target -> per-file clean PASS, gate keys on allErrors not the filtered
-// errors).
+// errors); test 46 keeps monorepo package caches under the project record and
+// namespaces them by tsconfig.
 //
 // SUBCOMMAND UNIT: this .cli file credits the `aidlc-sensor fire`
 // subcommand unit (covers KEY subcommand:aidlc-sensor:fire). `list` and
@@ -500,6 +501,7 @@ function runPassedTsReal(
   passedId: string;
   path: string;
   note: string;
+  cacheExists: boolean;
   detailExists: boolean;
   subdir: string;
 } {
@@ -519,7 +521,8 @@ function runPassedTsReal(
     passedId: auditField(f, "SENSOR_PASSED", "Fire id"),
     path: auditField(f, "SENSOR_PASSED", "Output path"),
     note: auditField(f, "SENSOR_PASSED", "Note"),
-    detailExists: existsSync(join(recordRoot(proj), ".aidlc-sensors")),
+    cacheExists: existsSync(join(recordRoot(proj), ".aidlc-sensors")),
+    detailExists: existsSync(join(recordRoot(proj), ".aidlc-sensors", stage)),
     subdir,
   };
 }
@@ -617,6 +620,7 @@ describe("t92 Group B: PASSED real round-trip per sensor", () => {
     expect(r.firedId).not.toBe("");
     expect(r.firedId).toBe(r.passedId);
     expect(isInteger(r.dur)).toBe(true);
+    expect(r.cacheExists).toBe(false);
     expect(r.detailExists).toBe(false);
     expect(r.path).toBe(`${r.subdir}/sample.ts`);
     expect(r.note).toBe("");
@@ -631,6 +635,7 @@ describe("t92 Group B: PASSED real round-trip per sensor", () => {
     expect(r.firedId).not.toBe("");
     expect(r.firedId).toBe(r.passedId);
     expect(isInteger(r.dur)).toBe(true);
+    expect(r.cacheExists).toBe(true);
     expect(r.detailExists).toBe(false);
     expect(r.path).toBe(`${r.subdir}/sample.ts`);
     expect(r.note).toBe("");
@@ -1365,4 +1370,81 @@ describe("t92 Group O: type-check status gate (cross-file errors, none for targe
     expect(auditEventCount(f, "SENSOR_FAILED")).toBe(0);
     expect(auditField(f, "SENSOR_PASSED", "Note")).toBe("");
   }, 30000);
+});
+
+// ============================================================
+// Group P — type-check incremental cache placement. A monorepo can have one
+// tsconfig per package, but the framework cache belongs to the project record,
+// not a package-local aidlc/ tree. Each project-relative tsconfig path gets a
+// stable hash suffix so package fires do not overwrite one shared buildinfo.
+// ============================================================
+
+describe("t92 Group P: type-check monorepo cache placement", () => {
+  test("46: package tsconfigs share the record cache with collision-resistant buildinfo files", () => {
+    const proj = makeProj();
+    const packagesDir = join(proj, "packages");
+    writeFileSync(
+      join(proj, "tsconfig.base.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          skipLibCheck: true,
+        },
+      }, null, 2)}\n`,
+      "utf-8",
+    );
+
+    const packageNames = ["pkg-100616", "pkg-114664"];
+    // These paths have the same first eight SHA-256 hex characters. Keeping
+    // both in this test prevents a shortened cache key from aliasing them.
+    for (const name of packageNames) {
+      const packageDir = join(packagesDir, name);
+      mkdirSync(join(packageDir, "src"), { recursive: true });
+      writeFileSync(
+        join(packageDir, "tsconfig.json"),
+        `${JSON.stringify({
+          extends: "../../tsconfig.base.json",
+          include: ["src/**/*.ts"],
+        }, null, 2)}\n`,
+        "utf-8",
+      );
+      writeFileSync(
+        join(packageDir, "src", "index.ts"),
+        "export const value: number = 1;\n",
+        "utf-8",
+      );
+    }
+
+    for (const name of packageNames) {
+      const result = fire(
+        [
+          "type-check",
+          "--stage",
+          "code-generation",
+          "--output-path",
+          join(packagesDir, name, "src", "index.ts"),
+        ],
+        { CLAUDE_PROJECT_DIR: proj },
+      );
+      expect(result.rc, `${name}: type-check fire`).toBe(0);
+    }
+
+    for (const name of packageNames) {
+      expect(
+        existsSync(join(packagesDir, name, "aidlc")),
+        `${name}: no package-local aidlc tree`,
+      ).toBe(false);
+    }
+
+    const cacheDir = join(recordRoot(proj), ".aidlc-sensors");
+    expect(existsSync(cacheDir), "project record cache exists").toBe(true);
+    const buildinfoFiles = readdirSync(cacheDir)
+      .filter((name) => /^\.tsbuildinfo-[0-9a-f]{64}$/.test(name))
+      .sort();
+    expect(buildinfoFiles).toHaveLength(2);
+    expect(new Set(buildinfoFiles).size).toBe(2);
+  }, 60000);
 });

--- a/tests/unit/t157-workspace-shell-seed.test.ts
+++ b/tests/unit/t157-workspace-shell-seed.test.ts
@@ -44,6 +44,7 @@
 // AIDLC_RULES_DIR seam (no LLM, no subprocess).
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
@@ -51,6 +52,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -259,6 +261,21 @@ describe("t157 seeded workspace shell + re-rooted .gitignore (SEED)", () => {
       expect(lines, `${h}: ignores per-intent .aidlc-*`).toContain(
         "aidlc/spaces/*/intents/*/.aidlc-*",
       );
+      expect(lines, `${h}: ignores engine-shaped sensor caches at any depth`).toContain(
+        "**/aidlc/spaces/*/intents/**/.aidlc-sensors/",
+      );
+
+      const repo = mkdtempSync(join(tmpdir(), `aidlc-t157-gitignore-${h}-`));
+      tempDirs.push(repo);
+      expect(spawnSync("git", ["init", "-q"], { cwd: repo }).status, `${h}: git init`).toBe(0);
+      writeFileSync(join(repo, ".gitignore"), gi, "utf-8");
+      const nestedSensorCache =
+        "packages/api/aidlc/spaces/default/intents/.aidlc-sensors/x";
+      expect(
+        spawnSync("git", ["check-ignore", "-q", nestedSensorCache], { cwd: repo }).status,
+        `${h}: nested sensor cache is functionally ignored`,
+      ).toBe(0);
+
       // The flat-layout ignore rules are GONE (no leftover aidlc-docs/ leaf).
       const hasActiveIgnore = (pat: string): boolean =>
         lines.some((l) => l === pat); // an ignore rule, not the in-comment mention

--- a/tests/unit/t314-source-freshness-receipts.test.ts
+++ b/tests/unit/t314-source-freshness-receipts.test.ts
@@ -421,21 +421,20 @@ describe("t314 workspace source fingerprint (in-process)", () => {
     }
   }, 20000);
 
-  // #646 review P2 - the aidlc-workspace exclusion was top-level
-  // only; the type-check sensor anchors `.aidlc-sensors/.tsbuildinfo` at the
-  // tsconfig dir (aidlc-sensor-type-check.ts's sensorsDir), which a monorepo
-  // subpackage can nest arbitrarily deep, so nested engine-written churn
-  // there altered the fingerprint with no real source change. The cache is
-  // matched by the path the engine actually writes (sensorsDir -> docsRoot ->
-  // intentsDir -> workspaceRoot), not by its leaf name - see the sibling test
-  // below for why the leaf alone is not safe to exclude.
+  // #646 review P2 - the aidlc-workspace exclusion was top-level only. Before
+  // 2.6.94, type-check anchored `.aidlc-sensors/.tsbuildinfo` at the tsconfig
+  // dir, so a monorepo subpackage could retain an engine-written cache
+  // arbitrarily deep after upgrade. That legacy churn must not alter the
+  // fingerprint. The cache is matched by the path the engine wrote
+  // (sensorsDir -> docsRoot -> intentsDir -> workspaceRoot), not by its leaf
+  // name - see the sibling test below for why the leaf alone is unsafe.
   test("excludes a nested .aidlc-sensors cache (any depth), but not real nested source", () => {
     const src = seedGitRepo(dir);
     const fp1 = workspaceSourceFingerprint(dir);
 
-    // Engine-written sensor cache, nested under a monorepo subpackage - not at
-    // the workspace root. The tsconfig anchor is `services/backend`, so the
-    // cache lands at the anchor's own `aidlc/spaces/<space>/intents/` root.
+    // Legacy engine-written sensor cache, nested under a monorepo subpackage -
+    // not at the workspace root. Before 2.6.94 the `services/backend` tsconfig
+    // anchor gave the cache its own `aidlc/spaces/<space>/intents/` root.
     const cache = join(
       dir, "services", "backend", "aidlc", "spaces", "default", "intents", ".aidlc-sensors",
     );


### PR DESCRIPTION
The type-check sensor anchored its incremental tsc cache on the nearest tsconfig.json directory, planting stray aidlc/spaces/default/intents/.aidlc-sensors/.tsbuildinfo trees inside every package of a per-package-tsconfig monorepo — paths the shipped root-anchored .gitignore does not cover, so they leak into commits. The cache now resolves through the project record (sensorsDir(resolveProjectDir()), matching the dispatcher and the sensor manifest) with a per-tsconfig .tsbuildinfo-<hash8> name to avoid cross-package cache thrash, and every harness gitignore gains a depth-tolerant **/aidlc/spaces/*/intents/**/.aidlc-sensors/ rule covering legacy strays. Adds a real-dispatcher monorepo regression test (t92 Group P) plus functional check-ignore coverage across all seven harnesses. Closes #900