### PR TITLE
docs(v2): fix Mermaid node label contrast in dark mode

### DIFF
--- a/docs/guide/04-phases-and-stages.md
+++ b/docs/guide/04-phases-and-stages.md
@@ -51,11 +51,11 @@ graph LR
     C7 -->|"Verification Gate 3"| O1
     O7 -.->|"Feedback Loop"| I1
 
-    style INITIALIZATION fill:#f3e5f5,stroke:#9c27b0
-    style IDEATION fill:#e8f5e9,stroke:#4caf50
-    style INCEPTION fill:#e3f2fd,stroke:#2196f3
-    style CONSTRUCTION fill:#fff3e0,stroke:#ff9800
-    style OPERATION fill:#fce4ec,stroke:#e91e63
+    style INITIALIZATION fill:#f3e5f5,stroke:#9c27b0,color:#000
+    style IDEATION fill:#e8f5e9,stroke:#4caf50,color:#000
+    style INCEPTION fill:#e3f2fd,stroke:#2196f3,color:#000
+    style CONSTRUCTION fill:#fff3e0,stroke:#ff9800,color:#000
+    style OPERATION fill:#fce4ec,stroke:#e91e63,color:#000
 ```
 
 <!-- Text fallback: Linear flow: INITIALIZATION (0.1-0.3) auto-proceeds to IDEATION (1.1-1.7), which passes through Verification Gate 1 to INCEPTION (2.1-2.9), through Verification Gate 2 to CONSTRUCTION (3.1-3.7), through Verification Gate 3 to OPERATION (4.1-4.7). A feedback loop returns from 4.7 back to 1.1. -->
@@ -110,14 +110,14 @@ flowchart TD
     S16 -.->|CONDITIONAL| S17
     S17 ==>|ALWAYS| VG1
 
-    style S11 fill:#c8e6c9,stroke:#388e3c
-    style S14 fill:#c8e6c9,stroke:#388e3c
-    style S17 fill:#c8e6c9,stroke:#388e3c
-    style S12 fill:#fff9c4,stroke:#f9a825
-    style S13 fill:#fff9c4,stroke:#f9a825
-    style S15 fill:#fff9c4,stroke:#f9a825
-    style S16 fill:#fff9c4,stroke:#f9a825
-    style VG1 fill:#ef9a9a,stroke:#c62828
+    style S11 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S14 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S17 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S12 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S13 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S15 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S16 fill:#fff9c4,stroke:#f9a825,color:#000
+    style VG1 fill:#ef9a9a,stroke:#c62828,color:#000
 ```
 
 <!-- Text fallback: 1.1 Intent Capture (ALWAYS) flows to 1.2 Market Research (CONDITIONAL) or directly to 1.4. 1.2 flows to 1.3 Feasibility (CONDITIONAL) or to 1.4. 1.3 flows to 1.4 Scope Definition (ALWAYS). 1.4 flows to 1.5 Team Formation (CONDITIONAL) or to 1.7. 1.5 flows to 1.6 Rough Mockups (CONDITIONAL, skip if no UI) or to 1.7. 1.6 flows to 1.7 Approval & Handoff (ALWAYS), then Verification Gate 1. -->
@@ -188,17 +188,17 @@ flowchart TD
     S2C ==>|ALWAYS| S27
     S27 ==>|ALWAYS| VG2
 
