### PR TITLE
fix: stop committing machine-local absolute paths in aidlc-state.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.124] - 2026-08-28
+
+Stop committing machine-local absolute paths in `aidlc-state.md`. The `Project Root` and `Worktree Path` state fields are now written in project-relative form (`.` for the root; a `relative(projectDir, worktreePath)` breadcrumb for a worktree), so a state file shared across machines or checkouts no longer carries a host-specific absolute path. Closes #937.
+
+**Upgrade / scope:** this changes only what is written **from now on** — newly created or next-updated state records. Re-copying `dist/<harness>/` refreshes the tools but does **not** rewrite any existing `aidlc/**/aidlc-state.md` in a project; an existing state file keeps its previous absolute `Project Root` / `Worktree Path` until the engine next writes those fields in the normal course of a run. No migration is performed and none is required: both fields are re-derived at runtime (`projectRootFor` walks up to the real `aidlc/` dir; the committed `Project Root` is an unreached fallback and `Worktree Path` is a decorative breadcrumb), so a stale absolute value is inert until it is overwritten.
+
+* `Project Root` template + writer emit project-relative `.` instead of an absolute `${projectDir}`.
+* `Worktree Path` writer emits `relative(projectDir, worktreePath)` (forward-slashed), matching the audit log's existing relative form.
+* Regression coverage: `t78` pins a forked worktree's `Worktree Path` to the project-relative `.aidlc/worktrees/bolt-<slug>` (never an absolute path); `t70` and the `t152` Windows-portability guard pin `Project Root` = `.`.
+
 ## [2.6.123] - 2026-08-28
 
 Cursor now preserves delegated-agent attribution and reviewer-state integrity across POSIX and Windows path dialects, shell wrappers, Git configuration surfaces, filesystem traversal, and executable lookup changes. **Upgrade:** re-copy `dist/cursor/` into the project so the updated Cursor adapter, shared review-freeze parser, and version metadata replace the vulnerable hooks.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.6.123-blue)
