### PR TITLE
test: bound Windows TUI startup cleanup

### DIFF
--- a/tests/e2e/t-startup-state-machine.test.ts
+++ b/tests/e2e/t-startup-state-machine.test.ts
@@ -1,0 +1,114 @@
+// covers: harness-instrument:tui-drive-startup
+//
+// Deterministic coverage for the grid-driven Claude startup reducer. The live
+// orientation journey proves the same reducer through tmux / ConPTY, but its
+// `t-tui` filename is folded behind the substrate capability gate. These cases
+// stay outside that gate so modal compatibility and ready-grid priority run in
+// every e2e tier without launching Claude.
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as os from "node:os";
+import { join } from "node:path";
+import {
+  advanceTuiStartup,
+  initialTuiStartupState,
+  resolveWinNode,
+} from "../harness/tui-drive.ts";
+
+const ORIENTATION_MARKER = "default · fixture · IDEATION";
+const READY = new RegExp(ORIENTATION_MARKER);
+const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
+const IS_WIN = os.platform() === "win32";
+const WIN_NODE = IS_WIN ? resolveWinNode() : null;
+
+describe("TUI startup state machine", () => {
+  test("returns immediately when the ready statusline is already painted", () => {
+    const step = advanceTuiStartup(
+      initialTuiStartupState(),
+      `[AIDLC] ${ORIENTATION_MARKER} [##........] 2/7 > Feasibility`,
+      READY,
+    );
+    expect(step.action).toBe("ready");
+  });
+
+  test("dismisses the older trust then bypass modals before accepting ready", () => {
+    let state = initialTuiStartupState();
+    let step = advanceTuiStartup(
+      state,
+      "Do you trust the files in this folder?\n1. Yes, I trust this folder\n2. No, exit",
+      READY,
+    );
+    expect(step.action).toBe("dismiss-trust");
+    state = step.state;
+
+    step = advanceTuiStartup(
+      state,
+      "1. Yes, I trust this folder\n" +
+        "Bypass Permissions mode\n1. No\n2. Yes, I accept\n" +
+        `[AIDLC] ${ORIENTATION_MARKER}`,
+      READY,
+    );
+    expect(step.action).toBe("dismiss-bypass");
+    state = step.state;
+
+    step = advanceTuiStartup(
+      state,
+      `[AIDLC] ${ORIENTATION_MARKER}`,
+      READY,
+    );
+    expect(step.action).toBe("ready");
+  });
+
+  test("answers each modal once while waiting for its grid to repaint", () => {
+    const trustGrid = "1. Yes, I trust this folder";
+    const first = advanceTuiStartup(
+      initialTuiStartupState(),
+      trustGrid,
+      READY,
+    );
+    expect(first.action).toBe("dismiss-trust");
+    expect(advanceTuiStartup(first.state, trustGrid, READY).action).toBe("wait");
+  });
+
+  test("does not mistake the normal bypass footer for the warning modal", () => {
+    const step = advanceTuiStartup(
+      initialTuiStartupState(),
+      `[AIDLC] ${ORIENTATION_MARKER}\n` +
+        "bypass permissions on (shift+tab to cycle)",
+      READY,
+    );
+    expect(step.action).toBe("ready");
+  });
+
+  test.skipIf(IS_WIN && WIN_NODE === null)(
+    "bounds a stalled process-tree snapshot before wait-dead begins",
+    () => {
+      const snapshotTimeoutMs = 100;
+      const wallBoundMs = 2_000;
+      const [bin, prefix] = IS_WIN
+        ? [WIN_NODE as string, ["--experimental-strip-types", DRIVER]]
+        : [process.execPath, [DRIVER]];
+      const result = spawnSync(
+        bin,
+        [
+          ...prefix,
+          "__snapshot-timeout-probe",
+          "--timeout-ms",
+          String(snapshotTimeoutMs),
+        ],
+        { encoding: "utf8" },
+      );
+
+      expect(result.status).toBe(0);
+      const probe = JSON.parse(result.stdout) as {
+        elapsedMs: number;
+        error: string;
+      };
+      expect(probe.error).toBe(
+        `process snapshot timed out after ${snapshotTimeoutMs}ms`,
+      );
+      expect(probe.elapsedMs).toBeLessThan(wallBoundMs);
+    },
+  );
+});

