### PR TITLE
fix: detect glibc in compiled Linux binaries

### DIFF
--- a/core/tools/aidlc-install-paths.ts
+++ b/core/tools/aidlc-install-paths.ts
@@ -554,9 +554,17 @@ export function targetTriple(): string {
   const os = platform() === "darwin" ? "darwin" : platform() === "win32" ? "windows" : "linux";
   const arch = process.arch === "arm64" ? "arm64" : "x64";
   const report = process.report?.getReport?.() as { header?: { glibcVersionRuntime?: string } } | undefined;
+  const muslArch = process.arch === "arm64" ? "aarch64" : process.arch === "x64" ? "x86_64" : process.arch;
+  const muslLoader = os === "linux" && [
+    "/lib/ld-musl-" + muslArch + ".so.1",
+    "/usr/lib/ld-musl-" + muslArch + ".so.1",
+    "/lib/libc.musl-" + muslArch + ".so.1",
+    "/usr/lib/libc.musl-" + muslArch + ".so.1",
+  ].some(existsSync);
+  // Bun-compiled binaries may not expose process.report; absence alone does not mean musl.
   const libc = process.env.AIDLC_LIBC?.trim().toLowerCase() ||
-    (os === "linux" && !report?.header?.glibcVersionRuntime ? "musl" : "glibc");
-  return `${os}-${arch}${os === "linux" && libc === "musl" ? "-musl" : ""}`;
+    (os === "linux" && !report?.header?.glibcVersionRuntime && muslLoader ? "musl" : "glibc");
+  return os + "-" + arch + (os === "linux" && libc === "musl" ? "-musl" : "");
 }
 
 // Only a `--project-dir` before the `--` delimiter selects the project; tokens


### PR DESCRIPTION
## Summary

- Detect concrete musl loader paths when Bun-compiled binaries do not expose `process.report`.
- Default ordinary Linux hosts to glibc instead of incorrectly selecting musl.
- Unblock native Unix lifecycle installation for the `v2.8.0` release.

## Failure

The shell installer selected the correct glibc binary, but the compiled binary reclassified the host as musl because `process.report` was unavailable. `install-apply` then requested the musl asset from the glibc release subset and exited 4.

https://github.com/awslabs/aidlc-workflows/actions/runs/34201655167/job/101985253728

## Validation

Not run at requester direction due to the urgent release unblock.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).