### PR TITLE
fix: accept source-ref-only release provenance checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,7 +405,7 @@ jobs:
               '--source-digest string'
             exit 0
           fi
-          { [ "$#" -eq 9 ] || [ "$#" -eq 13 ]; } || exit 2
+          { [ "$#" -eq 9 ] || [ "$#" -eq 11 ] || [ "$#" -eq 13 ]; } || exit 2
           [ "$1" = attestation ] || exit 2
           [ "$2" = verify ] || exit 2
           case "$3" in /*/checksums.txt) ;; *) exit 2 ;; esac
@@ -417,9 +417,11 @@ jobs:
           [ "$7" = "$AIDLC_TEST_GH_REPOSITORY" ] || exit 2
           [ "$8" = --signer-workflow ] || exit 2
           [ "$9" = "$AIDLC_TEST_GH_WORKFLOW" ] || exit 2
-          if [ "$#" -eq 13 ]; then
+          if [ "$#" -ge 11 ]; then
             [ "${10}" = --source-ref ] || exit 2
             [ "${11}" = "$AIDLC_TEST_GH_SOURCE_REF" ] || exit 2
+          fi
+          if [ "$#" -eq 13 ]; then
             [ "${12}" = --source-digest ] || exit 2
             [ "${13}" = "$AIDLC_TEST_GH_SOURCE_DIGEST" ] || exit 2
           fi
@@ -449,6 +451,7 @@ jobs:
             sh "$release/install.sh" --from "$release" --offline --quiet
           test -s "$gh_marker"
           grep -qx 'verified-9' "$gh_marker"
+          grep -qx 'verified-11' "$gh_marker"
           grep -qx 'verified-13' "$gh_marker"
           command="$AIDLC_BIN_DIR/aidlc"
           env PATH="/usr/bin:/bin" "$command" version

--- a/tests/unit/t244-install-management.test.ts
+++ b/tests/unit/t244-install-management.test.ts
@@ -1973,13 +1973,16 @@ describe("t244 Windows and completion release surfaces", () => {
     expect(unix).toContain('install.sh" --from "$release" --offline');
     expect(unix).toContain("aidlc-lifecycle-provenance-fixture");
     expect(unix).toContain('AIDLC_GH_BIN="$gh_bin"');
-    expect(unix).toContain('[ "$#" -eq 9 ] || [ "$#" -eq 13 ]');
+    expect(unix).toContain(
+      '[ "$#" -eq 9 ] || [ "$#" -eq 11 ] || [ "$#" -eq 13 ]',
+    );
     expect(unix).toContain('[ "$3" = --help ]');
     expect(unix).toContain("'--source-digest string'");
     expect(unix).toContain('[ "$4" = --bundle ] || exit 2');
     expect(unix).toMatch(
       /\[ "\$5" = "\$\{3%\/checksums\.txt\}\/aidlc-release\.intoto\.jsonl" \] \|\| exit 2/,
     );
+    expect(unix).toContain('if [ "$#" -ge 11 ]; then');
     expect(unix).toMatch(/\[ "\$\{10\}" = --source-ref \] \|\| exit 2/);
     expect(unix).toMatch(
       /\[ "\$\{11\}" = "\$AIDLC_TEST_GH_SOURCE_REF" \] \|\| exit 2/,
@@ -1992,6 +1995,7 @@ describe("t244 Windows and completion release surfaces", () => {
       '[ "$actual" = "$AIDLC_TEST_GH_CHECKSUM_SHA" ] || exit 2',
     );
     expect(unix).toContain('test -s "$gh_marker"');
+    expect(unix).toContain("grep -qx 'verified-11' \"$gh_marker\"");
     expect(unix).toContain(
       "for harness in claude codex copilot cursor kiro kiro-ide opencode; do",
     );


### PR DESCRIPTION
## Summary
- accept signer-only, source-ref-only, and source-digest-bound provenance verifier invocations in the Unix release lifecycle fixture
- require the release rehearsal to observe the 11-argument source-ref verification
- pin the three-shape contract in the release workflow unit assertions

## Validation
- parsed `.github/workflows/release.yml` with Bun YAML and validated the extracted Unix lifecycle script with `bash -n`
- replayed the failed release artifact locally; the installer succeeds when the fixture accepts 9, 11, and 13 arguments
- full tests not run per emergency release request