### PR TITLE
fix: preserve summary write receipts across workspace moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.83] - 2026-08-25
+
+Summary-confirmation artifact-write receipts now remain valid when the same workflow workspace is moved or cloned to a different filesystem location, without weakening their causal ordering. **Upgrade:** refresh your `dist/<harness>/` shell so completion guards use the portable receipt matcher.
+
+* Completion no longer reports `no recorded native-tool write after the human's consolidated summary confirmation` solely because an audit row contains the artifact's absolute path from the workspace's previous location.
+* Moved or cloned workspaces no longer deadlock when the completion guard rejects the old absolute prefix and review-freeze blocks the prescribed artifact re-save; the full space/intent/phase/stage-relative artifact tail now identifies the same recorded write.
+
 ## [2.6.82] - 2026-08-25
 
 `/aidlc --doctor` now catches hooks that Claude Code has globally disabled. Previously an install with `"disableAllHooks": true` could pass every check yet block at runtime because doctor verified that hook files were present and wired, but not that Claude Code would run them. **Upgrade:** refresh your `dist/<harness>/` shell to pick up the new check.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.82-blue)
+![version](https://img.shields.io/badge/version-2.6.83-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/dist/copilot/.aidlc/tools/aidlc-lib.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/dist/cursor/.cursor/tools/aidlc-lib.ts
+++ b/dist/cursor/.cursor/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -5479,6 +5479,7 @@ export function checkSummaryConfirmationEvidence(
 
     for (const artifact of summaryArtifactPaths(stage, question)) {
       const artifactAbs = resolvePath(artifact);
+      const artifactSuffix = "/" + toPosix(relative(projectDir, artifactAbs));
       const writes = events.filter((entry) => {
         if (
           entry.event !== "ARTIFACT_CREATED" &&
@@ -5487,8 +5488,14 @@ export function checkSummaryConfirmationEvidence(
           return false;
         }
         const file = auditBlockField(entry.block, "File");
-        return file !== null &&
-          resolveAuditProjectPath(projectDir, file) === artifactAbs;
+        if (file === null) return false;
+        const norm = file.replace(/\\/g, "/");
+        return (
+          resolveAuditProjectPath(projectDir, file) === artifactAbs ||
+          // #863: preserve writes across workspace moves. The leading slash
+          // and full space/intent/phase/stage tail prevent partial matches.
+          norm.endsWith(artifactSuffix)
+        );
       });
       const strictlyAfter = (
         later: AuditShardEvent,

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.82";
+export const AIDLC_VERSION = "2.6.83";

--- a/tests/integration/t185-stage-artifact-guard.test.ts
+++ b/tests/integration/t185-stage-artifact-guard.test.ts
@@ -41,7 +41,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, dirname, join, relative } from "node:path";
 import {
   AIDLC_SRC,
@@ -1608,6 +1614,40 @@ X. Other (please specify)
       const result = summaryGuarded(proj, ["advance", "feasibility"]);
       expect(result.rc).toBe(0);
       expect(field(proj, "Current Stage")).not.toBe("feasibility");
+    });
+
+    test("accepts a legacy pre-move absolute artifact write after the workspace moves", () => {
+      const questions = writeSummaryQuestions(proj);
+      confirmSummary(proj, questions);
+      const artifact = join(
+        seededRecordDir(proj),
+        "ideation",
+        "feasibility",
+        "feasibility-assessment.md",
+      );
+      writeRecordDoc(
+        proj,
+        "ideation/feasibility/feasibility-assessment.md",
+      );
+      appendFileSync(
+        seededAuditShard(proj),
+        [
+          "",
+          "## ARTIFACT_CREATED",
+          `**Timestamp**: ${new Date().toISOString()}`,
+          "**Event**: ARTIFACT_CREATED",
+          `**File**: ${artifact}`,
+          "**Tool**: Write",
+          "",
+          "---",
+          "",
+        ].join("\n"),
+      );
+      const moved = `${proj}-moved`;
+      renameSync(proj, moved);
+      proj = moved;
+
+      expect(summaryGuarded(proj, ["advance", "feasibility"]).rc).toBe(0);
     });
 
     test("normalizes line endings in a scoped receipt", () => {


### PR DESCRIPTION
checkSummaryConfirmationEvidence matched ARTIFACT_* audit rows by absolute path, so a workspace cloned or moved to a different directory could never complete an already-confirmed stage — and review-freeze blocked the prescribed re-save, a full deadlock. The completion guard now also matches the full record-relative artifact suffix (composing with the <project-dir> token from #813, which only covers rows written by 2.6.69+), leaving causal ordering untouched; proven by a t185 moved-workspace test that fails without the fallback.

Note: the committed version slot is 2.6.71; v2's CHANGELOG head has since moved to 2.6.74, so this slot re-bumps at landing per the changelog conflict policy.

Closes #863