### PR TITLE
docs: mark v2 current and explain Claude Bedrock default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,117 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe what went wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Set up ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: AI-DLC Version
+      description: Which version of AI-DLC are you using?
+      options:
+        - v1 (legacy)
+        - v2 (current)
+    validations:
+      required: true
+
+  - type: input
+    id: version-detail
+    attributes:
+      label: Release / Commit
+      description: The release number or git commit hash if running from source.
+      placeholder: e.g., 2.6.108 or abc1234
+
+  - type: dropdown
+    id: phase
+    attributes:
+      label: AI-DLC Phase
+      description: Which workflow phase were you in when the bug occurred?
+      options:
+        - Inception (requirements, user stories, application design)
+        - Construction (component design, code generation, testing)
+        - Operations (deployment, monitoring)
+        - Not phase-specific
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform / IDE
+      description: Which platform or IDE are you using AI-DLC with?
+      multiple: true
+      options:
+        - Kiro IDE
+        - Kiro CLI
+        - Amazon Q Developer IDE Plugin
+        - Cursor IDE
+        - Cline
+        - Claude Code
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: AI Model
+      description: Which AI model were you using?
+      placeholder: e.g., Claude Sonnet 4, GPT-4o, Amazon Nova
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any other relevant environment details (OS, IDE version, etc.).
+      placeholder: |
+        - OS: macOS 15.x
+        - IDE: VS Code 1.x
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or log output about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,57 @@
+name: Documentation Problem
+description: Report incorrect, unclear, or missing documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us improve the documentation. Please describe the problem you found or what is missing.
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: Which version of AI-DLC does this relate to?
+      options:
+        - v1 (legacy)
+        - v2 (current)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of Documentation Problem
+      options:
+        - Incorrect or outdated information
+        - Unclear or confusing explanation
+        - Missing documentation
+        - Broken link
+        - Typo or formatting issue
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Where is the problem? Provide a file path, URL, or section name.
+      placeholder: e.g., README.md, "Platform-Specific Setup" section
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe what is wrong or missing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Fix
+      description: If you have a suggestion for how to fix the documentation, describe it here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a small enhancement or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Suggest an enhancement or improvement. For larger, design-level proposals, please use the [RFC template](https://github.com/awslabs/aidlc-workflows/issues/new?template=rfc.yml) instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the feature or improvement you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: What problem does this solve or what workflow does it improve?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: Which version of AI-DLC does this relate to?
+      options:
+        - v1 (legacy)
+        - v2 (current)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: What area of AI-DLC does this relate to?
+      options:
+        - Inception phase rules
+        - Construction phase rules
+        - Operations phase rules
+        - New extension (e.g., compliance, security)
+        - Platform support
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, examples, or references that help explain the request.

--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -34,6 +34,23 @@ command -v bun    >/dev/null && echo "✓ bun installed"          || echo "✗ I
 
 This implementation ships configured for **AWS Bedrock**. The shipped `.claude/settings.json` sets:
 
+### Why Bedrock is the shipped default
+
+The Claude distribution needs a predictable runtime baseline across the
+orchestrator and its tier-pinned subagents. Bedrock lets the distribution name
+exact global inference profiles and their context variants, so a workflow does
+not silently pick different model aliases or context windows on different
+machines. It also uses the standard AWS SDK credential chain and IAM controls,
+which lets teams manage access without committing provider keys to a project.
+The repository's live Claude test environment uses the same provider baseline.
+
+This is a distribution default, not an AI-DLC methodology requirement. AI-DLC
+does not call the Bedrock API directly. To use the direct Anthropic API or
+another Claude Code-supported setup, remove the Bedrock-specific environment
+and model pins from the installed `.claude/settings.json`, then configure Claude
+Code normally. The workflow contract is unchanged; the selected models still
+need enough context for the orchestrator and delegated agents.
+
 | Variable | Value | Purpose |
 |----------|-------|---------|
 | `CLAUDE_CODE_USE_BEDROCK` | `1` | Routes Claude Code through Bedrock |


### PR DESCRIPTION
## Summary

  - mark v1 as legacy and v2 as current in issue forms
  - explain why Claude ships with Bedrock as the default
  - clarify that Bedrock is optional

  ## Validation

  - YAML issue forms validated
  - 17 documentation tests passed
  - package parity passed
  - git diff check passed

  No version bump: documentation-only change.