### PR TITLE
docs: Add DeepWiki badge for questions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ We're excited to announce the general availability of AI-DLC Workflows 2.0. The 
 <!-- TODO: Replace this Amplify URL with a permanent/stable URL when available -->
 AI-DLC is an intelligent software development workflow that adapts to your needs, maintains quality standards, and keeps you in control of the process. For learning more about AI-DLC Methodology, read this [blog](https://aws.amazon.com/blogs/devops/ai-driven-development-life-cycle/) and the [Method Definition Paper](https://prod.d13rzhkk8cj2z0.amplifyapp.com/) referenced in it.
 
+**Questions?:** [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/awslabs/aidlc-workflows)
+
 ## Table of Contents
 
 - [Common](#common)


### PR DESCRIPTION
# Summary

Added a DeepWiki badge link to the README so users can easily find where to ask questions about AI-DLC.

## Changes

- Added a "Questions?" section with a DeepWiki badge linking to `https://deepwiki.com/awslabs/aidlc-workflows`
- Positioned between the introductory description and the Table of Contents

## User experience

**Before:** Users had no clear path in the README to ask questions or get help about AI-DLC.

**After:** Users see a prominent "Questions?" badge that links directly to the DeepWiki page for the project, making it easy to find community support.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [[contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test Plan

1. Verify the badge image renders correctly in the README preview
2. Click the badge and confirm it navigates to `https://deepwiki.com/awslabs/aidlc-workflows`
3. Confirm no layout/formatting issues with surrounding content

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).