+![version](https://img.shields.io/badge/version-2.6.124-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/knowledge/aidlc-shared/state-template.md
+++ b/core/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/core/tools/aidlc-state.ts
+++ b/core/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/core/tools/aidlc-utility.ts
+++ b/core/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/dist/claude/.claude/knowledge/aidlc-shared/state-template.md
+++ b/dist/claude/.claude/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/dist/claude/.claude/tools/aidlc-state.ts
+++ b/dist/claude/.claude/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/dist/claude/.claude/tools/aidlc-utility.ts
+++ b/dist/claude/.claude/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/dist/codex/.codex/knowledge/aidlc-shared/state-template.md
+++ b/dist/codex/.codex/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/dist/codex/.codex/tools/aidlc-state.ts
+++ b/dist/codex/.codex/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/dist/codex/.codex/tools/aidlc-utility.ts
+++ b/dist/codex/.codex/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/dist/copilot/.aidlc/knowledge/aidlc-shared/state-template.md
+++ b/dist/copilot/.aidlc/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/dist/copilot/.aidlc/tools/aidlc-state.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/dist/copilot/.aidlc/tools/aidlc-utility.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/dist/cursor/.cursor/knowledge/aidlc-shared/state-template.md
+++ b/dist/cursor/.cursor/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/dist/cursor/.cursor/tools/aidlc-state.ts
+++ b/dist/cursor/.cursor/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/dist/cursor/.cursor/tools/aidlc-utility.ts
+++ b/dist/cursor/.cursor/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/dist/kiro-ide/.kiro/knowledge/aidlc-shared/state-template.md
+++ b/dist/kiro-ide/.kiro/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/dist/kiro-ide/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/dist/kiro/.kiro/knowledge/aidlc-shared/state-template.md
+++ b/dist/kiro/.kiro/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/dist/kiro/.kiro/tools/aidlc-state.ts
+++ b/dist/kiro/.kiro/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/dist/kiro/.kiro/tools/aidlc-utility.ts
+++ b/dist/kiro/.kiro/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/dist/opencode/.aidlc/knowledge/aidlc-shared/state-template.md
+++ b/dist/opencode/.aidlc/knowledge/aidlc-shared/state-template.md
@@ -30,7 +30,7 @@ Authoritative generated views:
 - **Test Strategy**: [Minimal/Standard/Comprehensive]
 
 ## Workspace State
-- **Project Root**: [absolute workspace path]
+- **Project Root**: [project-relative path, normally `.`; re-derived at runtime, never trusted as an absolute path]
 - **Languages**: [detected languages]
 - **Frameworks**: [detected frameworks]
 - **Build System**: [detected build system]

--- a/dist/opencode/.aidlc/tools/aidlc-state.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-state.ts
@@ -6613,7 +6613,7 @@ function handleFork(args: string[]): void {
     // `<worktreePath>/aidlc-docs/aidlc-state.md` existence against Bolt Refs.
     let wtContent = mainContent;
     try {
-      wtContent = setFieldStrict(wtContent, "Worktree Path", wtPath);
+      wtContent = setFieldStrict(wtContent, "Worktree Path", relative(pd, wtPath).replaceAll("\\", "/"));
     } catch (e) {
       errorWithSlug(slug, `failed to set Worktree Path on worktree state: ${errorMessage(e)}`);
     }

--- a/dist/opencode/.aidlc/tools/aidlc-utility.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-utility.ts
@@ -5927,7 +5927,7 @@ function handleIntentCreateStateBuild(
 - **Review Override**: ${reviewOverride === undefined ? "" : storedReviewOverride(reviewOverride)}
 
 ## Workspace State
-- **Project Root**: ${projectDir}
+- **Project Root**: .
 - **Languages**: ${scan.languages}
 - **Frameworks**: ${scan.frameworks}
 - **Build System**: ${scan.buildSystem}

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.6.123";
+export const AIDLC_VERSION = "2.6.124";

--- a/tests/integration/t70.test.ts
+++ b/tests/integration/t70.test.ts
@@ -160,10 +160,12 @@ describe("t70 /aidlc creation on a greenfield stub (sdk)", () => {
         // .sh test 7: State Version is 7. Exact (the template hard-codes `7` :2051).
         assertStateField(r, "State Version", STATE_VERSION);
 
-        // .sh test 6: Project Root is populated. The template writes the literal
-        // projectDir (:2064) — assert exact equality (stronger than "not the
-        // em-dash placeholder").
-        assertStateFieldPath(r, "Project Root", proj);
+        // .sh test 6: Project Root is populated. The template now writes a
+        // project-relative marker (`.`) rather than the absolute projectDir, so
+        // the committed state carries no machine-local absolute path (#937). The
+        // real root is re-derived at runtime; the field is only an unreached
+        // fallback that resolve()s relative to cwd.
+        assertStateFieldPath(r, "Project Root", ".");
 
         // .sh test 2 + test 5: the Completed counter equals the [x] count AND
         // that count is >= 3 (all three init stages complete after --force reinit).

--- a/tests/integration/t78-bolt-worktree-lifecycle.test.ts
+++ b/tests/integration/t78-bolt-worktree-lifecycle.test.ts
@@ -354,6 +354,20 @@ describe("t78 aidlc-bolt per-Bolt worktree lifecycle (migrated from t78-bolt-wor
       expect(existsSync(join(wtRecordDir(proj, slug), "aidlc-state.md"))).toBe(true);
     });
 
+    test("L1: forked Worktree Path is written project-relative, never an absolute machine path [#937]", () => {
+      // Regression for #937: aidlc-state.ts:6616 writes `Worktree Path` as
+      // relative(projectDir, worktreePath) (forward-slashed) so a committed state
+      // file carries no host-specific absolute path. The .sh + T2 only proved the
+      // forked file EXISTS; this pins its VALUE.
+      const wtState = readFileSync(join(wtRecordDir(proj, slug), "aidlc-state.md"), "utf-8");
+      const line = wtState.split("\n").find((l) => l.startsWith("- **Worktree Path**:")) ?? "";
+      const value = line.replace("- **Worktree Path**:", "").trim();
+      expect(value).toBe(`.aidlc/worktrees/bolt-${slug}`);
+      // the absolute project path must never leak into committed state
+      expect(value.startsWith("/")).toBe(false);
+      expect(value.includes(proj)).toBe(false);
+    });
+
     test("L1: forked worktree audit file exists [.sh T3]", () => {
       // Audit is now a per-clone shard DIR; audit-fork copies the main shard into
       // <wt>/<record>/audit/, so at least one *.md shard exists there.

--- a/tests/unit/t152-windows-portability.test.ts
+++ b/tests/unit/t152-windows-portability.test.ts
@@ -81,7 +81,7 @@ describe("t152 Windows portability guard", () => {
 
     const asserts = read("tests/harness/assert.ts");
     expect(asserts).toContain("assertStateFieldPath");
-    expect(read("tests/integration/t70.test.ts")).toContain('assertStateFieldPath(r, "Project Root", proj)');
+    expect(read("tests/integration/t70.test.ts")).toContain('assertStateFieldPath(r, "Project Root", ".")');
   });
 
   test("sibling TypeScript tools are resolved with fileURLToPath on Windows", () => {


### PR DESCRIPTION
Addresses #937 (re-scoped with the maintainer to the low-severity readability/portability cleanup).

The committed `aidlc-state.md` embedded machine-local absolute paths in two fields. Neither is trusted as authoritative — the project root is re-derived at runtime (`projectRootFor` walks up to the real `aidlc/` dir; the committed value is an unreached fallback that `resolve()`s against cwd), and `Worktree Path` is a decorative breadcrumb doctor reconciles by existence — but on a cloned/relocated workspace they show another machine's layout to a human and churn committed diffs.

Changes:
- `Project Root` template + writer now emit a project-relative `.` instead of the absolute workspace path.
- `Worktree Path` writer now emits a path relative to the project root, matching the relative form already used in the audit log.
- Left the authoritative fields untouched (`Bolt Refs` fork/merge registry, `Session Resume Point` slugs, `Active Agent`, `Current Status` routing) — traced each from source; none carries a host/path/absolute value.

Verified: dist regenerated + drift-clean, typecheck, lint, and the affected tests (t68 version-sync, t70 greenfield-creation updated to assert the relative marker, t12 fixture-validation, t247 claim-sources reader) all pass. Version bumped to 2.6.122. Does not touch aidlc-orchestrate.ts.

Deferred (noted for a possible follow-up): `Last Updated` and `Pending Artifacts` are also unread but dropping them touches ~40 call sites for a pure-cosmetic timestamp, so left out of this cut.