### PR TITLE
fix: Frontend mockups design artefacts are not flowing to the downstream stages (#999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.7.2] - 2026-09-02
+
+Close the design-intent contract so an approved layout reaches code generation by declaration rather than by an agent happening to read an undeclared file. Rough/refined mockups previously had no downstream consumer: `functional-design` re-authored the layout without citing the wireframes, and `code-generation` had no declared UI-design input — so a section order that lived only in an ASCII diagram could silently invert with nothing flagging it. `requirements-analysis`, `functional-design`, and `code-generation` now declare the mockup artifacts (`wireframes`, `user-flow`, `mockups`, `interaction-spec`) and `frontend-components` as optional inputs, read them when present, and are instructed to preserve the approved screen composition — including top-to-bottom section order — or record a deviation. All additions are `required: false`, so non-UI initiatives and scopes that skip the mockup stages are unaffected. **Upgrade:** replace the `dist/<harness>/` tree; no workflow state migration is required. Closes #999.
+
+* `functional-design`'s `frontend-components.md` must now cite the mockup it derives a UI layout from; on UI units the `upstream-coverage` sensor (advisory) will flag a mockup artifact that exists on disk but is never referenced.
+* `code-generation` now lists `frontend-components`, `mockups`, `interaction-spec`, and `wireframes` as consumed inputs and carries a Critical Rule to follow the approved layout order.
+
 ## [2.7.1] - 2026-09-01
 
 Fix a Plan Approval deadlock that made Code Generation unreachable on solo (non-team) workflows. The Stop hook's read-only `next` probe published the durable active-directive marker on every turn boundary, which bumped the Code Generation authority revision and reset the plan-approval runtime, so the approval challenge minted while answering "Approve Plan" was destroyed before its receipt could be written. The probe no longer publishes that marker for any workflow, matching the read-only contract it already advertised. **Upgrade:** replace the `dist/<harness>/` tree; no workflow state migration is required. Closes #995.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.7.1-blue)
+![version](https://img.shields.io/badge/version-2.7.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/stages/construction/code-generation.md
+++ b/core/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/core/aidlc-common/stages/construction/functional-design.md
+++ b/core/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/core/aidlc-common/stages/inception/requirements-analysis.md
+++ b/core/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun {{HARNESS_DIR}}/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/dist/claude/.claude/aidlc-common/stages/construction/functional-design.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/dist/claude/.claude/aidlc-common/stages/inception/requirements-analysis.md
+++ b/dist/claude/.claude/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun .claude/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/claude/.claude/tools/data/stage-graph.json
+++ b/dist/claude/.claude/tools/data/stage-graph.json
@@ -977,6 +977,14 @@
       {
         "artifact": "team-practices",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "user-flow",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1734,6 +1742,18 @@
       {
         "artifact": "contract-summary",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1760,7 +1780,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "summary_confirmation": "required",
-    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
     "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
     "rules_in_context": [
       {
@@ -2359,6 +2379,22 @@
       {
         "artifact": "requirements",
         "required": true
+      },
+      {
+        "artifact": "frontend-components",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
       }
     ],
     "requires_stage": [

--- a/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/dist/codex/.codex/aidlc-common/stages/construction/functional-design.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/dist/codex/.codex/aidlc-common/stages/inception/requirements-analysis.md
+++ b/dist/codex/.codex/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun .codex/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/codex/.codex/tools/data/stage-graph.json
+++ b/dist/codex/.codex/tools/data/stage-graph.json
@@ -977,6 +977,14 @@
       {
         "artifact": "team-practices",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "user-flow",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1734,6 +1742,18 @@
       {
         "artifact": "contract-summary",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1760,7 +1780,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "summary_confirmation": "required",
-    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
     "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
     "rules_in_context": [
       {
@@ -2359,6 +2379,22 @@
       {
         "artifact": "requirements",
         "required": true
+      },
+      {
+        "artifact": "frontend-components",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
       }
     ],
     "requires_stage": [

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/functional-design.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/dist/copilot/.aidlc/aidlc-common/stages/inception/requirements-analysis.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun .aidlc/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/copilot/.aidlc/tools/data/stage-graph.json
+++ b/dist/copilot/.aidlc/tools/data/stage-graph.json
@@ -977,6 +977,14 @@
       {
         "artifact": "team-practices",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "user-flow",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1734,6 +1742,18 @@
       {
         "artifact": "contract-summary",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1760,7 +1780,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "summary_confirmation": "required",
-    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
     "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
     "rules_in_context": [
       {
@@ -2359,6 +2379,22 @@
       {
         "artifact": "requirements",
         "required": true
+      },
+      {
+        "artifact": "frontend-components",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
       }
     ],
     "requires_stage": [

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/functional-design.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/dist/cursor/.cursor/aidlc-common/stages/inception/requirements-analysis.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun .cursor/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/cursor/.cursor/tools/data/stage-graph.json
+++ b/dist/cursor/.cursor/tools/data/stage-graph.json
@@ -977,6 +977,14 @@
       {
         "artifact": "team-practices",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "user-flow",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1734,6 +1742,18 @@
       {
         "artifact": "contract-summary",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1760,7 +1780,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "summary_confirmation": "required",
-    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
     "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
     "rules_in_context": [
       {
@@ -2359,6 +2379,22 @@
       {
         "artifact": "requirements",
         "required": true
+      },
+      {
+        "artifact": "frontend-components",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
       }
     ],
     "requires_stage": [

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/functional-design.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/inception/requirements-analysis.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun .kiro/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/kiro-ide/.kiro/tools/data/stage-graph.json
+++ b/dist/kiro-ide/.kiro/tools/data/stage-graph.json
@@ -977,6 +977,14 @@
       {
         "artifact": "team-practices",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "user-flow",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1734,6 +1742,18 @@
       {
         "artifact": "contract-summary",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1760,7 +1780,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "summary_confirmation": "required",
-    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
     "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
     "rules_in_context": [
       {
@@ -2359,6 +2379,22 @@
       {
         "artifact": "requirements",
         "required": true
+      },
+      {
+        "artifact": "frontend-components",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
       }
     ],
     "requires_stage": [

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/functional-design.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/dist/kiro/.kiro/aidlc-common/stages/inception/requirements-analysis.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun .kiro/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/kiro/.kiro/tools/data/stage-graph.json
+++ b/dist/kiro/.kiro/tools/data/stage-graph.json
@@ -977,6 +977,14 @@
       {
         "artifact": "team-practices",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "user-flow",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1734,6 +1742,18 @@
       {
         "artifact": "contract-summary",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1760,7 +1780,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "summary_confirmation": "required",
-    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
     "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
     "rules_in_context": [
       {
@@ -2359,6 +2379,22 @@
       {
         "artifact": "requirements",
         "required": true
+      },
+      {
+        "artifact": "frontend-components",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
       }
     ],
     "requires_stage": [

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -35,6 +35,14 @@ consumes:
     required: true
   - artifact: requirements
     required: true
+  - artifact: frontend-components
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
+  - artifact: wireframes
+    required: false
 requires_stage:
   - units-generation
   - functional-design
@@ -70,6 +78,7 @@ outputs: application code + code-generation-plan.md, code-generation-questions.m
 - Application code goes to workspace root, NEVER to the record dir
 - Brownfield: modify files in-place. NEVER create duplicates like ClassName_modified.java
 - Add data-testid attributes to interactive UI elements for test automation
+- UI code must follow the approved layout. When `frontend-components.md`, the refined mockups (`mockups.md`/`interaction-spec.md`), or the rough `wireframes.md` exist, preserve the screen composition they specify — including the top-to-bottom order of sections — rather than the order that happens to be convenient in code. A departure from the approved layout is allowed only when an upstream design artifact records it as a deliberate change.
 - Before review, write `source-manifest.json` listing every application-source path this unit created, modified, or deleted, including shell-, scaffolding-, and generator-written files
 - Measurable quality targets from NFR Requirements, NFR Design, and the Testing
   Contract coverage floor are inputs, not suggestions. NEVER relax, lower, or
@@ -88,6 +97,7 @@ Read all design artifacts for the current unit:
 - Unit definition from `<record>/inception/units-generation/unit-of-work.md` (if exists)
 - Story map from `<record>/inception/units-generation/unit-of-work-story-map.md` (if exists)
 - Requirements from `<record>/inception/requirements-analysis/requirements.md` (if exists)
+- For a UI unit, the approved layout: `frontend-components.md` in this unit's functional-design dir, the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`), and the rough `wireframes.md` from `<record>/ideation/rough-mockups/` (whichever exist). These are optional and absent for non-UI units or scopes that skip the mockup stages.
 
 Incremental scopes (bugfix, poc, refactor, security-patch) and the zero-Unit
 `express` scope skip Units Generation by design. When those inputs are absent,

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/functional-design.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/functional-design.md
@@ -36,6 +36,12 @@ consumes:
     required: true
   - artifact: contract-summary
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: mockups
+    required: false
+  - artifact: interaction-spec
+    required: false
 requires_stage:
   - units-generation
   - contract-design
@@ -52,7 +58,7 @@ scopes:
   - refactor
   - classic
   - workshop
-inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)
+inputs: unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)
 outputs: "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views."
 ---
 
@@ -83,6 +89,8 @@ Execute all steps sequentially as written.
 ### Step 1: Read Unit Context
 
 Read the unit definition from `<record>/inception/units-generation/unit-of-work.md` and assigned stories from `<record>/inception/units-generation/unit-of-work-story-map.md` (if they exist). Read `<record>/inception/requirements-analysis/requirements.md` (if exists), the component catalogue from `<record>/inception/domain-design/components.md` (if it exists), and the contracts for this unit's boundaries from `<record>/inception/contract-design/contract-summary.md` (if it exists).
+
+For a unit with frontend/UI, also read whichever mockups exist: the refined mockups from `<record>/inception/refined-mockups/` (`mockups.md`, `interaction-spec.md`) and, failing that, the rough wireframes from `<record>/ideation/rough-mockups/` (`wireframes.md`). These are the human-approved layout. When `frontend-components.md` re-authors any of it — component tree, screen composition, the top-to-bottom order of sections on a screen — reproduce the approved layout faithfully and cite the mockup you took it from. Do not silently reorder or drop a section that the approved design placed; if a design decision (e.g. an approved in-flight requirement change) supersedes the mockup, record that as an explicit deviation. These inputs are optional — absent for non-UI units and for scopes that skip the mockup stages; never invent their content.
 
 Incremental scopes (refactor) deliberately skip units-generation and domain-design, so those inputs are absent by design there. When an input is absent, work from what the scope does provide — the requirements and, on a brownfield workspace, the reverse-engineered code knowledge base at `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints) — and treat the existing code structure as the de-facto domain design. Never invent the content of a missing artifact.
 
@@ -116,7 +124,7 @@ Generate the following in `<record>/construction/{unit-name}/functional-design/`
 - **entities.md**: The entity model. Carries a fenced ```yaml source-of-truth block listing each entity with its description, attributes (name, logical type, required/unique, references, allowed values, defaults, min/max, constraints), entity-level constraints, and relationships (cardinality + direction). Follow the block with a short human-readable summary of the entity set.
 - **rules.md**: The business rules. Carries a fenced ```yaml source-of-truth block listing each numbered rule (`id: BRx.y`, e.g. `BR1.1` — the `BR{group}.{seq}` format the traceability sensor recognizes) with its statement, category (validation/authorization/constraint/calculation/policy), what it applies to, trigger, logic (IF…THEN in plain language), violation behaviour, and source (FR-n/NFR-n). Follow the block with a short human-readable rules summary table.
 - **functional-spec.md**: The behavioural specification. It is the **source of truth for workflows and state machines** — the numbered step sequences a use case follows and the lifecycle-entity state transitions — because `entities.md` (data shape) and `rules.md` (decision logic) do not capture ordered behaviour or transitions. It also carries two **derived** views for readability: an entity-relationship `mermaid` diagram (derived from `entities.md` — the YAML there is source of truth) and a rules summary (derived from `rules.md`). For a UI-only unit that produces `functional-spec.md` without `entities.md`/`rules.md`, this file is self-contained: it authoritatively specifies the interaction workflows and screen/state transitions from the unit definition and requirements, with no entity/rule dependency.
-- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points
+- **frontend-components.md** (CONDITIONAL — only if unit includes frontend/UI): Component hierarchy, props/state design, interaction flows, form validation rules, API integration points. Where the mockups (refined `mockups.md`/`interaction-spec.md`, or rough `wireframes.md`) exist, the component hierarchy and on-screen composition — including the top-to-bottom order of sections — must match the approved layout, and each screen must cite the mockup it derives from. Any intentional departure from the approved layout is a recorded deviation, not a silent one.
 
 Create
 `<record>/construction/{unit-name}/functional-design/traceability.json`.
@@ -168,7 +176,7 @@ This stage's outputs are markdown design artefacts under `<record>/construction/
 
 Imports: `required-sections`, `upstream-coverage`, `linter`, `type-check`, `traceability`.
 
-Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`.
+Upstream targets: `unit-of-work`, `unit-of-work-story-map`, `requirements`, `components`, `contract-summary`, `wireframes`, `mockups`, `interaction-spec`.
 
 `linter` and `type-check` inspect matching TypeScript/JavaScript snippets.
 `traceability` validates per-Unit acceptance-criteria coverage, checks

--- a/dist/opencode/.aidlc/aidlc-common/stages/inception/requirements-analysis.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/inception/requirements-analysis.md
@@ -30,6 +30,10 @@ consumes:
     conditional_on: brownfield
   - artifact: team-practices
     required: false
+  - artifact: wireframes
+    required: false
+  - artifact: user-flow
+    required: false
 requires_stage:
   - approval-handoff
   - reverse-engineering
@@ -59,6 +63,7 @@ outputs: requirements.md, requirements-analysis-questions.md (under this stage's
 ### Step 1: Load Prior Context
 
 - If brownfield: Read RE artifacts from `aidlc/spaces/<active-space>/codekb/<repo>/` (the directory `codekb-path --repo <repo>` prints)
+- If they exist, read the rough mockups from `<record>/ideation/rough-mockups/` (`wireframes.md`, `user-flow.md`). When a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), cite the wireframe rather than restating it as unattributed prose — that citation is what keeps the design decision auditable downstream. These inputs are optional: absent for non-UI initiatives and for scopes that skip rough-mockups; never invent their content.
 - Run the fixed command
   `bun .aidlc/tools/aidlc-utility.ts project-description` and use its
   returned `description` verbatim as the authoritative initial request. A
@@ -237,7 +242,7 @@ This stage's outputs are markdown artefacts under `<record>/inception/requiremen
 
 Imports: `required-sections`, `upstream-coverage`.
 
-Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`.
+Upstream targets: `intent-statement`, `scope-document`, `business-overview`, `architecture`, `code-structure`, `team-practices`, `wireframes`, `user-flow`.
 
 ## Learn
 

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/opencode/.aidlc/tools/data/stage-graph.json
+++ b/dist/opencode/.aidlc/tools/data/stage-graph.json
@@ -977,6 +977,14 @@
       {
         "artifact": "team-practices",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "user-flow",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1734,6 +1742,18 @@
       {
         "artifact": "contract-summary",
         "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
       }
     ],
     "requires_stage": [
@@ -1760,7 +1780,7 @@
     "reviewer_max_iterations": 2,
     "review_class": "adversarial",
     "summary_confirmation": "required",
-    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+    "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
     "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
     "rules_in_context": [
       {
@@ -2359,6 +2379,22 @@
       {
         "artifact": "requirements",
         "required": true
+      },
+      {
+        "artifact": "frontend-components",
+        "required": false
+      },
+      {
+        "artifact": "mockups",
+        "required": false
+      },
+      {
+        "artifact": "interaction-spec",
+        "required": false
+      },
+      {
+        "artifact": "wireframes",
+        "required": false
       }
     ],
     "requires_stage": [

--- a/tests/fixtures/designer-export/export.json
+++ b/tests/fixtures/designer-export/export.json
@@ -978,6 +978,14 @@
         {
           "artifact": "team-practices",
           "required": false
+        },
+        {
+          "artifact": "wireframes",
+          "required": false
+        },
+        {
+          "artifact": "user-flow",
+          "required": false
         }
       ],
       "requires_stage": [
@@ -1735,6 +1743,18 @@
         {
           "artifact": "contract-summary",
           "required": false
+        },
+        {
+          "artifact": "wireframes",
+          "required": false
+        },
+        {
+          "artifact": "mockups",
+          "required": false
+        },
+        {
+          "artifact": "interaction-spec",
+          "required": false
         }
       ],
       "requires_stage": [
@@ -1761,7 +1781,7 @@
       "reviewer_max_iterations": 2,
       "review_class": "adversarial",
       "summary_confirmation": "required",
-      "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced)",
+      "inputs": "unit-of-work.md, unit-of-work-story-map.md, requirements.md, domain-design components.md, contract-design contract-summary.md (if produced), mockups.md/interaction-spec.md or wireframes.md (if a UI unit and the mockups exist)",
       "outputs": "entities.md, rules.md, functional-spec.md, traceability.json, CONDITIONAL: frontend-components.md (under this stage's per-unit record dir, engine-resolved); per-kind applicability via produces_kinds (untagged unit: all). entities.md and rules.md each carry a fenced ```yaml source-of-truth block; functional-spec.md is the source of truth for workflows and state machines and carries derived ER-diagram and rules-summary views.",
       "rules_in_context": [
         {
@@ -2360,6 +2380,22 @@
         {
           "artifact": "requirements",
           "required": true
+        },
+        {
+          "artifact": "frontend-components",
+          "required": false
+        },
+        {
+          "artifact": "mockups",
+          "required": false
+        },
+        {
+          "artifact": "interaction-spec",
+          "required": false
+        },
+        {
+          "artifact": "wireframes",
+          "required": false
         }
       ],
       "requires_stage": [

--- a/tests/integration/t65.test.ts
+++ b/tests/integration/t65.test.ts
@@ -199,12 +199,37 @@ beforeAll(() => {
     }
   }
 
+  // Producer universe for OPTIONAL consumes: produces[] UNION
+  // optional_produces[]. Mirrors aidlc-graph.ts's producersOf(), which unions
+  // both so a CONDITIONAL output (functional-design's frontend-components,
+  // written only for a UI unit) still resolves to its producing stage.
+  const anyProduces = new Set<string>(produces);
+  for (const p of parsed) {
+    if (Array.isArray(p.obj.optional_produces)) {
+      for (const name of p.obj.optional_produces as unknown[]) {
+        if (typeof name === "string") anyProduces.add(name);
+      }
+    }
+  }
+
   // Consumer coverage: every consumes[].artifact has a producer.
+  //
+  // The bar depends on `required`, matching what the engine enforces in
+  // aidlc-graph.ts's validate seam (which skips `required: false` consumes):
+  //   - required: true  -> the producer must GUARANTEE the artifact, so it must
+  //     appear in some stage's produces[]. A required consume of a merely
+  //     optional output is an unsatisfiable contract: the producing stage may
+  //     legitimately never write it, starving a hard input.
+  //   - required: false -> produces[] UNION optional_produces[] is enough. The
+  //     consumer already handles absence, so a conditional producer is a valid
+  //     upstream (this is what lets code-generation declare frontend-components).
   const missingProducers: Aggregate["missingProducers"] = [];
   for (const p of parsed) {
     if (Array.isArray(p.obj.consumes)) {
       for (const c of p.obj.consumes as Array<Record<string, unknown>>) {
-        if (c && typeof c.artifact === "string" && !produces.has(c.artifact)) {
+        if (!c || typeof c.artifact !== "string") continue;
+        const universe = c.required === true ? produces : anyProduces;
+        if (!universe.has(c.artifact)) {
           missingProducers.push({ slug: p.slug, artifact: c.artifact });
         }
       }
@@ -519,6 +544,8 @@ describe("t65 produces[] union + slug shape (in-process)", () => {
 // ============================================================
 describe("t65 cross-stage integrity (in-process)", () => {
   // .sh #14: "every consumes[].artifact appears in some stage's produces[]"
+  // (required consumes need produces[]; optional ones may resolve to
+  // optional_produces[] too - see the missingProducers derivation above)
   test("every consumes[].artifact appears in some stage's produces[]", () => {
     expect(agg.missingProducers).toEqual([]);
   });


### PR DESCRIPTION
Closes #999.

## Problem

Design intent captured in a mockup had **no declared consumer downstream of inception**. `wireframes` was consumed only by `approval-handoff` and `refined-mockups`; `refined-mockups`' own outputs (`mockups`, `interaction-spec`, `design-system-mapping`, `accessibility-checklist`) had no construction-phase consumer at all. So the layout a human approved reached `code-generation` only because agents opportunistically read files that were not declared inputs — and the one dimension of that layout with no textual carrier (top-to-bottom section order) silently inverted, with no sensor or gate reporting it.

## Fix — close the contract

The chain is now declared end to end. Every addition is `required: false`, so non-UI initiatives and scopes that skip the mockup stages are unaffected.

| Stage | Added to `consumes` | Added instruction |
|---|---|---|
| `inception/requirements-analysis` | `wireframes`, `user-flow` | Read the rough mockups if present; when a requirement traces to something the wireframes decided (a screen, a flow, a layout choice), **cite the wireframe** rather than restating it as unattributed prose. |
| `construction/functional-design` | `wireframes`, `mockups`, `interaction-spec` | `frontend-components.md` must reproduce the approved screen composition — **including the top-to-bottom order of sections** — and cite the mockup it derives from. A departure is a recorded deviation, not a silent one. |
| `construction/code-generation` | `frontend-components`, `mockups`, `interaction-spec`, `wireframes` | New Critical Rule: UI code follows the approved layout, not the order that happens to be convenient in code. |

`upstream-coverage` targets were extended on `requirements-analysis` and `functional-design`, so a mockup artifact that exists on disk but is never referenced is now flagged (advisory).

This addresses directions **1**, **3**, and part of **4** from the issue. Direction 2 (emitting named, machine-checkable ordered regions such as `L1`/`L2` that `traceability` could verify) is deliberately left out of this PR — it changes the `rough-mockups` output shape and deserves its own change.

## Verification

Re-ran the affected chain on the same initiative (`260902-customer-segments`) with `refined-mockups` executed rather than skipped.

**Expectation** — the approved layout in `inception/refined-mockups/mockups.md`, chosen layout `Q1=B` (single flat, indented condition list):

```
+---------------------------------------------------------------+
| Segments                                                      |
+---------------------------------------------------------------+
| Name: [ High-value APAC leisure         ]  [New] [Save]       |
|                                                               |
|  Match [ALL v] of the groups                                  |
|                                                               |
|  Group 1  — match [ANY v]                          [x group]  |
|    - [Region        v] [is one of  v] [APAC][EUROPE +] [x]    |
|      [+ add condition]                                        |
|                                                               |
|  [+ add group]                                                |
|                                                               |
|  [ Get count ]      12 customers match                        |
+---------------------------------------------------------------+
```

followed by the `Saved segments` region — a table with `Name | Created by | Actions (Load / Edit / Delete)`.

**Result** — the generated screen (screenshot below) matches the approved mockup section by section:

| Approved in `mockups.md` | Generated | Match |
|---|---|---|
| Name input + `New` / `Save` at the top of the builder card | `Name` + `Created by` inputs, `New` / `Save` beside them | yes |
| `Match [ALL] of the groups` between the name row and the groups | present, in that position | yes |
| Group row carrying its own `ALL/ANY` + `× group`, indented condition rows below it | `Group 1 — match [ALL] × group`, then the indented `Field… / Operator… / ×` row | yes |
| `+ add condition` under the group's conditions, `+ add group` after the groups | both present, in that order | yes |
| `Get count` at the bottom of the builder | present, bottom of the card | yes |
| **`Saved segments` table below the builder, `Name / Created by / Actions`** | **renders below the builder with exactly those columns and `Load Edit Delete`** | **yes** |
| Empty-value states (`Field…`, `Operator…` placeholders) | present | yes |

The section order that inverted in the run reported in #999 is now the order the mockup specifies, and `frontend-components.md` cites the mockup it derived it from — so the fidelity is auditable rather than incidental.

<!-- Screenshot of the generated Segments screen (evidence) — drag the image here -->

## Release

Bumped to `2.7.2` with a matching `CHANGELOG.md` entry and README badge; `dist/` regenerated (`bun scripts/package.ts --check` → all harness trees in sync).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