-    style S21 fill:#bbdefb,stroke:#1565c0
-    style S2P fill:#fff9c4,stroke:#f9a825
-    style S22 fill:#c8e6c9,stroke:#388e3c
-    style S26 fill:#c8e6c9,stroke:#388e3c
-    style S27 fill:#c8e6c9,stroke:#388e3c
-    style S23 fill:#fff9c4,stroke:#f9a825
-    style S24 fill:#fff9c4,stroke:#f9a825
-    style S25 fill:#fff9c4,stroke:#f9a825
-    style S2C fill:#fff9c4,stroke:#f9a825
-    style VG2 fill:#ef9a9a,stroke:#c62828
-    style RE_DETAIL fill:#e8eaf6,stroke:#3f51b5
+    style S21 fill:#bbdefb,stroke:#1565c0,color:#000
+    style S2P fill:#fff9c4,stroke:#f9a825,color:#000
+    style S22 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S26 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S27 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S23 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S24 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S25 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S2C fill:#fff9c4,stroke:#f9a825,color:#000
+    style VG2 fill:#ef9a9a,stroke:#c62828,color:#000
+    style RE_DETAIL fill:#e8eaf6,stroke:#3f51b5,color:#000
 ```
 
 <!-- Text fallback: Brownfield check (from stage 0.3). If yes, 2.1 Reverse Engineering runs as a two-link pipeline (developer code scan then architect synthesis-and-write). Then 2.2 Practices Discovery runs as a hub-and-spoke on every included scope (lead draft, mutually blind quality/developer/devsecops spokes, human interview, lead integration) and promotes affirmed work to active-space memory. Next are 2.3 Requirements Analysis (ALWAYS), optional 2.4 User Stories mob, optional 2.5 Refined Mockups, optional 2.6 Domain Design, 2.7 Units Generation (ALWAYS), optional 2.8 Contract Design, and 2.9 Delivery Planning (ALWAYS), followed by Verification Gate 2. -->
@@ -268,15 +268,15 @@ flowchart TD
     S36 -.->|"skip CI if\nnot in scope"| VG3
     S37 -.-> VG3
 
-    style STAGE1 fill:#bbdefb,stroke:#1565c0
-    style GATE1 fill:#ffcc80,stroke:#e65100
-    style LADDER fill:#fff59d,stroke:#f57f17
-    style MODE_AUTO fill:#c8e6c9,stroke:#388e3c
-    style MODE_GATED fill:#f8bbd0,stroke:#c2185b
-    style NEXT fill:#bbdefb,stroke:#1565c0
-    style S36 fill:#c8e6c9,stroke:#388e3c
-    style S37 fill:#fff9c4,stroke:#f9a825
-    style VG3 fill:#ef9a9a,stroke:#c62828
+    style STAGE1 fill:#bbdefb,stroke:#1565c0,color:#000
+    style GATE1 fill:#ffcc80,stroke:#e65100,color:#000
+    style LADDER fill:#fff59d,stroke:#f57f17,color:#000
+    style MODE_AUTO fill:#c8e6c9,stroke:#388e3c,color:#000
+    style MODE_GATED fill:#f8bbd0,stroke:#c2185b,color:#000
+    style NEXT fill:#bbdefb,stroke:#1565c0,color:#000
+    style S36 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S37 fill:#fff9c4,stroke:#f9a825,color:#000
+    style VG3 fill:#ef9a9a,stroke:#c62828,color:#000
 ```
 
 <!-- Text fallback: Begin Construction → read unit-of-work-dependency.md for the Unit DAG (bolt-plan.md is planning) → run the first in-scope Construction EXECUTE stage for every Unit → walking-skeleton gate → ladder prompt (autonomous skips remaining stage gates; gated keeps them) → remaining stages stage-major, Code Generation last → 3.6 Build and Test then optionally 3.7 CI Pipeline → Verification Gate 3. -->
@@ -306,14 +306,14 @@ flowchart LR
     B --> GBC
     C --> GBC
 
-    style S1 fill:#bbdefb,stroke:#1565c0
-    style GA fill:#ffcc80,stroke:#e65100
-    style L fill:#fff59d,stroke:#f57f17
-    style A fill:#bbdefb,stroke:#1565c0
-    style B fill:#bbdefb,stroke:#1565c0
-    style C fill:#bbdefb,stroke:#1565c0
-    style CG fill:#fff3e0,stroke:#e65100
-    style GBC fill:#ffcc80,stroke:#e65100
+    style S1 fill:#bbdefb,stroke:#1565c0,color:#000
+    style GA fill:#ffcc80,stroke:#e65100,color:#000
+    style L fill:#fff59d,stroke:#f57f17,color:#000
+    style A fill:#bbdefb,stroke:#1565c0,color:#000
+    style B fill:#bbdefb,stroke:#1565c0,color:#000
+    style C fill:#bbdefb,stroke:#1565c0,color:#000
+    style CG fill:#fff3e0,stroke:#e65100,color:#000
+    style GBC fill:#ffcc80,stroke:#e65100,color:#000
 ```
 
 <!-- Text fallback: The first Construction EXECUTE stage runs for every eligible Unit, then one walking-skeleton gate and the ladder prompt. Remaining design stages stay stage-major. At Code Generation, Unit A can unblock B and C so those two may run as a parallel batch. Under an autonomous swarm, one Code Generation stage gate covers the stage after the final DAG batch converges. -->
@@ -372,15 +372,15 @@ flowchart TD
     S47 -->|"Approve"| DONE(["Workflow Complete"])
     S47 -->|"Start New Cycle"| IDEATION(["Return to Ideation 1.1"])
 
-    style S41 fill:#fce4ec,stroke:#c62828
-    style S42 fill:#fce4ec,stroke:#c62828
-    style S43 fill:#fce4ec,stroke:#c62828
-    style S44 fill:#fce4ec,stroke:#c62828
-    style S45 fill:#fce4ec,stroke:#c62828
-    style S46 fill:#fce4ec,stroke:#c62828
-    style S47 fill:#fce4ec,stroke:#c62828
-    style DONE fill:#a5d6a7,stroke:#2e7d32
-    style IDEATION fill:#e8f5e9,stroke:#4caf50
+    style S41 fill:#fce4ec,stroke:#c62828,color:#000
+    style S42 fill:#fce4ec,stroke:#c62828,color:#000
+    style S43 fill:#fce4ec,stroke:#c62828,color:#000
+    style S44 fill:#fce4ec,stroke:#c62828,color:#000
+    style S45 fill:#fce4ec,stroke:#c62828,color:#000
+    style S46 fill:#fce4ec,stroke:#c62828,color:#000
+    style S47 fill:#fce4ec,stroke:#c62828,color:#000
+    style DONE fill:#a5d6a7,stroke:#2e7d32,color:#000
+    style IDEATION fill:#e8f5e9,stroke:#4caf50,color:#000
 ```
 
 <!-- Text fallback: All Operation stages are CONDITIONAL. 4.1 through 4.7 flow sequentially. Stage 4.7 can either complete the workflow or loop back to start a new Ideation cycle at 1.1. -->

