### PR TITLE
fix: correlate tagged release dispatch runs

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -34,6 +34,41 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+
+      - name: Snapshot existing release runs
+        id: release_run_baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          TAG="${BRANCH#release/}"
+          KNOWN_RUN_IDS=""
+
+          for attempt in $(seq 1 5); do
+            RUNS_JSON=$(gh run list \
+              --workflow=release.yml \
+              --repo "$REPO" \
+              --limit 100 \
+              --json databaseId,headBranch,event 2>/dev/null || true)
+
+            if printf '%s\n' "$RUNS_JSON" | jq -e 'type == "array"' >/dev/null 2>&1; then
+              KNOWN_RUN_IDS=$(printf '%s\n' "$RUNS_JSON" | jq -c --arg tag "$TAG" \
+                '[.[] | select(.event == "workflow_dispatch" and .headBranch == $tag) | .databaseId]')
+              break
+            fi
+
+            echo "Could not read release workflow runs (attempt $attempt/5)"
+            sleep 2
+          done
+
+          if ! printf '%s\n' "$KNOWN_RUN_IDS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "::error::Could not establish a valid release-run baseline for $TAG. No tag was created."
+            exit 1
+          fi
+
+          echo "known_run_ids=$KNOWN_RUN_IDS" >> "$GITHUB_OUTPUT"
+
       - name: Create tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,15 +97,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
+          KNOWN_RUN_IDS: ${{ steps.release_run_baseline.outputs.known_run_ids }}
         run: |
           TAG="${BRANCH#release/}"
-          KNOWN_RUN_IDS=$(gh run list \
-            --workflow=release.yml \
-            --repo "$REPO" \
-            --limit 100 \
-            --json databaseId,headBranch,event | \
-            jq -c --arg tag "$TAG" \
-              '[.[] | select(.event == "workflow_dispatch" and .headBranch == $tag) | .databaseId]')
+
+          if ! printf '%s\n' "$KNOWN_RUN_IDS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "::error::Invalid release-run baseline for $TAG."
+            exit 1
+          fi
+
           echo "Dispatching release.yml on ref $TAG"
           gh workflow run release.yml --ref "$TAG" --repo "$REPO"
 

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -64,14 +64,34 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           TAG="${BRANCH#release/}"
+          KNOWN_RUN_IDS=$(gh run list \
+            --workflow=release.yml \
+            --repo "$REPO" \
+            --limit 100 \
+            --json databaseId,headBranch,event | \
+            jq -c --arg tag "$TAG" \
+              '[.[] | select(.event == "workflow_dispatch" and .headBranch == $tag) | .databaseId]')
           echo "Dispatching release.yml on ref $TAG"
           gh workflow run release.yml --ref "$TAG" --repo "$REPO"
 
-          # Wait for the run to appear, then watch it to completion
-          echo "Waiting for release workflow run to appear..."
+          # Find only a newly created workflow_dispatch run for this exact tag.
+          echo "Waiting for the release workflow run for $TAG to appear..."
           sleep 5
           for i in $(seq 1 12); do
-            RUN_ID=$(gh run list --workflow=release.yml --repo "$REPO" --json databaseId,headBranch,event,status --jq '[.[] | select(.event=="workflow_dispatch")] | first | .databaseId' 2>/dev/null || echo "")
+            RUN_ID=$(gh run list \
+              --workflow=release.yml \
+              --repo "$REPO" \
+              --limit 100 \
+              --json databaseId,headBranch,event | \
+              jq -r \
+                --arg tag "$TAG" \
+                --argjson known "$KNOWN_RUN_IDS" \
+                '[.[]
+                  | select(.event == "workflow_dispatch" and .headBranch == $tag)
+                  | .databaseId as $id
+                  | select(($known | index($id)) == null)]
+                | first
+                | .databaseId // empty' 2>/dev/null || echo "")
             if [[ -n "$RUN_ID" ]]; then
               break
             fi


### PR DESCRIPTION
## Summary

- capture the existing `release.yml` dispatch run IDs for the target tag before dispatch
- select only a newly created `workflow_dispatch` run whose `headBranch` matches that exact tag
- prevent concurrent default-branch forwarders from making `tag-on-merge.yml` watch an unrelated release run

Companion fix for #991.

## Validation

Not run, per maintainer request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).