### PR TITLE
test: report requested live files with no executed tests as unmet

### DIFF
--- a/docs/reference/09-testing.md
+++ b/docs/reference/09-testing.md
@@ -357,6 +357,14 @@ environment already set it. This makes the "everything with traces" profile run
 the live, token-spending TUI journeys by default; set `AIDLC_TUI_LIVE=0`
 explicitly to keep those files on their in-test SKIP path.
 
+The runner classifies a file whose every testcase skipped as `SKIP`, distinct
+from both `PASS` and `FAIL`. That remains non-blocking for optional coverage. If
+the file's own live-gate variable is explicitly `1`, the status becomes `UNMET`;
+the console, per-file metadata, verbose summary, and failures report all preserve
+that state, and the aggregate result is nonzero. A requested live file that
+registers zero testcases is also `UNMET`; an ordinary empty suite remains
+`PASS`.
+
 ## Parallel Execution
 
 `--parallel N` (or `-P N`) runs up to N test files concurrently within a tier. Default is serial (`1`).

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,13 @@ journey skips cleanly until its runtime, credentials, and explicit live-gate
 variable are present. For the cross-platform invariance story and the Windows
 substrate, see the runbook below.
 
+An all-skipped file is reported as `SKIP`, not `PASS`. Optional skips remain
+non-blocking, but when that file's own live-gate variable is explicitly `1`,
+the runner reports `UNMET`, lists it separately in the summary, and returns a
+nonzero result so requested live coverage cannot pass without executing a test.
+The same `UNMET` rule applies when a requested live file registers zero
+testcases; ordinary empty suites remain `PASS`.
+
 ## Cross-Platform
 
 The suite runs on macOS, Linux, and Windows through the native Bun runner (`bun tests/run-tests.ts`). `bash tests/run-tests.sh` remains as a POSIX compatibility wrapper for existing POSIX commands. The Windows runbook in `tests/harness/windows/` provisions a disposable Windows Server 2022 SSM host, syncs the committed git tree, installs dependencies, and runs `bun tests/run-tests.ts --all --debug` with live TUI enabled. Portability conventions used throughout the suite:

--- a/tests/integration/t112.serial.test.ts
+++ b/tests/integration/t112.serial.test.ts
@@ -1,21 +1,20 @@
-// covers: harness-instrument:runner-exit-equals-failed-files
+// covers: harness-instrument:runner-exit-equals-blocking-files
 //
 // t112 — "who tests the tester". The master runner's load-bearing contract is
-// that its PROCESS EXIT CODE equals the NUMBER OF FAILED TEST FILES. Every tier
+// that its PROCESS EXIT CODE equals the NUMBER OF BLOCKING TEST FILES: failures
+// plus explicitly requested live files that execute no tests. Every tier
 // result reported up the chain (CI gates, release gates, the SUMMARY block)
-// rests on this number being trustworthy. If aggregate_tier_results miscounts
-// STATUS=FAIL metas, or a refactor swaps `exit "$FAILED_FILES"` for a plain
+// rests on this number being trustworthy. If aggregation miscounts FAIL/UNMET
+// metas, or a refactor swaps the blocking count for a plain
 // `exit 1` / boolean, the runner would still "look" red on failure but lie
 // about the magnitude — and a 0-vs-nonzero regression would silently flip a
 // real failure into a green run. This calibrates the instrument itself.
 //
-// Source contract (tests/run-tests.sh):
-//   - run_bun_test_file derives STATUS from the child rc: rc!=0 => FAIL.
-//   - run_bun_test_file writes a 6-line .meta sidecar per file, incl. STATUS=.
-//   - aggregate_tier_results sources each .meta and does
-//       if [ "$STATUS" = "FAIL" ]; then FAILED_FILES=$((FAILED_FILES + 1)); fi   (:459-461)
-//   - the final line is `exit "$FAILED_FILES"` (:706); the smoke fail-fast path
-//     also exits "$FAILED_FILES" (:540).
+// Source contract (tests/run-tests.ts):
+//   - buildMeta derives PASS/FAIL/SKIP from Bun's JUnit + process rc.
+//   - runBunTestFile overlays UNMET when no tests execute for a live gate at `1`.
+//   - each file writes one 6-line .meta sidecar carrying that status.
+//   - aggregation counts FAIL and UNMET separately, then exits their sum.
 //
 // TECHNIQUE: invariant. For N in {0,1,2,3} arrange EXACTLY N failing test files
 // (plus M passing ones, to prove passes do not perturb the count) and assert the
@@ -35,13 +34,16 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { buildMeta } from "../lib/bun-junit-to-meta.ts";
 
 const REAL_RUNNER = join(import.meta.dir, "..", "run-tests.sh");
 const REAL_RUNNER_TS = join(import.meta.dir, "..", "run-tests.ts");
@@ -71,10 +73,45 @@ function passingBunTest(j: number): string {
   return `import { expect, test } from "bun:test";\n\ntest("seeded pass ${j}", () => {\n  expect(1).toBe(1);\n});\n`;
 }
 
