### PR TITLE
fix: normalize blank subagent types in completion audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.7.2] - 2026-09-04
+
+Subagent completion audit rows now always carry a usable agent type without rewriting valid harness identities. **Upgrade:** replace your `dist/<harness>/` tree so every harness receives the corrected completion hook.
+
+* `SUBAGENT_COMPLETED` normalizes absent, non-string, empty, and whitespace-only agent types to `unknown`, while preserving the exact nonblank value and the existing optional Agent ID and Message fields.
+* Real hook-to-audit regression coverage pins malformed JSON, malformed identity fields, blank variants, and exact valid identity output.
+
 ## [2.7.1] - 2026-09-01
 
 Fix a Plan Approval deadlock that made Code Generation unreachable on solo (non-team) workflows. The Stop hook's read-only `next` probe published the durable active-directive marker on every turn boundary, which bumped the Code Generation authority revision and reset the plan-approval runtime, so the approval challenge minted while answering "Approve Plan" was destroyed before its receipt could be written. The probe no longer publishes that marker for any workflow, matching the read-only contract it already advertised. **Upgrade:** replace the `dist/<harness>/` tree; no workflow state migration is required. Closes #995.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.7.1-blue)
+![version](https://img.shields.io/badge/version-2.7.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/hooks/aidlc-log-subagent.ts
+++ b/core/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/claude/.claude/hooks/aidlc-log-subagent.ts
+++ b/dist/claude/.claude/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/codex/.codex/hooks/aidlc-log-subagent.ts
+++ b/dist/codex/.codex/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/copilot/.aidlc/hooks/aidlc-log-subagent.ts
+++ b/dist/copilot/.aidlc/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/cursor/.cursor/hooks/aidlc-log-subagent.ts
+++ b/dist/cursor/.cursor/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/kiro-ide/.kiro/hooks/aidlc-log-subagent.ts
+++ b/dist/kiro-ide/.kiro/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/kiro/.kiro/hooks/aidlc-log-subagent.ts
+++ b/dist/kiro/.kiro/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/opencode/.aidlc/hooks/aidlc-log-subagent.ts
+++ b/dist/opencode/.aidlc/hooks/aidlc-log-subagent.ts
@@ -78,7 +78,10 @@ export async function run(input: string): Promise<number> {
     );
   }
 
-  const agentType = parsed.agent_type ?? "unknown";
+  const agentType =
+    typeof parsed.agent_type === "string" && parsed.agent_type.trim()
+      ? parsed.agent_type
+      : "unknown";
   const agentId: string = parsed.agent_id ?? "";
   const agentMessage: string = (parsed.last_assistant_message ?? "").slice(0, 200);
 

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/tests/unit/t09.test.ts
+++ b/tests/unit/t09.test.ts
@@ -18,8 +18,9 @@
 // appendAuditEntryUnlocked renders each as `**<key>**: <value>` under a
 // `## Subagent Completed` heading with `**Event**: SUBAGENT_COMPLETED`. Message
 // is sliced to the first 200 chars — the truncation the .sh's
-// test 6 asserts. agentType defaults to "unknown", agentId defaults to ""
-// (omitted when falsy).
+// test 6 asserts. agentType defaults to "unknown" when absent, malformed, or
+// blank without rewriting nonblank values; agentId defaults to "" (omitted
+// when falsy).
 //
 // SEED BASELINE (load-bearing for parity strength). The .sh seeds audit-sample.md
 // (fixtures.sh seed_audit_file) which ALREADY CONTAINS one SUBAGENT_COMPLETED
@@ -279,6 +280,81 @@ describe("t09 aidlc-log-subagent hook (migrated from t09-hook-log-subagent.sh + 
     expect(blk.Message).toBeUndefined();
   });
 
+  for (const {
+    label,
+    payload,
+    expectedType,
+    expectedId,
+    expectedMessage,
+  } of [
+    {
+      label: "absent",
+      payload: {},
+      expectedType: "unknown",
+      expectedId: undefined,
+      expectedMessage: undefined,
+    },
+    {
+      label: "malformed non-string",
+      payload: {
+        agent_type: 28,
+        agent_id: "agent-28",
+        last_assistant_message: "malformed identity",
+      },
+      expectedType: "unknown",
+      expectedId: "agent-28",
+      expectedMessage: "malformed identity",
+    },
+    {
+      label: "empty",
+      payload: { agent_type: "" },
+      expectedType: "unknown",
+      expectedId: undefined,
+      expectedMessage: undefined,
+    },
+    {
+      label: "whitespace-only",
+      payload: {
+        agent_type: " \t ",
+        agent_id: "agent-whitespace",
+        last_assistant_message: "done",
+      },
+      expectedType: "unknown",
+      expectedId: "agent-whitespace",
+      expectedMessage: "done",
+    },
+    {
+      label: "exact nonblank identity",
+      payload: {
+        agent_type: "  aidlc-developer-agent  ",
+        agent_id: "agent-valid",
+        last_assistant_message: "complete",
+      },
+      expectedType: "  aidlc-developer-agent  ",
+      expectedId: "agent-valid",
+      expectedMessage: "complete",
+    },
+  ]) {
+    test(`2 identity normalization: ${label}`, () => {
+      const p = proj();
+      const before = subagentCompletedCount(readShards(p));
+      runHook(JSON.stringify(payload), p);
+      expect(subagentCompletedCount(readShards(p))).toBe(before + 1);
+      const blk = lastSubagentBlock(readShards(p));
+      expect(blk["Agent Type"]).toBe(expectedType);
+      if (expectedId === undefined) {
+        expect(blk["Agent ID"]).toBeUndefined();
+      } else {
+        expect(blk["Agent ID"]).toBe(expectedId);
+      }
+      if (expectedMessage === undefined) {
+        expect(blk.Message).toBeUndefined();
+      } else {
+        expect(blk.Message).toBe(expectedMessage);
+      }
+    });
+  }
+
   test("3a: no state leaves an existing audit shard byte-identical", () => {
     const p = proj({ state: false });
     const shard = join(auditDirOf(p), pinnedShardName());
@@ -373,6 +449,14 @@ describe("t09 aidlc-log-subagent hook (migrated from t09-hook-log-subagent.sh + 
     expect(r.status).toBe(0);
     // STRONGER: empty stdin -> JSON.parse("") throws -> exit 0 before any append,
     // so the audit must be byte-identical (the .sh captured BEFORE but never diffed).
+    expect(readShards(p)).toBe(before);
+  });
+
+  test("5b: handles malformed JSON gracefully (exit 0, audit unchanged)", () => {
+    const p = proj();
+    const before = readShards(p);
+    const r = runHook('{"agent_type":', p);
+    expect(r.status).toBe(0);
     expect(readShards(p)).toBe(before);
   });
 


### PR DESCRIPTION
## Summary

- normalize absent, non-string, empty, and whitespace-only subagent types to `unknown`
- preserve exact nonblank harness identities and optional Agent ID/Message fields
- add real hook-to-audit regression coverage for malformed and valid payloads
- regenerate all harness distributions

## Verification

- `bash tests/run-tests.sh --debug -P 8 --unit --filter '^(t09|t68-version-changelog-sync)$'`
- `bun run check`
- native Windows `t09` and version-sync slice: PASS

## Upgrade

Replace the complete `dist/<harness>/` tree.

This PR uses patch slot `2.7.2`; rebase and re-bump if another release PR lands first.
