### PR TITLE
docs: copy the shipped .gitignore in the Claude Code and Kiro install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Ad-hoc AI coding works until the project gets real. Then context drifts between 
 
 | Harness | Install (copy into your project) | Invoke | Install & usage guide |
 | --- | --- | --- | --- |
-| **Kiro IDE** | `dist/kiro-ide/.kiro/` + `dist/kiro-ide/aidlc/` → `<project>/` (+ `dist/kiro-ide/AGENTS.md`, `dist/kiro-ide/.gitignore`) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro IDE](docs/guide/harnesses/kiro-ide.md). |
-| **Kiro CLI** (≥ 2.6) | `dist/kiro/.kiro/` + `dist/kiro/aidlc/` → `<project>/` (+ `dist/kiro/AGENTS.md`, `dist/kiro/.gitignore`) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro CLI](docs/guide/harnesses/kiro-cli.md). |
-| **Claude Code** | `dist/claude/.claude/` + `dist/claude/aidlc/` + `dist/claude/.gitignore` → `<project>/` | `/aidlc` | [Quick Start](#quick-start) below + [Getting Started](docs/guide/01-getting-started.md). |
+| **Kiro IDE** | `dist/kiro-ide/.kiro/` + `dist/kiro-ide/aidlc/` → `<project>/` (+ `dist/kiro-ide/AGENTS.md`; copy or merge the AI-DLC `.gitignore` section) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro IDE](docs/guide/harnesses/kiro-ide.md). |
+| **Kiro CLI** (≥ 2.6) | `dist/kiro/.kiro/` + `dist/kiro/aidlc/` → `<project>/` (+ `dist/kiro/AGENTS.md`; copy or merge the AI-DLC `.gitignore` section) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro CLI](docs/guide/harnesses/kiro-cli.md). |
+| **Claude Code** | `dist/claude/.claude/` + `dist/claude/aidlc/` → `<project>/` (copy or merge the AI-DLC `.gitignore` section) | `/aidlc` | [Quick Start](#quick-start) below + [Getting Started](docs/guide/01-getting-started.md). |
 | **Codex CLI** (≥ 0.145.0) | `dist/codex/` → `<project>/` (`.codex/` + `.agents/` + `aidlc/` + `AGENTS.md`) | `$aidlc` (or `/skills` → aidlc) | [Quick Start](#quick-start) below + [AI-DLC on Codex CLI](docs/guide/harnesses/codex-cli.md). |
 | **Cursor** | `bun dist/cursor/install.ts <project>` | `/aidlc` | [Quick Start](#quick-start) below + [AI-DLC on Cursor](docs/guide/harnesses/cursor.md). |
 | **opencode** (≥ 1.17) | `dist/opencode/` → `<project>/` (`.aidlc/` + `.opencode/` + `aidlc/` + `opencode.json` + `AGENTS.md`) | `/aidlc` | [Quick Start](#quick-start) below + [AI-DLC on opencode](docs/guide/harnesses/opencode.md). |
@@ -131,10 +131,13 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro-ide/.kiro/. your-project/.kiro/
 cp -R dist/kiro-ide/aidlc/. your-project/aidlc/     # the workspace shell — a sibling of .kiro/, not inside it
 cp dist/kiro-ide/AGENTS.md your-project/AGENTS.md   # merge if you already have one
-cp dist/kiro-ide/.gitignore your-project/.gitignore # merge if you already have one
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/kiro-ide/.gitignore your-project/.gitignore
+fi
 ```
 
-The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The `## Git Integration` section of the installed onboarding file assumes those rules are in place.
+The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The guarded command copies the complete starter file only when the project has no `.gitignore`. If one exists, preserve every project-owned rule and merge only the section from `# AI-DLC` through the end of the shipped file; do not copy its generic starter rules. The `## Git Integration` section of the installed onboarding file assumes the AI-DLC rules are in place.
 
 Open `your-project/` in Kiro IDE. The `/aidlc` command loads the shipped conductor skill, and `.kiro/agents/aidlc.md` exposes the conductor in the IDE agent selector. Agents are Markdown-only in this distribution; Kiro CLI's agent-v1 JSON files and `settings/cli.json` do not ship. The install registers the framework hooks in both formats: `.kiro/hooks/aidlc-*.json` (v2 schema for IDE >= 1.0) and `.kiro/hooks/aidlc-*.kiro.hook` (legacy format for pre-1.0 IDEs). In the chat panel, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start.
 
@@ -160,11 +163,14 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro/.kiro/. your-project/.kiro/
 cp -R dist/kiro/aidlc/. your-project/aidlc/    # the workspace shell — a sibling of .kiro/, not inside it
 cp dist/kiro/AGENTS.md your-project/AGENTS.md   # merge if you already have one
-cp dist/kiro/.gitignore your-project/.gitignore # merge if you already have one
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/kiro/.gitignore your-project/.gitignore
+fi
 cd your-project && kiro-cli chat
 ```
 
-The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The `## Git Integration` section of the installed onboarding file assumes those rules are in place.
+The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The guarded command copies the complete starter file only when the project has no `.gitignore`. If one exists, preserve every project-owned rule and merge only the section from `# AI-DLC` through the end of the shipped file; do not copy its generic starter rules. The `## Git Integration` section of the installed onboarding file assumes the AI-DLC rules are in place.
 
 The install ships `.kiro/settings/cli.json` with `chat.defaultAgent` set to `aidlc`, so `/aidlc` is active by default. Inside the session, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start. The [Kiro CLI guide](docs/guide/harnesses/kiro-cli.md) has the full prerequisites and harness differences.
 
@@ -201,11 +207,14 @@ curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del in
 # Copy the implementation (engine + the workspace shell sibling), then launch
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/     # the workspace shell — a sibling of .claude/, not inside it
-cp    dist/claude/.gitignore your-project/.gitignore # merge if you already have one
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/claude/.gitignore your-project/.gitignore
+fi
 cd your-project && claude
 ```
 
-The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The `## Git Integration` section of the installed onboarding file assumes those rules are in place.
+The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The guarded command copies the complete starter file only when the project has no `.gitignore`. If one exists, preserve every project-owned rule and merge only the section from `# AI-DLC` through the end of the shipped file; do not copy its generic starter rules. The `## Git Integration` section of the installed onboarding file assumes the AI-DLC rules are in place.
 
 Then, inside the Claude Code session:
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Ad-hoc AI coding works until the project gets real. Then context drifts between 
 
 | Harness | Install (copy into your project) | Invoke | Install & usage guide |
 | --- | --- | --- | --- |
-| **Kiro IDE** | `dist/kiro-ide/.kiro/` + `dist/kiro-ide/aidlc/` → `<project>/` (+ `dist/kiro-ide/AGENTS.md`) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro IDE](docs/guide/harnesses/kiro-ide.md). |
-| **Kiro CLI** (≥ 2.6) | `dist/kiro/.kiro/` + `dist/kiro/aidlc/` → `<project>/` (+ `dist/kiro/AGENTS.md`) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro CLI](docs/guide/harnesses/kiro-cli.md). |
-| **Claude Code** | `dist/claude/.claude/` + `dist/claude/aidlc/` → `<project>/` | `/aidlc` | [Quick Start](#quick-start) below + [Getting Started](docs/guide/01-getting-started.md). |
+| **Kiro IDE** | `dist/kiro-ide/.kiro/` + `dist/kiro-ide/aidlc/` → `<project>/` (+ `dist/kiro-ide/AGENTS.md`, `dist/kiro-ide/.gitignore`) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro IDE](docs/guide/harnesses/kiro-ide.md). |
+| **Kiro CLI** (≥ 2.6) | `dist/kiro/.kiro/` + `dist/kiro/aidlc/` → `<project>/` (+ `dist/kiro/AGENTS.md`, `dist/kiro/.gitignore`) | `/aidlc` | [Quick Start](#quick-start) below + [Running AI-DLC on Kiro CLI](docs/guide/harnesses/kiro-cli.md). |
+| **Claude Code** | `dist/claude/.claude/` + `dist/claude/aidlc/` + `dist/claude/.gitignore` → `<project>/` | `/aidlc` | [Quick Start](#quick-start) below + [Getting Started](docs/guide/01-getting-started.md). |
 | **Codex CLI** (≥ 0.145.0) | `dist/codex/` → `<project>/` (`.codex/` + `.agents/` + `aidlc/` + `AGENTS.md`) | `$aidlc` (or `/skills` → aidlc) | [Quick Start](#quick-start) below + [AI-DLC on Codex CLI](docs/guide/harnesses/codex-cli.md). |
 | **Cursor** | `bun dist/cursor/install.ts <project>` | `/aidlc` | [Quick Start](#quick-start) below + [AI-DLC on Cursor](docs/guide/harnesses/cursor.md). |
 | **opencode** (≥ 1.17) | `dist/opencode/` → `<project>/` (`.aidlc/` + `.opencode/` + `aidlc/` + `opencode.json` + `AGENTS.md`) | `/aidlc` | [Quick Start](#quick-start) below + [AI-DLC on opencode](docs/guide/harnesses/opencode.md). |
@@ -131,9 +131,10 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro-ide/.kiro/. your-project/.kiro/
 cp -R dist/kiro-ide/aidlc/. your-project/aidlc/     # the workspace shell — a sibling of .kiro/, not inside it
 cp dist/kiro-ide/AGENTS.md your-project/AGENTS.md   # merge if you already have one
+cp dist/kiro-ide/.gitignore your-project/.gitignore # merge if you already have one
 ```
 
-The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it.
+The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The `## Git Integration` section of the installed onboarding file assumes those rules are in place.
 
 Open `your-project/` in Kiro IDE. The `/aidlc` command loads the shipped conductor skill, and `.kiro/agents/aidlc.md` exposes the conductor in the IDE agent selector. Agents are Markdown-only in this distribution; Kiro CLI's agent-v1 JSON files and `settings/cli.json` do not ship. The install registers the framework hooks in both formats: `.kiro/hooks/aidlc-*.json` (v2 schema for IDE >= 1.0) and `.kiro/hooks/aidlc-*.kiro.hook` (legacy format for pre-1.0 IDEs). In the chat panel, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start.
 
@@ -159,10 +160,11 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro/.kiro/. your-project/.kiro/
 cp -R dist/kiro/aidlc/. your-project/aidlc/    # the workspace shell — a sibling of .kiro/, not inside it
 cp dist/kiro/AGENTS.md your-project/AGENTS.md   # merge if you already have one
+cp dist/kiro/.gitignore your-project/.gitignore # merge if you already have one
 cd your-project && kiro-cli chat
 ```
 
-The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it.
+The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The `## Git Integration` section of the installed onboarding file assumes those rules are in place.
 
 The install ships `.kiro/settings/cli.json` with `chat.defaultAgent` set to `aidlc`, so `/aidlc` is active by default. Inside the session, run `/aidlc --doctor` to verify, then `/aidlc <description>` to start. The [Kiro CLI guide](docs/guide/harnesses/kiro-cli.md) has the full prerequisites and harness differences.
 
@@ -199,10 +201,11 @@ curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del in
 # Copy the implementation (engine + the workspace shell sibling), then launch
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/     # the workspace shell — a sibling of .claude/, not inside it
+cp    dist/claude/.gitignore your-project/.gitignore # merge if you already have one
 cd your-project && claude
 ```
 
-The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it.
+The `aidlc/` shell ships the pre-built `aidlc/spaces/default/memory/` method tree the engine reads; `/aidlc --doctor` fails its "workspace shell ready" check without it. The `.gitignore` carries the workspace's commit/ignore split: the per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`) and machine-local runtime stay untracked, while the shared records — method memory, state, audit shards, artifacts — travel with git. The `## Git Integration` section of the installed onboarding file assumes those rules are in place.
 
 Then, inside the Claude Code session:
 

--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -211,18 +211,23 @@ Expand your harness:
 ```bash
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/     # the workspace shell — a sibling of .claude/, not inside it
-cp    dist/claude/.gitignore your-project/.gitignore # merge if you already have one
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/claude/.gitignore your-project/.gitignore
+fi
 ```
 
 The first line copies the engine — the orchestrator, stage files, agent personas, hooks, knowledge files, and default settings. The second copies the **workspace shell**: the pre-built `aidlc/spaces/default/memory/` method tree the engine reads. It ships as a **sibling** of `.claude/` (not inside it), so it must be copied separately — or copy the whole `dist/claude/` tree at once. `/aidlc --doctor` fails its "workspace shell ready" check if `aidlc/spaces/default/memory/` is missing.
 
-The third line copies the `.gitignore` AI-DLC ships for a workspace. Without it
-your first commit picks up the per-user cursors (`aidlc/active-space`,
+The guarded block copies the complete starter `.gitignore` only when the project
+does not already have one. Otherwise, preserve every project-owned rule and
+merge only the section from `# AI-DLC` through the end of the shipped file; do
+not copy its generic starter rules. Without the AI-DLC section, your first
+commit picks up the per-user cursors (`aidlc/active-space`,
 `aidlc/spaces/*/intents/active-intent`) and machine-local runtime
 (`aidlc/.aidlc-clone-id`, `runtime-graph.json`, sensor caches,
 `spaces/*/knowledge/.sources.local.json`), which the `## Git Integration`
-section of the installed `.claude/CLAUDE.md` states are already excluded. Merge
-its entries if your project already has a `.gitignore`.
+section of the installed `.claude/CLAUDE.md` states are already excluded.
 
 Start (or fully restart) Claude Code from the project root, approve the project hooks when prompted or through `/hooks`, then fully restart Claude Code again so the approval takes effect; `/clear` is not enough. On managed fleets, if `/hooks` says hooks are restricted by policy, follow [Claude managed policy blocks project hooks](15-troubleshooting.md#claude-managed-policy-blocks-project-hooks).
 
@@ -236,8 +241,16 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro/.kiro/. your-project/.kiro/
 cp -R dist/kiro/aidlc/. your-project/aidlc/    # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
 cp dist/kiro/AGENTS.md your-project/AGENTS.md  # merge if you already have one
-cp dist/kiro/.gitignore your-project/.gitignore # merge if you already have one
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/kiro/.gitignore your-project/.gitignore
+fi
 ```
+
+The guarded block copies the complete starter `.gitignore` only when the project
+does not already have one. Otherwise, preserve every project-owned rule and
+merge only the section from `# AI-DLC` through the end of the shipped file; do
+not copy its generic starter rules.
 
 Then continue in [Running AI-DLC on Kiro CLI](harnesses/kiro-cli.md): prerequisites (Kiro CLI ≥ 2.6, a paid plan for Opus 4.8) and the shipped default-agent setting.
 
@@ -453,7 +466,10 @@ command -v bun    >/dev/null && echo "✓ bun"          || echo "✗ bun"
 # Install (engine + the workspace shell sibling)
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/
-cp    dist/claude/.gitignore your-project/.gitignore
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/claude/.gitignore your-project/.gitignore
+fi
 
 # Launch Claude Code in your project
 cd your-project && claude

--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -211,9 +211,18 @@ Expand your harness:
 ```bash
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/     # the workspace shell — a sibling of .claude/, not inside it
+cp    dist/claude/.gitignore your-project/.gitignore # merge if you already have one
 ```
 
 The first line copies the engine — the orchestrator, stage files, agent personas, hooks, knowledge files, and default settings. The second copies the **workspace shell**: the pre-built `aidlc/spaces/default/memory/` method tree the engine reads. It ships as a **sibling** of `.claude/` (not inside it), so it must be copied separately — or copy the whole `dist/claude/` tree at once. `/aidlc --doctor` fails its "workspace shell ready" check if `aidlc/spaces/default/memory/` is missing.
+
+The third line copies the `.gitignore` AI-DLC ships for a workspace. Without it
+your first commit picks up the per-user cursors (`aidlc/active-space`,
+`aidlc/spaces/*/intents/active-intent`) and machine-local runtime
+(`aidlc/.aidlc-clone-id`, `runtime-graph.json`, sensor caches,
+`spaces/*/knowledge/.sources.local.json`), which the `## Git Integration`
+section of the installed `.claude/CLAUDE.md` states are already excluded. Merge
+its entries if your project already has a `.gitignore`.
 
 Start (or fully restart) Claude Code from the project root, approve the project hooks when prompted or through `/hooks`, then fully restart Claude Code again so the approval takes effect; `/clear` is not enough. On managed fleets, if `/hooks` says hooks are restricted by policy, follow [Claude managed policy blocks project hooks](15-troubleshooting.md#claude-managed-policy-blocks-project-hooks).
 
@@ -227,6 +236,7 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro/.kiro/. your-project/.kiro/
 cp -R dist/kiro/aidlc/. your-project/aidlc/    # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
 cp dist/kiro/AGENTS.md your-project/AGENTS.md  # merge if you already have one
+cp dist/kiro/.gitignore your-project/.gitignore # merge if you already have one
 ```
 
 Then continue in [Running AI-DLC on Kiro CLI](harnesses/kiro-cli.md): prerequisites (Kiro CLI ≥ 2.6, a paid plan for Opus 4.8) and the shipped default-agent setting.
@@ -443,6 +453,7 @@ command -v bun    >/dev/null && echo "✓ bun"          || echo "✗ bun"
 # Install (engine + the workspace shell sibling)
 cp -r dist/claude/.claude/ your-project/.claude/
 cp -r dist/claude/aidlc/   your-project/aidlc/
+cp    dist/claude/.gitignore your-project/.gitignore
 
 # Launch Claude Code in your project
 cd your-project && claude

--- a/docs/guide/harnesses/kiro-cli.md
+++ b/docs/guide/harnesses/kiro-cli.md
@@ -35,7 +35,10 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro/.kiro/. your-project/.kiro/
 cp -R dist/kiro/aidlc/. your-project/aidlc/    # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
 cp dist/kiro/AGENTS.md your-project/AGENTS.md  # merge if you already have one
-cp dist/kiro/.gitignore your-project/.gitignore # merge if you already have one
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/kiro/.gitignore your-project/.gitignore
+fi
 ```
 
 The `aidlc/` directory is the workspace shell — it ships the pre-built
@@ -48,8 +51,11 @@ per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`)
 and machine-local runtime (`aidlc/.aidlc-clone-id`, `runtime-graph.json`, sensor
 caches, `spaces/*/knowledge/.sources.local.json`) stay untracked, while the
 shared records — method memory, state, audit shards, artifacts — travel with
-git. The `## Git Integration` section of the installed `AGENTS.md` states those
-rules are already in place, so copy or merge the file before your first
+git. The guarded command copies the complete starter file only when the project
+has no `.gitignore`. If one exists, preserve every project-owned rule and merge
+only the section from `# AI-DLC` through the end of the shipped file; do not
+copy its generic starter rules. The `## Git Integration` section of the
+installed `AGENTS.md` assumes the AI-DLC rules are in place before your first
 workflow.
 
 Then start a session in your project:

--- a/docs/guide/harnesses/kiro-cli.md
+++ b/docs/guide/harnesses/kiro-cli.md
@@ -35,12 +35,22 @@ mkdir -p your-project/.kiro your-project/aidlc
 cp -R dist/kiro/.kiro/. your-project/.kiro/
 cp -R dist/kiro/aidlc/. your-project/aidlc/    # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
 cp dist/kiro/AGENTS.md your-project/AGENTS.md  # merge if you already have one
+cp dist/kiro/.gitignore your-project/.gitignore # merge if you already have one
 ```
 
 The `aidlc/` directory is the workspace shell — it ships the pre-built
 `aidlc/spaces/default/memory/` method tree the engine reads. It is a **sibling**
 of `.kiro/`, so copy it separately (or copy the whole `dist/kiro/` tree at once).
 `/aidlc --doctor` fails its "workspace shell ready" check if it is missing.
+
+The shipped `.gitignore` carries the workspace's commit/ignore split: the
+per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`)
+and machine-local runtime (`aidlc/.aidlc-clone-id`, `runtime-graph.json`, sensor
+caches, `spaces/*/knowledge/.sources.local.json`) stay untracked, while the
+shared records — method memory, state, audit shards, artifacts — travel with
+git. The `## Git Integration` section of the installed `AGENTS.md` states those
+rules are already in place, so copy or merge the file before your first
+workflow.
 
 Then start a session in your project:
 

--- a/docs/guide/harnesses/kiro-ide.md
+++ b/docs/guide/harnesses/kiro-ide.md
@@ -57,7 +57,10 @@ rm -f \
 cp -R dist/kiro-ide/.kiro/. your-project/.kiro/
 cp -R dist/kiro-ide/aidlc/. your-project/aidlc/     # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
 cp dist/kiro-ide/AGENTS.md your-project/AGENTS.md   # merge if you already have one
-cp dist/kiro-ide/.gitignore your-project/.gitignore # merge if you already have one
+# Existing .gitignore: preserve it and merge only the section beginning "# AI-DLC".
+if [ ! -e your-project/.gitignore ]; then
+  cp dist/kiro-ide/.gitignore your-project/.gitignore
+fi
 ```
 
 The first removal loop is the v2.5.57 hook-name migration. The second removes
@@ -79,8 +82,11 @@ per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`)
 and machine-local runtime (`aidlc/.aidlc-clone-id`, `runtime-graph.json`, sensor
 caches, `spaces/*/knowledge/.sources.local.json`) stay untracked, while the
 shared records — method memory, state, audit shards, artifacts — travel with
-git. The `## Git Integration` section of the installed `AGENTS.md` states those
-rules are already in place, so copy or merge the file before your first
+git. The guarded command copies the complete starter file only when the project
+has no `.gitignore`. If one exists, preserve every project-owned rule and merge
+only the section from `# AI-DLC` through the end of the shipped file; do not
+copy its generic starter rules. The `## Git Integration` section of the
+installed `AGENTS.md` assumes the AI-DLC rules are in place before your first
 workflow.
 
 Open `your-project/` in Kiro IDE. The install ships:

--- a/docs/guide/harnesses/kiro-ide.md
+++ b/docs/guide/harnesses/kiro-ide.md
@@ -57,6 +57,7 @@ rm -f \
 cp -R dist/kiro-ide/.kiro/. your-project/.kiro/
 cp -R dist/kiro-ide/aidlc/. your-project/aidlc/     # the workspace shell (spaces/default/memory) — a sibling of .kiro/, not inside it
 cp dist/kiro-ide/AGENTS.md your-project/AGENTS.md   # merge if you already have one
+cp dist/kiro-ide/.gitignore your-project/.gitignore # merge if you already have one
 ```
 
 The first removal loop is the v2.5.57 hook-name migration. The second removes
@@ -72,6 +73,15 @@ The `aidlc/` directory is the workspace shell — it ships the pre-built
 `aidlc/spaces/default/memory/` method tree the engine reads. It is a **sibling**
 of `.kiro/`, so copy it separately (or copy the whole `dist/kiro-ide/` tree at
 once). `/aidlc --doctor` fails its "workspace shell ready" check if it is missing.
+
+The shipped `.gitignore` carries the workspace's commit/ignore split: the
+per-user cursors (`aidlc/active-space`, `aidlc/spaces/*/intents/active-intent`)
+and machine-local runtime (`aidlc/.aidlc-clone-id`, `runtime-graph.json`, sensor
+caches, `spaces/*/knowledge/.sources.local.json`) stay untracked, while the
+shared records — method memory, state, audit shards, artifacts — travel with
+git. The `## Git Integration` section of the installed `AGENTS.md` states those
+rules are already in place, so copy or merge the file before your first
+workflow.
 
 Open `your-project/` in Kiro IDE. The install ships:
 


### PR DESCRIPTION
Closes #959.

## What

Adds the missing `.gitignore` step to the three copy-based install paths that
never had it — Claude Code, Kiro IDE, Kiro CLI:

```bash
cp -r dist/claude/.claude/ your-project/.claude/
cp -r dist/claude/aidlc/   your-project/aidlc/
cp    dist/claude/.gitignore your-project/.gitignore # merge if you already have one
```

- `README.md` — the copy line in the Claude Code / Kiro IDE / Kiro CLI blocks, the
  file named in the harness table, and one sentence on what the split is.
- `docs/guide/01-getting-started.md` — the same line in Installation Step 1
  (Claude Code, Kiro CLI) and in the Quick Reference, plus a paragraph naming what
  lands in git without it.
- `docs/guide/harnesses/kiro-cli.md`, `docs/guide/harnesses/kiro-ide.md` — the same
  line and paragraph.

## Why

`harness/<name>/manifest.ts` emits `dist/<harness>/.gitignore` as a projectRoot
file for all seven harnesses (`tests/harness/harness-matrix.ts` lists it in
`rootFiles`), and every shipped onboarding file says, present tense, that "The
shipped `.gitignore` excludes the per-user cursors and machine-local runtime".
Codex/opencode/Copilot readers are told to apply those entries (README:240, 308,
341) and Cursor's `install.ts` merges them, but Claude Code and both Kiro trees
were never told about the file — so the documented happy path leaves a workspace
with no ignore rules, and `--doctor`'s own advisory (`git add aidlc/ && git commit
&& git push`) then commits the per-user cursor.

## Verification

- Ran the corrected Claude Code steps into a fresh `git init` project (macOS 14.6,
  bun 1.4.0, AI-DLC 2.6.120). `git add -A` now stages only the eight shared
  method-memory files; `aidlc/active-space` is ignored. The doctor advisory drops
  from "9 uncommitted change(s) under aidlc/" to 8 — the difference is exactly the
  cursor — and `--doctor` stays at **50 passed, 0 failed**.
- `bun scripts/package.ts --check` → "all harness trees in sync with core/ +
  harness/." (documentation only; no `core/`, `harness/` or `dist/` file touched).
- `markdownlint-cli2` with the repo config: clean on `README.md` (the CI job's
  globs) and on the changed guide chapters. `docs/guide/harnesses/kiro-ide.md`
  reports one MD032 that pre-dates this change (present at ea060628, outside the
  CI globs), so I left it alone rather than mixing in an unrelated fix.
- Not exercised on Windows CMD / PowerShell. The added line is the same POSIX `cp`
  form as the lines it sits beside in the same block, so it carries the same
  platform assumptions as the existing steps — happy to reshape it if you want a
  Windows-safe variant alongside.
- No version bump or CHANGELOG entry, per the Changelog Policy for pure docs.

## Note on scope

If the preferred fix is the installer direction (#722 / #756, closed #721), treat
this as the stopgap for the copy-based install that ships today — or close it and
I'll follow the installer instead.
