### PR TITLE
fix(kiro-ide): scope plan-approval fallback guard to active workflows (#965)

### DIFF
--- a/dist/kiro-ide/.kiro/hooks/aidlc-kiro-adapter.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-kiro-adapter.ts
@@ -1502,7 +1502,7 @@ function buildForward(): Forward {
               };
             }
           }
-          if (Object.keys(toolArgs).length > 0 && toolName !== "execute_bash") {
+          if (state.active && Object.keys(toolArgs).length > 0 && toolName !== "execute_bash") {
             return {
               hook: "__legacy_plan_approval_block__",
               input: {

--- a/harness/kiro-ide/hooks/aidlc-kiro-adapter.ts
+++ b/harness/kiro-ide/hooks/aidlc-kiro-adapter.ts
@@ -1502,7 +1502,7 @@ function buildForward(): Forward {
               };
             }
           }
-          if (Object.keys(toolArgs).length > 0 && toolName !== "execute_bash") {
+          if (state.active && Object.keys(toolArgs).length > 0 && toolName !== "execute_bash") {
             return {
               hook: "__legacy_plan_approval_block__",
               input: {


### PR DESCRIPTION
## Summary

Fixes #965. The legacy plan-approval **fallback** guard in the kiro-ide adapter blocks every path-less, mutation-capable tool call that carries arguments, regardless of whether an AI-DLC workflow is active. On Kiro IDE this blocks all MCP tool calls and subagent dispatch during normal chat when no workflow is running.

## Root cause

In `harness/kiro-ide/hooks/aidlc-kiro-adapter.ts`, inside the `toolName === "" || mutationCapableTool(toolName)` block:

- The earlier guard (~line 1462) is correctly gated: `if (state.active && !state.approved && !LEGACY_PLANNING_WRITE_TOOLS.has(toolName))`.
- The fallback at line 1505 was **missing the `state.active` check**:

```js
if (Object.keys(toolArgs).length > 0 && toolName !== "execute_bash") {
  return { hook: "__legacy_plan_approval_block__", input: { reason:
    "Plan Approval blocked a mutation-capable payload whose target path is missing or unsupported." } };
}
```

So with no active workflow, that fallback still fires for any path-less tool with arguments.

## Fix

Add `state.active &&` to the fallback so it only engages during an active workflow:

```js
if (state.active && Object.keys(toolArgs).length > 0 && toolName !== "execute_bash") {
```

Code-generation protection is unchanged — the guard still applies whenever `state.active` is true.

## Reproduction

```
printf '%s' '{"toolName":"atlassian_search","toolArgs":{"query":"test"}}' \
  | bun .kiro/hooks/aidlc-kiro-adapter.ts plan-approval-guard
```

- Before: exit 2 (blocked), no active workflow present.
- After: exit 0. `execute_bash` and path-carrying write tools are unaffected either way.

Also validated live in Kiro IDE: after the change, a path-less read-only MCP tool call with arguments passes the guard and returns data.

## Notes

- Source edited in `harness/kiro-ide/`; `dist/kiro-ide/` regenerated with `bun scripts/package.ts kiro-ide`.
- `bun scripts/package.ts --check` and `biome check` both pass.