--- a/docs/guide/06-agents.md
+++ b/docs/guide/06-agents.md
@@ -72,11 +72,11 @@ flowchart TD
     DLA -->|"delivery plan"| DEVA
     OA ==>|"feedback loop:\noperational insights"| PA
 
-    style ORCH fill:#e1bee7,stroke:#7b1fa2
-    style PA fill:#c8e6c9,stroke:#388e3c
-    style OA fill:#fce4ec,stroke:#c62828
-    style DEVA fill:#fff3e0,stroke:#e65100
-    style AA fill:#bbdefb,stroke:#1565c0
+    style ORCH fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style PA fill:#c8e6c9,stroke:#388e3c,color:#000
+    style OA fill:#fce4ec,stroke:#c62828,color:#000
+    style DEVA fill:#fff3e0,stroke:#e65100,color:#000
+    style AA fill:#bbdefb,stroke:#1565c0,color:#000
 ```
 
 <!-- Text fallback: The SKILL.md conductor delegates to all 11 agents. Key flows: aidlc-product-agent sends requirements/stories to aidlc-architect-agent, who sends specs to aidlc-developer-agent. aidlc-developer-agent sends code to aidlc-quality-agent, who sends test results back. aidlc-aws-platform-agent provisions infrastructure for aidlc-pipeline-deploy-agent, who deploys for aidlc-operations-agent. The feedback loop: aidlc-operations-agent sends operational insights back to aidlc-product-agent, closing the cycle. -->

--- a/docs/guide/07-interaction-modes.md
+++ b/docs/guide/07-interaction-modes.md
@@ -128,16 +128,16 @@ flowchart TD
 
     ADD_STAGE --> ADD_EXEC
 
-    style COMPLETE fill:#e8f5e9,stroke:#388e3c
-    style REPORT_AWAITING fill:#e3f2fd,stroke:#1565c0
-    style ASK fill:#bbdefb,stroke:#1565c0
-    style APPROVE fill:#a5d6a7,stroke:#2e7d32
-    style CHANGES fill:#fff9c4,stroke:#f9a825
-    style REPORT_REJECTED fill:#fff3e0,stroke:#ef6c00
-    style REPORT_REVISED fill:#e3f2fd,stroke:#1565c0
-    style ACCEPT fill:#ffccbc,stroke:#bf360c
-    style ADD_STAGE fill:#e1bee7,stroke:#7b1fa2
-    style NEXT_STAGE fill:#c8e6c9,stroke:#388e3c
+    style COMPLETE fill:#e8f5e9,stroke:#388e3c,color:#000
+    style REPORT_AWAITING fill:#e3f2fd,stroke:#1565c0,color:#000
+    style ASK fill:#bbdefb,stroke:#1565c0,color:#000
+    style APPROVE fill:#a5d6a7,stroke:#2e7d32,color:#000
+    style CHANGES fill:#fff9c4,stroke:#f9a825,color:#000
+    style REPORT_REJECTED fill:#fff3e0,stroke:#ef6c00,color:#000
+    style REPORT_REVISED fill:#e3f2fd,stroke:#1565c0,color:#000
+    style ACCEPT fill:#ffccbc,stroke:#bf360c,color:#000
+    style ADD_STAGE fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style NEXT_STAGE fill:#c8e6c9,stroke:#388e3c,color:#000
 ```
 
 <!-- Text fallback: Stage work completes, report awaiting-approval opens the gate (the engine records STAGE_AWAITING_APPROVAL), and AskUserQuestion presents the approval gate. Approve: report approved with the exact choice so the engine records GATE_APPROVED, completes, and routes; show progress; proceed. Request Changes: report rejected with the exact Request Changes choice and separate feedback (the engine records GATE_REJECTED), check revision count (if <3, note escape hatch coming, revise, report revised to re-open the gate, and re-present; if >=3, Accept-as-is becomes available). Accept as-is: report approved with that exact label. Add Skipped Stage (Ideation/Inception only): recompose the plan. The report calls own the gate's audit trail; no separate log entries are added for the gate prompt or choice. -->

