### PR TITLE
fix: normalize positive pathspecs in codekbScopeFingerprint so a trailing slash survives an exclude (2.6.75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.91] - 2026-08-25
+
+Lone-repository CodeKB scope fingerprints now avoid Git's unreliable combination of positive and exclude pathspecs and reject fingerprints that contain no files. **Upgrade:** refresh your `dist/<harness>/` shell before minting or checking CodeKB scope fingerprints, and re-mint (or re-run reverse engineering for) any stored scope timestamp whose fingerprint is `4b825dc642cb6eb9a060e54bf8d69288fbee4904`, the empty-tree value written by the pre-fix bug.
+
+* `codekbScopeFingerprint` stages analyzed paths first and removes framework-owned exclusions from its temporary index separately, preserving root and nested-project scope boundaries without silently rewriting malformed absolute paths.
+* Scopes that stage zero paths now mint `unknown` and report `UNVERIFIED`, never a false `CURRENT` or permanent `STALE` verdict.
+* Deterministic regression coverage simulates the affected Git pathspec behavior on CI and verifies narrow, full-root, nested-project, malformed-path, and empty-scope cases.
+
 ## [2.6.90] - 2026-08-25
 
 `/aidlc --doctor` now distinguishes hook directories that have not had a chance to populate from dead hook seams after a workflow stage ran. **Upgrade:** refresh your `dist/<harness>/` shell so doctor can detect this condition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 
 Lone-repository CodeKB scope fingerprints now avoid Git's unreliable combination of positive and exclude pathspecs and reject fingerprints that contain no files. **Upgrade:** refresh your `dist/<harness>/` shell before minting or checking CodeKB scope fingerprints, and re-mint (or re-run reverse engineering for) any stored scope timestamp whose fingerprint is `4b825dc642cb6eb9a060e54bf8d69288fbee4904`, the empty-tree value written by the pre-fix bug.
 
-* `codekbScopeFingerprint` stages analyzed paths first and removes framework-owned exclusions from its temporary index separately, preserving root and nested-project scope boundaries without silently rewriting malformed absolute paths.
+* `codekbScopeFingerprint` omits exclusions outside analyzed roots, drops analyzed paths covered by exclusions, and preserves root and nested-project scope boundaries without silently rewriting malformed absolute paths.
 * Scopes that stage zero paths now mint `unknown` and report `UNVERIFIED`, never a false `CURRENT` or permanent `STALE` verdict.
-* Deterministic regression coverage simulates the affected Git pathspec behavior on CI and verifies narrow, full-root, nested-project, malformed-path, and empty-scope cases.
+* Deterministic regression coverage verifies distinct narrow fingerprints, full-root exclusions, nested-project boundaries, malformed paths, and empty scopes.
 
 ## [2.6.90] - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.90-blue)
