### PR TITLE
fix: retain Plan Approval tags under nested headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.7.2] - 2026-09-05
+
+Plan Approval now retains answers and fingerprints under nested Markdown headings. **Upgrade:** replace the complete `dist/<harness>/` tree; no workflow state migration is required.
+
+* Explanatory subheadings no longer cause misleading missing-fingerprint or missing-answer errors during Plan Approval (#1022).
+* Unit merge evidence uses the same latest-section approval readers as the runtime guard.
+* Git source snapshots preserve blob headers across buffer refills, preventing valid worktree creation from failing at particular content sizes.
+
 ## [2.7.1] - 2026-09-01
 
 Fix a Plan Approval deadlock that made Code Generation unreachable on solo (non-team) workflows. The Stop hook's read-only `next` probe published the durable active-directive marker on every turn boundary, which bumped the Code Generation authority revision and reset the plan-approval runtime, so the approval challenge minted while answering "Approve Plan" was destroyed before its receipt could be written. The probe no longer publishes that marker for any workflow, matching the read-only contract it already advertised. **Upgrade:** replace the `dist/<harness>/` tree; no workflow state migration is required. Closes #995.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A native implementation of the **AI-DLC methodology** (AI-Driven Development Lif
 
 The methodology lives once, in a harness-neutral `core/`; each harness adds a thin surface that decides how it shows up on that harness. So you edit the methodology in one place, and every harness distribution is generated from it — no harness gets special treatment. (See [Repository layout](#repository-layout) for how the pieces fit together.)
 
-![version](https://img.shields.io/badge/version-2.7.1-blue)
+![version](https://img.shields.io/badge/version-2.7.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 ![Kiro IDE](https://img.shields.io/badge/harness-Kiro%20IDE-orange)
 ![Kiro CLI](https://img.shields.io/badge/harness-Kiro%20CLI-orange)

--- a/core/aidlc-common/stages/construction/code-generation.md
+++ b/core/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun {{HARNESS_DIR}}/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/core/tools/aidlc-testing-posture.ts
+++ b/core/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/core/tools/aidlc-unit.ts
+++ b/core/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
+++ b/dist/claude/.claude/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun .claude/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/dist/claude/.claude/tools/aidlc-lib.ts
+++ b/dist/claude/.claude/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/dist/claude/.claude/tools/aidlc-testing-posture.ts
+++ b/dist/claude/.claude/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/dist/claude/.claude/tools/aidlc-unit.ts
+++ b/dist/claude/.claude/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/dist/claude/.claude/tools/aidlc-version.ts
+++ b/dist/claude/.claude/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
+++ b/dist/codex/.codex/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun .codex/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/dist/codex/.codex/tools/aidlc-lib.ts
+++ b/dist/codex/.codex/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/dist/codex/.codex/tools/aidlc-testing-posture.ts
+++ b/dist/codex/.codex/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/dist/codex/.codex/tools/aidlc-unit.ts
+++ b/dist/codex/.codex/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/dist/codex/.codex/tools/aidlc-version.ts
+++ b/dist/codex/.codex/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/copilot/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun .aidlc/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/dist/copilot/.aidlc/tools/aidlc-lib.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/dist/copilot/.aidlc/tools/aidlc-testing-posture.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/dist/copilot/.aidlc/tools/aidlc-unit.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/dist/copilot/.aidlc/tools/aidlc-version.ts
+++ b/dist/copilot/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
+++ b/dist/cursor/.cursor/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun .cursor/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/dist/cursor/.cursor/tools/aidlc-lib.ts
+++ b/dist/cursor/.cursor/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/dist/cursor/.cursor/tools/aidlc-testing-posture.ts
+++ b/dist/cursor/.cursor/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/dist/cursor/.cursor/tools/aidlc-unit.ts
+++ b/dist/cursor/.cursor/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/dist/cursor/.cursor/tools/aidlc-version.ts
+++ b/dist/cursor/.cursor/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro-ide/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun .kiro/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/dist/kiro-ide/.kiro/tools/aidlc-testing-posture.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/dist/kiro-ide/.kiro/tools/aidlc-unit.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/dist/kiro-ide/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro-ide/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
+++ b/dist/kiro/.kiro/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun .kiro/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/dist/kiro/.kiro/tools/aidlc-lib.ts
+++ b/dist/kiro/.kiro/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/dist/kiro/.kiro/tools/aidlc-testing-posture.ts
+++ b/dist/kiro/.kiro/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/dist/kiro/.kiro/tools/aidlc-unit.ts
+++ b/dist/kiro/.kiro/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/dist/kiro/.kiro/tools/aidlc-version.ts
+++ b/dist/kiro/.kiro/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
+++ b/dist/opencode/.aidlc/aidlc-common/stages/construction/code-generation.md
@@ -219,7 +219,9 @@ bun .aidlc/tools/aidlc-testing-posture.ts fingerprint --stage-level
 
 Write the returned hash into the Plan Approval section as
 `[Approval Fingerprint]: sha256:<hash>`, followed by both options below and a
-blank `[Answer]:` tag:
+blank `[Answer]:` tag. Nested headings remain inside this question; a heading
+of the same or a shallower level ends its section. Keep both tags inside the
+latest Plan Approval section (including when using a numbered question heading):
 
 - "Approve Plan" — proceed to code generation
 - "Request Changes" — revise the plan

--- a/dist/opencode/.aidlc/tools/aidlc-lib.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-lib.ts
@@ -10923,7 +10923,8 @@ function readSyncBufferedLine(
         : Buffer.concat(chunks, total);
     }
     const chunk = reader.buffer.subarray(reader.offset, reader.end);
-    chunks.push(chunk);
+    // A refill overwrites reader.buffer; retain owned bytes for split headers.
+    chunks.push(Buffer.from(chunk));
     total += chunk.length;
     reader.offset = reader.end;
     if (total > maxBytes) return null;

--- a/dist/opencode/.aidlc/tools/aidlc-testing-posture.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-testing-posture.ts
@@ -858,6 +858,7 @@ function latestPlanApproval(body: string): {
   fingerprint: string | null;
 } {
   let inPlanApproval = false;
+  let questionHeadingLevel = 0;
   let awaitingNumberedQuestionText = false;
   let foundPlanApproval = false;
   let latestAnswer: string | null = null;
@@ -866,6 +867,11 @@ function latestPlanApproval(body: string): {
   for (const line of visibleMarkdownLines(body)) {
     const heading = line.match(MARKDOWN_HEADING_RE);
     if (heading) {
+      const headingLevel = heading[1].length;
+      // A Markdown section includes its subsections; only a sibling or ancestor
+      // heading ends the active question. Preserve tags below explanatory headings.
+      if (inPlanApproval && headingLevel > questionHeadingLevel) continue;
+      questionHeadingLevel = headingLevel;
       const headingText = heading[2].trim();
       inPlanApproval = isPlanApprovalLabel(
         headingText.replace(QUESTION_PREFIX_RE, ""),

--- a/dist/opencode/.aidlc/tools/aidlc-unit.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-unit.ts
@@ -72,6 +72,8 @@ import {
 } from "./aidlc-lib.js";
 import {
   parseTestingContract,
+  questionsFileApprovalFingerprint,
+  questionsFileApproved,
   PLAN_APPROVAL_CHECKPOINT,
   resolveTestingPosture,
 } from "./aidlc-testing-posture.ts";
@@ -1613,8 +1615,7 @@ function candidateEvidence(
       `${recordPrefix}/construction/${claim.unit}/code-generation/unit-test-instructions.md`,
     );
     const questions = gitTextAt(projectDir, claim.oid, questionsPath);
-    const fingerprint =
-      /^\[Approval Fingerprint\]:\s*(sha256:[0-9a-f]{64})\s*$/m.exec(questions);
+    const fingerprint = questionsFileApprovalFingerprint(questions);
     const embedded = parseTestingContract(plan);
     const currentContract = resolveTestingPosture(projectDir);
     const approvalEvent = events.findLast((event) =>
@@ -1650,7 +1651,7 @@ function candidateEvidence(
       auditBlockField(approvalEvent.block, "Intent") ===
         claim.payload.intent_uuid &&
       auditBlockField(approvalEvent.block, "Approval Fingerprint") ===
-        fingerprint[1] &&
+        fingerprint &&
       auditBlockField(approvalEvent.block, "Questions File") ===
         questionsPath &&
       auditBlockField(approvalEvent.block, "Questions SHA-256") ===
@@ -1661,9 +1662,9 @@ function candidateEvidence(
         0 &&
       (auditBlockField(approvalEvent.block, "Run floor") ?? "").length > 0 &&
       (auditBlockField(approvalEvent.block, "Session") ?? "").length > 0 &&
-      /^\[Answer\]:\s*A\.\s*Approve Plan\s*$/m.test(questions)
+      questionsFileApproved(questions)
     ) {
-      planFingerprint = fingerprint[1];
+      planFingerprint = fingerprint;
     }
   }
   const mergeHeld = (getField(state, "Merge-Held") ?? "").trim() === "true";

--- a/dist/opencode/.aidlc/tools/aidlc-version.ts
+++ b/dist/opencode/.aidlc/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.7.1";
+export const AIDLC_VERSION = "2.7.2";

--- a/tests/unit/t299-testing-posture-wiring.test.ts
+++ b/tests/unit/t299-testing-posture-wiring.test.ts
@@ -24,6 +24,7 @@ import {
   parseTestingContract,
   questionsFileApprovalFingerprint,
   questionsFileApproved,
+  questionsFileHasPendingPlanApproval,
   renderTestingContract,
   resolveCodeGenerationAuthority,
   resolveTestingPosture,
@@ -802,5 +803,36 @@ describe("t299 (5) authored consumers use the same contract", () => {
         "stage-protocol-construction.md` — load on the first Construction directive of the session and on every `invoke-swarm`",
       );
     }
+  });
+});
+
+
+describe("Plan Approval Markdown section boundaries", () => {
+  const fingerprint = `sha256:${"a".repeat(64)}`;
+  for (const level of [1, 2, 3, 4, 5]) {
+    for (const label of ["Plan Approval", "Q1: Plan Approval", "Q1\n\n**Plan Approval**"]) {
+      test(`level ${level} ${label} retains tags under nested headings`, () => {
+        const body = `${"#".repeat(level)} ${label}\n${"#".repeat(level + 1)} Why re-approval is needed\n[Approval Fingerprint]: ${fingerprint}\n${"#".repeat(level + 1)} Options\n[Answer]: A. Approve Plan\n`;
+        expect(questionsFileApprovalFingerprint(body)).toBe(fingerprint);
+        expect(questionsFileApproved(body)).toBe(true);
+        expect(questionsFileHasPendingPlanApproval(body)).toBe(false);
+        const pending = body.replace("[Answer]: A. Approve Plan", "[Answer]: ___");
+        expect(questionsFileApproved(pending)).toBe(false);
+        expect(questionsFileHasPendingPlanApproval(pending)).toBe(true);
+      });
+    }
+  }
+  test("same-level and shallower sections cannot supply approval tags", () => {
+    for (const closing of ["# Other section", "## Other question"]) {
+      const body = `## Plan Approval\n### Notes\n${closing}\n[Approval Fingerprint]: ${fingerprint}\n[Answer]: A. Approve Plan\n`;
+      expect(questionsFileApprovalFingerprint(body)).toBe(null);
+      expect(questionsFileApproved(body)).toBe(false);
+    }
+  });
+  test("a later unanswered approval supersedes an earlier approval with nested content", () => {
+    const body = `## Plan Approval\n### Options\n[Approval Fingerprint]: ${fingerprint}\n[Answer]: A. Approve Plan\n## Q2\nPlan Approval\n### Updated plan\n[Answer]: ___\n`;
+    expect(questionsFileApprovalFingerprint(body)).toBe(null);
+    expect(questionsFileApproved(body)).toBe(false);
+    expect(questionsFileHasPendingPlanApproval(body)).toBe(true);
   });
 });

--- a/tests/unit/t314-source-freshness-receipts.test.ts
+++ b/tests/unit/t314-source-freshness-receipts.test.ts
@@ -38,6 +38,7 @@
 
 import { afterAll, beforeEach, afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   appendFileSync,
   existsSync,
@@ -352,6 +353,29 @@ describe("t314 workspace source fingerprint (in-process)", () => {
     dir = mkdtempSync(join(tmpdir(), "t314-fp-"));
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  for (const size of [1, 65440, 65450, 65460, 65536]) {
+    test(`commit blob headers survive a buffer refill after ${size} bytes`, () => {
+      seedGitRepo(dir);
+      // a.bin sorts first: vary its length so the next cat-file header spans
+      // the 64 KiB reader boundary, alongside controls on either side.
+      const content = Buffer.alloc(size, 0x78);
+      writeFileSync(join(dir, "a.bin"), content);
+      // Keep enough data after the split header to overwrite the reused buffer.
+      writeFileSync(join(dir, "z.bin"), Buffer.alloc(65536, 0x79));
+      git(dir, ["add", "a.bin", "z.bin"]);
+      git(dir, ["commit", "-qm", "boundary fixture"]);
+      const head = spawnSync("git", ["-C", dir, "rev-parse", "HEAD"], {
+        encoding: "utf-8",
+      }).stdout.trim();
+      const digest = createHash("sha256").update(content).digest("hex");
+      const listing = gitCommitSourceListing(dir, head, true);
+      expect(listing).not.toBeNull();
+      expect(listing?.size).toBe(3);
+      expect(listing?.get("\0a.bin")).toBe(`100644 ${digest}`);
+      expect(listing?.has("\0app.ts")).toBe(true);
+    });
+  }
 
   test("deterministic, content-addressed, and edit-sensitive", () => {
     const src = seedGitRepo(dir);


### PR DESCRIPTION
# Summary

Fixes #1022. A nested heading inside a Plan Approval question currently hides its answer or fingerprint from the parser, causing misleading approval errors even when both tags are present.

## Changes

- Track the question heading level so nested Markdown sections retain approval tags; sibling and ancestor headings end the section.
- Use the shared latest-section readers for unit merge evidence instead of whole-file regexes.
- Cover direct and numbered headings across five nesting levels, pending answers, section exits, and later unanswered approvals.
- Document section boundaries and regenerate all harness distributions. Bump to 2.7.2 with the required changelog and badge updates.

## Validation-discovered repair

Regenerating the distribution exposed an existing Git source-snapshot bug in the release-binary gates: a `cat-file` header split across the 64 KiB read boundary retained a slice of the reusable buffer. The next refill could overwrite that slice and make a valid source tree unbindable. Copying the unfinished line fragment before refilling preserves the bytes. t314 exercises real Git fixtures on both sides of the boundary and includes enough subsequent data to overwrite the reused buffer; byte-copy and synchronous byte-write sibling paths already consume their data before refill.

This small prerequisite repair is included because the generated distribution otherwise fails the native worktree gates. A similar buffer copy existed in closed, unmerged #978; I found it during overlap screening after independently reproducing the failure. Its replacement #1000, current main, and the other inspected open source-snapshot PR heads still retain the unsafe slice. #1000 also touches the approval parser, so these changes may need rebasing if it lands first.

## User experience

An explanatory subheading such as `### Why re-approval is needed` beneath `## Plan Approval` no longer causes a missing-fingerprint or missing-answer error. Tags in a following sibling section still cannot authorize the plan, and an unanswered later approval supersedes an earlier one.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested (results and limitations below)
* [x] Changes are documented

## Test plan

- New boundary regression table: 16 failures before the fix; all 17 cases pass afterward.
- Focused approval/runtime/version tests: 109 passed.
- `bun run check`: passed (distribution parity, type checks, lint).
- Initial full deterministic run (`--no-llm --parallel 4`): 388 files, four failing files. t180 and t327 hit timeout/resource failures; t295 exceeded its RSS limit. Those three files passed unchanged on focused reruns with CI-pinned Bun 1.3.14.
- The fourth failure, t238 native binary worktree creation, reproduced until the buffer repair described below. It now passes with Bun 1.3.14: 3 tests, 128 expectations.
- Buffer boundary regression: 3 failures and 2 controls passing on the original helper; all 5 pass after repair.
- Final source/approval/unit-merge slice (`--unit --integration --no-llm --parallel 2 --filter 't299|t314|t326'`, Bun 1.3.14): all 7 files / 251 tests passed, including all 122 source-freshness cases and 27 pinned unit-merge cases.
- The full 388-file suite has not been rerun after the buffer repair; the relevant files have. No live-model evaluation was run.

Implemented with OpenAI Codex. No live model services were used for validation.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