--- a/docs/guide/08-knowledge.md
+++ b/docs/guide/08-knowledge.md
@@ -34,10 +34,10 @@ flowchart TD
     TK_SHARED -->|"Step 4"| AC
     TK_AGENT -->|"Step 5"| AC
 
-    style TIER1 fill:#e3f2fd,stroke:#1565c0
-    style TIER2 fill:#e8f5e9,stroke:#388e3c
-    style RULES fill:#fce4ec,stroke:#c62828
-    style CONTEXT fill:#f3e5f5,stroke:#7b1fa2
+    style TIER1 fill:#e3f2fd,stroke:#1565c0,color:#000
+    style TIER2 fill:#e8f5e9,stroke:#388e3c,color:#000
+    style RULES fill:#fce4ec,stroke:#c62828,color:#000
+    style CONTEXT fill:#f3e5f5,stroke:#7b1fa2,color:#000
 ```
 
 <!-- Text fallback: The resolved rule chain loads first, then Tier 1 methodology knowledge (shared, then agent-specific), then Tier 2 team knowledge (shared, then agent-specific). All feed into the agent context for stage execution. -->

--- a/docs/guide/11-session-management.md
+++ b/docs/guide/11-session-management.md
@@ -57,11 +57,11 @@ flowchart TD
     PARKED -->|Yes| UNPARK --> CONTINUE
     PARKED -->|No| CONTINUE
 
-    style START fill:#e1bee7,stroke:#7b1fa2
-    style RESUME_MENU fill:#bbdefb,stroke:#1565c0
-    style CONTINUE fill:#c8e6c9,stroke:#388e3c
-    style WARN fill:#ffcdd2,stroke:#c62828
-    style NO_STATE fill:#ffcdd2,stroke:#c62828
+    style START fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style RESUME_MENU fill:#bbdefb,stroke:#1565c0,color:#000
+    style CONTINUE fill:#c8e6c9,stroke:#388e3c,color:#000
+    style WARN fill:#ffcdd2,stroke:#c62828,color:#000
+    style NO_STATE fill:#ffcdd2,stroke:#c62828,color:#000
 ```
 
 <!-- Text fallback: bare /aidlc with state checks the recovery breadcrumb and shows four resume options; without state it starts scope detection. /aidlc --resume with state clears a park marker if needed and continues directly; without state it errors. /aidlc --resume --stage jumps to the named stage. -->

--- a/docs/guide/12-cli-commands.md
+++ b/docs/guide/12-cli-commands.md
@@ -97,7 +97,7 @@ flowchart TD
     Q2 -->|"Jump to a phase"| A6
     Q3 -->|"Verify setup"| A8
 
-    style START fill:#e1bee7,stroke:#7b1fa2
+    style START fill:#e1bee7,stroke:#7b1fa2,color:#000
 ```
 
 <!-- Text fallback: Starting a new workflow: use /aidlc classic (known scope) or /aidlc Build a payments API (auto-detect; the first intent auto-creates). Managing an existing workflow: /aidlc (resume), /aidlc --status (view progress), /aidlc --stage (jump to stage), /aidlc --phase (jump to phase). Verify setup: /aidlc --doctor (health check). -->

--- a/docs/guide/14-artifacts-reference.md
+++ b/docs/guide/14-artifacts-reference.md
@@ -143,9 +143,9 @@ flowchart LR
 
     CREATE --> REVIEW --> COMMIT --> CONSUME --> VERIFY
 
-    style CREATE fill:#e3f2fd,stroke:#2196f3
-    style REVIEW fill:#fff3e0,stroke:#ff9800
-    style VERIFY fill:#fce4ec,stroke:#e91e63
+    style CREATE fill:#e3f2fd,stroke:#2196f3,color:#000
+    style REVIEW fill:#fff3e0,stroke:#ff9800,color:#000
+    style VERIFY fill:#fce4ec,stroke:#e91e63,color:#000
 ```
 
 <!-- Text fallback: Stage creates artifact, reviewed at approval gate, committed to version control, consumed by downstream stages, verified at phase boundary. -->

