### PR TITLE
fix: emit permissionDecision allow on Codex PreToolUse input rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.8.2] - 2026-09-09
+
+Make Codex apply PreToolUse input rewrites again. Codex only honors a `hookSpecificOutput.updatedInput` rewrite when the same envelope carries an explicit `permissionDecision: "allow"`; without it the rewrite is silently dropped and the original tool input runs. The Codex adapter now emits that decision on both of its rewrite paths — the Bash session-binding prefix and the `deliver-stage-rules` core output it forwards — so subagent dispatches receive the active-stage rule bundle and Bash commands inherit the validated session again. The harness-neutral core hook is unchanged: it still emits no permission decision, and every other harness keeps its native approval flow. **Upgrade:** `aidlc update` (or `install.sh --version 2.8.2` / `install.ps1 -Version 2.8.2`), then `aidlc config` to refresh the project's Codex hook tree; no workflow state migration is required.
+
+* `spawn_agent` dispatches on Codex carry the exact active-stage rule bundle instead of the unmodified prompt.
+* Bash commands on Codex inherit the validated payload session via the `AIDLC_SESSION_OVERRIDE` prefix again.
+
 ## [2.8.1] - 2026-09-08
 
 Fix two defects found while exercising the 2.8.0 native install on Linux and Windows: the guided `aidlc config` setup cancelled itself when Enter was pressed to accept a default, and `aidlc update` on an already-current install failed its integrity check under a normal shell umask. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.1` / `install.ps1 -Version 2.8.1`; no project changes are required, and `aidlc config` refreshes projects when convenient.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ structured, verifiable software-delivery workflows. One harness-neutral core
 runs natively in Claude Code, Kiro CLI, Kiro IDE, Codex CLI, Cursor, opencode,
 and GitHub Copilot.
 
-![version](https://img.shields.io/badge/version-2.8.1-blue)
+![version](https://img.shields.io/badge/version-2.8.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 
 The Quick Start below installs the latest stable AI-DLC release.

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.8.1";
+export const AIDLC_VERSION = "2.8.2";

--- a/harness/codex/hooks/aidlc-codex-adapter.ts
+++ b/harness/codex/hooks/aidlc-codex-adapter.ts
@@ -358,13 +358,34 @@ function wrapContext(coreStdout: string, eventName: string): string {
   return coreStdout;
 }
 
+// Codex applies a PreToolUse updatedInput rewrite only when the same envelope
+// carries an explicit permissionDecision "allow"; without it the rewrite is
+// dropped and the original input runs. The decision authorizes only the
+// rewritten input — Codex's own approval flow still governs the call.
 function wrapUpdatedInput(updatedInput: Record<string, unknown>): string {
   return `${JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
+      permissionDecision: "allow",
       updatedInput,
     },
   })}\n`;
+}
+
+// Re-emit a core hook's PreToolUse rewrite with the explicit "allow" Codex
+// needs to apply it. Output without an updatedInput passes through untouched.
+function authorizeUpdatedInput(coreStdout: string): string {
+  try {
+    const parsed = JSON.parse(coreStdout) as {
+      hookSpecificOutput?: { updatedInput?: Record<string, unknown> };
+    };
+    if (parsed.hookSpecificOutput?.updatedInput) {
+      return wrapUpdatedInput(parsed.hookSpecificOutput.updatedInput);
+    }
+  } catch {
+    // unparseable core output — pass through untouched
+  }
+  return coreStdout;
 }
 
 // --- D-4: SESSION_ENDED reconcile-at-next-start ------------------------------
@@ -639,11 +660,15 @@ switch (target) {
   case "deliver-stage-rules": {
     // Codex 0.145 consumes the same PreToolUse hookSpecificOutput.updatedInput
     // contract as Claude. The core hook recognizes spawn_agent and appends the
-    // exact active-stage bundle to message/items without adapter re-shaping.
+    // exact active-stage bundle to message/items without adapter re-shaping —
+    // but Codex only applies the rewrite when the envelope also carries
+    // permissionDecision "allow", so the adapter re-wraps the core output
+    // here instead of changing the harness-neutral core hook.
     const r = runCoreWithStderr("aidlc-deliver-stage-rules.ts", rawInput);
+    const output = authorizeUpdatedInput(r.stdout);
     const answeredCode = r.code === 2 ? 2 : 0;
-    persistResponse(r.stdout, answeredCode, r.stderr);
-    if (r.stdout) process.stdout.write(r.stdout);
+    persistResponse(output, answeredCode, r.stderr);
+    if (output) process.stdout.write(output);
     if (r.code === 2) {
       process.stderr.write(r.stderr);
       return 2;

--- a/tests/unit/t149-codex-hook-adapter.test.ts
+++ b/tests/unit/t149-codex-hook-adapter.test.ts
@@ -444,10 +444,14 @@ describe("t149 Codex hook adapter (live-captured payload fixtures)", () => {
       const output = JSON.parse(r.stdout) as {
         hookSpecificOutput?: {
           hookEventName?: string;
+          permissionDecision?: string;
           updatedInput?: { command?: string };
         };
       };
       expect(output.hookSpecificOutput?.hookEventName).toBe("PreToolUse");
+      // Codex drops an updatedInput rewrite that does not carry an explicit
+      // "allow", so the session prefix would silently never bind.
+      expect(output.hookSpecificOutput?.permissionDecision).toBe("allow");
       expect(output.hookSpecificOutput?.updatedInput?.command).toBe(
         "export AIDLC_SESSION_OVERRIDE='codex-command-session' " +
           "AIDLC_SESSION_OVERRIDE_SOURCE='payload'; " +
@@ -542,9 +546,13 @@ describe("t149 Codex hook adapter (live-captured payload fixtures)", () => {
       expect(r.code, r.stderr).toBe(0);
       const out = JSON.parse(r.stdout) as {
         hookSpecificOutput?: {
+          permissionDecision?: string;
           updatedInput?: { message?: string };
         };
       };
+      // The adapter re-wraps the core rewrite with the explicit "allow" Codex
+      // needs to apply it; the harness-neutral core hook never emits one.
+      expect(out.hookSpecificOutput?.permissionDecision).toBe("allow");
       const message = out.hookSpecificOutput?.updatedInput?.message ?? "";
       expect(message).toContain("first-class");
       expect(message).toContain("Given/When/Then");


### PR DESCRIPTION
# Summary

On Codex CLI, a PreToolUse `hookSpecificOutput.updatedInput` rewrite is applied only when the same envelope carries an explicit `permissionDecision: "allow"`. Without it the rewrite is silently dropped and the original tool input runs, so both Codex rewrite paths were inert: `spawn_agent` dispatches never received the active-stage rule bundle from `deliver-stage-rules`, and Bash commands never inherited the validated payload session prefix (`AIDLC_SESSION_OVERRIDE`).

## Changes

* `harness/codex/hooks/aidlc-codex-adapter.ts`: `wrapUpdatedInput` now emits `permissionDecision: "allow"` alongside `updatedInput`, and the `deliver-stage-rules` target re-wraps the core hook's output through a new `authorizeUpdatedInput` helper instead of forwarding it verbatim. Output without an `updatedInput` (or unparseable output) passes through untouched, and the re-wrapped response is what gets persisted for duplicate-delivery replay.
* The harness-neutral `core/hooks/aidlc-deliver-stage-rules.ts` is deliberately **unchanged**: it still emits no permission decision (as pinned by t248), so Claude Code and every other harness keep their native approval flow. The `allow` decision authorizes only the rewritten input on Codex; Codex's own approval flow still governs whether the call runs.
* `tests/unit/t149-codex-hook-adapter.test.ts`: pins `permissionDecision: "allow"` on both the `bind-bash-session` rewrite and the `deliver-stage-rules` dispatch rewrite.
* Version bumped to 2.8.2 (rebased over the 2.8.x native-distribution releases) with a matching CHANGELOG entry; local projections regenerated via `bun scripts/package.ts` (dist trees are no longer committed).

## User experience

Before: on Codex, subagent dispatches ran with the unmodified prompt (no active-stage rule bundle) and Bash commands ran without the validated session binding — both silently, since the dropped rewrite produces no error.

After: `spawn_agent` dispatches carry the exact active-stage rule bundle and Bash commands inherit the validated payload session again. Other harnesses are unaffected.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test plan

* `bun scripts/package.ts && bun scripts/package.ts --check` — all harness trees in sync, no drift.
* `bun run typecheck` and `bun run lint` — clean.
* `bun test tests/unit/t149-codex-hook-adapter.test.ts tests/unit/t248-steering-content-delivery.test.ts tests/unit/t150-codex-packaging.test.ts tests/unit/t228-hook-run-exports.test.ts` — 109 pass, 0 fail (includes the two new `permissionDecision` pins and the existing t248 pin that the core hook emits **no** decision).
* Adapter-adjacent suites (t01, t02, gen-coverage-registry, t144, t146, t230, t265, t308, t318, t145, t55, t239, t68, t121, t188, t300) — all pass.
* `bun tests/run-tests.ts --smoke --unit --parallel 8` — the only failing files fail identically on an unmodified checkout of `main` in my environment (pre-existing local-environment failures; verified by stash-and-rerun diff of the failure sets).

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