--- a/tests/e2e/t-tui-journey-orientation.serial.test.ts
+++ b/tests/e2e/t-tui-journey-orientation.serial.test.ts
@@ -62,6 +62,11 @@ const DRIVER = join(import.meta.dir, "..", "harness", "tui-drive.ts");
 const FIXTURE = join(import.meta.dir, "..", "fixtures", "state-mid-ideation.md");
 const IS_WIN = os.platform() === "win32";
 const WIN_NODE = IS_WIN ? resolveWinNode() : null;
+const ORIENTATION_MARKER = "default · fixture · IDEATION";
+const STARTUP_TIMEOUT_MS = 15_000;
+const STARTUP_WALL_BOUND_MS = 20_000;
+const PROCESS_EXIT_TIMEOUT_MS = 5_000;
+const WINDOWS_SAMPLE_COUNT = 3;
 
 interface Run {
   rc: number;
@@ -75,22 +80,6 @@ function drive(args: string[]): Run {
   const res = spawnSync(bin, [...prefix, ...args], { encoding: "utf-8" });
   return { rc: res.status ?? -1, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
 }
-function waitFor(session: string, pattern: string, timeoutMs: number, stableMs: number): boolean {
-  return (
-    drive([
-      "wait",
-      "--session",
-      session,
-      "--pattern",
-      pattern,
-      "--timeout-ms",
-      String(timeoutMs),
-      "--stable-ms",
-      String(stableMs),
-    ]).rc === 0
-  );
-}
-
 // Gate: the watched live-TUI tier (AIDLC_TUI_LIVE) + the substrate. On POSIX the
 // substrate is tmux; claude is needed on every platform; the distributable +
 // the fixture must be present. A creds-less / binary-less machine SKIPs with a
@@ -117,16 +106,25 @@ function absentReason(): string | null {
 }
 const ABSENT_REASON = absentReason();
 
+interface OrientationSample {
+  pane: string;
+  startupWallMs: number;
+}
+
 // Launch the claude TUI on the >1-space + active-intent fixture and return the
 // captured pane once the orientation-bearing workflow statusline has painted.
-function captureOrientationStatusline(): string {
-  const session = `aidlc_tui_journey_orient_${process.pid}`;
+// Every launch uses a unique session and proves its process tree is gone before
+// the next launch can begin.
+function captureOrientationStatusline(sampleIndex: number): OrientationSample {
+  const session = `aidlc_tui_journey_orient_${process.pid}_${sampleIndex}`;
   // setupTuiProject seeds the per-intent shell (default space's record + cursors)
   // and writes the mid-ideation state into it; secondSpace seeds a non-default
   // sibling space so listSpaces().length > 1 and the orientation prefix paints
   // its `<space> ·` segment. With the active space still `default`, the prefix
   // renders `default · fixture · IDEATION …`. No prompt, no tokens.
   const sandbox = setupTuiProject({ withState: "state-mid-ideation.md", secondSpace: true });
+  let sample: OrientationSample | undefined;
+  let launchError: unknown;
   try {
     // The statusLine key is what wires aidlc-statusline.ts into the TUI; a copy
     // that dropped it would render no [AIDLC] line at all.
@@ -134,6 +132,7 @@ function captureOrientationStatusline(): string {
       '"statusLine"',
     );
 
+    const launchStartedAt = Date.now();
     const started = drive([
       "start",
       "--session",
@@ -150,39 +149,93 @@ function captureOrientationStatusline(): string {
     ]);
     expect(started.rc).toBe(0);
 
-    // Clear the two startup modals (idempotent — only act if present).
-    if (waitFor(session, "trust this folder", 60000, 600)) {
-      drive(["send", "--session", session, "--keys", "1"]);
-    }
-    if (waitFor(session, "Bypass Permissions mode", 15000, 600)) {
-      drive(["send", "--session", session, "--keys", "2"]);
-    }
-
-    // Wait for the FULL orientation prefix to paint: `default · fixture ·`
-    // immediately before IDEATION. This is the net-new assertion — a single-space
-    // fixture would paint only `fixture · IDEATION` (no space token), so matching
-    // the space segment proves the >1-space rule fired live in the pane.
-    const sawMarker = waitFor(session, "default · fixture · IDEATION", 45000, 1000);
+    // One bounded grid-driven startup loop handles both old Claude modal paths
+    // and the current preseeded path. A visible trust / bypass modal is answered;
+    // otherwise the already-painted orientation statusline returns immediately.
+    const startup = drive([
+      "startup",
+      "--session",
+      session,
+      "--ready-pattern",
+      ORIENTATION_MARKER,
+      "--timeout-ms",
+      String(STARTUP_TIMEOUT_MS),
+    ]);
     const pane = drive(["capture", "--session", session]).stdout;
-    if (!sawMarker) {
+    if (startup.rc !== 0) {
       throw new Error(
-        `orientation statusline "default · fixture · IDEATION" never painted.\n` +
+        `orientation statusline "${ORIENTATION_MARKER}" never painted.\n` +
+          `---- startup stderr ----\n${startup.stderr}\n` +
           `---- last pane ----\n${pane}\n-------------------`,
       );
     }
-    return pane;
-  } finally {
-    drive(["kill", "--session", session]);
-    cleanupTuiProject(sandbox);
+    sample = {
+      pane,
+      startupWallMs: Date.now() - launchStartedAt,
+    };
+  } catch (error) {
+    launchError = error;
   }
+
+  const killed = drive(["kill", "--session", session]);
+  const dead = drive([
+    "wait-dead",
+    "--session",
+    session,
+    "--timeout-ms",
+    String(PROCESS_EXIT_TIMEOUT_MS),
+  ]);
+  let fixtureCleanupError: unknown;
+  try {
+    cleanupTuiProject(sandbox);
+  } catch (error) {
+    fixtureCleanupError = error;
+  }
+
+  if (killed.rc !== 0 || dead.rc !== 0 || fixtureCleanupError !== undefined) {
+    throw new Error(
+      `TUI session '${session}' did not cleanly reap its process tree and fixture.\n` +
+        `---- kill stderr ----\n${killed.stderr}\n` +
+        `---- wait-dead stderr ----\n${dead.stderr}\n` +
+        `---- fixture cleanup ----\n${String(fixtureCleanupError ?? "ok")}\n` +
+        `---- original launch error ----\n${String(launchError ?? "none")}\n`,
+    );
+  }
+
+  if (launchError !== undefined) throw launchError;
+  if (sample === undefined) {
+    throw new Error(`TUI session '${session}' produced no orientation sample`);
+  }
+  return sample;
 }
 
 describe("t-tui-journey-orientation (live Claude TUI — the render-half 'you are here')", () => {
-  let PANE: string | null = null;
-  function pane(): string {
-    if (PANE === null) PANE = captureOrientationStatusline();
-    return PANE;
+  const sampleCount = IS_WIN ? WINDOWS_SAMPLE_COUNT : 1;
+  let SAMPLES: OrientationSample[] | null = null;
+  function samples(): OrientationSample[] {
+    if (SAMPLES === null) {
+      SAMPLES = Array.from(
+        { length: sampleCount },
+        (_, index) => captureOrientationStatusline(index + 1),
+      );
+    }
+    return SAMPLES;
   }
+
+  test.skipIf(ABSENT_REASON !== null || !IS_WIN)(
+    `three native Windows launches stay within ${STARTUP_WALL_BOUND_MS}ms and reap each process tree` +
+      `${ABSENT_REASON ? ` — SKIP: ${ABSENT_REASON}` : !IS_WIN ? " — SKIP: Windows-only" : ""}`,
+    () => {
+      const observed = samples();
+      expect(observed).toHaveLength(WINDOWS_SAMPLE_COUNT);
+      for (const sample of observed) {
+        expect(sample.startupWallMs).toBeLessThanOrEqual(
+          STARTUP_WALL_BOUND_MS,
+        );
+      }
+    },
+    90_000,
+  );
 
   // The full orientation prefix: space token (because >1 space) + intent slug +
   // phase, in the `<space> · <intent> · <phase>` order the builder emits. This is
@@ -191,7 +244,9 @@ describe("t-tui-journey-orientation (live Claude TUI — the render-half 'you ar
   test.skipIf(ABSENT_REASON !== null)(
     `paints the "default · fixture · IDEATION" orientation prefix (>1 space)${ABSENT_REASON ? ` — SKIP: ${ABSENT_REASON}` : ""}`,
     () => {
-      expect(pane()).toContain("default · fixture · IDEATION");
+      for (const sample of samples()) {
+        expect(sample.pane).toContain(ORIENTATION_MARKER);
+      }
     },
     90_000,
   );
@@ -202,7 +257,9 @@ describe("t-tui-journey-orientation (live Claude TUI — the render-half 'you ar
   test.skipIf(ABSENT_REASON !== null)(
     `the oriented line still carries the stage "> Feasibility"${ABSENT_REASON ? ` — SKIP: ${ABSENT_REASON}` : ""}`,
     () => {
-      expect(pane()).toContain("> Feasibility");
+      for (const sample of samples()) {
+        expect(sample.pane).toContain("> Feasibility");
+      }
     },
     90_000,
   );

--- a/tests/harness/tui-drive.ts
+++ b/tests/harness/tui-drive.ts
@@ -60,11 +60,19 @@
 //          appears (use when the screen is actively streaming — the statusline
 //          token counter / spinner means it never goes byte-stable).
 //          Exits 0 on match, 1 on timeout.
+//   startup --session <name> --ready-pattern <regex> [--timeout-ms N]
+//          One bounded grid-driven startup loop for Claude: dismiss a visible
+//          supported trust / bypass modal, or return immediately once the
+//          caller's ready UI/statusline pattern is painted. Exits 1 on timeout.
 //   capture --session <name> [--ansi]
 //          Print the current pane (plain text; --ansi keeps colour escapes —
 //          tmux only; the node-pty grid is always plain text).
 //   kill   --session <name>
 //          Kill the session (idempotent).
+//   wait-dead --session <name> [--timeout-ms N]
+//          Poll the backend until the session process tree is gone. On Windows
+//          this checks the recorded daemon, pty child, and kill-time descendant
+//          PIDs. Exits 1 if any tracked process survives the bound.
 //   answer-gate --session <name> --project-dir <dir>
 //          [--per-gate-timeout-ms N] [--overall-timeout-ms N]
 //          [--until-file <relpath>] [--until-state-field <name=regex>]
@@ -136,6 +144,9 @@ import { stateFilePathFor } from "./sdk-drive.ts";
 const POLL_INTERVAL_MS = 150;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_STABLE_MS = 600;
+const DEFAULT_STARTUP_TIMEOUT_MS = 15_000;
+const DEFAULT_DEAD_TIMEOUT_MS = 5_000;
+const DEFAULT_PROCESS_SNAPSHOT_TIMEOUT_MS = 2_000;
 const DEFAULT_TUI_SETTING_SOURCES = "project";
 const DEFAULT_ANSWER_GATE_TRACE_POLL_MS = 10_000;
 
@@ -326,7 +337,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Backend contract (§2.3). Both backends satisfy the same five operations; the
+// Backend contract (§2.3). Both backends satisfy the same operations; the
 // CLI dispatch and the `wait` polling loop are backend-agnostic.
 // ---------------------------------------------------------------------------
 
@@ -350,6 +361,8 @@ interface Backend {
   capture(session: string, ansi: boolean): string;
   /** Kill the session (idempotent). */
   kill(session: string): void;
+  /** Labels for live backend processes or cleanup-verification blockers. */
+  liveProcesses(session: string): string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -432,6 +445,11 @@ const tmuxBackend: Backend = {
   kill(session) {
     tmux(["kill-session", "-t", session]); // idempotent; ignore errors
   },
+
+  liveProcesses(session) {
+    const r = tmux(["has-session", "-t", session]);
+    return r.code === 0 ? [`tmux-session:${session}`] : [];
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -451,6 +469,8 @@ const tmuxBackend: Backend = {
 //                     capture/wait clients read it.
 //   <dir>/meta.json — { cols, rows } so a client can resize/diagnose.
 //   <dir>/pid       — the daemon pid, for kill's force-terminate backstop.
+//   <dir>/child.pid — the node-pty child pid.
+//   <dir>/tree.pids — the daemon's kill-time process-tree snapshot.
 // The channels are deliberately dumb files (no named pipes / sockets) so the
 // same code runs anywhere a filesystem does.
 // ---------------------------------------------------------------------------
@@ -462,6 +482,140 @@ function winSessionDir(session: string): string {
   return join(tmpdir(), "tui-drive", safe);
 }
 
+function readPid(path: string): number | null {
+  if (!existsSync(path)) return null;
+  const pid = Number.parseInt(readFileSync(path, "utf8").trim(), 10);
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runBoundedProcessSnapshotCommand(
+  file: string,
+  args: string[],
+  timeoutMs = DEFAULT_PROCESS_SNAPSHOT_TIMEOUT_MS,
+): { stdout: string; error?: string } {
+  const result = spawnSync(file, args, {
+    encoding: "utf8",
+    maxBuffer: 5 * 1024 * 1024,
+    windowsHide: true,
+    timeout: timeoutMs,
+  });
+  const spawnError = result.error as NodeJS.ErrnoException | undefined;
+  if (spawnError?.code === "ETIMEDOUT") {
+    return {
+      stdout: result.stdout ?? "",
+      error: `process snapshot timed out after ${timeoutMs}ms`,
+    };
+  }
+  if (spawnError || result.status !== 0 || !(result.stdout ?? "").trim()) {
+    return {
+      stdout: result.stdout ?? "",
+      error:
+        spawnError?.message ??
+        (result.stderr ?? "").trim() ??
+        `process snapshot exited ${result.status ?? "without status"}`,
+    };
+  }
+  return { stdout: result.stdout ?? "" };
+}
+
+function cmdSnapshotTimeoutProbe(a: Args): void {
+  const timeoutMs = Number(a.flags["timeout-ms"] ?? "100");
+  const expectedError = `process snapshot timed out after ${timeoutMs}ms`;
+  const startedAt = Date.now();
+  const result = runBoundedProcessSnapshotCommand(
+    process.execPath,
+    ["-e", "setInterval(() => {}, 1000)"],
+    timeoutMs,
+  );
+  const elapsedMs = Date.now() - startedAt;
+  if (result.error !== expectedError) {
+    fail(
+      `snapshot timeout probe expected '${expectedError}', got ` +
+        `'${result.error ?? "no error"}'`,
+      1,
+    );
+  }
+  process.stdout.write(`${JSON.stringify({ elapsedMs, error: result.error })}\n`);
+}
+
+function winProcessTreePids(rootPids: number[]): {
+  pids: number[];
+  error?: string;
+} {
+  if (process.platform !== "win32") return { pids: rootPids };
+  const result = runBoundedProcessSnapshotCommand(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-Command",
+      "Get-CimInstance Win32_Process | " +
+        "Select-Object ProcessId,ParentProcessId | ConvertTo-Json -Compress",
+    ],
+  );
+  if (result.error) {
+    return {
+      pids: rootPids,
+      error: result.error,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as
+      | { ProcessId: number; ParentProcessId: number }
+      | Array<{ ProcessId: number; ParentProcessId: number }>;
+    const rows = Array.isArray(parsed) ? parsed : [parsed];
+    const tree = new Set<number>(rootPids);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const row of rows) {
+        if (
+          tree.has(Number(row.ParentProcessId)) &&
+          !tree.has(Number(row.ProcessId))
+        ) {
+          tree.add(Number(row.ProcessId));
+          changed = true;
+        }
+      }
+    }
+    return { pids: [...tree] };
+  } catch (error) {
+    return {
+      pids: rootPids,
+      error: `invalid PowerShell process snapshot: ${String(error)}`,
+    };
+  }
+}
+
+function trackedWinPids(dir: string): Map<number, Set<string>> {
+  const tracked = new Map<number, Set<string>>();
+  const add = (pid: number | null, label: string): void => {
+    if (pid === null) return;
+    const labels = tracked.get(pid) ?? new Set<string>();
+    labels.add(label);
+    tracked.set(pid, labels);
+  };
+  add(readPid(join(dir, "pid")), "daemon");
+  add(readPid(join(dir, "child.pid")), "pty-child");
+  const treePath = join(dir, "tree.pids");
+  if (existsSync(treePath)) {
+    for (const line of readFileSync(treePath, "utf8").split(/\r?\n/)) {
+      const pid = Number.parseInt(line.trim(), 10);
+      if (Number.isFinite(pid) && pid > 0) add(pid, "tree");
+    }
+  }
+  return tracked;
+}
+
 const win32Backend: Backend = {
   async start(session, cwd, width, height, cmd) {
     if (cmd.length === 0) fail("no command after `--` to run in the session");
@@ -469,6 +623,20 @@ const win32Backend: Backend = {
     const dir = winSessionDir(session);
     // Idempotent start: tear down any stale daemon + channel dir first.
     win32Backend.kill(session);
+    const staleDeadline = Date.now() + DEFAULT_DEAD_TIMEOUT_MS;
+    while (
+      win32Backend.liveProcesses(session).length > 0 &&
+      Date.now() < staleDeadline
+    ) {
+      await sleep(POLL_INTERVAL_MS);
+    }
+    const stale = win32Backend.liveProcesses(session);
+    if (stale.length > 0) {
+      fail(
+        `stale Windows session '${session}' survived cleanup: ${stale.join(", ")}`,
+        1,
+      );
+    }
     rmSync(dir, { recursive: true, force: true });
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "meta.json"), JSON.stringify({ cols: width, rows: height }));
@@ -543,6 +711,21 @@ const win32Backend: Backend = {
   kill(session) {
     const dir = winSessionDir(session);
     if (!existsSync(dir)) return;
+    const daemonPid = readPid(join(dir, "pid"));
+    const childPid = readPid(join(dir, "child.pid"));
+    const roots = [daemonPid, childPid].filter(
+      (pid): pid is number => pid !== null,
+    );
+    if (roots.length > 0) {
+      const snapshot = winProcessTreePids(roots);
+      writeFileSync(join(dir, "tree.pids"), `${snapshot.pids.join("\n")}\n`);
+      const errorPath = join(dir, "tree.error");
+      if (snapshot.error) {
+        writeFileSync(errorPath, snapshot.error);
+      } else {
+        rmSync(errorPath, { force: true });
+      }
+    }
     // 1) Ask the daemon to tear the pty down cleanly (it filters the ConPTY
     //    "Socket is closed" / AttachConsole teardown noise itself).
     try {
@@ -553,27 +736,43 @@ const win32Backend: Backend = {
     // 2) Force-kill backstop: node-pty hangs on ConPTY teardown (p.kill() →
     //    "Socket is closed"), so never block on it. Hard-terminate the daemon
     //    pid after a short grace; the daemon's process.exit closes the pty.
-    const pidPath = join(dir, "pid");
-    if (existsSync(pidPath)) {
-      const pid = Number.parseInt(readFileSync(pidPath, "utf8").trim(), 10);
-      if (Number.isFinite(pid)) {
-        // Best-effort: SIGTERM, then the OS reaps. On Windows taskkill /F /PID
-        // is the reliable force-terminate (Stop-Process equivalent from the
-        // capture-v3 spike); on POSIX a plain kill suffices (this branch only
-        // runs on win32 in practice, but stays portable for local inspection).
-        if (process.platform === "win32") {
-          spawnSync("taskkill", ["/F", "/T", "/PID", String(pid)], {
+    if (daemonPid !== null) {
+      // Best-effort: SIGTERM, then the OS reaps. On Windows taskkill /F /PID
+      // is the reliable force-terminate (Stop-Process equivalent from the
+      // capture-v3 spike); on POSIX a plain kill suffices (this branch only
+      // runs on win32 in practice, but stays portable for local inspection).
+      if (process.platform === "win32") {
+        spawnSync("taskkill", ["/F", "/T", "/PID", String(daemonPid)], {
+          stdio: "ignore",
+        });
+        if (childPid !== null && processIsAlive(childPid)) {
+          spawnSync("taskkill", ["/F", "/T", "/PID", String(childPid)], {
             stdio: "ignore",
           });
-        } else {
-          try {
-            process.kill(pid, "SIGTERM");
-          } catch {
-            // already dead
-          }
+        }
+      } else {
+        try {
+          process.kill(daemonPid, "SIGTERM");
+        } catch {
+          // already dead
         }
       }
     }
+  },
+
+  liveProcesses(session) {
+    const dir = winSessionDir(session);
+    if (!existsSync(dir)) return [];
+    const live = [...trackedWinPids(dir)]
+      .filter(([pid]) => processIsAlive(pid))
+      .map(([pid, labels]) => `${[...labels].sort().join("+")}:${pid}`);
+    const errorPath = join(dir, "tree.error");
+    if (existsSync(errorPath)) {
+      live.unshift(
+        `tree-snapshot-error:${readFileSync(errorPath, "utf8").trim()}`,
+      );
+    }
+    return live;
   },
 };
 
@@ -658,6 +857,7 @@ async function runWinDaemon(a: Args): Promise<void> {
     cwd,
     env: process.env as Record<string, string>,
   });
+  writeFileSync(join(dir, "child.pid"), String(child.pid));
 
   child.onData((data) => term.write(data));
 
@@ -886,6 +1086,132 @@ async function cmdWait(backend: Backend, a: Args): Promise<void> {
   process.exit(1);
 }
 
+export type TuiStartupAction =
+  | "wait"
+  | "ready"
+  | "dismiss-trust"
+  | "dismiss-bypass";
+
+export interface TuiStartupState {
+  trustDismissed: boolean;
+  bypassDismissed: boolean;
+}
+
+export function initialTuiStartupState(): TuiStartupState {
+  return { trustDismissed: false, bypassDismissed: false };
+}
+
+const CLAUDE_TRUST_MODAL_RE =
+  /(?:Do you trust (?:the files in )?this folder|Yes, I trust this folder)/i;
+const CLAUDE_BYPASS_MODAL_RE = /Bypass Permissions mode/i;
+
+function regexMatches(re: RegExp, text: string): boolean {
+  re.lastIndex = 0;
+  return re.test(text);
+}
+
+/**
+ * Pure reducer for Claude's startup grid. Visible supported modals take
+ * precedence over a ready marker because older Claude versions can paint the
+ * underlying UI before the modal is dismissed. Each modal is answered at most
+ * once so a slow repaint cannot spill repeated numeric input into the prompt.
+ */
+export function advanceTuiStartup(
+  state: TuiStartupState,
+  screen: string,
+  readyPattern: RegExp,
+): { state: TuiStartupState; action: TuiStartupAction } {
+  const trustVisible = regexMatches(CLAUDE_TRUST_MODAL_RE, screen);
+  const bypassVisible = regexMatches(CLAUDE_BYPASS_MODAL_RE, screen);
+
+  if (trustVisible && !state.trustDismissed) {
+    return {
+      state: { ...state, trustDismissed: true },
+      action: "dismiss-trust",
+    };
+  }
+  if (bypassVisible && !state.bypassDismissed) {
+    return {
+      state: { ...state, bypassDismissed: true },
+      action: "dismiss-bypass",
+    };
+  }
+  if (trustVisible || bypassVisible) {
+    return { state, action: "wait" };
+  }
+  if (regexMatches(readyPattern, screen)) {
+    return { state, action: "ready" };
+  }
+  return { state, action: "wait" };
+}
+
+async function cmdStartup(backend: Backend, a: Args): Promise<void> {
+  const session = requireFlag(a, "session");
+  const readyPatternText = requireFlag(a, "ready-pattern");
+  const timeoutMs = Number(
+    a.flags["timeout-ms"] ?? DEFAULT_STARTUP_TIMEOUT_MS,
+  );
+  const readyPattern = new RegExp(readyPatternText);
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+  let state = initialTuiStartupState();
+  let screen = "";
+
+  writeTuiTrace(session, "startup_begin", {
+    readyPattern: readyPatternText,
+    timeoutMs,
+  });
+
+  while (Date.now() < deadline) {
+    screen = backend.capture(session, false);
+    const step = advanceTuiStartup(state, screen, readyPattern);
+    state = step.state;
+
+    if (step.action === "ready") {
+      const elapsedMs = Date.now() - startedAt;
+      writeTuiTrace(session, "startup_ready", {
+        readyPattern: readyPatternText,
+        elapsedMs,
+        state,
+        screen,
+      });
+      process.stdout.write(
+        `startup ready /${readyPatternText}/ after ${elapsedMs}ms\n`,
+      );
+      return;
+    }
+
+    if (step.action === "dismiss-trust") {
+      writeTuiTrace(session, "startup_action", {
+        action: step.action,
+        screen,
+      });
+      backend.send(session, "1", false, false);
+    } else if (step.action === "dismiss-bypass") {
+      writeTuiTrace(session, "startup_action", {
+        action: step.action,
+        screen,
+      });
+      backend.send(session, "2", false, false);
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  writeTuiTrace(session, "startup_timeout", {
+    readyPattern: readyPatternText,
+    timeoutMs,
+    state,
+    screen,
+  });
+  process.stderr.write(
+    `tui-drive: timed out after ${timeoutMs}ms waiting for startup ` +
+      `ready /${readyPatternText}/\n` +
+      `---- last pane ----\n${screen}\n-------------------\n`,
+  );
+  process.exit(1);
+}
+
 function cmdCapture(backend: Backend, a: Args): void {
   const session = requireFlag(a, "session");
   const ansi = a.bools.ansi === true;
@@ -899,6 +1225,42 @@ function cmdKill(backend: Backend, a: Args): void {
   writeTuiTrace(session, "kill", {});
   backend.kill(session);
   process.stdout.write(`killed session '${session}'\n`);
+}
+
+async function cmdWaitDead(backend: Backend, a: Args): Promise<void> {
+  const session = requireFlag(a, "session");
+  const timeoutMs = Number(
+    a.flags["timeout-ms"] ?? DEFAULT_DEAD_TIMEOUT_MS,
+  );
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+  let live = backend.liveProcesses(session);
+  writeTuiTrace(session, "wait_dead_begin", { timeoutMs, live });
+
+  while (live.length > 0 && Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    live = backend.liveProcesses(session);
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  if (live.length === 0) {
+    writeTuiTrace(session, "wait_dead_complete", { elapsedMs });
+    process.stdout.write(
+      `session '${session}' process tree exited after ${elapsedMs}ms\n`,
+    );
+    return;
+  }
+
+  writeTuiTrace(session, "wait_dead_timeout", {
+    timeoutMs,
+    elapsedMs,
+    live,
+  });
+  process.stderr.write(
+    `tui-drive: session '${session}' still has live processes after ` +
+      `${timeoutMs}ms: ${live.join(", ")}\n`,
+  );
+  process.exit(1);
 }
 
 // ---------------------------------------------------------------------------
@@ -1628,6 +1990,9 @@ async function main(): Promise<void> {
   if (sub === "__win-daemon") {
     return runWinDaemon(a);
   }
+  if (sub === "__snapshot-timeout-probe") {
+    return cmdSnapshotTimeoutProbe(a);
+  }
 
   const backend = selectBackend();
   switch (sub) {
@@ -1637,16 +2002,20 @@ async function main(): Promise<void> {
       return cmdSend(backend, a);
     case "wait":
       return cmdWait(backend, a);
+    case "startup":
+      return cmdStartup(backend, a);
     case "capture":
       return cmdCapture(backend, a);
     case "kill":
       return cmdKill(backend, a);
+    case "wait-dead":
+      return cmdWaitDead(backend, a);
     case "answer-gate":
       return cmdAnswerGate(backend, a);
     default:
       fail(
         `unknown subcommand '${sub ?? ""}'. ` +
-          `Use: start | send | wait | capture | kill | answer-gate`,
+          `Use: start | send | wait | startup | capture | kill | wait-dead | answer-gate`,
       );
   }
 }


### PR DESCRIPTION
## Summary
- replace serial startup waits with one bounded grid-driven state machine
- handle supported trust and bypass prompts or return immediately when ready
- verify repeated Windows launches reap their process trees

## Verification
- deterministic startup state-machine tests
- three repeated native Windows TUI launches