--- a/docs/reference/01-architecture.md
+++ b/docs/reference/01-architecture.md
@@ -44,11 +44,11 @@ graph LR
     C7 -->|"Verification Gate 3"| O1
     O7 -.->|"Feedback Loop"| I1
 
-    style INITIALIZATION fill:#f3e5f5,stroke:#9c27b0
-    style IDEATION fill:#e8f5e9,stroke:#4caf50
-    style INCEPTION fill:#e3f2fd,stroke:#2196f3
-    style CONSTRUCTION fill:#fff3e0,stroke:#ff9800
-    style OPERATION fill:#fce4ec,stroke:#e91e63
+    style INITIALIZATION fill:#f3e5f5,stroke:#9c27b0,color:#000
+    style IDEATION fill:#e8f5e9,stroke:#4caf50,color:#000
+    style INCEPTION fill:#e3f2fd,stroke:#2196f3,color:#000
+    style CONSTRUCTION fill:#fff3e0,stroke:#ff9800,color:#000
+    style OPERATION fill:#fce4ec,stroke:#e91e63,color:#000
 ```
 
 ## Five Layers
@@ -200,9 +200,9 @@ flowchart LR
         TS1 --> TS2 --> TS3 --> TS4 --> TS5 --> TS6
     end
 
-    style INLINE fill:#e8f5e9,stroke:#4caf50
-    style SUBAGENT fill:#e3f2fd,stroke:#2196f3
-    style TWOSTEP fill:#fff3e0,stroke:#ff9800
+    style INLINE fill:#e8f5e9,stroke:#4caf50,color:#000
+    style SUBAGENT fill:#e3f2fd,stroke:#2196f3,color:#000
+    style TWOSTEP fill:#fff3e0,stroke:#ff9800,color:#000
 ```
 
 ### Conductor Inline Stage Execution

--- a/docs/reference/03-orchestrator.md
+++ b/docs/reference/03-orchestrator.md
@@ -202,12 +202,12 @@ flowchart TD
     SCOPE_DETECT -->|"Freeform text"| FREEFORM --> CONFIRM_SCOPE
     CONFIRM_SCOPE --> CREATE
 
-    style START fill:#e1bee7,stroke:#7b1fa2
-    style RESUME_MENU fill:#bbdefb,stroke:#1565c0
-    style CONTINUE fill:#c8e6c9,stroke:#388e3c
-    style CREATE fill:#c8e6c9,stroke:#388e3c
-    style WARN fill:#ffcdd2,stroke:#c62828
-    style NO_STATE fill:#ffcdd2,stroke:#c62828
+    style START fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style RESUME_MENU fill:#bbdefb,stroke:#1565c0,color:#000
+    style CONTINUE fill:#c8e6c9,stroke:#388e3c,color:#000
+    style CREATE fill:#c8e6c9,stroke:#388e3c,color:#000
+    style WARN fill:#ffcdd2,stroke:#c62828,color:#000
+    style NO_STATE fill:#ffcdd2,stroke:#c62828,color:#000
 ```
 
 ### State File Schema

--- a/docs/reference/04-stage-protocol.md
+++ b/docs/reference/04-stage-protocol.md
@@ -240,16 +240,16 @@ flowchart TD
 
     ADD_STAGE --> ADD_EXEC
 
-    style COMPLETE fill:#e8f5e9,stroke:#388e3c
-    style REPORT_AWAITING fill:#e3f2fd,stroke:#1565c0
-    style ASK fill:#bbdefb,stroke:#1565c0
-    style APPROVE fill:#a5d6a7,stroke:#2e7d32
-    style CHANGES fill:#fff9c4,stroke:#f9a825
-    style REPORT_REJECTED fill:#fff3e0,stroke:#ef6c00
-    style REPORT_REVISED fill:#e3f2fd,stroke:#1565c0
-    style ACCEPT fill:#ffccbc,stroke:#bf360c
-    style ADD_STAGE fill:#e1bee7,stroke:#7b1fa2
-    style NEXT_STAGE fill:#c8e6c9,stroke:#388e3c
+    style COMPLETE fill:#e8f5e9,stroke:#388e3c,color:#000
+    style REPORT_AWAITING fill:#e3f2fd,stroke:#1565c0,color:#000
+    style ASK fill:#bbdefb,stroke:#1565c0,color:#000
+    style APPROVE fill:#a5d6a7,stroke:#2e7d32,color:#000
+    style CHANGES fill:#fff9c4,stroke:#f9a825,color:#000
+    style REPORT_REJECTED fill:#fff3e0,stroke:#ef6c00,color:#000
+    style REPORT_REVISED fill:#e3f2fd,stroke:#1565c0,color:#000
+    style ACCEPT fill:#ffccbc,stroke:#bf360c,color:#000
+    style ADD_STAGE fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style NEXT_STAGE fill:#c8e6c9,stroke:#388e3c,color:#000
 ```
 
 ---