-// Build a scratch <root>/tests with the REAL runner + glue copied in, seed the
-// smoke/ level dir with `nFail` failing and `nPass` passing Bun files, then
-// drive the real runner against ONLY those files via --smoke -P 1.
-function driveRunner(nFail: number, nPass: number): { code: number; stdout: string } {
+function skippedBunTest(requestedLiveGate = false): string {
+  const condition = requestedLiveGate
+    ? 'process.env.AIDLC_KIRO_IDE_LIVE === "1"'
+    : "true";
+  return [
+    'import { test } from "bun:test";',
+    "",
+    `test.skipIf(${condition})("seeded skip", () => {`,
+    '  throw new Error("skip body must not execute");',
+    "});",
+    "",
+  ].join("\n");
+}
+
+function importFailureBunTest(): string {
+  return 'throw new Error("seeded import failure");\n';
+}
+
+function requestedEmptyBunTest(): string {
+  return [
+    'import { test } from "bun:test";',
+    "",
+    'if (process.env.AIDLC_KIRO_IDE_LIVE === "1" && process.env.T112_REGISTER_LIVE_CASE === "1") {',
+    '  test("conditionally registered live case", () => {});',
+    "}",
+    "",
+  ].join("\n");
+}
+
+interface SeededFile {
+  name: string;
+  source: string;
+}
+
+function driveSeededFiles(
+  files: SeededFile[],
+  envOverrides: Record<string, string> = {},
+  debug = false,
+): { code: number; stdout: string; summary: string; failures: string } {
   const root = mkdtempSync(join(tmpdir(), "t112-runner-exit-"));
   scratchRoots.push(root);
 
@@ -88,25 +125,122 @@ function driveRunner(nFail: number, nPass: number): { code: number; stdout: stri
   copyFileSync(REAL_RUNNER_TS, join(testsDir, "run-tests.ts"));
   copyFileSync(REAL_GLUE, join(libDir, "bun-junit-to-meta.ts"));
 
+  for (const file of files) {
+    writeFileSync(join(smokeDir, file.name), file.source);
+  }
+
+  const runnerArgs = [join(testsDir, "run-tests.sh"), "--smoke", "-P", "1"];
+  if (debug) runnerArgs.push("--debug");
+  const res = spawnSync("bash", runnerArgs, {
+    encoding: "utf8",
+    env: { ...process.env, AIDLC_NO_LLM: "0", ...envOverrides },
+  });
+  const stdout = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+  const logDir =
+    stdout
+      .split(/\r?\n/)
+      .find((line) => line.startsWith("Verbose mode: logging to "))
+      ?.slice("Verbose mode: logging to ".length)
+      .trim() ?? "";
+  const summary =
+    logDir && existsSync(join(logDir, "summary.txt"))
+      ? readFileSync(join(logDir, "summary.txt"), "utf8")
+      : "";
+  const failures =
+    logDir && existsSync(join(logDir, "failures.txt"))
+      ? readFileSync(join(logDir, "failures.txt"), "utf8")
+      : "";
+  return { code: res.status ?? -1, stdout, summary, failures };
+}
+
+// Build a scratch <root>/tests with the REAL runner + glue copied in, seed the
+// smoke/ level dir with `nFail` failing and `nPass` passing Bun files, then
+// drive the real runner against ONLY those files via --smoke -P 1.
+function driveRunner(nFail: number, nPass: number): { code: number; stdout: string } {
+  const files: SeededFile[] = [];
   // Distinct numeric stems keep glob ordering deterministic and avoid collisions
   // between the fail/pass families.
   for (let i = 1; i <= nFail; i++) {
-    writeFileSync(join(smokeDir, `t90${i}-fail.test.ts`), failingBunTest(i));
+    files.push({ name: `t90${i}-fail.test.ts`, source: failingBunTest(i) });
   }
   for (let j = 1; j <= nPass; j++) {
-    writeFileSync(join(smokeDir, `t95${j}-pass.test.ts`), passingBunTest(j));
+    files.push({ name: `t95${j}-pass.test.ts`, source: passingBunTest(j) });
   }
-
-  const res = spawnSync(
-    "bash",
-    [join(testsDir, "run-tests.sh"), "--smoke", "-P", "1"],
-    { encoding: "utf8" },
-  );
-  // spawnSync sets .status to the exit code, or null if killed by a signal.
-  return { code: res.status ?? -1, stdout: `${res.stdout}\n${res.stderr}` };
+  return driveSeededFiles(files);
 }
 
-describe("run-tests.sh exit code equals number of failed files (harness calibration)", () => {
+const XML_ALL_PASS = `<?xml version="1.0"?>
+<testsuites tests="2" failures="0" skipped="0" time="0.002">
+  <testsuite tests="2" failures="0" skipped="0">
+    <testcase name="pass one" />
+    <testcase name="pass two" />
+  </testsuite>
+</testsuites>`;
+
+const XML_PASS_SKIP = `<?xml version="1.0"?>
+<testsuites tests="2" failures="0" skipped="1" time="0.003">
+  <testsuite tests="2" failures="0" skipped="1">
+    <testcase name="pass" />
+    <testcase name="skip"><skipped /></testcase>
+  </testsuite>
+</testsuites>`;
+
+const XML_ALL_SKIP = `<?xml version="1.0"?>
+<testsuites tests="2" failures="0" skipped="2" time="0.004">
+  <testsuite tests="2" failures="0" skipped="2">
+    <testcase name="skip one"><skipped /></testcase>
+    <testcase name="skip two"><skipped /></testcase>
+  </testsuite>
+</testsuites>`;
+
+describe("JUnit per-file status classification", () => {
+  test("all-pass is PASS", () => {
+    expect(buildMeta(XML_ALL_PASS, "all-pass", 0)).toMatchObject({
+      status: "PASS",
+      tests: 2,
+      failed: 0,
+      rc: 0,
+    });
+  });
+
+  test("mixed pass/skip is PASS", () => {
+    expect(buildMeta(XML_PASS_SKIP, "mixed", 0)).toMatchObject({
+      status: "PASS",
+      tests: 2,
+      failed: 0,
+      rc: 0,
+    });
+  });
+
+  test("all-skip is SKIP", () => {
+    expect(buildMeta(XML_ALL_SKIP, "all-skip", 0)).toMatchObject({
+      status: "SKIP",
+      tests: 2,
+      failed: 0,
+      rc: 0,
+    });
+  });
+
+  test("empty suite is PASS", () => {
+    expect(buildMeta("", "empty", 0)).toMatchObject({
+      status: "PASS",
+      tests: 0,
+      failed: 0,
+      rc: 0,
+    });
+  });
+
+  test("import failure is FAIL", () => {
+    expect(buildMeta("", "import-failure", 1)).toMatchObject({
+      status: "FAIL",
+      tests: 0,
+      failed: 1,
+      rc: 1,
+    });
+  });
+});
+
+describe("run-tests.sh exit code equals number of blocking files (harness calibration)", () => {
   // The core invariant: for N failing files, the runner must exit N.
   for (const n of [0, 1, 2, 3]) {
     test(`${n} failing file(s) + 2 passing => exits ${n}`, () => {
@@ -140,5 +274,78 @@ describe("run-tests.sh exit code equals number of failed files (harness calibrat
     expect(code).toBe(3);
     expect(stdout).toContain("Failed files: 3");
     expect(stdout).toContain("RESULT: FAIL");
+  });
+});
+
+describe("all-skipped runner aggregation", () => {
+  test("an optional all-skipped file stays SKIP and does not make the tier red", () => {
+    const result = driveSeededFiles([
+      { name: "t980-optional-skip.test.ts", source: skippedBunTest() },
+    ]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("--- SKIP: t980-optional-skip.test.ts");
+    expect(result.stdout).toContain("=== DONE t980-optional-skip.test.ts (SKIP) ===");
+    expect(result.stdout).toContain("Skipped files: 1");
+    expect(result.stdout).toContain("Unmet live files: 0");
+    expect(result.stdout).toContain("RESULT: PASS");
+  });
+
+  test("a requested live all-skipped file is UNMET across console, summaries, and exit", () => {
+    const result = driveSeededFiles(
+      [{ name: "t981-requested-live-skip.test.ts", source: skippedBunTest(true) }],
+      { AIDLC_KIRO_IDE_LIVE: "1" },
+      true,
+    );
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain(
+      "--- UNMET: t981-requested-live-skip.test.ts (AIDLC_KIRO_IDE_LIVE=1 requested, but no tests executed) ---",
+    );
+    expect(result.stdout).toContain("=== DONE t981-requested-live-skip.test.ts (UNMET) ===");
+    expect(result.stdout).toContain("Failed files: 0");
+    expect(result.stdout).toContain("Skipped files: 0");
+    expect(result.stdout).toContain("Unmet live files: 1");
+    expect(result.stdout).toContain("RESULT: FAIL");
+    expect(result.summary).toContain("t981-requested-live-skip");
+    expect(result.summary).toContain("UNMET");
+    expect(result.summary).toContain("Unmet live files: 1");
+    expect(result.summary).toContain("Result: FAIL");
+    expect(result.failures).toContain(
+      "UNMET: t981-requested-live-skip (requested live gate executed no tests)",
+    );
+  });
+
+  test("a requested live empty suite is UNMET rather than zero-test PASS", () => {
+    const result = driveSeededFiles(
+      [{ name: "t982-requested-live-empty.test.ts", source: requestedEmptyBunTest() }],
+      { AIDLC_KIRO_IDE_LIVE: "1", T112_REGISTER_LIVE_CASE: "0" },
+      true,
+    );
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain(
+      "--- UNMET: t982-requested-live-empty.test.ts (AIDLC_KIRO_IDE_LIVE=1 requested, but no tests executed) ---",
+    );
+    expect(result.stdout).toContain("=== DONE t982-requested-live-empty.test.ts (UNMET) ===");
+    expect(result.stdout).toContain("Failed files: 0");
+    expect(result.stdout).toContain("Skipped files: 0");
+    expect(result.stdout).toContain("Unmet live files: 1");
+    expect(result.stdout).toContain("Total assertions: 0");
+    expect(result.stdout).toContain("RESULT: FAIL");
+    expect(result.summary).toContain("t982-requested-live-empty");
+    expect(result.summary).toContain("UNMET");
+    expect(result.failures).toContain(
+      "UNMET: t982-requested-live-empty (requested live gate executed no tests)",
+    );
+  });
+
+  test("an import crash remains FAIL rather than empty-suite PASS", () => {
+    const result = driveSeededFiles([
+      { name: "t983-import-failure.test.ts", source: importFailureBunTest() },
+    ]);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("--- FAIL: t983-import-failure.test.ts ---");
+    expect(result.stdout).toContain("=== DONE t983-import-failure.test.ts (FAIL) ===");
+    expect(result.stdout).toContain("Failed files: 1");
+    expect(result.stdout).toContain("Unmet live files: 0");
+    expect(result.stdout).toContain("RESULT: FAIL");
   });
 });

--- a/tests/lib/bun-junit-to-meta.test.ts
+++ b/tests/lib/bun-junit-to-meta.test.ts
@@ -11,8 +11,10 @@
 // Cases covered (per the brief):
 //   1. 3 testcases / 1 failure   => TESTS=3 FAILED=1 STATUS=FAIL
 //   2. 5 testcases / 3 failures  => TESTS=5 FAILED=3 STATUS=FAIL
-//   3. N testcases / 0 failures  => FAILED=0 STATUS=PASS
-//   4. 0 testcases (empty suite) => TESTS=0 FAILED=0 STATUS=PASS RC=0
+//   3. N passing testcases       => FAILED=0 STATUS=PASS
+//   4. mixed pass/skip           => STATUS=PASS
+//   5. all skipped               => STATUS=SKIP
+//   6. 0 testcases (empty suite) => TESTS=0 FAILED=0 STATUS=PASS RC=0
 // Plus: emitted .meta is exactly 6 lines, bash-sourceable (KEY=value), NAME
 // matches the requested input, and DURATION carries bun's float verbatim.
 
@@ -36,6 +38,17 @@ const _rcTmps: string[] = [];
 afterEach(() => {
   for (const d of _rcTmps.splice(0)) rmSync(d, { recursive: true, force: true });
 });
+function bashPath(path: string): string {
+  if (process.platform !== "win32") return path;
+  return path
+    .replace(/^([A-Za-z]):[\\/]/, (_match, drive: string) => `/${drive.toLowerCase()}/`)
+    .replaceAll("\\", "/");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
 function writeAndSourceRc(xml: string, name: string, bunRc: number | null) {
   const dir = mkdtempSync(join(tmpdir(), "junit-meta-rc-"));
   _rcTmps.push(dir);
@@ -44,7 +57,10 @@ function writeAndSourceRc(xml: string, name: string, bunRc: number | null) {
   writeFileSync(metaPath, content, "utf8");
   const out = execFileSync(
     "bash",
-    ["-c", `set -eu; source "${metaPath}"; echo "$NAME|$STATUS|$TESTS|$FAILED|$DURATION|$RC"`],
+    [
+      "-c",
+      `set -eu; source ${shellQuote(bashPath(metaPath))}; echo "$NAME|$STATUS|$TESTS|$FAILED|$DURATION|$RC"`,
+    ],
     { encoding: "utf8" },
   ).trim();
   return { metaPath, content, sourced: out };
@@ -107,6 +123,16 @@ const XML_9_0 = `<?xml version="1.0" encoding="UTF-8"?>
   </testsuite>
 </testsuites>`;
 
+// Mixed pass/skip with no failures: the file executed one real test, so it is
+// PASS rather than SKIP.
+const XML_PASS_SKIP = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="2" assertions="1" failures="0" skipped="1" time="0.004000">
+  <testsuite name="t.test.ts" file="t.test.ts" tests="2" assertions="1" failures="0" skipped="1" time="0" hostname="h">
+    <testcase name="passes" classname="" time="0" file="t.test.ts" line="2" assertions="1" />
+    <testcase name="skips" classname="" time="0" file="t.test.ts" line="3" assertions="0"><skipped /></testcase>
+  </testsuite>
+</testsuites>`;
+
 // Mixed: 2 pass + 2 fail + 1 skip = 5 tests, 2 failures. `tests` INCLUDES the
 // skip (verified against the real probe). STATUS must be FAIL (failures>0),
 // skips do not flip it.
@@ -129,7 +155,7 @@ const XML_SKIP_MIX = `<?xml version="1.0" encoding="UTF-8"?>
   </testsuite>
 </testsuites>`;
 
-// All-skip: 2 tests, 0 failures, exit 0 in real bun => PASS.
+// All-skip: 2 tests, 0 failures, exit 0 in real bun => SKIP.
 const XML_ALL_SKIP = `<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="bun test" tests="2" assertions="0" failures="0" skipped="2" time="0.010998">
   <testsuite name="t.test.ts" file="t.test.ts" tests="2" assertions="0" failures="0" skipped="2" time="0" hostname="h">
@@ -142,23 +168,61 @@ const XML_ALL_SKIP = `<?xml version="1.0" encoding="UTF-8"?>
 
 describe("parseJUnit reads root totals", () => {
   test("3 testcases / 1 failure", () => {
-    expect(parseJUnit(XML_3_1)).toEqual({ tests: 3, failed: 1, duration: "0.012345" });
+    expect(parseJUnit(XML_3_1)).toEqual({
+      tests: 3,
+      failed: 1,
+      skipped: 0,
+      duration: "0.012345",
+    });
   });
   test("5 testcases / 3 failures", () => {
-    expect(parseJUnit(XML_5_3)).toEqual({ tests: 5, failed: 3, duration: "0.020000" });
+    expect(parseJUnit(XML_5_3)).toEqual({
+      tests: 5,
+      failed: 3,
+      skipped: 0,
+      duration: "0.020000",
+    });
   });
   test("9 testcases / 0 failures", () => {
-    expect(parseJUnit(XML_9_0)).toEqual({ tests: 9, failed: 0, duration: "0.028891" });
+    expect(parseJUnit(XML_9_0)).toEqual({
+      tests: 9,
+      failed: 0,
+      skipped: 0,
+      duration: "0.028891",
+    });
+  });
+  test("mixed pass/skip counts one skipped testcase", () => {
+    expect(parseJUnit(XML_PASS_SKIP)).toEqual({
+      tests: 2,
+      failed: 0,
+      skipped: 1,
+      duration: "0.004000",
+    });
   });
   test("skip is counted in tests but not in failures", () => {
-    expect(parseJUnit(XML_SKIP_MIX)).toEqual({ tests: 5, failed: 2, duration: "0.013767" });
+    expect(parseJUnit(XML_SKIP_MIX)).toEqual({
+      tests: 5,
+      failed: 2,
+      skipped: 1,
+      duration: "0.013767",
+    });
   });
   test("all-skip: tests counted, zero failures", () => {
-    expect(parseJUnit(XML_ALL_SKIP)).toEqual({ tests: 2, failed: 0, duration: "0.010998" });
+    expect(parseJUnit(XML_ALL_SKIP)).toEqual({
+      tests: 2,
+      failed: 0,
+      skipped: 2,
+      duration: "0.010998",
+    });
   });
   test("empty/missing XML => 0 tests, 0 failures, 0 duration", () => {
-    expect(parseJUnit("")).toEqual({ tests: 0, failed: 0, duration: "0" });
-    expect(parseJUnit("   \n  ")).toEqual({ tests: 0, failed: 0, duration: "0" });
+    expect(parseJUnit("")).toEqual({ tests: 0, failed: 0, skipped: 0, duration: "0" });
+    expect(parseJUnit("   \n  ")).toEqual({
+      tests: 0,
+      failed: 0,
+      skipped: 0,
+      duration: "0",
+    });
   });
 });
 
@@ -182,12 +246,17 @@ describe("buildMeta derives STATUS and RC", () => {
     expect(m.failed).toBe(0);
     expect(m.rc).toBe(0);
   });
+  test("mixed pass/skip => PASS / RC=0", () => {
+    const m = buildMeta(XML_PASS_SKIP, "t");
+    expect(m.status).toBe("PASS");
+    expect(m.rc).toBe(0);
+  });
   test("skip-mix with failures => FAIL", () => {
     expect(buildMeta(XML_SKIP_MIX, "t").status).toBe("FAIL");
   });
-  test("all-skip => PASS / RC=0 (skips never fail a file)", () => {
+  test("all-skip => SKIP / RC=0", () => {
     const m = buildMeta(XML_ALL_SKIP, "t");
-    expect(m.status).toBe("PASS");
+    expect(m.status).toBe("SKIP");
     expect(m.rc).toBe(0);
   });
   test("empty suite => TESTS=0 FAILED=0 PASS RC=0", () => {
@@ -241,14 +310,15 @@ describe("emitted .meta is bash-sourceable and round-trips", () => {
     tmps.push(dir);
     const metaPath = join(dir, `${name}.meta`);
     const content = renderMeta(buildMeta(xml, name));
-    Bun.write(metaPath, content);
-    // Force the write to land synchronously before sourcing.
-    require("node:fs").writeFileSync(metaPath, content, "utf8");
+    writeFileSync(metaPath, content, "utf8");
     // Source the .meta in a clean bash and echo back the variables. If any line
     // were not a valid assignment, `source` would error / produce wrong output.
     const out = execFileSync(
       "bash",
-      ["-c", `set -eu; source "${metaPath}"; echo "$NAME|$STATUS|$TESTS|$FAILED|$DURATION|$RC"`],
+      [
+        "-c",
+        `set -eu; source ${shellQuote(bashPath(metaPath))}; echo "$NAME|$STATUS|$TESTS|$FAILED|$DURATION|$RC"`,
+      ],
       { encoding: "utf8" },
     ).trim();
     return { metaPath, content, sourced: out };

--- a/tests/lib/bun-junit-to-meta.ts
+++ b/tests/lib/bun-junit-to-meta.ts
@@ -15,8 +15,8 @@
 // FAILED_FILES by counting `.meta` files whose STATUS=FAIL — one increment per
 // FILE regardless of how many testcases failed inside it. So the bun exit code
 // is discarded; STATUS in the `.meta` is the single source of truth the parent
-// reads, and RC here is a self-consistent exit code (0 PASS / 1 FAIL) the tool
-// itself returns for any direct caller.
+// reads, and RC here is a self-consistent exit code (0 PASS/SKIP / 1 FAIL) the
+// tool itself returns for any direct caller.
 //
 // ─── VERIFIED bun 1.2.22 JUnit XML SHAPE (probed this session) ───────────────
 // Command: bun test <file> --reporter=junit --reporter-outfile=<X>
@@ -55,7 +55,7 @@
 // ─── .meta CONTRACT (run-tests.sh :287-292, re-confirmed this session) ───────
 // Exactly 6 lines, bash-sourceable (KEY=value, no spaces around =), in order:
 //   NAME=<basename, no extension>
-//   STATUS=<PASS|FAIL>
+//   STATUS=<PASS|FAIL|SKIP|UNMET>
 //   TESTS=<count of testcases>
 //   FAILED=<count of failures>
 //   DURATION=<seconds, may be float>
@@ -73,14 +73,16 @@
 //     is absent.
 //   - FAILED = root <testsuites failures> (fallback: sum of <testsuite failures>,
 //     final fallback: count of <failure ...> elements).
-//   - STATUS = FAIL iff FAILED > 0; PASS otherwise. (Skips do NOT fail a file —
-//     mirrors bun exit 0 on all-skip, and the runner treats only rc!=0 as FAIL.)
+//   - STATUS = FAIL iff FAILED > 0 or bun exited nonzero; SKIP iff every declared
+//     testcase skipped; PASS otherwise. Empty suites remain PASS because they
+//     declared no skipped testcases. The runner may overlay UNMET when the
+//     skipped file's own live gate was explicitly requested.
 //   - DURATION = root <testsuites time> float seconds (fallback: 0). Sources fine
 //     in bash; the bash-file branch emits an integer here, the contract permits a
 //     float, and aggregate does float-free integer += only on TESTS/FAILED.
-//   - RC = 0 when PASS, 1 when FAIL. Self-consistent with STATUS; the parent never
-//     reads RC for aggregation (it keys off STATUS), but RC keeps the `.meta`
-//     faithful to the bash-file shape and gives a direct caller a real exit code.
+//   - RC = 0 when PASS/SKIP, 1 when FAIL. The runner writes RC=1 for its UNMET
+//     overlay. RC keeps the `.meta` self-consistent and gives a direct caller a
+//     real exit code.
 //
 // CLI CONTRACT:
 //   bun bun-junit-to-meta.ts --xml <junit.xml> --out <target.meta> [--name <NAME>] [--bun-rc <N>]
@@ -101,14 +103,14 @@
 //                            XML). Without it, an import crash maps to PASS.
 //
 //   Process exits with the RC it wrote into the `.meta` (= --bun-rc when given,
-//   else 0 PASS / 1 FAIL). A usage error (no --out) exits 2 on stderr.
+//   else 0 PASS/SKIP / 1 FAIL). A usage error (no --out) exits 2 on stderr.
 
 import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { basename } from "node:path";
 
 export interface MetaCounts {
   name: string;
-  status: "PASS" | "FAIL";
+  status: "PASS" | "FAIL" | "SKIP" | "UNMET";
   tests: number;
   failed: number;
   duration: string; // kept as a string so we preserve bun's float formatting verbatim
@@ -165,20 +167,27 @@ function sanitizeDuration(raw: string): string {
  * `xml` empty/whitespace (the empty-suite case where bun wrote no file) yields
  * 0 tests / 0 failures.
  */
-export function parseJUnit(xml: string): { tests: number; failed: number; duration: string } {
+export function parseJUnit(xml: string): {
+  tests: number;
+  failed: number;
+  skipped: number;
+  duration: string;
+} {
   const text = (xml ?? "").trim();
-  if (text === "") return { tests: 0, failed: 0, duration: "0" };
+  if (text === "") return { tests: 0, failed: 0, skipped: 0, duration: "0" };
 
   // ROOT <testsuites ...> opening tag (singular: there is one root document).
   const rootMatch = text.match(/<testsuites\b[^>]*>/);
   let tests: number | null = null;
   let failed: number | null = null;
+  let skipped: number | null = null;
   let duration: string | null = null;
 
   if (rootMatch) {
     const root = rootMatch[0];
     tests = attrInt(root, "tests");
     failed = attrInt(root, "failures");
+    skipped = attrInt(root, "skipped");
     duration = attrStr(root, "time");
   }
 
@@ -194,11 +203,13 @@ export function parseJUnit(xml: string): { tests: number; failed: number; durati
     if (!rootMatch) {
       let tSum = 0;
       let fSum = 0;
+      let sSum = 0;
       let dSum = 0;
       let sawDuration = false;
       for (const tag of suiteTags) {
         tSum += attrInt(tag, "tests") ?? 0;
         fSum += attrInt(tag, "failures") ?? 0;
+        sSum += attrInt(tag, "skipped") ?? 0;
         const d = attrStr(tag, "time");
         if (d !== null) {
           dSum += Number(d) || 0;
@@ -207,6 +218,7 @@ export function parseJUnit(xml: string): { tests: number; failed: number; durati
       }
       tests = tSum;
       failed = fSum;
+      skipped = sSum;
       duration = sawDuration ? String(dSum) : "0";
     }
   }
@@ -219,9 +231,12 @@ export function parseJUnit(xml: string): { tests: number; failed: number; durati
   if (tests === null) {
     tests = (text.match(/<testcase\b/g) ?? []).length;
   }
+  if (skipped === null) {
+    skipped = (text.match(/<skipped\b/g) ?? []).length;
+  }
   if (duration === null || duration === "") duration = "0";
 
-  return { tests, failed, duration };
+  return { tests, failed, skipped, duration };
 }
 
 /**
@@ -251,8 +266,10 @@ export function deriveName(metaPath: string): string {
  * would contribute +0 to FAILED_FILES, silently under-reporting the failure.
  *
  * Rule: STATUS=FAIL iff (parsed failures > 0) OR (bunRc is known and nonzero).
- * In the crash case (bunRc != 0 but parsed failed == 0) we synthesize
- * `failed = 1` so the FAIL is visible in the count, and RC mirrors bunRc.
+ * Otherwise STATUS=SKIP iff the document declares at least one testcase and
+ * every testcase skipped. Empty suites remain PASS. In the crash case
+ * (bunRc != 0 but parsed failed == 0) we synthesize `failed = 1` so the FAIL is
+ * visible in the count, and RC mirrors bunRc.
  *
  * `bunRc` is OPTIONAL (default null): omitting it preserves the original
  * XML-only behaviour exactly, so a caller that cannot supply the exit code (or
@@ -263,7 +280,12 @@ export function buildMeta(xml: string, name: string, bunRc: number | null = null
   const parsed = parseJUnit(xml);
   const tests = parsed.tests;
   const rcFail = bunRc !== null && bunRc !== 0;
-  const status: "PASS" | "FAIL" = parsed.failed > 0 || rcFail ? "FAIL" : "PASS";
+  const status: MetaCounts["status"] =
+    parsed.failed > 0 || rcFail
+      ? "FAIL"
+      : tests > 0 && parsed.skipped === tests
+        ? "SKIP"
+        : "PASS";
   // If bun reported a nonzero exit but the XML carried no countable failure
   // (the import-crash case), surface at least one failure so STATUS=FAIL is
   // backed by a nonzero FAILED count the parent's per-FILE aggregation honors.

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -4,7 +4,8 @@
 // tests/run-tests.sh remains as a POSIX compatibility wrapper. Keep behavior
 // aligned with the old runner because smoke/t05 drives the public runner
 // contract: flags, tier banners, START/DONE markers, summary fields, verbose
-// log dirs, debug trace locations, and the "exit == failed files" convention.
+// log dirs, debug trace locations, and the "exit == blocking files" convention
+// (FAIL plus explicitly requested live files that execute no tests).
 
 import { spawn, spawnSync } from "node:child_process";
 import {
@@ -43,7 +44,7 @@ const LIVE_MODEL_GATES = [
 ] as const;
 
 type Level = "smoke" | "unit" | "integration" | "e2e";
-type Status = "PASS" | "FAIL" | "SKIP";
+type Status = "PASS" | "FAIL" | "SKIP" | "UNMET";
 
 interface ParsedArgs {
   runSmoke: boolean;
@@ -348,6 +349,8 @@ if (needsLlm && !commandExists("timeout")) {
 
 let totalFiles = 0;
 let failedFiles = 0;
+let skippedFiles = 0;
+let unmetLiveFiles = 0;
 let totalTests = 0;
 let totalFailed = 0;
 const resultRows: ResultRow[] = [];
@@ -364,28 +367,48 @@ function shouldSkipForClaude(file: string): boolean {
   return !claudeGateOpen && isClaudeRequiredFile(file);
 }
 
+const requestedLiveGateCache = new Map<string, string[]>();
+
+function requestedLiveGates(file: string): string[] {
+  const cached = requestedLiveGateCache.get(file);
+  if (cached) return cached;
+
+  let source = "";
+  try {
+    source = readFileSync(file, "utf8");
+  } catch {
+    source = "";
+  }
+
+  const requested: string[] = [];
+  for (const gate of LIVE_MODEL_GATES) {
+    if (process.env[gate] !== "1") continue;
+    if (
+      source.includes(`process.env.${gate}`) ||
+      (gate === "AIDLC_CLAUDE_SDK_LIVE" && isClaudeRequiredFile(file))
+    ) {
+      requested.push(gate);
+    }
+  }
+  requestedLiveGateCache.set(file, requested);
+  return requested;
+}
+
+function blockingFiles(): number {
+  return failedFiles + unmetLiveFiles;
+}
+
 function writeMeta(name: string, meta: MetaCounts | ResultRow): void {
   const status = meta.status;
-  const rc = status === "FAIL" ? 1 : 0;
-  const content =
-    status === "SKIP"
-      ? [
-          `NAME=${name}`,
-          "STATUS=SKIP",
-          "TESTS=0",
-          "FAILED=0",
-          "DURATION=0",
-          "RC=0",
-          "",
-        ].join("\n")
-      : renderMeta({
-          name,
-          status,
-          tests: meta.tests,
-          failed: meta.failed,
-          duration: meta.duration,
-          rc,
-        });
+  const rc = status === "FAIL" || status === "UNMET" ? 1 : 0;
+  const content = renderMeta({
+    name,
+    status,
+    tests: meta.tests,
+    failed: meta.failed,
+    duration: meta.duration,
+    rc,
+  });
   writeFileSync(join(resultsDir, `${name}.meta`), content, "utf8");
 }
 
@@ -403,7 +426,10 @@ function parseMeta(file: string): ResultRow {
     const key = line.slice(0, eq);
     const value = line.slice(eq + 1);
     if (key === "NAME") row.name = value;
-    else if (key === "STATUS" && (value === "PASS" || value === "FAIL" || value === "SKIP")) {
+    else if (
+      key === "STATUS" &&
+      (value === "PASS" || value === "FAIL" || value === "SKIP" || value === "UNMET")
+    ) {
       row.status = value;
     } else if (key === "TESTS") row.tests = Number(value) || 0;
     else if (key === "FAILED") row.failed = Number(value) || 0;
@@ -423,6 +449,8 @@ function aggregateTierResults(): void {
     totalTests += row.tests;
     totalFailed += row.failed;
     if (row.status === "FAIL") failedFiles += 1;
+    else if (row.status === "SKIP") skippedFiles += 1;
+    else if (row.status === "UNMET") unmetLiveFiles += 1;
     resultRows.push(row);
   }
   for (const meta of metas) rmSync(meta, { force: true });
@@ -599,10 +627,16 @@ async function runBunTestFile(file: string, parallelMode = false): Promise<void>
   if (filterRegex && !filterRegex.test(base) && !filterRegex.test(name)) return;
 
   if (shouldSkipForClaude(file)) {
-    process.stdout.write(`\n=== SKIP ${base} ===\n`);
-    process.stdout.write(`--- SKIP: ${base} (Claude substrate unavailable; derived live mechanism) ---\n`);
-    process.stdout.write(`=== DONE ${base} (SKIP) ===\n`);
-    writeMeta(name, { name, status: "SKIP", tests: 0, failed: 0, duration: "0" });
+    const requested = requestedLiveGates(file);
+    const status: Status = requested.length > 0 ? "UNMET" : "SKIP";
+    process.stdout.write(`\n=== ${status} ${base} ===\n`);
+    process.stdout.write(
+      status === "UNMET"
+        ? `--- UNMET: ${base} (${requested.map((gate) => `${gate}=1`).join(", ")} requested, but Claude substrate unavailable) ---\n`
+        : `--- SKIP: ${base} (Claude substrate unavailable; derived live mechanism) ---\n`,
+    );
+    process.stdout.write(`=== DONE ${base} (${status}) ===\n`);
+    writeMeta(name, { name, status, tests: 0, failed: 0, duration: "0" });
     return;
   }
 
@@ -701,6 +735,13 @@ async function runBunTestFile(file: string, parallelMode = false): Promise<void>
     xml = "";
   }
   const meta = buildMeta(xml, name, run.rc);
+  const noTestsExecuted =
+    meta.status === "SKIP" || (meta.status === "PASS" && meta.tests === 0);
+  const requested = noTestsExecuted ? requestedLiveGates(file) : [];
+  if (requested.length > 0) {
+    meta.status = "UNMET";
+    meta.rc = 1;
+  }
   // Preserve a duration even if a future Bun omits root time.
   if (meta.duration === "0") meta.duration = String(Math.max(0, (Date.now() - start) / 1000));
   writeMeta(name, meta);
@@ -709,7 +750,17 @@ async function runBunTestFile(file: string, parallelMode = false): Promise<void>
   const body = run.output;
   const doneBlock = (): void => {
     if (!args.debug) process.stdout.write(body);
-    process.stdout.write(status === "FAIL" ? `--- FAIL: ${base} ---\n` : `--- PASS: ${base} ---\n`);
+    if (status === "FAIL") {
+      process.stdout.write(`--- FAIL: ${base} ---\n`);
+    } else if (status === "UNMET") {
+      process.stdout.write(
+        `--- UNMET: ${base} (${requested.map((gate) => `${gate}=1`).join(", ")} requested, but no tests executed) ---\n`,
+      );
+    } else if (status === "SKIP") {
+      process.stdout.write(`--- SKIP: ${base} (every test skipped) ---\n`);
+    } else {
+      process.stdout.write(`--- PASS: ${base} ---\n`);
+    }
     process.stdout.write(`=== DONE ${base} (${status}) ===\n`);
   };
   if (parallelMode) {
@@ -728,7 +779,9 @@ async function runBunTestFile(file: string, parallelMode = false): Promise<void>
         `Test: ${base}`,
         `File: ${file}`,
         `Status: ${status}`,
-        `Exit code: ${run.rc}`,
+        `Requested live gates: ${requested.length > 0 ? requested.map((gate) => `${gate}=1`).join(", ") : "none"}`,
+        `Bun exit code: ${run.rc}`,
+        `Metadata RC: ${meta.rc}`,
         `Timestamp: ${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}`,
         "",
         "--- Output ---",
@@ -848,13 +901,15 @@ function printSummary(): void {
   process.stdout.write("==============================\n");
   process.stdout.write(`Test files: ${totalFiles}\n`);
   process.stdout.write(`Failed files: ${failedFiles}\n`);
+  process.stdout.write(`Skipped files: ${skippedFiles}\n`);
+  process.stdout.write(`Unmet live files: ${unmetLiveFiles}\n`);
   process.stdout.write(`Total assertions: ${totalTests}\n`);
   process.stdout.write(`Failed assertions: ${totalFailed}\n`);
   if (args.verbose && logDir) {
     process.stdout.write(`Log directory: ${displayLogDirPath(logDir)}\n`);
   }
   process.stdout.write("==============================\n");
-  process.stdout.write(failedFiles > 0 ? "RESULT: FAIL\n" : "RESULT: PASS\n");
+  process.stdout.write(blockingFiles() > 0 ? "RESULT: FAIL\n" : "RESULT: PASS\n");
 }
 
 function writeVerboseSummary(): void {
@@ -888,17 +943,23 @@ function writeVerboseSummary(): void {
     "Totals:",
     `  Test files: ${totalFiles}`,
     `  Failed files: ${failedFiles}`,
+    `  Skipped files: ${skippedFiles}`,
+    `  Unmet live files: ${unmetLiveFiles}`,
     `  Total assertions: ${totalTests}`,
     `  Failed assertions: ${totalFailed}`,
-    `  Result: ${failedFiles > 0 ? "FAIL" : "PASS"}`,
+    `  Result: ${blockingFiles() > 0 ? "FAIL" : "PASS"}`,
   );
   writeFileSync(join(logDir, "summary.txt"), `${lines.join("\n")}\n`, "utf8");
 
   const failures: string[] = [];
-  if (failedFiles > 0) {
+  if (blockingFiles() > 0) {
     for (const row of resultRows) {
-      if (row.status !== "FAIL") continue;
-      failures.push(`FAIL: ${row.name} (${row.failed} failed assertions)`);
+      if (row.status !== "FAIL" && row.status !== "UNMET") continue;
+      failures.push(
+        row.status === "FAIL"
+          ? `FAIL: ${row.name} (${row.failed} failed assertions)`
+          : `UNMET: ${row.name} (requested live gate executed no tests)`,
+      );
       const logFile = join(logDir, `${row.name}.log`);
       if (existsSync(logFile)) {
         // bun:test marks a failing case with a line that STARTS WITH `(fail)`
@@ -925,11 +986,11 @@ async function main(): Promise<number> {
   process.stdout.write("======================\n");
 
   if (args.runSmoke) await runTier("smoke", "Smoke Tests (structural)");
-  if (args.runSmoke && failedFiles > 0) {
+  if (args.runSmoke && blockingFiles() > 0) {
     process.stdout.write("\nSMOKE FAILURES DETECTED -- aborting before unit/integration levels\n");
     writeVerboseSummary();
     printSummary();
-    return failedFiles;
+    return blockingFiles();
   }
 
   if (args.runUnit) await runTier("unit", "Unit Tests (single-component isolation)");
@@ -1013,7 +1074,7 @@ async function main(): Promise<number> {
 
   writeVerboseSummary();
   printSummary();
-  return failedFiles;
+  return blockingFiles();
 }
 
 try {

--- a/tests/unit/t331-bun-junit-to-meta.test.ts
+++ b/tests/unit/t331-bun-junit-to-meta.test.ts
@@ -1,0 +1,3 @@
+// Keep the low-level JUnit metadata parser suite inside standard runner
+// discovery while retaining its fixtures beside the parser implementation.
+import "../lib/bun-junit-to-meta.test.ts";


### PR DESCRIPTION
## Summary

- distinguish all-skipped files from passing files in runner metadata
- report explicitly requested live files that execute no tests as `UNMET`
- preserve optional skips, empty suites, and import-failure behavior
- wire the low-level JUnit metadata suite into standard runner discovery

## Verification

- `bash tests/run-tests.sh --debug -P 8 --filter 't112|t331-bun-junit-to-meta'`
- `bash tests/run-tests.sh --debug -P 8 --smoke --filter '^t05-run-tests-parallel$'`
- `bun run check`
- native Windows runner-contract slice: PASS

Test-infrastructure-only change; no release metadata update.
