### PR TITLE
test: parse custom-harness SDK directive output on Windows

### DIFF
--- a/tests/e2e/t-tui-custom-harness.serial.test.ts
+++ b/tests/e2e/t-tui-custom-harness.serial.test.ts
@@ -131,6 +131,7 @@ import {
   SNAPSHOT_STAGE_PHASE,
   SNAPSHOT_STAGE_SLUG,
 } from "../harness/custom-harness.ts";
+import { parseDirectiveOutput } from "../harness/directive-output.ts";
 import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 import { driveAidlc, recordDirFor, stateFilePathFor } from "../harness/sdk-drive.ts";
 import { resolveWinNode } from "../harness/tui-drive.ts";
@@ -427,13 +428,11 @@ describe("t-tui-custom-harness (the {sdk,tui} two-driver journey)", () => {
           .map((tr) => tr.resultText)
           .find((text) => text.includes(`"lead_agent":"${CUSTOM_AGENT_SLUG}"`));
         expect(directiveText).toBeDefined();
-        const directive = JSON.parse((directiveText as string).trim()) as {
-          kind?: string;
-          stage?: string;
-          lead_agent?: string;
-          consumes?: string[];
-        };
+        const { directive } = parseDirectiveOutput(directiveText as string);
         expect(directive.kind).toBe("run-stage");
+        if (directive.kind !== "run-stage") {
+          throw new Error(`Expected run-stage directive, got ${directive.kind}`);
+        }
         expect(directive.stage).toBe(SNAPSHOT_STAGE_SLUG);
         expect(directive.lead_agent).toBe(CUSTOM_AGENT_SLUG);
       } finally {

--- a/tests/harness/directive-output.ts
+++ b/tests/harness/directive-output.ts
@@ -1,0 +1,111 @@
+// Parse an engine tool result at its authoritative record boundary.
+//
+// aidlc-orchestrate emits exactly one compact directive JSON object followed by
+// a newline. Shell/SDK layers may append diagnostic lines to the same tool
+// result (for example, Claude Code on Windows reports a cwd reset). Treat each
+// complete line as a transport record instead of slicing around braces, because
+// directive string fields can legitimately contain braces.
+
+import { isDeepStrictEqual } from "node:util";
+import {
+  type Directive,
+  validateDirective,
+} from "../../core/tools/aidlc-directive.ts";
+
+export interface ParsedDirectiveOutput {
+  directive: Directive;
+  diagnostics: string[];
+}
+
+export class DirectiveOutputError extends Error {
+  constructor(
+    message: string,
+    readonly diagnostics: string[],
+  ) {
+    super(message);
+    this.name = "DirectiveOutputError";
+  }
+}
+
+interface DirectiveRecord {
+  directive: Directive;
+  lineNumber: number;
+}
+
+interface MalformedRecord {
+  lineNumber: number;
+  reason: string;
+}
+
+export function parseDirectiveOutput(output: string): ParsedDirectiveOutput {
+  const diagnostics: string[] = [];
+  const records: DirectiveRecord[] = [];
+  const malformed: MalformedRecord[] = [];
+
+  for (const [index, line] of output.split(/\r?\n/).entries()) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Engine records are compact JSON objects. Everything else remains
+    // available to the caller as shell/SDK diagnostics.
+    if (!trimmed.startsWith("{")) {
+      diagnostics.push(line);
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      malformed.push({
+        lineNumber: index + 1,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    const validation = validateDirective(parsed);
+    if (!validation.valid) {
+      malformed.push({
+        lineNumber: index + 1,
+        reason: validation.errors.join("; "),
+      });
+      continue;
+    }
+    records.push({ directive: validation.data, lineNumber: index + 1 });
+  }
+
+  if (malformed.length > 0) {
+    const details = malformed
+      .map((record) => `line ${record.lineNumber}: ${record.reason}`)
+      .join(" | ");
+    throw new DirectiveOutputError(
+      `Malformed directive JSON record${malformed.length === 1 ? "" : "s"}: ${details}`,
+      diagnostics,
+    );
+  }
+
+  if (records.length === 0) {
+    throw new DirectiveOutputError(
+      "Expected exactly one directive JSON record; found none",
+      diagnostics,
+    );
+  }
+
+  if (records.length > 1) {
+    const duplicate = records
+      .slice(1)
+      .every((record) => isDeepStrictEqual(record.directive, records[0].directive));
+    throw new DirectiveOutputError(
+      `Expected exactly one directive JSON record; found ${records.length} ${
+        duplicate ? "duplicate" : "conflicting"
+      } records on lines ${records.map((record) => record.lineNumber).join(", ")}`,
+      diagnostics,
+    );
+  }
+
+  return {
+    directive: records[0].directive,
+    diagnostics,
+  };
+}

--- a/tests/unit/t324-sdk-directive-output.test.ts
+++ b/tests/unit/t324-sdk-directive-output.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DirectiveOutputError,
+  parseDirectiveOutput,
+} from "../harness/directive-output.ts";
+import type { RunStageDirective } from "../../core/tools/aidlc-directive.ts";
+
+const WINDOWS_ANNOTATION =
+  String.raw`Shell cwd was reset to C:\Users\ADMINI~1\AppData\Local\Temp\aidlc-tui-34DDiM`;
+
+const DIRECTIVE: RunStageDirective = {
+  kind: "run-stage",
+  stage: "schema-snapshot",
+  phase: "inception",
+  lead_agent: "aidlc-data-migration-agent",
+  support_agents: [],
+  mode: "inline",
+  inline_context_paths: [],
+  gate: true,
+  memory_path:
+    "aidlc/spaces/default/intents/260823-data-migration/inception/schema-snapshot/memory.md",
+  consumes: [],
+  produces: [
+    "aidlc/spaces/default/intents/260823-data-migration/inception/schema-snapshot/source-schema.md",
+  ],
+  rules_in_context: [],
+  sensors_applicable: ["schema-validator"],
+  stage_file: ".claude/aidlc-common/stages/inception/schema-snapshot.md",
+  narration: "Literal braces inside a JSON string stay structural: {keep these}.",
+};
+
+function captureError(output: string): DirectiveOutputError {
+  try {
+    parseDirectiveOutput(output);
+  } catch (error) {
+    expect(error).toBeInstanceOf(DirectiveOutputError);
+    return error as DirectiveOutputError;
+  }
+  throw new Error("parseDirectiveOutput unexpectedly succeeded");
+}
+
+describe("SDK directive output parsing", () => {
+  test("parses the directive record and preserves the exact Windows cwd annotation separately", () => {
+    const parsed = parseDirectiveOutput(
+      `${JSON.stringify(DIRECTIVE)}\n${WINDOWS_ANNOTATION}`,
+    );
+
+    expect(parsed.directive).toEqual(DIRECTIVE);
+    expect(parsed.diagnostics).toEqual([WINDOWS_ANNOTATION]);
+  });
+
+  test("rejects malformed JSON records without consuming their braces as delimiters", () => {
+    const error = captureError(
+      `{"kind":"print","message":"unterminated { brace}"\n${WINDOWS_ANNOTATION}`,
+    );
+
+    expect(error.message).toContain("Malformed directive JSON record");
+    expect(error.message).toContain("line 1");
+    expect(error.diagnostics).toEqual([WINDOWS_ANNOTATION]);
+  });
+
+  test("rejects structurally invalid directive objects", () => {
+    const error = captureError(
+      `${JSON.stringify({ kind: "run-stage", stage: "schema-snapshot" })}\n${WINDOWS_ANNOTATION}`,
+    );
+
+    expect(error.message).toContain("Malformed directive JSON record");
+    expect(error.message).toContain("run-stage:");
+    expect(error.diagnostics).toEqual([WINDOWS_ANNOTATION]);
+  });
+
+  test("rejects output with no directive record", () => {
+    const error = captureError(WINDOWS_ANNOTATION);
+
+    expect(error.message).toBe(
+      "Expected exactly one directive JSON record; found none",
+    );
+    expect(error.diagnostics).toEqual([WINDOWS_ANNOTATION]);
+  });
+
+  test("rejects duplicate directive records", () => {
+    const line = JSON.stringify(DIRECTIVE);
+    const error = captureError(`${line}\n${line}\n${WINDOWS_ANNOTATION}`);
+
+    expect(error.message).toContain("found 2 duplicate records");
+    expect(error.diagnostics).toEqual([WINDOWS_ANNOTATION]);
+  });
+
+  test("rejects conflicting directive records", () => {
+    const error = captureError(
+      `${JSON.stringify(DIRECTIVE)}\n${JSON.stringify({
+        kind: "print",
+        message: "different directive",
+      })}\n${WINDOWS_ANNOTATION}`,
+    );
+
+    expect(error.message).toContain("found 2 conflicting records");
+    expect(error.diagnostics).toEqual([WINDOWS_ANNOTATION]);
+  });
+});


### PR DESCRIPTION
## Summary

- parse engine output at newline-delimited machine-record boundaries
- preserve shell and SDK diagnostics separately from the directive
- reject malformed, missing, duplicate, and conflicting directive records
- cover the exact Windows `Shell cwd was reset to ...` annotation
- use the structured parser in the live custom-harness SDK assertion

## Verification

- `bash tests/run-tests.sh --debug -P 8 --unit --filter '^t324-sdk-directive-output$'`
- focused live custom-harness SDK journey
- `bun run check`
- native Windows unit parser suite: PASS
- native Windows focused live SDK journey: PASS

Test-infrastructure-only change; no release metadata update.