--- a/docs/reference/diagrams.md
+++ b/docs/reference/diagrams.md
@@ -55,11 +55,11 @@ graph LR
     C7 -->|"Verification Gate 3"| O1
     O7 -.->|"Feedback Loop"| I1
 
-    style INITIALIZATION fill:#f3e5f5,stroke:#9c27b0
-    style IDEATION fill:#e8f5e9,stroke:#4caf50
-    style INCEPTION fill:#e3f2fd,stroke:#2196f3
-    style CONSTRUCTION fill:#fff3e0,stroke:#ff9800
-    style OPERATION fill:#fce4ec,stroke:#e91e63
+    style INITIALIZATION fill:#f3e5f5,stroke:#9c27b0,color:#000
+    style IDEATION fill:#e8f5e9,stroke:#4caf50,color:#000
+    style INCEPTION fill:#e3f2fd,stroke:#2196f3,color:#000
+    style CONSTRUCTION fill:#fff3e0,stroke:#ff9800,color:#000
+    style OPERATION fill:#fce4ec,stroke:#e91e63,color:#000
 ```
 
 ---
@@ -91,14 +91,14 @@ flowchart TD
     S16 -.->|CONDITIONAL| S17
     S17 ==>|ALWAYS| VG1
 
-    style S11 fill:#c8e6c9,stroke:#388e3c
-    style S14 fill:#c8e6c9,stroke:#388e3c
-    style S17 fill:#c8e6c9,stroke:#388e3c
-    style S12 fill:#fff9c4,stroke:#f9a825
-    style S13 fill:#fff9c4,stroke:#f9a825
-    style S15 fill:#fff9c4,stroke:#f9a825
-    style S16 fill:#fff9c4,stroke:#f9a825
-    style VG1 fill:#ef9a9a,stroke:#c62828
+    style S11 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S14 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S17 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S12 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S13 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S15 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S16 fill:#fff9c4,stroke:#f9a825,color:#000
+    style VG1 fill:#ef9a9a,stroke:#c62828,color:#000
 ```
 
 ---
@@ -149,16 +149,16 @@ flowchart TD
     S28 -.->|CONDITIONAL| S27
     S27 ==>|ALWAYS| VG2
 
-    style S21 fill:#bbdefb,stroke:#1565c0
-    style S22 fill:#c8e6c9,stroke:#388e3c
-    style S27 fill:#c8e6c9,stroke:#388e3c
-    style S22a fill:#fff9c4,stroke:#f9a825
-    style S23 fill:#fff9c4,stroke:#f9a825
-    style S24 fill:#fff9c4,stroke:#f9a825
-    style S25 fill:#fff9c4,stroke:#f9a825
-    style S26 fill:#fff9c4,stroke:#f9a825
-    style VG2 fill:#ef9a9a,stroke:#c62828
-    style RE_DETAIL fill:#e8eaf6,stroke:#3f51b5
+    style S21 fill:#bbdefb,stroke:#1565c0,color:#000
+    style S22 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S27 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S22a fill:#fff9c4,stroke:#f9a825,color:#000
+    style S23 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S24 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S25 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S26 fill:#fff9c4,stroke:#f9a825,color:#000
+    style VG2 fill:#ef9a9a,stroke:#c62828,color:#000
+    style RE_DETAIL fill:#e8eaf6,stroke:#3f51b5,color:#000
 ```
 
 ---
@@ -196,15 +196,15 @@ flowchart TD
     S36 -.->|"skip CI if\nnot in scope"| VG3
     S37 -.-> VG3
 
-    style PER_STAGE fill:#fff3e0,stroke:#e65100
-    style S35 fill:#bbdefb,stroke:#1565c0
-    style S31 fill:#fff9c4,stroke:#f9a825
-    style S32 fill:#fff9c4,stroke:#f9a825
-    style S33 fill:#fff9c4,stroke:#f9a825
-    style S34 fill:#fff9c4,stroke:#f9a825
-    style S36 fill:#c8e6c9,stroke:#388e3c
-    style S37 fill:#fff9c4,stroke:#f9a825
-    style VG3 fill:#ef9a9a,stroke:#c62828
+    style PER_STAGE fill:#fff3e0,stroke:#e65100,color:#000
+    style S35 fill:#bbdefb,stroke:#1565c0,color:#000
+    style S31 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S32 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S33 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S34 fill:#fff9c4,stroke:#f9a825,color:#000
+    style S36 fill:#c8e6c9,stroke:#388e3c,color:#000
+    style S37 fill:#fff9c4,stroke:#f9a825,color:#000
+    style VG3 fill:#ef9a9a,stroke:#c62828,color:#000
 ```
 
 ---
