### PR TITLE
test: reject blocked Kiro IDE chat surfaces

### DIFF
--- a/tests/e2e/t-ide-kiro-checkpoint.serial.test.ts
+++ b/tests/e2e/t-ide-kiro-checkpoint.serial.test.ts
@@ -69,12 +69,16 @@ import { cleanupTuiProject, KIRO_IDE_SRC, setupTuiProject } from "../harness/tui
 import {
   autoApprove,
   generateKiroIdeSeed,
+  inspectKiroIdeChatSurfaceDocument,
   KIRO_IDE_BIN,
   launchKiroIde,
   pageTarget,
+  prepareKiroIdeChat,
   removeSeedDir,
+  settleKiroIdeChatSurface,
   snapshotChatDom,
   teardown,
+  type KiroIdeChatSurfaceState,
   typeAndSubmit,
   waitForCdp,
   waitForChatInput,
@@ -226,6 +230,46 @@ function skipReason(): string | null {
 }
 const SKIP_REASON = skipReason();
 
+const CLEAR_CHAT_SURFACE: KiroIdeChatSurfaceState = {
+  chatFrameCount: 1,
+  blockedHitPoints: [],
+  blockingOverlays: [],
+};
+const MIGRATION_BLOCKED_CHAT_SURFACE: KiroIdeChatSurfaceState = {
+  chatFrameCount: 1,
+  blockedHitPoints: [
+    {
+      x: 852,
+      y: 666,
+      hitTag: "DIV",
+      hitClassName: "welcome-carousel-modal-block",
+      hitText:
+        "We've upgraded how sessions are stored " +
+        "Migrate your previous sessions to keep them accessible.",
+    },
+  ],
+  blockingOverlays: [
+    {
+      text:
+        "We've upgraded how sessions are stored " +
+        "Migrate your previous sessions to keep them accessible. " +
+        "Go to documentation Remind me later",
+      className: "welcome-carousel-modal-block",
+      role: "dialog",
+      ariaModal: "true",
+      rect: { x: 0, y: 0, width: 1024, height: 768 },
+    },
+  ],
+};
+
+async function assertChatSurfaceUnblocked(port: number): Promise<string | null> {
+  const prepared = await prepareKiroIdeChat(port);
+  expect(prepared.surface.chatFrameCount).toBeGreaterThan(0);
+  expect(prepared.surface.blockingOverlays).toHaveLength(0);
+  expect(prepared.surface.blockedHitPoints).toHaveLength(0);
+  return prepared.dismissed;
+}
+
 // ---------------------------------------------------------------------------
 // Disk-only assertion helpers (never assert on chat prose).
 // ---------------------------------------------------------------------------
@@ -274,6 +318,126 @@ function gateOpenedCountFor(sandbox: string, slug: string): number {
   return auditEventCountFor(sandbox, "STAGE_AWAITING_APPROVAL", slug);
 }
 
+describe("kiro-ide-driver startup overlay reconciliation", () => {
+  test("the real DOM probe rejects a non-ARIA element intercepting the chat iframe", () => {
+    const rect = {
+      x: 688,
+      y: 35,
+      left: 688,
+      top: 35,
+      right: 1016,
+      bottom: 746,
+      width: 328,
+      height: 711,
+      toJSON: () => ({}),
+    };
+    const blocker = {
+      tagName: "DIV",
+      className: "opaque-startup-overlay",
+      innerText: "Blocking startup overlay",
+      textContent: "Blocking startup overlay",
+    } as unknown as Element;
+    const frame = {
+      tagName: "IFRAME",
+      className: "webview ready",
+      getBoundingClientRect: () => rect,
+      contains: () => false,
+    } as unknown as Element;
+    const doc = {
+      querySelectorAll: (selector: string) =>
+        selector === "[aria-modal='true']" ? [] : [frame],
+      elementFromPoint: () => blocker,
+    } as unknown as Document;
+    const styleOf = (() => ({
+      display: "block",
+      visibility: "visible",
+      opacity: "1",
+      pointerEvents: "auto",
+    })) as unknown as typeof getComputedStyle;
+
+    const surface = inspectKiroIdeChatSurfaceDocument(doc, styleOf);
+
+    expect(surface.chatFrameCount).toBe(1);
+    expect(surface.blockingOverlays).toHaveLength(0);
+    expect(surface.blockedHitPoints).toHaveLength(2);
+    expect(surface.blockedHitPoints.map((hit) => hit.hitClassName)).toEqual([
+      "opaque-startup-overlay",
+      "opaque-startup-overlay",
+    ]);
+  });
+
+  test("dismisses the current session-migration modal and waits for a clear chat hit-test", async () => {
+    const surfaces = [MIGRATION_BLOCKED_CHAT_SURFACE, CLEAR_CHAT_SURFACE];
+    let now = 0;
+    let dismissCalls = 0;
+
+    const prepared = await settleKiroIdeChatSurface(
+      {
+        inspect: async () => surfaces.shift() ?? CLEAR_CHAT_SURFACE,
+        dismissMigration: async () => {
+          dismissCalls++;
+          return "clicked:remind me later";
+        },
+        wait: async (ms) => {
+          now += ms;
+        },
+        now: () => now,
+      },
+      20,
+      5,
+    );
+
+    expect(dismissCalls).toBe(1);
+    expect(prepared.dismissed).toBe("clicked:remind me later");
+    expect(prepared.surface).toEqual(CLEAR_CHAT_SURFACE);
+  });
+
+  test("older Kiro with no migration modal proceeds without a dismissal", async () => {
+    let dismissCalls = 0;
+    const prepared = await settleKiroIdeChatSurface(
+      {
+        inspect: async () => CLEAR_CHAT_SURFACE,
+        dismissMigration: async () => {
+          dismissCalls++;
+          return null;
+        },
+        wait: async () => {},
+        now: () => 0,
+      },
+      20,
+      5,
+    );
+
+    expect(dismissCalls).toBe(0);
+    expect(prepared.dismissed).toBeNull();
+    expect(prepared.surface).toEqual(CLEAR_CHAT_SURFACE);
+  });
+
+  test("does not accept CDP-reachable chat behind a persistent blocking overlay", async () => {
+    let now = 0;
+    let dismissCalls = 0;
+
+    await expect(
+      settleKiroIdeChatSurface(
+        {
+          inspect: async () => MIGRATION_BLOCKED_CHAT_SURFACE,
+          dismissMigration: async () => {
+            dismissCalls++;
+            return dismissCalls === 1 ? "clicked:remind me later" : null;
+          },
+          wait: async (ms) => {
+            now += ms;
+          },
+          now: () => now,
+        },
+        10,
+        5,
+      ),
+    ).rejects.toThrow("blocking overlay remains over chat");
+    expect(dismissCalls).toBeGreaterThan(1);
+  });
+});
+
 describe("t-ide-kiro-checkpoint (live Kiro IDE human-turn recording + core gate enforcement)", () => {
   // Drives the SHIPPED dist/kiro-ide tree and asserts the live HUMAN_TURN event
   // plus the committed GATE_APPROVED ledger row. The second, fabricated approval
@@ -318,6 +482,8 @@ describe("t-ide-kiro-checkpoint (live Kiro IDE human-turn recording + core gate 
         // Poll for the chat input instead of a fixed settle sleep.
         expect(await waitForChatInput(handle.port)).toBe(true);
         diagnostic("chat-ready");
+        const startupDismissed = await assertChatSurfaceUnblocked(handle.port);
+        diagnostic("chat-surface-unblocked", { startupDismissed });
 
         const t = await pageTarget(handle.port);
         // typeAndSubmit focuses + verifies the text landed + retries before Enter -
@@ -477,6 +643,8 @@ describe("t-ide-kiro-checkpoint (live Kiro IDE human-turn recording + core gate 
       try {
         expect(await waitForCdp(handle.port)).toBe(true);
         expect(await waitForChatInput(handle.port)).toBe(true);
+        const startupDismissed = await assertChatSurfaceUnblocked(handle.port);
+        diagnostic("chat-surface-unblocked", { startupDismissed });
 
         const t = await pageTarget(handle.port);
         // A prompt that drives FIVE separate shell tool calls in one un-ended turn, so

--- a/tests/harness/kiro-ide-driver.ts
+++ b/tests/harness/kiro-ide-driver.ts
@@ -78,6 +78,38 @@ export interface KiroIdeDomSnapshot {
   }>;
 }
 
+export interface KiroIdeBlockingOverlay {
+  text: string;
+  className: string;
+  role: string;
+  ariaModal: string;
+  rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+}
+
+export interface KiroIdeBlockedHitPoint {
+  x: number;
+  y: number;
+  hitTag: string;
+  hitClassName: string;
+  hitText: string;
+}
+
+export interface KiroIdeChatSurfaceState {
+  chatFrameCount: number;
+  blockedHitPoints: KiroIdeBlockedHitPoint[];
+  blockingOverlays: KiroIdeBlockingOverlay[];
+}
+
+export interface KiroIdeChatPreparation {
+  dismissed: string | null;
+  surface: KiroIdeChatSurfaceState;
+}
+
 /** One CDP connection to a single page/iframe target. JSON-RPC over a Bun-native
  *  WebSocket. Accumulates Runtime.executionContextCreated events so nested webview
  *  frames are reachable by contextId (the only way to reach the doubly-nested chat
@@ -216,6 +248,11 @@ export class CdpTarget {
 // committing or copying any real profile - nothing sensitive ever touches the repo. The
 // two extra rows + settings only mute cosmetic notification toasts (MCP tools, Builder
 // steering, git-repo prompt); the onboarding row is what unblocks chat.
+//
+// Current Kiro versions can additionally show a session-storage migration carousel.
+// Its "Remind me later" action does not persist a durable global-state key, so it is
+// handled after launch by prepareKiroIdeChat(). The seed stays version-neutral and
+// credential-free instead of copying a mutable Kiro profile or guessing private state.
 const SEED_STATE_ROWS: ReadonlyArray<readonly [string, string]> = [
   ["kiroAgent.onboarding.onboardingCompleted", "true"], // load-bearing: skips the import wall
   ["releaseNotes/lastVersion", "0.0.0"], // mute the release-notes popup (version-agnostic stub)
@@ -433,6 +470,162 @@ export async function waitForChatInput(port: number, timeoutMs = 60_000): Promis
     await sleep(800);
   }
   return false;
+}
+
+// A chat editor can be live inside its nested webview while a top-level overlay
+// intercepts the visible UI. Probe the real top-level hit-testing surface: only the
+// chat iframe itself proves the sampled point is unobstructed. ARIA metadata is useful
+// diagnostics, but is not trusted as the condition for deciding whether a hit blocks.
+export function inspectKiroIdeChatSurfaceDocument(
+  doc: Document = document,
+  styleOf: typeof getComputedStyle = getComputedStyle,
+): KiroIdeChatSurfaceState {
+  const norm = (s: unknown): string => String(s || "").replace(/\s+/g, " ").trim();
+  const visible = (e: Element): boolean => {
+    const r = e.getBoundingClientRect?.();
+    if (!r || !(r.width > 0 && r.height > 0)) return false;
+    const s = styleOf(e);
+    return (
+      s.display !== "none" &&
+      s.visibility !== "hidden" &&
+      Number.parseFloat(s.opacity || "1") > 0
+    );
+  };
+  const rectOf = (e: Element): KiroIdeBlockingOverlay["rect"] => {
+    const r = e.getBoundingClientRect();
+    return { x: r.x, y: r.y, width: r.width, height: r.height };
+  };
+  const modalSelector = "[aria-modal='true']";
+  const blockingOverlays = [...doc.querySelectorAll(modalSelector)]
+    .filter((e) => visible(e) && styleOf(e).pointerEvents !== "none")
+    .map((e) => ({
+      text: norm((e as HTMLElement).innerText || e.textContent).slice(0, 1000),
+      className: String(e.className || ""),
+      role: String(e.getAttribute("role") || ""),
+      ariaModal: String(e.getAttribute("aria-modal") || ""),
+      rect: rectOf(e),
+    }));
+  const chatFrames = [
+    ...new Set([
+      ...doc.querySelectorAll("iframe.webview.ready"),
+      ...doc.querySelectorAll("iframe[src*='extensionId=kiro.kiroAgent']"),
+    ]),
+  ].filter(visible);
+  const blockedHitPoints: KiroIdeBlockedHitPoint[] = [];
+  for (const frame of chatFrames) {
+    const r = frame.getBoundingClientRect();
+    const points = [
+      [r.left + r.width / 2, r.top + r.height / 2],
+      [r.left + r.width / 2, r.bottom - Math.min(80, r.height / 4)],
+    ];
+    for (const [x, y] of points) {
+      const hit = doc.elementFromPoint(x, y);
+      const clear = hit === frame || (hit && frame.contains(hit));
+      if (clear) continue;
+      blockedHitPoints.push({
+        x,
+        y,
+        hitTag: String(hit?.tagName || ""),
+        hitClassName: String(hit?.className || ""),
+        hitText: norm((hit as HTMLElement | null)?.innerText || hit?.textContent).slice(0, 500),
+      });
+    }
+  }
+  return {
+    chatFrameCount: chatFrames.length,
+    blockedHitPoints,
+    blockingOverlays,
+  };
+}
+
+const CHAT_SURFACE_STATE_EXPR = `(${inspectKiroIdeChatSurfaceDocument.toString()})()`;
+
+/** Inspect the visible top-level workbench surface, not just the nested chat DOM. */
+export async function inspectKiroIdeChatSurface(port: number): Promise<KiroIdeChatSurfaceState> {
+  const t = await pageTarget(port);
+  try {
+    return await t.evaluate<KiroIdeChatSurfaceState>(CHAT_SURFACE_STATE_EXPR);
+  } finally {
+    t.close();
+  }
+}
+
+const SESSION_MIGRATION_TITLE = "upgraded how sessions are stored";
+const SESSION_MIGRATION_BODY = "migrate your previous sessions";
+
+function hasSessionMigrationOverlay(surface: KiroIdeChatSurfaceState): boolean {
+  return surface.blockingOverlays.some((overlay) => {
+    const text = overlay.text.toLowerCase();
+    return text.includes(SESSION_MIGRATION_TITLE) && text.includes(SESSION_MIGRATION_BODY);
+  });
+}
+
+function chatSurfaceIsReady(surface: KiroIdeChatSurfaceState): boolean {
+  return (
+    surface.chatFrameCount > 0 &&
+    surface.blockingOverlays.length === 0 &&
+    surface.blockedHitPoints.length === 0
+  );
+}
+
+export interface KiroIdeChatSurfaceAdapter {
+  inspect: () => Promise<KiroIdeChatSurfaceState>;
+  dismissMigration: () => Promise<string | null>;
+  wait: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+/** Reconcile supported startup overlays and return only after the chat iframe is
+ * visibly unobstructed. The injected adapter keeps current/older/persistent-modal
+ * behavior deterministic in tests without launching Electron. */
+export async function settleKiroIdeChatSurface(
+  adapter: KiroIdeChatSurfaceAdapter,
+  timeoutMs = 15_000,
+  pollMs = 250,
+): Promise<KiroIdeChatPreparation> {
+  const deadline = adapter.now() + timeoutMs;
+  let dismissed: string | null = null;
+  let surface: KiroIdeChatSurfaceState = {
+    chatFrameCount: 0,
+    blockedHitPoints: [],
+    blockingOverlays: [],
+  };
+
+  for (;;) {
+    surface = await adapter.inspect();
+    if (chatSurfaceIsReady(surface)) return { dismissed, surface };
+
+    if (hasSessionMigrationOverlay(surface)) {
+      const clicked = await adapter.dismissMigration();
+      if (clicked) dismissed = clicked;
+    }
+
+    if (adapter.now() >= deadline) break;
+    await adapter.wait(pollMs);
+  }
+
+  throw new Error(
+    "kiro-ide-driver: blocking overlay remains over chat after startup reconciliation: " +
+      JSON.stringify(surface),
+  );
+}
+
+/** Dismiss the current Kiro session-migration carousel when present, while allowing
+ * older versions where it is absent. Success requires both zero aria-modal overlays
+ * and clear hit tests over the chat iframe. */
+export function prepareKiroIdeChat(
+  port: number,
+  timeoutMs = 15_000,
+): Promise<KiroIdeChatPreparation> {
+  return settleKiroIdeChatSurface(
+    {
+      inspect: () => inspectKiroIdeChatSurface(port),
+      dismissMigration: () => clickByText(port, ["remind me later"]),
+      wait: sleep,
+      now: Date.now,
+    },
+    timeoutMs,
+  );
 }
 
 /** Cmd+Shift+L on macOS or Ctrl+Shift+L on Windows focuses the Kiro chat input. */


### PR DESCRIPTION
## Summary
- detect startup overlays that intercept the visible Kiro chat surface
- dismiss the current session-migration modal deterministically
- retain compatibility with older Kiro versions that expose no modal

## Verification
- focused driver tests
- native Windows Kiro IDE slice