### PR TITLE
docs: add sbx-as-evaluator-substrate dogfooding proof

### DIFF
--- a/scripts/aidlc-evaluator/demo_sbx_dogfood/DOGFOODING.md
+++ b/scripts/aidlc-evaluator/demo_sbx_dogfood/DOGFOODING.md
@@ -1,0 +1,89 @@
+# Dogfooding proof: Docker Sandboxes as AI-DLC's evaluator execution substrate
+
+Local/fork-only proof artifact — not a PR against `awslabs/aidlc-workflows`.
+Demonstrates that `sbx` (Docker Sandboxes) can replace the evaluator's own
+bespoke `docker run aidlc-sandbox:latest ...` mechanism
+(`packages/shared/src/shared/sandbox.py`) for running AI-generated code
+under isolation, without needing the evaluator's own custom Dockerfile.
+
+**Scope of this proof, up front:** only the synchronous install+test path
+(`sandbox_run`, `post_run.py`'s real call path) was run live end-to-end.
+The detached/contract-test path (`sandbox_run_detached`, used by
+`contracttest/server.py`) was verified standalone via a probe sequence, not
+against its real caller — treat it as designed-but-not-yet-live-tested. See
+"What this proves, and what it doesn't" below for the full breakdown.
+
+## What's here
+
+- `../packages/shared/src/shared/sbx_sandbox.py` — a drop-in module matching
+  `shared.sandbox`'s public surface (`SandboxResult`, `sandbox_run`,
+  `sandbox_run_detached`, `sandbox_stop`, `sandbox_is_running`,
+  `sandbox_logs`), backed by real `sbx` calls instead of raw `docker run`.
+  Added alongside the original — nothing in the evaluator's real code paths
+  was modified.
+- `toy_project/` — a minimal real Python project (pyproject.toml + a
+  passing test) used to exercise the real command AI-DLC's own
+  `aidlc_runner.post_run._PROJECT_MARKERS` would run for a Python project.
+- `run_demo.py` — runs that real install+test command through
+  `sbx_sandbox.sandbox_run` end to end, no mocking.
+
+## What was actually verified, live, not assumed
+
+Run: `python3 run_demo.py` (needs only stdlib + a working `sbx` — no `uv
+sync`, no package install on the host; `sys.path` injection reaches
+`shared.sbx_sandbox` directly).
+
+Result: real install (`uv venv` + `uv pip install -qq -e ".[dev]"`) and real
+test (`uv run pytest ...`) both ran inside a fresh `sbx` `shell`-agent
+sandbox and succeeded — `1 passed`, correct exit codes, sandbox
+auto-removed after each step.
+
+Also verified along the way, each a real finding, not a guess:
+
+- **The `shell-docker` sbx template already ships Python 3.14, `uv`, Node
+  22, and `git`** — the same toolchain the bespoke `aidlc-sandbox` Dockerfile
+  installs by hand. No custom image needed for parity on this axis.
+- **The workspace mounts at the same absolute host path inside the
+  sandbox** (via `$WORKSPACE_DIR`), not a fixed `/workspace` — and files
+  written inside appear on the host owned by the host user with no
+  `--user=uid:gid` mapping needed. virtiofs handles this transparently;
+  the original module's explicit UID mapping has no sbx equivalent because
+  it doesn't need one.
+- **`sbx create` enforces a 1 GiB memory minimum** — below that, creation
+  fails loudly (`memory 512m is below the minimum of 1 GiB`), not silently.
+- **`sbx exec`'s exit code and `-d` (detached) both work exactly as
+  needed** — verified with a real `exit 42` and a real detached
+  `sleep 5 && echo done > marker` before checking the marker file.
+- **The real `post_run.py` marker command for a Python project has a
+  latent gap independent of the sandbox backend**: `uv pip install -qq -e
+  ".[dev]"` alone fails with "No virtual environment found" in a fresh
+  sandbox — needs a `uv venv` first. Confirmed this isn't sbx-specific: the
+  original bespoke Dockerfile has no venv setup either, so the same failure
+  would occur there too. Worth raising with AI-DLC upstream separately; not
+  fixed here since it's their code, not this integration's.
+
+## Known gap, not papered over
+
+`network=False` has no verified `sbx` equivalent to `--network=none`'s
+blanket isolation — `sbx create --deny-network` only narrows an existing
+allow policy, it cannot express "nothing at all." Checked: no real call
+site in this codebase passes `network=False` today, so `sbx_sandbox.py`
+raises `NotImplementedError` for that case rather than silently providing
+weaker isolation than requested. If a real caller needs it, that's new
+scoping work, not a bug in this proof.
+
+`sandbox_logs()` returns empty strings — `sbx` has no `docker logs`
+equivalent for an arbitrary background exec. The one real caller of
+`sandbox_run_detached` (`contracttest/server.py`) already polls a published
+port for readiness rather than reading logs, so this gap doesn't block that
+use case, but it's a real difference from the original module's contract.
+
+## What this proves, and what it doesn't
+
+Proves: the execution mechanics work end-to-end for the real, most-used
+call path (`post_run.py`'s sandboxed install+test). Does not prove: the
+detached/contract-test path works identically (not exercised live here —
+`sandbox_run_detached`'s mechanics were verified standalone via the probe
+sequence in the parent session, not against the real `contracttest/server.py`
+caller). Treat the detached path as designed-but-not-yet-live-tested against
+its real caller, not as fully proven.

--- a/scripts/aidlc-evaluator/demo_sbx_dogfood/run_demo.py
+++ b/scripts/aidlc-evaluator/demo_sbx_dogfood/run_demo.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Proof: AI-DLC's post_run.py install+test flow, run through a real sbx
+sandbox instead of the bespoke aidlc-sandbox:latest Docker image.
+
+Mirrors aidlc_runner.post_run._run_step's real sandboxed branch and the
+real (marker_file, project_type, install_cmd, test_cmd) entry for
+pyproject.toml from aidlc_runner.post_run._PROJECT_MARKERS, verbatim —
+this is not a synthetic toy command, it's the actual command AI-DLC's own
+evaluator would run for a Python project, executed via shared.sbx_sandbox
+instead of shared.sandbox.
+
+No package installation needed on the host beyond stdlib — shared.sbx_sandbox
+only needs shared.credential_scrubber and shared.sandbox.SandboxResult,
+both stdlib-only.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_EVALUATOR_ROOT = _HERE.parent
+sys.path.insert(0, str(_EVALUATOR_ROOT / "packages" / "shared" / "src"))
+
+from shared.sbx_sandbox import is_sbx_available, sandbox_run  # noqa: E402
+
+TOY_PROJECT = _HERE / "toy_project"
+
+# The pyproject.toml entry's test_cmd is verbatim from
+# aidlc_runner.post_run._PROJECT_MARKERS. The install_cmd needed a `uv venv`
+# prefix — verified live that this is a pre-existing gap in the marker
+# command itself (no venv exists yet in a fresh sandbox), independent of
+# which sandbox backend runs it: the original bespoke Dockerfile has no venv
+# setup either, so `uv pip install -qq -e ".[dev]"` alone would fail there
+# too. Worth flagging upstream separately; not an sbx-specific issue, so not
+# papered over here beyond documenting it.
+INSTALL_CMD = 'uv venv -q .venv && . .venv/bin/activate && uv pip install -qq -e ".[dev]"'
+TEST_CMD = ". .venv/bin/activate && uv run pytest --tb=short -q --no-header -o console_output_style=classic"
+
+
+def run_step(label: str, command: str) -> dict:
+    print(f"\n=== {label}: {command} ===")
+    result = sandbox_run(command, workspace=TOY_PROJECT, timeout=120)
+    output = result.stdout + result.stderr
+    print(output)
+    print(f"[exit_code={result.exit_code} timed_out={result.timed_out}]")
+    return {
+        "command": command,
+        "exit_code": result.exit_code,
+        "success": result.exit_code == 0,
+        "sandboxed": True,
+    }
+
+
+def main() -> int:
+    print(f"is_sbx_available() = {is_sbx_available()}")
+    if not is_sbx_available():
+        print("sbx not available — aborting demo", file=sys.stderr)
+        return 1
+
+    install = run_step("install (real post_run.py marker command)", INSTALL_CMD)
+    if not install["success"]:
+        print("\nInstall step failed — stopping (matches real _run_step early-exit behavior)")
+        return 1
+
+    test = run_step("test (real post_run.py marker command)", TEST_CMD)
+
+    print("\n=== Summary ===")
+    print(f"install: success={install['success']}")
+    print(f"test:    success={test['success']}")
+    return 0 if test["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/pyproject.toml
+++ b/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "toy-project"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["toy_project"]

--- a/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/tests/test_add.py
+++ b/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/tests/test_add.py
@@ -1,0 +1,5 @@
+from toy_project import add
+
+
+def test_add():
+    assert add(2, 3) == 5

--- a/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/toy_project/__init__.py
+++ b/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/toy_project/__init__.py
@@ -1,0 +1,2 @@
+def add(a, b):
+    return a + b

--- a/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/uv.lock
+++ b/scripts/aidlc-evaluator/demo_sbx_dogfood/toy_project/uv.lock
@@ -1,0 +1,78 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "toy-project"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" }]
+provides-extras = ["dev"]

--- a/scripts/aidlc-evaluator/packages/shared/src/shared/sbx_sandbox.py
+++ b/scripts/aidlc-evaluator/packages/shared/src/shared/sbx_sandbox.py
@@ -1,0 +1,236 @@
+"""Docker Sandboxes (``sbx``)-backed sandbox for running untrusted commands.
+
+Drop-in alternative to :mod:`shared.sandbox`, backed by Docker Sandboxes'
+``sbx`` CLI instead of a bespoke ``docker run`` + hand-rolled Dockerfile.
+Same public surface (:class:`SandboxResult`, ``sandbox_run``,
+``sandbox_run_detached``, ``sandbox_stop``, ``sandbox_is_running``,
+``sandbox_logs``) so a caller can switch modules without changing call
+sites — see ``aidlc_runner.post_run._run_step`` for the real integration
+point this was proven against.
+
+This is a proof-of-concept for a fork, not an upstream contribution: it
+demonstrates that Docker Sandboxes can serve as AI-DLC's own execution
+substrate for running AI-generated code, using the non-agentic ``shell``
+sandbox kind rather than an AI-DLC phase kit (those pair with the ``claude``
+agent kit and run an actual coding agent — a different use case from
+"execute this already-generated project's install+test command").
+
+Every claim below was verified against a real installed ``sbx`` binary
+(v0.39.0), not assumed from documentation:
+- The workspace mounts at the *same absolute host path* inside the sandbox
+  (unlike the raw-Docker version's fixed ``/workspace``) — confirmed via
+  ``$WORKSPACE_DIR`` and a live file-write round-trip.
+- Files written inside the sandbox appear on the host owned by the host
+  user, with no ``--user=uid:gid`` mapping needed — the virtiofs mount
+  handles this transparently, unlike a raw Linux bind mount.
+- ``sbx create`` enforces a 1 GiB memory minimum; the ``memory`` default
+  here (``"2g"``) is safely above it, but a caller-supplied value below 1
+  GiB will fail loudly rather than silently clamp.
+- ``sbx exec`` propagates the wrapped command's real exit code and supports
+  ``-d`` for a true detached background exec.
+
+Known gap, honestly stated rather than papered over: ``network=False`` has
+no verified ``sbx`` equivalent to raw Docker's ``--network=none`` blanket
+isolation. ``--deny-network`` only *narrows* an existing allow policy — it
+cannot express "nothing at all." No real call site in this codebase passes
+``network=False`` today (grep confirms every caller passes ``network=True``),
+so this module raises ``NotImplementedError`` for that case rather than
+silently providing weaker isolation than requested.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+from shared.credential_scrubber import scrub_credentials
+from shared.sandbox import SandboxResult
+
+_MIN_MEMORY_GIB = 1  # sbx-enforced minimum; see module docstring.
+
+
+def is_sbx_available() -> bool:
+    """Check whether the ``sbx`` CLI is installed and its daemon responds."""
+    try:
+        result = subprocess.run(
+            ["sbx", "ls"],
+            capture_output=True,
+            timeout=15,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _sandbox_name(prefix: str = "aidlc-eval") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+def _create(
+    name: str,
+    workspace: Path,
+    *,
+    template: str | None,
+    memory: str,
+    cpus: int,
+    ports: dict[int, int] | None,
+) -> None:
+    cmd: list[str] = [
+        "sbx", "create",
+        "--name", name,
+        "--memory", memory,
+        "--cpus", str(cpus),
+    ]
+    if template:
+        cmd += ["--template", template]
+    if ports:
+        for host_port, container_port in ports.items():
+            cmd += ["-p", f"127.0.0.1:{host_port}:{container_port}"]
+    cmd += ["shell", str(workspace.resolve())]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if result.returncode != 0:
+        raise RuntimeError(f"sbx create failed: {result.stderr.strip()}")
+
+
+def sandbox_run(
+    command: str,
+    workspace: Path,
+    *,
+    image: str | None = None,
+    timeout: int = 300,
+    network: bool = True,
+    env: dict[str, str] | None = None,
+    ports: dict[int, int] | None = None,
+    memory: str = "2g",
+    cpus: int = 2,
+) -> SandboxResult:
+    """Run *command* inside a real ``sbx`` sandbox with *workspace* mounted.
+
+    Same signature and return type as :func:`shared.sandbox.sandbox_run`.
+    ``image`` maps to ``sbx create --template`` (accepts a plain image
+    reference, same as ``--template`` does for any agent). Unlike the raw
+    Docker version, no ``--user`` mapping is needed — see module docstring.
+    """
+    if not network:
+        raise NotImplementedError(
+            "network=False has no verified sbx equivalent to --network=none "
+            "(see module docstring) and no real caller needs it today"
+        )
+
+    name = _sandbox_name()
+    try:
+        _create(name, workspace, template=image, memory=memory, cpus=cpus, ports=ports)
+
+        exec_cmd: list[str] = ["sbx", "exec"]
+        if env:
+            for key, value in env.items():
+                exec_cmd += ["-e", f"{key}={value}"]
+        exec_cmd += [name, "--", "bash", "-c", command]
+
+        try:
+            result = subprocess.run(
+                exec_cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return SandboxResult(
+                exit_code=result.returncode,
+                stdout=scrub_credentials(result.stdout),
+                stderr=scrub_credentials(result.stderr),
+            )
+        except subprocess.TimeoutExpired as e:
+            stdout = e.stdout if isinstance(e.stdout, str) else (e.stdout or b"").decode("utf-8", errors="replace")
+            stderr = e.stderr if isinstance(e.stderr, str) else (e.stderr or b"").decode("utf-8", errors="replace")
+            return SandboxResult(
+                exit_code=None,
+                stdout=scrub_credentials(stdout),
+                stderr=scrub_credentials(stderr),
+                timed_out=True,
+            )
+    finally:
+        subprocess.run(["sbx", "rm", "-f", name], capture_output=True, timeout=30)
+
+
+def sandbox_run_detached(
+    command: str,
+    workspace: Path,
+    *,
+    image: str | None = None,
+    network: bool = True,
+    env: dict[str, str] | None = None,
+    ports: dict[int, int] | None = None,
+    memory: str = "2g",
+    cpus: int = 2,
+) -> str:
+    """Start a detached long-running command inside a real ``sbx`` sandbox.
+
+    Returns the sandbox *name* (not a raw container ID — the identifier
+    ``sandbox_stop``/``sandbox_is_running``/``sandbox_logs`` below expect).
+    Raises ``RuntimeError`` if the sandbox or the detached exec fails to
+    start.
+    """
+    if not network:
+        raise NotImplementedError(
+            "network=False has no verified sbx equivalent to --network=none "
+            "(see module docstring) and no real caller needs it today"
+        )
+
+    name = _sandbox_name()
+    _create(name, workspace, template=image, memory=memory, cpus=cpus, ports=ports)
+
+    exec_cmd: list[str] = ["sbx", "exec", "-d"]
+    if env:
+        for key, value in env.items():
+            exec_cmd += ["-e", f"{key}={value}"]
+    exec_cmd += [name, "--", "bash", "-c", command]
+
+    result = subprocess.run(exec_cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        subprocess.run(["sbx", "rm", "-f", name], capture_output=True, timeout=30)
+        raise RuntimeError(f"Failed to start detached exec: {result.stderr.strip()}")
+    return name
+
+
+def sandbox_stop(container_id: str, timeout: int = 10) -> None:
+    """Remove the sandbox identified by *container_id* (really: sandbox name)."""
+    subprocess.run(
+        ["sbx", "rm", "-f", container_id],
+        capture_output=True,
+        timeout=timeout + 20,  # sandbox removal is slower than a container stop
+    )
+
+
+def sandbox_is_running(container_id: str) -> bool:
+    """Check whether the named sandbox still exists and is running."""
+    try:
+        result = subprocess.run(
+            ["sbx", "ls", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return False
+        import json
+        for sandbox in json.loads(result.stdout or "[]"):
+            if sandbox.get("name") == container_id:
+                return str(sandbox.get("status", "")).lower() == "running"
+        return False
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return False
+
+
+def sandbox_logs(container_id: str) -> tuple[str, str]:
+    """Return (stdout, stderr) captured so far from the named sandbox's exec.
+
+    Honest limitation: ``sbx`` has no direct ``docker logs`` equivalent for
+    an arbitrary background exec (logs are per-agent-session, not per-exec).
+    This returns empty strings rather than fabricate content — a caller
+    relying on this for a live server's output should poll via a health
+    check on a published port instead, which is what
+    ``contracttest/server.py``'s real usage already does.
+    """
+    return "", ""


### PR DESCRIPTION
Local/fork-only proof artifact showing sbx can replace AI-DLC's bespoke docker-run sandbox mechanism, verified live end-to-end for the real install+test call path. Not a PR against upstream aidlc-workflows.

# Summary

> replace with your summary...

## Changes

> replace with a description of the changes

## User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

## Test Plan

> replace with instructions or a checklist for reviewers to verify

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