@@ -233,15 +233,15 @@ flowchart TD
     S47 -->|"Approve"| DONE(["Workflow Complete"])
     S47 -->|"Start New Cycle"| IDEATION(["Return to Ideation 1.1"])
 
-    style S41 fill:#fce4ec,stroke:#c62828
-    style S42 fill:#fce4ec,stroke:#c62828
-    style S43 fill:#fce4ec,stroke:#c62828
-    style S44 fill:#fce4ec,stroke:#c62828
-    style S45 fill:#fce4ec,stroke:#c62828
-    style S46 fill:#fce4ec,stroke:#c62828
-    style S47 fill:#fce4ec,stroke:#c62828
-    style DONE fill:#a5d6a7,stroke:#2e7d32
-    style IDEATION fill:#e8f5e9,stroke:#4caf50
+    style S41 fill:#fce4ec,stroke:#c62828,color:#000
+    style S42 fill:#fce4ec,stroke:#c62828,color:#000
+    style S43 fill:#fce4ec,stroke:#c62828,color:#000
+    style S44 fill:#fce4ec,stroke:#c62828,color:#000
+    style S45 fill:#fce4ec,stroke:#c62828,color:#000
+    style S46 fill:#fce4ec,stroke:#c62828,color:#000
+    style S47 fill:#fce4ec,stroke:#c62828,color:#000
+    style DONE fill:#a5d6a7,stroke:#2e7d32,color:#000
+    style IDEATION fill:#e8f5e9,stroke:#4caf50,color:#000
 ```
 
 ---
@@ -307,11 +307,11 @@ flowchart TD
     DLA -->|"delivery plan"| DEVA
     OA ==>|"feedback loop:\noperational insights"| PA
 
-    style ORCH fill:#e1bee7,stroke:#7b1fa2
-    style PA fill:#c8e6c9,stroke:#388e3c
-    style OA fill:#fce4ec,stroke:#c62828
-    style DEVA fill:#fff3e0,stroke:#e65100
-    style AA fill:#bbdefb,stroke:#1565c0
+    style ORCH fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style PA fill:#c8e6c9,stroke:#388e3c,color:#000
+    style OA fill:#fce4ec,stroke:#c62828,color:#000
+    style DEVA fill:#fff3e0,stroke:#e65100,color:#000
+    style AA fill:#bbdefb,stroke:#1565c0,color:#000
 ```
 
 ---
@@ -365,10 +365,10 @@ flowchart LR
         MB1 --> MB2 --> MB3 --> MB4 --> MB5 --> MB6
     end
 
-    style INLINE fill:#e8f5e9,stroke:#4caf50
-    style SUBAGENT fill:#e3f2fd,stroke:#2196f3
-    style TWOSTEP fill:#fff3e0,stroke:#ff9800
-    style MOB fill:#f3e5f5,stroke:#9c27b0
+    style INLINE fill:#e8f5e9,stroke:#4caf50,color:#000
+    style SUBAGENT fill:#e3f2fd,stroke:#2196f3,color:#000
+    style TWOSTEP fill:#fff3e0,stroke:#ff9800,color:#000
+    style MOB fill:#f3e5f5,stroke:#9c27b0,color:#000
 ```
 
 ---
@@ -426,10 +426,10 @@ flowchart TD
     SCOPE_DETECT -->|"Freeform text"| FREEFORM --> CONFIRM_SCOPE
     CONFIRM_SCOPE --> CREATE
 
-    style START fill:#e1bee7,stroke:#7b1fa2
-    style RESUME_MENU fill:#bbdefb,stroke:#1565c0
-    style CREATE fill:#c8e6c9,stroke:#388e3c
-    style WARN fill:#ffcdd2,stroke:#c62828
+    style START fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style RESUME_MENU fill:#bbdefb,stroke:#1565c0,color:#000
+    style CREATE fill:#c8e6c9,stroke:#388e3c,color:#000
+    style WARN fill:#ffcdd2,stroke:#c62828,color:#000
 ```
 
 ---
@@ -529,16 +529,16 @@ flowchart TD
 
     ADD_STAGE --> ADD_EXEC
 