+![version](https://img.shields.io/badge/version-2.6.91-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/dist/copilot/.aidlc/tools/aidlc-lib.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/dist/copilot/.aidlc/tools/aidlc-lib.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/dist/cursor/.cursor/tools/aidlc-lib.ts
+++ b/dist/cursor/.cursor/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/dist/cursor/.cursor/tools/aidlc-lib.ts
+++ b/dist/cursor/.cursor/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -1865,15 +1865,42 @@ export function parseReScope(body: string): ReScopeParse {
 // rebases/squashes/amends that vaporise a recorded commit hash cannot break
 // the comparison, and reverting an edit restores the original fingerprint.
 // Ignored files stay excluded (git add semantics). Callers may exclude generated
-// paths that live inside an analyzed root, such as the codekb being fingerprinted.
+// paths that live inside an analyzed root, such as the codekb being fingerprinted;
+// exclusions outside every analyzed root are omitted before invoking git.
 // Returns null when repoDir is not a git work tree, git is unavailable, or any
-// pathspec is invalid/unmatched (callers report UNVERIFIED, never a false verdict).
+// pathspec is invalid/unmatched or stages zero paths (callers report UNVERIFIED,
+// never a false verdict or the empty-tree fingerprint).
 export function codekbScopeFingerprint(
   repoDir: string,
   paths: string[],
   excludedPaths: string[] = [],
 ): string | null {
   if (paths.length === 0) return null;
+  const normalizePath = (path: string): string => {
+    let normalized = path.replaceAll("\\", "/");
+    normalized = normalized.replace(/^(?:\.\/)+/, "").replace(/\/+$/, "");
+    return normalized === "." ? "" : normalized;
+  };
+  const normalizedExclusions = excludedPaths.map(normalizePath);
+  const survivingPaths = paths
+    .map((original) => ({ original, normalized: normalizePath(original) }))
+    .filter(
+      ({ normalized: positive }) =>
+        !normalizedExclusions.some(
+          (exclusion) =>
+            exclusion === positive || positive.startsWith(`${exclusion}/`),
+        ),
+    );
+  if (survivingPaths.length === 0) return null;
+  const exclusions = normalizedExclusions
+    .filter((exclusion) =>
+      survivingPaths.some(
+        ({ normalized: positive }) =>
+          positive === "" || exclusion.startsWith(`${positive}/`),
+      ),
+    )
+    .map((exclusion) => `:(exclude,literal)${exclusion}`);
+
   const inTree = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: repoDir,
     encoding: "utf-8",
@@ -1882,19 +1909,22 @@ export function codekbScopeFingerprint(
   const indexFile = join(tmpdir(), `.aidlc-scope-index-${randomUUID()}`);
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   try {
-    const exclusions = excludedPaths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "")
-      .map((p) => `:(exclude,literal)${p}`);
-    const positives = paths
-      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
-      .filter((p) => p !== "");
-    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
+    const add = spawnSync(
+      "git",
+      ["add", "-A", "--", ...survivingPaths.map(({ original }) => original), ...exclusions],
+      {
+        cwd: repoDir,
+        env,
+        encoding: "utf-8",
+      },
+    );
+    if (add.status !== 0) return null;
+    const staged = spawnSync("git", ["ls-files", "-z"], {
       cwd: repoDir,
       env,
       encoding: "utf-8",
     });
-    if (add.status !== 0) return null;
+    if (staged.status !== 0 || staged.stdout.length === 0) return null;
     const wt = spawnSync("git", ["write-tree"], { cwd: repoDir, env, encoding: "utf-8" });
     if (wt.status !== 0) return null;
     const hash = wt.stdout.trim();

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -1886,7 +1886,10 @@ export function codekbScopeFingerprint(
       .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
       .filter((p) => p !== "")
       .map((p) => `:(exclude,literal)${p}`);
-    const add = spawnSync("git", ["add", "-A", "--", ...paths, ...exclusions], {
+    const positives = paths
+      .map((p) => p.replaceAll("\\", "/").replace(/^\.?\//, "").replace(/\/+$/, ""))
+      .filter((p) => p !== "");
+    const add = spawnSync("git", ["add", "-A", "--", ...positives, ...exclusions], {
       cwd: repoDir,
       env,
       encoding: "utf-8",

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.90";
+export const AIDLC_VERSION = "2.6.91";

--- a/tests/unit/t248-codekb-scope-diff.test.ts
+++ b/tests/unit/t248-codekb-scope-diff.test.ts
@@ -42,6 +42,7 @@ import {
 const BUN = process.execPath;
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const UTILITY = join(REPO_ROOT, "dist", "claude", ".claude", "tools", "aidlc-utility.ts");
+const SHA1_EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 resetAidlcEnv();
 
@@ -234,6 +235,82 @@ describe("t248 codekbScopeFingerprint — scoped write-tree", () => {
     expect(codekbScopeFingerprint(proj, ["src/payments/"])).toBe(fp1);
   });
 
+  test("lone-repo exclusions are omitted beside narrow scopes", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    mkdirSync(join(proj, "src", "auth"), { recursive: true });
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "payments\n");
+    writeFileSync(join(proj, "src", "auth", "login.ts"), "auth\n");
+
+    const payments = codekbScopeFingerprint(proj, ["./src/payments/"], ["aidlc"]);
+    const auth = codekbScopeFingerprint(proj, ["src/auth/"], ["aidlc"]);
+    expect(payments).not.toBeNull();
+    expect(auth).not.toBeNull();
+    expect(payments).not.toBe(SHA1_EMPTY_TREE);
+    expect(auth).not.toBe(SHA1_EMPTY_TREE);
+    expect(payments).not.toBe(auth);
+    expect(payments).toBe(codekbScopeFingerprint(proj, ["./src/payments/"]));
+    expect(auth).toBe(codekbScopeFingerprint(proj, ["src/auth/"]));
+  });
+
+  test("root exclusions ignore framework edits but retain scoped source edits", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src"), { recursive: true });
+    mkdirSync(join(proj, "aidlc"), { recursive: true });
+    const source = join(proj, "src", "app.ts");
+    const generated = join(proj, "aidlc", "state.md");
+    writeFileSync(source, "source one\n");
+    writeFileSync(generated, "state one\n");
+
+    const fp1 = codekbScopeFingerprint(proj, ["./"], [".\\aidlc\\"]);
+    expect(fp1).not.toBeNull();
+    writeFileSync(generated, "state two\n");
+    expect(codekbScopeFingerprint(proj, ["./"], [".\\aidlc\\"])).toBe(fp1);
+    writeFileSync(source, "source two\n");
+    const fp2 = codekbScopeFingerprint(proj, ["./"], [".\\aidlc\\"]);
+    expect(fp2).not.toBeNull();
+    expect(fp2).not.toBe(fp1);
+  });
+
+  test("a root scope containing only its excluded directory stages nothing", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "aidlc"), { recursive: true });
+    writeFileSync(join(proj, "aidlc", "state.md"), "state\n");
+
+    expect(codekbScopeFingerprint(proj, ["./"], ["aidlc"])).toBeNull();
+  });
+
+  test("positives covered by exclusions are dropped, including all-dropped scopes", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src"), { recursive: true });
+    mkdirSync(join(proj, "aidlc", "nested"), { recursive: true });
+    writeFileSync(join(proj, "src", "app.ts"), "source\n");
+    writeFileSync(join(proj, "aidlc", "nested", "state.md"), "state\n");
+
+    const mixed = codekbScopeFingerprint(
+      proj,
+      ["src/", ".\\aidlc\\nested\\"],
+      ["./aidlc/"],
+    );
+    expect(mixed).toBe(codekbScopeFingerprint(proj, ["src/"]));
+    expect(
+      codekbScopeFingerprint(proj, [".\\aidlc\\nested\\"], ["./aidlc/"]),
+    ).toBeNull();
+  });
+
+  test("absolute analyzed paths remain invalid instead of becoming repository-relative", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "payments\n");
+
+    expect(codekbScopeFingerprint(proj, ["/src/payments/"], ["aidlc"])).toBeNull();
+  });
+
   test("non-git directory → null (callers report UNVERIFIED, never a verdict)", () => {
     const proj = freshProject(); // createTestProject does NOT git init
     expect(codekbScopeFingerprint(proj, ["src/"])).toBeNull();
@@ -343,6 +420,8 @@ describe("t248 codekb-scope-diff verb — status mode", () => {
     const proj = join(parent, "package");
     mkdirSync(join(proj, "src"), { recursive: true });
     writeFileSync(join(proj, "src", "app.ts"), "a\n");
+    const outside = join(parent, "outside.ts");
+    writeFileSync(outside, "outside one\n");
 
     const mint = runVerb(proj, "--mint", "--paths", "./");
     expect(mint.status).toBe(0);
@@ -356,6 +435,7 @@ describe("t248 codekb-scope-diff verb — status mode", () => {
       }),
     );
 
+    writeFileSync(outside, "outside two\n");
     expect(JSON.parse(runVerb(proj, "--json").stdout).verdict).toBe("CURRENT");
   });
 
@@ -504,6 +584,23 @@ describe("t248 codekb-scope-diff verb — compare mode", () => {
 });
 
 describe("t248 codekb-scope-diff verb — mint mode", () => {
+  test("lone-repo narrow scopes mint distinct non-empty-tree fingerprints", () => {
+    const proj = freshProject();
+    gitInit(proj);
+    mkdirSync(join(proj, "src", "payments"), { recursive: true });
+    mkdirSync(join(proj, "src", "auth"), { recursive: true });
+    writeFileSync(join(proj, "src", "payments", "gw.ts"), "payments\n");
+    writeFileSync(join(proj, "src", "auth", "login.ts"), "auth\n");
+
+    const payments = runVerb(proj, "--mint", "--paths", "src/payments/");
+    const auth = runVerb(proj, "--mint", "--paths", "src/auth/");
+    expect(payments.status).toBe(0);
+    expect(auth.status).toBe(0);
+    expect(payments.stdout.trim()).not.toBe(SHA1_EMPTY_TREE);
+    expect(auth.stdout.trim()).not.toBe(SHA1_EMPTY_TREE);
+    expect(payments.stdout.trim()).not.toBe(auth.stdout.trim());
+  });
+
   test("--mint prints the same fingerprint the lib computes; --json carries paths", () => {
     const proj = freshProject();
     gitInit(proj);


### PR DESCRIPTION
## The bug

`codekb-scope-diff` reports **STALE for every scope, permanently**, in the lone-repo layout.

`codekbScopeFingerprint` (`core/tools/aidlc-lib.ts`) normalizes its **exclude** pathspecs — stripping a leading `./` and any trailing slash — but spreads the **positive** paths in raw. Git matches nothing when a positive pathspec carrying a trailing slash is combined with any exclude pathspec:

```bash
git init -q repo && cd repo && mkdir -p src/payments aidlc
printf 'a\n' > src/payments/gw.ts && echo x > aidlc/f.txt

GIT_INDEX_FILE=/tmp/i1 git add -A -- "src/payments/"                           # 1 file
GIT_INDEX_FILE=/tmp/i2 git add -A -- "src/payments"  ":(exclude,literal)aidlc" # 1 file
GIT_INDEX_FILE=/tmp/i3 git add -A -- "src/payments/" ":(exclude,literal)aidlc" # 0 files  <-- empty tree
```

The empty match makes `git write-tree` return git's empty-tree hash, `4b825dc642cb6eb9a060e54bf8d69288fbee4904`, which never equals the stored fingerprint — so the staleness verdict is stuck at STALE and the check stops carrying information.

## Why it only bites one layout

The exclude list is non-empty in exactly one case. `aidlc-utility.ts` passes `["aidlc"]` when `repoDir === projectDir`, to keep the framework's own workspace tree out of a full-root fingerprint:

```ts
const fingerprintExcludes = repoDir === projectDir ? ["aidlc"] : [];
```

A sibling-repo layout passes no excludes and is unaffected. Analyzed paths are conventionally written with a trailing slash — `t248`'s own fixture uses `src/payments/` — so within that layout the affected path is the ordinary one, not an edge case.

## The fix

Run the positive paths through the same normalization already applied to the exclusions, so `src/payments/` and `src/payments` fingerprint identically.

## Testing

`tests/unit/t248-codekb-scope-diff.test.ts` goes from **32 pass / 2 fail → 34 pass / 0 fail**. No new test is added, because those two cases already asserted the correct behaviour and were failing against the shipped code:

- `matching fingerprint → CURRENT; edit inside scope → STALE` — expected `CURRENT`, received `STALE`
- `--mint prints the same fingerprint the lib computes` — expected `15aa89e9…`, received `4b825dc6…` (the empty tree)

Also green: `bun run check` exits 0 (package `--check` parity across all 7 trees, typecheck, Biome), `t68-version-changelog-sync` 7 pass, and `bun scripts/package.ts --check` clean.

Verified on **git 2.50.1 (Apple Git-155)**. The pathspec behaviour is git-version-dependent, which is the likely reason CI has not caught this — worth confirming against the git version on your runners.

## Note for the release entry

The CHANGELOG entry carries an upgrade instruction that matters beyond the code fix: any scope timestamp whose recorded fingerprint is `4b825dc642cb6eb9a060e54bf8d69288fbee4904` was written by this bug and should be re-minted. Fixing the computation alone leaves that value sitting in existing records, where it will keep comparing unequal forever.

## Base branch

Opened against `v2`, since that is where the affected code lives and the only branch `ci.yml` triggers on for pull requests. `CONTRIBUTING.md` says to work against `main` — flagging in case that guidance needs updating.