-    style COMPLETE fill:#e8f5e9,stroke:#388e3c
-    style REPORT_AWAITING fill:#e3f2fd,stroke:#1565c0
-    style ASK fill:#bbdefb,stroke:#1565c0
-    style APPROVE fill:#a5d6a7,stroke:#2e7d32
-    style CHANGES fill:#fff9c4,stroke:#f9a825
-    style REPORT_REJECTED fill:#fff3e0,stroke:#ef6c00
-    style REPORT_REVISED fill:#e3f2fd,stroke:#1565c0
-    style ACCEPT fill:#ffccbc,stroke:#bf360c
-    style ADD_STAGE fill:#e1bee7,stroke:#7b1fa2
-    style NEXT_STAGE fill:#c8e6c9,stroke:#388e3c
+    style COMPLETE fill:#e8f5e9,stroke:#388e3c,color:#000
+    style REPORT_AWAITING fill:#e3f2fd,stroke:#1565c0,color:#000
+    style ASK fill:#bbdefb,stroke:#1565c0,color:#000
+    style APPROVE fill:#a5d6a7,stroke:#2e7d32,color:#000
+    style CHANGES fill:#fff9c4,stroke:#f9a825,color:#000
+    style REPORT_REJECTED fill:#fff3e0,stroke:#ef6c00,color:#000
+    style REPORT_REVISED fill:#e3f2fd,stroke:#1565c0,color:#000
+    style ACCEPT fill:#ffccbc,stroke:#bf360c,color:#000
+    style ADD_STAGE fill:#e1bee7,stroke:#7b1fa2,color:#000
+    style NEXT_STAGE fill:#c8e6c9,stroke:#388e3c,color:#000
 ```
 
 ---
@@ -617,10 +617,10 @@ flowchart TD
         NS4 -->|"begin target stage"| IP4B
     end
 
-    style NORMAL fill:#e8f5e9,stroke:#4caf50
-    style SKIP fill:#fff9c4,stroke:#f9a825
-    style REDO fill:#e3f2fd,stroke:#2196f3
-    style JUMP fill:#fce4ec,stroke:#e91e63
+    style NORMAL fill:#e8f5e9,stroke:#4caf50,color:#000
+    style SKIP fill:#fff9c4,stroke:#f9a825,color:#000
+    style REDO fill:#e3f2fd,stroke:#2196f3,color:#000
+    style JUMP fill:#fce4ec,stroke:#e91e63,color:#000
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes #971 — Mermaid diagram node labels had poor contrast in dark mode across the `v2` docs.

Every colored Mermaid node used `style <NODE> fill:#xxxxxx,stroke:#xxxxxx` with no `color` set, so GitHub's dark theme rendered light-colored text on the same fixed pale fill, hurting readability. This PR pins `color:#000` on every such directive so labels stay black (and legible) in both light and dark mode.

## Change

- Appended `,color:#000` to all 170 `style ... fill:#...,stroke:#...` directives across 11 doc files under `docs/`.
- No fill/stroke colors changed, no diagram structure changed — text-color-only fix.
- Confirmed every `fill` value in scope is a pale/pastel shade, so black text is legible against all of them in both themes.

## Files changed (11, 170 directives)

- `docs/reference/diagrams.md` (68)
- `docs/guide/04-phases-and-stages.md` (50)
- `docs/guide/07-interaction-modes.md` (10)
- `docs/reference/04-stage-protocol.md` (10)
- `docs/reference/01-architecture.md` (8)
- `docs/reference/03-orchestrator.md` (6)
- `docs/guide/11-session-management.md` (5)
- `docs/guide/06-agents.md` (5)
- `docs/guide/08-knowledge.md` (4)
- `docs/guide/14-artifacts-reference.md` (3)
- `docs/guide/12-cli-commands.md` (1)

Other docs with Mermaid diagrams don't use colored `style` directives and are unaffected: `docs/reference/12-state-machine.md`, `docs/guide/10-state-and-audit.md`, `docs/guide/02-your-first-workflow.md`, `docs/reference/10-knowledge-system.md`, `docs/reference/agents/README.md`, `docs/reference/17-skill-system.md`, `docs/reference/06-hooks-and-tools.md`.

## Testing

- Verified via regex scan that all 170 original `style ... fill:#...,stroke:#...` lines now carry `,color:#000` and none were missed or double-patched.
- Rendered the changed pages on GitHub (fork branch) in both light and dark mode; labels are legible in both.
- Doc-only change — no code, tests, or `dist/` output affected, so no build/test suite run was required.

## Images
- Before Image
<img width="2008" height="1572" alt="image" src="https://github.com/user-attachments/assets/e5aec610-4df4-46af-afd2-52a98f4db13a" />

- After Image
<img width="1812" height="1552" alt="image" src="https://github.com/user-attachments/assets/d2b4e1d2-796e-41c8-95cc-58be511b1e16" />


## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
