### PR TITLE
feat(plugins): ddd — domain model as an enforced deliverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.8.1] - 2026-09-08
+
+Add the `ddd` plugin: Domain-Driven Design as an installable AIDLC plugin that makes the domain model a first-class deliverable. It adds a `ddd-domain-modeling` stage in Inception (ubiquitous language, bounded contexts, aggregates, invariants, state machines, domain events, business rules), a `ddd-conformance` hard gate after Build and Test that generates and runs a domain-conformance test suite, contributions onto Units Generation, Functional Design, Code Generation, and Build and Test, an advisory `ddd-conformance` sensor, a `ddd-modeling` scope, and architect-agent modeling methodology knowledge. **Install:** copy `dist/plugins/ddd/<harness>/` into the project and run `/aidlc plugin sync`.
+
+* New stages `ddd-domain-modeling` (2.15, Inception) and `ddd-conformance` (3.9, Construction) run when the plugin is selected under the `enterprise`, `feature`, `mvp`, or `workshop` scopes. The plugin's `ddd-modeling` scope is a standalone modeling-only path (initialization, requirements analysis, domain modeling — no build, no gate) whose deliverable is the approved domain model.
+* The conformance gate adjudicates violations as either code fixes or human-approved domain-model amendments, and folds the generated domain tests into the standing suite.
+
 ## [2.8.0] - 2026-09-08
 
 AI-DLC 2.8.0 consolidates the 2.7.x release cycle into a new minor baseline without changing runtime behavior from 2.7.2. **Upgrade:** use `install.sh --version 2.8.0`, `install.ps1 -Version 2.8.0`, or replace a manual copy with `runtime/<harness>/` from `aidlc-runtime-2.8.0.tar.gz`. Existing 2.7.2 workflow records require no migration. Upgrades from earlier releases must still apply every intervening **Upgrade**, **Breaking**, and migration note below.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ structured, verifiable software-delivery workflows. One harness-neutral core
 runs natively in Claude Code, Kiro CLI, Kiro IDE, Codex CLI, Cursor, opencode,
 and GitHub Copilot.
 
-![version](https://img.shields.io/badge/version-2.8.0-blue)
+![version](https://img.shields.io/badge/version-2.8.1-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 
 The Quick Start below installs the latest stable AI-DLC release.

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.8.0";
+export const AIDLC_VERSION = "2.8.1";

--- a/plugins/ddd/.aidlc-plugin/plugin.json
+++ b/plugins/ddd/.aidlc-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "ddd",
+  "version": "0.1.0",
+  "description": "Domain-Driven Design as a first-class, inviolable control plane. Adds a domain-modeling stage that produces a structured ddd-domain-model (ubiquitous language, bounded contexts, aggregates, invariants, finite state machines, domain events) and a ddd-conformance gate stage that compiles the model into executable tests (structural rule-0 + invariants + FSM + business rules) and runs them as a hard gate. Reuses aidlc-architect-agent (lead) and aidlc-product-agent (business voice).",
+  "author": { "name": "AWS AIDLC" },
+  "dependencies": ["core"],
+  "aidlc": {
+    "contributes": {
+      "stages": "stages/",
+      "overlays": "contributions/",
+      "scopes": "scopes/",
+      "knowledge": "knowledge/",
+      "sensors": "sensors/",
+      "tools": "tools/"
+    }
+  }
+}

--- a/plugins/ddd/README.md
+++ b/plugins/ddd/README.md
@@ -1,0 +1,50 @@
+# ddd — Domain-Driven Design plugin
+
+Makes the domain model a **first-class, inviolable deliverable** and enforces it with **deterministic,
+blocking controls**: the model compiles into executable tests, and a failing test is a hard stop.
+
+## What it adds
+
+- **Stage `ddd-domain-modeling`** (inception) — produces the structured `ddd-domain-model` artifact
+  (ubiquitous language, bounded contexts, context map, entities/value objects, aggregates with finite
+  state machines, domain events, and rules). Facilitated event storming: architect leads, product
+  supplies business language, business stakeholders confirm at the gate.
+- **Stage `ddd-conformance`** (construction, after `build-and-test`) — the hard gate. Derives rule-0
+  structural rules from the model, compiles invariants → property tests, FSMs → exhaustive
+  transition-matrix tests, business rules → functional tests, runs them, and fails on any failure.
+  Also the human adjudication gate: a violation is resolved by fixing the code or by a
+  human-approved model amendment (which re-enters `ddd-domain-modeling`).
+- **Contributions** (additive, no core edits) — `units-generation` and `functional-design` consume
+  the model and gain the advisory `ddd-conformance` sensor (design-time pre-check); `code-generation`
+  injects runtime FSM guards + invariant assertions and glossary naming; `build-and-test` folds the
+  domain tests into the standing suite.
+- **Sensor `ddd-conformance`** — advisory today (framework has no blocking severity yet); reads
+  `ddd-conformance-report.json`. Flip `default_severity` to `blocking` when the framework ships it.
+- **Scope `ddd-modeling`** — a standalone modeling-only engagement (init → requirements-analysis →
+  ddd-domain-modeling; the requirements-analysis contribution joins that core stage to the scope).
+  The full build path — both ddd stages including the conformance gate — runs under the core
+  `enterprise`/`feature`/`mvp`/`workshop` scopes when the plugin is enabled.
+
+## Enforcement model
+
+The failing test is the single enforcement primitive. Structured rules (structural conformance,
+invariant predicates, FSM transitions) are elevated to domain-level enforcement — runtime
+guards/assertions + exhaustive/property tests; given/when/then is the example-based fallback. See
+`knowledge/aidlc-architect-agent/ddd-modeling-method.md` and the design spec
+(`ddd-model-and-rule-schema.md`).
+
+## Design principles held
+
+- **Core immutable** — no `core/` edits; everything is additive via new stages + contributions.
+- **Hard gate is a dedicated stage** — `ddd-conformance` owns a real `requires_stage: [build-and-test]`
+  edge and runs the tests itself, so enforcement never depends on the deferred `adds.requires_stage`.
+- **Portable topology** — `mode: inline` with core reviewer agents, so compose stays clean on every
+  harness (no plugin-agent dispatch surface required). Promote to `mob` later for live
+  business-in-the-room adjudication once per-harness dispatch surfaces exist.
+
+## Status
+
+Authored against the `core/` stage/sensor/plugin schemas (mirrors `plugins/test-pro/`). Validate with
+`aidlc-graph compile` + `scripts/package.ts` before publishing. Advisory sensor + test-based hard gate
+today; blocking-sensor severity is a framework capability this plugin is authored to adopt when it
+ships.

--- a/plugins/ddd/contributions/construction/build-and-test.md
+++ b/plugins/ddd/contributions/construction/build-and-test.md
@@ -1,0 +1,23 @@
+---
+target: build-and-test
+plugin: ddd
+adds:
+  consumes:
+    - artifact: ddd-conformance-suite
+      required: false
+fragments:
+  - anchor: end-of-steps
+    order: 100
+---
+
+## fragment: end-of-steps
+
+### Step (ddd): Fold the domain-conformance tests into the canonical suite
+
+The `ddd-conformance` gate stage generates the domain tests (structural rule-0, invariant/property,
+FSM transition-matrix, and business-rule tests) into the workspace. Ensure the canonical build/test
+command discovers and runs them alongside the functional tests, so they persist and re-run in CI on
+every future change — not only during the one-time gate. A failing domain test fails the build.
+
+(The authoritative hard gate remains the `ddd-conformance` stage, which runs these tests and
+adjudicates violations; this step keeps them in the standing suite.)

--- a/plugins/ddd/contributions/construction/code-generation.md
+++ b/plugins/ddd/contributions/construction/code-generation.md
@@ -1,0 +1,32 @@
+---
+target: code-generation
+plugin: ddd
+adds:
+  consumes:
+    - artifact: ddd-domain-model
+      required: false
+fragments:
+  - anchor: end-of-steps
+    order: 100
+---
+
+## fragment: end-of-steps
+
+### Step (ddd): Generate code that honors the domain model (runtime enforcement)
+
+If `ddd-domain-model` is present, generated code must embed the model's guarantees at runtime — this
+is where the domain-level rules become always-on, not just test-time:
+
+- **Naming** — domain types, methods, and public API terms come from the `ubiquitous_language`
+  glossary; do not introduce synonyms.
+- **Aggregates** — expose each aggregate only through its `root`; keep members non-public.
+- **FSM guards** — for an aggregate with a `state_machine`, generate a single guarded transition
+  function that permits only declared transitions and rejects all others (e.g. `cancel` from
+  `SHIPPED`).
+- **Invariant assertions** — for each `kind: invariant`, inject a runtime check on the aggregate root
+  that re-asserts the predicate after every mutation.
+- **Cross-context** — reference other contexts by ID or through the declared `context_map` seam
+  (anti-corruption layer), never a shared in-memory type.
+
+The `ddd-conformance` gate after build-and-test verifies these structurally and by test; generating
+them correctly here is what makes it pass.

--- a/plugins/ddd/contributions/construction/functional-design.md
+++ b/plugins/ddd/contributions/construction/functional-design.md
@@ -1,0 +1,34 @@
+---
+target: functional-design
+plugin: ddd
+adds:
+  consumes:
+    - artifact: ddd-domain-model
+      required: false
+  sensors:
+    - ddd-conformance
+fragments:
+  - anchor: end-of-steps
+    order: 100
+---
+
+## fragment: end-of-steps
+
+### Step (ddd): Align functional design to the domain model
+
+If `ddd-domain-model` is present, this unit's functional design must project the shared model, not
+re-invent it. Bind the projection to this stage's three source-of-truth artifacts:
+
+- **`entities.md`** — every entity in the YAML block traces to an entity, value object, or aggregate
+  member declared for this unit's bounded context in the domain model (cite the stable model ID).
+  Names come from the `ubiquitous_language` glossary. Cross-context references appear as ID
+  references through a declared `context_map` seam — never a shared in-memory type.
+- **`rules.md`** — each aggregate `invariant` that this unit realizes appears as a rule tracing to
+  its model rule ID. Do not restate rule-0 structural rules (the conformance generator derives
+  those); do not weaken a model invariant here.
+- **`functional-spec.md`** — the lifecycle state machines conform to the owning aggregate's
+  `state_machine`: no transitions beyond the model's edges. A needed extra transition is a model
+  amendment (a business decision back in `ddd-domain-modeling`), not a local addition.
+
+ADVISORY pre-check (the `ddd-conformance` sensor reports drift). The hard gate is `ddd-conformance`
+after build-and-test.

--- a/plugins/ddd/contributions/inception/requirements-analysis.md
+++ b/plugins/ddd/contributions/inception/requirements-analysis.md
@@ -1,0 +1,15 @@
+---
+target: requirements-analysis
+plugin: ddd
+adds:
+  scopes:
+    - ddd-modeling
+---
+
+<!-- Frontmatter-only contribution: no prose fragments.
+
+Puts core requirements-analysis under the ddd-modeling scope so the scope is a
+runnable standalone path: init -> requirements-analysis -> ddd-domain-modeling.
+requirements-analysis has no required consumes (every input is optional), so it
+anchors the modeling-only engagement without pulling in the rest of Inception.
+ddd-domain-modeling's required `requirements` consume is produced on-path. -->

--- a/plugins/ddd/contributions/inception/units-generation.md
+++ b/plugins/ddd/contributions/inception/units-generation.md
@@ -1,0 +1,33 @@
+---
+target: units-generation
+plugin: ddd
+adds:
+  consumes:
+    - artifact: ddd-domain-model
+      required: false
+  sensors:
+    - ddd-conformance
+  # requires_stage: [ddd-domain-modeling]
+  #   INTENDED ordering edge — makes units-generation run AFTER the domain model so
+  #   decomposition is bounded upfront. DEFERRED: doc 18 §6 `adds.requires_stage` is not yet an
+  #   implemented merge surface (compose logs it as an advisory drop and ignores it). Uncomment
+  #   the line above the day that surface graduates — no other change needed. Until then, upfront
+  #   ordering is not enforced; the ddd-conformance gate (after build-and-test) is the backstop.
+fragments:
+  - anchor: end-of-steps
+    order: 100
+---
+
+## fragment: end-of-steps
+
+### Step (ddd): Bound decomposition to the domain model
+
+If `ddd-domain-model` is present, treat its `bounded_contexts` as the **default unit boundaries** —
+each bounded context maps to one unit of work unless the team explicitly decides otherwise. Confirm
+the boundaries against the model rather than eliciting them cold; ask a Business-Domain question only
+to resolve a genuine gap or conflict (a story mapping to no context, a unit spanning two contexts, a
+term absent from the ubiquitous-language glossary). Do not split an aggregate across units; integrate
+contexts via the model's `context_map` seams, not shared state.
+
+This is an ADVISORY pre-check — the advisory `ddd-conformance` sensor reports drift here before code
+exists. The hard, blocking enforcement is the `ddd-conformance` gate stage after build-and-test.

--- a/plugins/ddd/ddd-model-and-rule-schema.md
+++ b/plugins/ddd/ddd-model-and-rule-schema.md
@@ -1,0 +1,110 @@
+# ddd-domain-model — model and rule schema
+
+The design spec for the `ddd-domain-model` artifact: the machine-checkable contract between the
+`ddd-domain-modeling` stage (producer), the design/code-generation contributions (projectors), and
+the `ddd-conformance` gate (enforcer). The artifact is a Markdown file with YAML frontmatter (the
+source of truth this schema describes) plus a human-readable prose body carrying at minimum the
+`## Ubiquitous Language`, `## Bounded Contexts`, and `## Aggregates` H2 sections.
+
+## Stable IDs
+
+Every model element carries a stable ID of the form `{project}.{context}.{type}.{name}`
+(e.g. `orders.fulfillment.aggregate.shipment`, `orders.fulfillment.rule.br-3`). IDs are the
+traceability currency: downstream artifacts (`entities.md`, `rules.md`, `functional-spec.md`,
+generated tests, the conformance report) cite model elements by ID, never by prose name.
+
+## Frontmatter schema
+
+```yaml
+ubiquitous_language:            # the naming source for rule-0 conformance
+  - term: Shipment              # ONE business term per concept
+    definition: ...
+    displaces: [Parcel, Package] # near-synonyms this term displaces (internal coinages flagged)
+
+bounded_contexts:
+  - id: orders.fulfillment
+    name: Fulfillment
+    purpose: ...
+
+context_map:                    # every cross-context relationship, typed + directed
+  - from: orders.fulfillment
+    to: orders.billing
+    type: customer-supplier     # shared-kernel | customer-supplier | conformist | acl |
+    direction: downstream       #   ohs | published-language | separate-ways
+
+entities:                       # identity-tracked over time
+  - id: orders.fulfillment.entity.shipment-leg
+    context: orders.fulfillment
+    attributes: [...]
+
+value_objects:                  # interchangeable when values match; no identity
+  - id: orders.fulfillment.vo.address
+
+aggregates:
+  - id: orders.fulfillment.aggregate.shipment
+    root: orders.fulfillment.entity.shipment-leg
+    members: [...]              # entity/VO IDs reachable only through the root
+    invariant: ...              # the single-transaction consistency statement
+    state_machine:              # OPTIONAL — lifecycle as a closed FSM
+      states: [pending, dispatched, delivered, cancelled]
+      initial: pending
+      transitions:              # the COMPLETE allowed set; absence = disallowed
+        - { from: pending, on: dispatch, to: dispatched }
+        - { from: pending, on: cancel, to: cancelled }
+        - { from: dispatched, on: deliver, to: delivered }
+
+domain_events:                  # past-tense names (rule-0 checks this)
+  - id: orders.fulfillment.event.shipment-dispatched
+    aggregate: orders.fulfillment.aggregate.shipment
+
+rules:                          # authored rules, most-structured form first
+  - id: orders.fulfillment.rule.br-1
+    kind: invariant             # data/cardinality predicate
+    expr: "shipment.legs.length >= 1"
+    aggregate: orders.fulfillment.aggregate.shipment
+  - id: orders.fulfillment.rule.br-2
+    kind: functional            # temporal/cross-aggregate/process — example-based fallback
+    given: ...
+    when: ...
+    then: ...
+```
+
+## The rule tiers and what each compiles to
+
+| Tier | Authored as | Compiled by `ddd-conformance` into |
+|------|-------------|-------------------------------------|
+| Rule-0 structural | NOT authored — derived from model shape | architecture/boundary/naming tests (ArchUnit, dependency-cruiser/ts-arch, import-linter — per the tech environment) |
+| Invariant | `kind: invariant` + `expr` | property-based test + verification that the runtime assertion injected at code-generation is present |
+| FSM | `state_machine` on an aggregate | exhaustive (state × event) transition-matrix test: every allowed edge succeeds, every absent edge is rejected |
+| Functional | `kind: functional` given/when/then | one example test per rule |
+
+Derived rule-0 checks: boundary integrity (each module maps to one context; cross-context only via a
+declared context-map seam), aggregate integrity (members reached only through the root),
+repository-per-aggregate-root, reference-by-ID/ACL, ubiquitous-language naming, past-tense event
+naming, and FSM model-closure (no transition in code that the model does not declare).
+
+## Projection into core artifacts
+
+The model bounds — never duplicates — the core per-unit design artifacts:
+
+- `entities.md` (functional-design): every YAML entity traces to a model entity/VO/aggregate-member ID
+- `rules.md` (functional-design): realized invariants trace to model rule IDs; rule-0 is never restated
+- `functional-spec.md` (functional-design): lifecycle state machines are subsets of the owning
+  aggregate's `state_machine`
+- `components.md` (domain-design): component entity ownership respects aggregate and context boundaries
+
+## Conformance report shape
+
+`ddd-conformance` emits `ddd-conformance-report.json` beside its markdown outputs:
+
+```json
+{
+  "violations": [
+    { "rule_id": "orders.fulfillment.rule.br-1", "kind": "invariant", "scope": "unit-a", "detail": "..." }
+  ],
+  "summary": { "total": 0, "passed": 0, "failed": 0 }
+}
+```
+
+A violation is adjudicated as either a code fix or a human-approved model amendment (version bump,
+back through `ddd-domain-modeling`) — never a silent pass, never an in-place model edit.

--- a/plugins/ddd/knowledge/aidlc-architect-agent/ddd-modeling-method.md
+++ b/plugins/ddd/knowledge/aidlc-architect-agent/ddd-modeling-method.md
@@ -1,0 +1,54 @@
+# DDD Modeling Method (ddd plugin)
+
+Methodology knowledge for the architect (and product) when running `ddd-domain-modeling` and
+`ddd-conformance`. The domain model is a **first-class, inviolable deliverable** — a structured
+contract that bounds decomposition, design, and code, enforced by tests.
+
+## The enforcement thesis
+
+The failing test is the single enforcement primitive. The `ddd-conformance` gate compiles the domain
+model into executable tests and runs them; a failure is a hard stop. Maximize what can be expressed
+**structurally**, because structure is elevated to domain-level (rule-0) deterministic enforcement —
+runtime guards/assertions plus exhaustive/property tests — while given/when/then is only an
+example-based fallback.
+
+| Enforcement class | Rule kinds | Source | Compiles to |
+|-------------------|-----------|--------|-------------|
+| Domain-level (rule 0), hard | structural conformance; data/cardinality invariants; state transitions (FSM) | conformance derived from model shape; invariants + FSM authored as structured declarations | runtime enforcement + exhaustive/property tests |
+| Business tier (1..N) | anything not structurable (temporal, cross-aggregate, process) | authored given/when/then | example functional tests |
+
+## Building the model (ddd-domain-modeling)
+
+1. **Ubiquitous language** — one business term per concept; flag implementation coinages as internal.
+2. **Bounded contexts + context map** — name contexts and their integration seams (ACL, etc.).
+3. **Entities vs value objects** — identity test: interchangeable when values match → value object;
+   tracked over time → entity.
+4. **Aggregates** — one root, a single-transaction invariant, kept small.
+5. **Structured rules — reach for the tightest form:**
+   - `state_machine` on an aggregate for lifecycles (disallowed transitions become derived rule-0);
+   - `kind: invariant` with `expr` for data/cardinality (→ runtime assertion + property test);
+   - `kind: functional` (given/when/then) only when neither fits.
+6. Write `ddd-domain-model.md`: machine-checkable YAML frontmatter + prose body; stable IDs
+   `{project}.{context}.{type}.{name}`.
+
+Brownfield: seed from `business-overview.md` (Business Dictionary → glossary; Component descriptions →
+candidate contexts; Business Transactions → candidate events). Extraction never infers identity or
+aggregate boundaries — decide those with the team.
+
+## Enforcing the model (ddd-conformance)
+
+Derive rule-0 structural rules from the model; compile invariants → property tests, FSM → exhaustive
+(state × event) transition-matrix test, functional rules → example tests; verify the runtime guards
+and assertions injected at code-generation are present; run everything; fail on any failure.
+
+Structural-test tooling is per-project (JVM → ArchUnit; TS/JS → dependency-cruiser / ts-arch; Python
+→ import-linter / pytest-arch). The rules are language-neutral; the generator targets the declared
+stack.
+
+## Adjudication and amendment
+
+A conformance failure forks: fix the code (technical) or amend the model (business — relaxing an
+invariant, changing an FSM edge, or renaming a term changes business meaning, so it needs PM /
+stakeholder sign-off and re-enters `ddd-domain-modeling`, bumping `version`). Downstream stages
+consume the model and never mutate it — that is what keeps the domain inviolable while allowing
+legitimate refinement.

--- a/plugins/ddd/scopes/ddd-modeling.md
+++ b/plugins/ddd/scopes/ddd-modeling.md
@@ -1,0 +1,37 @@
+---
+name: ddd-modeling
+plugin: ddd
+depth: Comprehensive
+keywords:
+  - ddd
+  - domain model
+  - domain-driven design
+  - bounded context
+description: Domain modeling engagement — capture requirements and produce the formal domain model, no build
+skeleton: off
+runner: true
+---
+
+# ddd-modeling scope
+
+A modeling-only engagement: initialization, core `requirements-analysis` (joined to this scope by
+the plugin's requirements-analysis contribution), then `ddd-domain-modeling`. The deliverable is the
+approved `ddd-domain-model` artifact — ubiquitous language, bounded contexts, context map,
+aggregates with invariants and state machines, domain events, and structured rules — the formal
+specification of the domain, produced and business-approved without decomposition or code.
+
+## Why these stages, why skip those
+
+The domain model is a standalone deliverable: it seeds a knowledge base, bounds a future build, or
+closes a discovery/workshop engagement. Requirements analysis is the only upstream stage the model
+needs (all of its own inputs are optional, so the path is self-sufficient greenfield or brownfield).
+Everything downstream — decomposition, design, code generation, and the `ddd-conformance` hard gate —
+belongs to a full build and runs under the core `enterprise`, `feature`, `mvp`, or `workshop` scopes
+with the plugin enabled.
+
+## Membership
+
+Keyword triggers: `ddd`, `domain model`, `domain-driven design`, `bounded context`. This scope runs
+initialization + `requirements-analysis` + `ddd-domain-modeling`. The `ddd-conformance` gate is NOT
+in this scope (there is no build to gate); it executes under the four core full-lifecycle scopes,
+where both ddd stages also run so DDD enforcement layers onto a normal workflow.

--- a/plugins/ddd/sensors/aidlc-ddd-conformance.md
+++ b/plugins/ddd/sensors/aidlc-ddd-conformance.md
@@ -1,0 +1,32 @@
+---
+id: ddd-conformance
+kind: deterministic
+command: bun {{HARNESS_DIR}}/tools/aidlc-sensor-ddd-conformance.ts
+default_severity: advisory
+description: Reports domain-model conformance violations recorded in ddd-conformance-report.json (ddd plugin, advisory)
+category: document-shape
+matches: "**/{aidlc-docs,intents}/**"
+input_schema:
+  output_path: string
+  stage_slug: string
+output_schema:
+  pass: boolean
+  findings_count: integer
+  violations: string[]
+timeout_seconds: 5
+---
+
+# ddd-conformance sensor (ddd)
+
+ADVISORY. Reads the machine-readable conformance report (`ddd-conformance-report.json`) that the
+`ddd-conformance` gate stage emits — and that the advisory contributions on `units-generation` /
+`functional-design` may emit as an early design-time pre-check — and reports any recorded violation
+(boundary crossing, aggregate split, invariant/FSM/business-rule failure, naming drift). Works from
+`--output-path` alone; targets travel inside the JSON.
+
+## Advisory note
+
+The framework has no blocking sensor severity yet, so a `SENSOR_FAILED` here is REPORTED, not
+enforced. Hard enforcement is the `ddd-conformance` gate stage, which RUNS the generated tests and
+fails on any failure. This sensor is the earlier, softer signal at design time; when the framework
+ships blocking severity, flip `default_severity` to `blocking` to make the design-time check hard too.

--- a/plugins/ddd/stages/construction/ddd-conformance.md
+++ b/plugins/ddd/stages/construction/ddd-conformance.md
@@ -1,0 +1,122 @@
+---
+slug: ddd-conformance
+number: 3.9
+name: DDD Conformance Gate
+plugin: ddd
+phase: construction
+execution: CONDITIONAL
+condition: Execute once after build-and-test when the ddd plugin is active — derive and RUN the domain-conformance test suite (structural rule-0 + invariants + FSM + business rules) as a hard gate, and adjudicate any violation (fix code, or human-approved model amendment).
+lead_agent: aidlc-architect-agent
+support_agents:
+  - aidlc-product-agent
+  - aidlc-quality-agent
+mode: inline
+reviewer: aidlc-architecture-reviewer-agent
+review_artifact: ddd-conformance-results
+reviewer_max_iterations: 2
+workspace_requires: true
+produces:
+  - ddd-conformance-suite
+  - ddd-conformance-results
+consumes:
+  - artifact: ddd-domain-model
+    required: true
+  - artifact: build-and-test-summary
+    required: false
+requires_stage:
+  - build-and-test
+sensors:
+  - required-sections
+  - upstream-coverage
+scopes:
+  - enterprise
+  - feature
+  - mvp
+  - workshop
+inputs: <record>/inception/ddd-domain-modeling/ddd-domain-model.md, the generated workspace code, build-and-test-summary.md
+outputs: ddd-conformance-suite.md, ddd-conformance-results.md, ddd-conformance-report.json (+ generated test files written to the workspace)
+---
+
+# DDD Conformance Gate
+
+MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
+
+The hard, deterministic enforcement point for the domain model. It compiles the `ddd-domain-model`
+into **executable tests**, writes them into the workspace, runs them, and FAILS on any failure — the
+failing test is the enforcement primitive. It is also the **human adjudication gate**: a violation
+forks into *fix the code* (technical) or *amend the model* (business — requires PM / stakeholder
+sign-off and re-enters `ddd-domain-modeling`, bumping `version`).
+
+## Steps
+
+### Step 1: Load Agent Personas
+
+Load aidlc-architect-agent (lead) and knowledge from `{{HARNESS_DIR}}/knowledge/aidlc-architect-agent/`.
+Adopt aidlc-product-agent (business adjudication voice) and aidlc-quality-agent (test authorship) inline.
+
+### Step 2: Load the Domain Model and Code
+
+Read `ddd-domain-model.md` (required) and the generated workspace code. Parse the model frontmatter:
+`bounded_contexts`, `context_map`, `aggregates` (+ `state_machine`), `entities`, `value_objects`,
+`ubiquitous_language`, `domain_events`, `rules`.
+
+### Step 3: Derive Rule-0 Structural Rules
+
+From the model shape, derive the structural conformance rules (NOT authored): boundary integrity
+(each module maps to one context; cross-context only via a declared context-map seam), aggregate
+integrity (members reached only through the root), repository-per-aggregate-root, reference-by-ID/ACL,
+ubiquitous-language naming, past-tense event naming, and FSM model-closure.
+
+### Step 4: Compile Rules to Tests (per the project tech environment)
+
+Emit executable tests into the workspace, using the language/tooling the tech environment declares
+(e.g. JVM → ArchUnit; TS/JS → dependency-cruiser / ts-arch; Python → import-linter / pytest-arch):
+- **rule-0 conformance** → architecture/boundary/naming tests;
+- **`kind: invariant`** → property-based tests (and verify the runtime assertion injected at
+  code-generation is present);
+- **`state_machine`** → an exhaustive (state × event) transition-matrix test (every allowed edge
+  succeeds, every disallowed edge is rejected) + verify the guarded transition function;
+- **`kind: functional`** → one example test per given/when/then rule.
+
+### Step 5: Run the Suite
+
+Execute all generated tests. Write `ddd-conformance-suite.md` (what was generated, mapped to model
+element / rule id) and `ddd-conformance-results.md` (pass/fail per rule). Emit machine-readable
+`ddd-conformance-report.json` beside them: `{ "violations": [{ "rule_id", "kind", "scope", "detail" }],
+"summary": { "total": n, "passed": n, "failed": n } }` (the advisory `ddd-conformance` sensor reads it).
+
+### Step 6: Adjudicate Violations (fix code vs amend model)
+
+If all pass, proceed to the gate. If any fail, TRIAGE each violation with the human:
+- **Fix the code** — the code violates a legitimate model rule. Correct the code and re-run.
+- **Amend the model** — the rule itself is wrong (invariant too strict, FSM edge missing, term
+  renamed). This is a BUSINESS decision: capture the amendment, get PM / stakeholder sign-off, and
+  re-enter `ddd-domain-modeling` (version bump). Never edit the model here.
+A conformance failure does not silently pass — it is resolved by one of these before approval.
+
+### Step 7: Open the Approval Gate
+
+Run `bun {{HARNESS_DIR}}/tools/aidlc-orchestrate.ts report --stage ddd-conformance --result awaiting-approval`.
+
+### Step 8: Present Completion & Request Approval
+
+Completion emoji: :shield:
+Summary: rules by tier (rule-0 / invariant / FSM / functional), pass/fail counts, any amendment
+decisions. Review path: this stage's record dir. Standard 2-option approval (Approve / Request
+Changes). STOP for the human response. Report Approve with `--result approved --user-input "<choice>"`;
+Request Changes with `--result rejected --user-input "<feedback>"`, revise, then `--result revised`.
+
+## Sensors
+
+`ddd-conformance-suite.md` and `ddd-conformance-results.md` are markdown artifacts under the record
+dir; `required-sections` and `upstream-coverage` check them. The advisory `ddd-conformance` sensor
+reads `ddd-conformance-report.json`.
+
+## Learn
+
+Follow stage-protocol.md §13: maintain `<record>/<phase>/<stage>/memory.md`
+under the four standard headings while working; before the approval gate,
+surface candidates with `aidlc-learnings.ts`;
+still ask the mandatory "Anything to add for next time?" question, and persist confirmed selections
+with the tool. The memory file stays in the artefact directory, and the stage
+file remains immutable.

--- a/plugins/ddd/stages/inception/ddd-domain-modeling.md
+++ b/plugins/ddd/stages/inception/ddd-domain-modeling.md
@@ -1,0 +1,137 @@
+---
+slug: ddd-domain-modeling
+number: 2.15
+name: DDD Domain Modeling
+plugin: ddd
+phase: inception
+execution: CONDITIONAL
+condition: Execute when the ddd plugin is active — produce the structured ddd-domain-model (ubiquitous language, bounded contexts, aggregates, invariants, finite state machines, domain events, business rules) that bounds downstream decomposition, design, and code generation.
+lead_agent: aidlc-architect-agent
+support_agents:
+  - aidlc-product-agent
+mode: inline
+reviewer: aidlc-product-lead-agent
+review_artifact: ddd-domain-model
+reviewer_max_iterations: 2
+produces:
+  - ddd-domain-model
+consumes:
+  - artifact: requirements
+    required: true
+  - artifact: stories
+    required: false
+  - artifact: business-overview
+    required: false
+    conditional_on: brownfield
+  - artifact: component-inventory
+    required: false
+    conditional_on: brownfield
+requires_stage:
+  - requirements-analysis
+  - reverse-engineering
+sensors:
+  - required-sections
+  - upstream-coverage
+scopes:
+  - enterprise
+  - feature
+  - mvp
+  - workshop
+  - ddd-modeling
+inputs: <record>/inception/requirements-analysis/requirements.md, stories.md (if produced), business-overview.md (brownfield)
+outputs: ddd-domain-model.md (under this stage's record dir, engine-resolved)
+---
+
+# DDD Domain Modeling
+
+MANDATORY: Follow stage-protocol.md for approval gates, question format, and completion messages.
+
+This stage builds the **bounded domain model** — the inviolable contract that downstream stages
+consume and the `ddd-conformance` gate enforces. It is facilitated event storming: the architect
+captures the model, the product manager supplies the business language and rules, and business
+stakeholders confirm it at the gate. The output frontmatter is machine-checkable (parsed by the
+conformance generator and the advisory sensor); the prose body is for humans.
+
+## Steps
+
+### Step 1: Load Agent Personas
+
+Load aidlc-architect-agent persona from `agents/aidlc-architect-agent.md` and knowledge from `{{HARNESS_DIR}}/knowledge/aidlc-architect-agent/` (includes `ddd-modeling-method.md`).
+Load aidlc-product-agent as the business-language voice from `agents/aidlc-product-agent.md` and knowledge from `{{HARNESS_DIR}}/knowledge/aidlc-product-agent/`. On this inline stage the product voice is adopted, not dispatched.
+
+### Step 2: Load Prior Context
+
+- Read `<record>/inception/requirements-analysis/requirements.md` (required).
+- Read `<record>/inception/user-stories/stories.md` if produced.
+- If brownfield: read `business-overview.md` from the codekb and SEED the model from its Business
+  Dictionary (→ ubiquitous language), Component Level Business Descriptions (→ candidate bounded
+  contexts), Business Transactions (→ candidate domain events). Machine extraction never infers
+  identity or aggregate boundaries — those are decided here.
+
+### Step 3: Build the Ubiquitous Language
+
+Agree ONE business term per concept; record the near-synonym each displaces. Flag
+implementation/pattern coinages as internal (not ubiquitous). This glossary is the naming source for
+rule-0 conformance.
+
+### Step 4: Draw Bounded Contexts and the Context Map
+
+Name each bounded context and its purpose; note where a term means two things across contexts. Record
+the context map with integration types (shared-kernel / customer-supplier / conformist / ACL / OHS /
+published-language / separate-ways) and dependency direction.
+
+### Step 5: Classify Entities and Value Objects; Form Aggregates
+
+Run each noun through the identity test (interchangeable if values match → Value Object; tracked over
+time → Entity). Cluster into aggregates with one root and a stated single-transaction invariant. Keep
+aggregates small.
+
+### Step 6: Declare Structured Rules (maximize the domain-level tier)
+
+Reach for the most structured form each rule fits — it elevates the rule to hard, deterministic
+enforcement:
+- **Finite state machine** (`state_machine` on an aggregate) for lifecycles — disallowed transitions
+  become derived rule-0 checks (no authored rule per forbidden edge).
+- **Invariant predicate** (`kind: invariant`, `expr`) for data/cardinality rules — compiles to a
+  runtime assertion + property test.
+- **Given/when/then** (`kind: functional`) only for temporal/cross-aggregate/process rules that fit
+  no structured form.
+
+Structural conformance rules (boundaries, aggregate integrity, repository-per-root, ACL, naming,
+event naming) are NOT authored here — the conformance generator derives them from the structure above.
+
+### Step 7: Write the Domain Model Artifact
+
+Write `<record>/inception/ddd-domain-modeling/ddd-domain-model.md` with machine-checkable YAML
+frontmatter (`ubiquitous_language`, `bounded_contexts`, `context_map`, `entities`, `value_objects`,
+`aggregates` with `state_machine`, `domain_events`, `rules`) plus a human-readable prose body. Use
+stable IDs `{project}.{context}.{type}.{name}`. Include `## Ubiquitous Language`, `## Bounded
+Contexts`, and `## Aggregates` H2 sections in the body.
+
+### Step 8: Open the Approval Gate (business confirmation)
+
+Run `bun {{HARNESS_DIR}}/tools/aidlc-orchestrate.ts report --stage ddd-domain-modeling --result awaiting-approval`.
+
+### Step 9: Present Completion & Request Approval
+
+Completion emoji: :triangular_ruler:
+Review path: this stage's engine-resolved record dir.
+Business stakeholders confirm the glossary, rules, and lifecycles. Standard 2-option approval
+(Approve / Request Changes). STOP for the human response. Report Approve with
+`--result approved --user-input "<exact choice>"`; report Request Changes with
+`--result rejected --user-input "<feedback>"`, revise, then report `--result revised` before
+re-presenting. Any later amendment re-enters through this stage and bumps the model `version`.
+
+## Sensors
+
+This stage's output is a markdown artifact under its record dir; `required-sections` and
+`upstream-coverage` check it.
+
+## Learn
+
+Follow stage-protocol.md §13: maintain `<record>/<phase>/<stage>/memory.md`
+under the four standard headings while working; before the approval gate,
+surface candidates with `aidlc-learnings.ts`;
+still ask the mandatory "Anything to add for next time?" question, and persist confirmed selections
+with the tool. The memory file stays in the artefact directory, and the stage
+file remains immutable.

--- a/plugins/ddd/tests/plugin.test.ts
+++ b/plugins/ddd/tests/plugin.test.ts
@@ -1,0 +1,139 @@
+// The ddd plugin's own content validation and compose smoke.
+//
+// Distinct from the framework compose guard (t188): this checks the plugin's
+// authored content before packaging, then composes the built claude projection
+// into a disposable install and asserts the DDD surfaces actually land.
+//
+// Run: bun test plugins/ddd/tests/plugin.test.ts
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  composePluginFixture,
+  validatePluginContent,
+  walkMarkdownFiles,
+} from "../../../tests/harness/plugin-kit.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = join(HERE, "..");
+const PLUGIN_NAME = "ddd";
+
+describe("ddd plugin own content validation", () => {
+  test("passes the reusable plugin content validator", () => {
+    expect(validatePluginContent(PLUGIN_ROOT)).toEqual([]);
+  });
+
+  test("ships stages, contributions, sensor, scope, and knowledge", () => {
+    expect(walkMarkdownFiles(join(PLUGIN_ROOT, "stages")).length).toBe(2);
+    expect(
+      walkMarkdownFiles(join(PLUGIN_ROOT, "contributions")).length,
+    ).toBe(5);
+    expect(
+      existsSync(join(PLUGIN_ROOT, "sensors", "aidlc-ddd-conformance.md")),
+    ).toBe(true);
+    expect(existsSync(join(PLUGIN_ROOT, "scopes", "ddd-modeling.md"))).toBe(
+      true,
+    );
+    expect(
+      existsSync(
+        join(
+          PLUGIN_ROOT,
+          "knowledge",
+          "aidlc-architect-agent",
+          "ddd-modeling-method.md",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("both stages bind their reviewer to a produced review_artifact", () => {
+    for (const [stage, artifact] of [
+      ["stages/inception/ddd-domain-modeling.md", "ddd-domain-model"],
+      ["stages/construction/ddd-conformance.md", "ddd-conformance-results"],
+    ]) {
+      const body = readFileSync(join(PLUGIN_ROOT, stage), "utf-8");
+      expect(body, stage).toContain(`review_artifact: ${artifact}`);
+    }
+  });
+});
+
+describe(`${PLUGIN_NAME} plugin — composed into a disposable claude install`, () => {
+  let projectDir = "";
+  let tmpRoot = "";
+
+  beforeAll(() => {
+    const fixture = composePluginFixture({
+      plugin: PLUGIN_NAME,
+      harness: "claude",
+    });
+    projectDir = fixture.projectDir;
+    tmpRoot = dirname(projectDir);
+  }, 120_000);
+
+  afterAll(() => {
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  test("both DDD stages land in the composed stage tree", () => {
+    const stagesDir = join(projectDir, ".claude", "aidlc-common", "stages");
+    expect(
+      existsSync(join(stagesDir, "inception", "ddd-domain-modeling.md")),
+    ).toBe(true);
+    expect(
+      existsSync(join(stagesDir, "construction", "ddd-conformance.md")),
+    ).toBe(true);
+  });
+
+  test("contributions merge into all four core target stages", () => {
+    const stagesDir = join(projectDir, ".claude", "aidlc-common", "stages");
+    for (const target of [
+      "inception/units-generation.md",
+      "construction/functional-design.md",
+      "construction/code-generation.md",
+      "construction/build-and-test.md",
+    ]) {
+      const body = readFileSync(join(stagesDir, target), "utf-8");
+      expect(body, target).toContain("plugin:ddd");
+    }
+  });
+
+  test("requirements-analysis joins the ddd-modeling scope (standalone modeling path)", () => {
+    const stagesDir = join(projectDir, ".claude", "aidlc-common", "stages");
+    const ra = readFileSync(
+      join(stagesDir, "inception", "requirements-analysis.md"),
+      "utf-8",
+    );
+    expect(ra).toContain("- ddd-modeling");
+    // The conformance gate stays out of the modeling-only scope.
+    const gate = readFileSync(
+      join(stagesDir, "construction", "ddd-conformance.md"),
+      "utf-8",
+    );
+    expect(gate).not.toContain("- ddd-modeling");
+  });
+
+  test("sensor manifest, sensor tool, scope, and knowledge are copied", () => {
+    const harnessDir = join(projectDir, ".claude");
+    expect(
+      existsSync(join(harnessDir, "sensors", "aidlc-ddd-conformance.md")),
+    ).toBe(true);
+    expect(
+      existsSync(join(harnessDir, "tools", "aidlc-sensor-ddd-conformance.ts")),
+    ).toBe(true);
+    expect(existsSync(join(harnessDir, "scopes", "ddd-modeling.md"))).toBe(
+      true,
+    );
+    expect(
+      existsSync(
+        join(
+          harnessDir,
+          "knowledge",
+          "aidlc-architect-agent",
+          "ddd-modeling-method.md",
+        ),
+      ),
+    ).toBe(true);
+  });
+});

--- a/plugins/ddd/tools/aidlc-sensor-ddd-conformance.ts
+++ b/plugins/ddd/tools/aidlc-sensor-ddd-conformance.ts
@@ -1,0 +1,79 @@
+// aidlc-sensor-ddd-conformance.ts — ADVISORY domain-conformance sensor (ddd plugin).
+//
+// Reads the machine-readable conformance report the ddd-conformance gate stage emits
+// (ddd-conformance-report.json) and reports any recorded violation. ADVISORY: the framework has no
+// blocking sensor severity yet, so a failure is reported, not enforced — the ddd-conformance gate
+// stage runs the generated tests and is the hard gate. Self-contained: no import of the framework's
+// aidlc-lib (a plugin tool ships in its own delta). Shipped to {{HARNESS_DIR}}/tools/ via the
+// plugin's contributes.tools.
+import { existsSync, readFileSync } from "node:fs";
+
+const errorMessage = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+interface Violation {
+  rule_id?: string;
+  kind?: string;
+  scope?: string;
+  detail?: string;
+}
+
+interface Result {
+  pass: boolean;
+  findings_count: number;
+  violations: string[];
+}
+
+interface Flags {
+  stage?: string;
+  outputPath?: string;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const out: Flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--stage") out.stage = argv[++i];
+    else if (argv[i] === "--output-path") out.outputPath = argv[++i];
+  }
+  return out;
+}
+
+function fail(msg: string): never {
+  process.stderr.write(`aidlc-sensor-ddd-conformance: ${msg}\n`);
+  process.exit(1);
+}
+
+// The dispatcher fires on EVERY write under the record dir (matches glob), not only this sensor's
+// JSON, so most fires are for some other artifact and must report a clean no-op rather than a finding.
+function passThrough(): never {
+  process.stdout.write(`${JSON.stringify({ pass: true, findings_count: 0, violations: [] })}\n`);
+  process.exit(0);
+}
+
+function main(): void {
+  const flags = parseFlags(process.argv.slice(2));
+  if (!flags.outputPath) fail("--output-path is required");
+  // Only act on this sensor's own machine-readable file; any other write is a clean pass-through.
+  if (!flags.outputPath.endsWith("ddd-conformance-report.json")) passThrough();
+  if (!existsSync(flags.outputPath)) passThrough();
+
+  let parsed: { violations?: Violation[] };
+  try {
+    parsed = JSON.parse(readFileSync(flags.outputPath, "utf-8"));
+  } catch (err) {
+    fail(`failed to parse conformance report ${flags.outputPath}: ${errorMessage(err)}`);
+  }
+
+  const violations = Array.isArray(parsed.violations) ? parsed.violations : [];
+  const summaries = violations.map(
+    (v) => `${v.rule_id ?? "?"} [${v.kind ?? "?"}] @ ${v.scope ?? "?"}: ${v.detail ?? ""}`.trim(),
+  );
+
+  const result: Result = {
+    pass: summaries.length === 0,
+    findings_count: summaries.length,
+    violations: summaries,
+  };
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+main();


### PR DESCRIPTION
# Summary

Adds the `ddd` plugin: Domain-Driven Design as an installable AIDLC plugin that makes the domain
model a first-class, machine-checkable deliverable — produced early, approved by the business, and
enforced against generated code as a hard gate. 18 files, ~920 lines, no `core/` edits: everything
is additive through the plugin mechanism, following the `test-pro` reference plugin's conventions
including its own `tests/` suite on the plugin test kit.

Generated code is only as trustworthy as the constraints around it. This plugin treats the domain
model as a formal specification — ubiquitous language, bounded contexts, a typed context map,
aggregates with declared invariants and finite state machines, domain events, structured rules — in
machine-checkable YAML with stable IDs (`{project}.{context}.{type}.{name}`). The `ddd-conformance`
gate compiles that model into executable tests and runs them after Build and Test. Code either
conforms, or a human adjudicates: fix the code, or amend the model as a business decision with
sign-off. Nothing passes silently, and the model is never weakened in place.

This builds on the #711 domain/contract design restructure. #711 gave every unit machine-checkable
design artifacts — `entities.md` and `rules.md` with YAML source-of-truth blocks, `functional-spec.md`
owning workflows and state machines, `components.md` with single-owner entity catalogues. What was
missing is a *global* model that bounds them all, plus enforcement. Roadmap context: #723 names a
design plugin (#527) as a first-party candidate; this is offered as that candidate or as input to it.

## Changes

**New stages**

* `ddd-domain-modeling` (2.15, Inception) — produces the `ddd-domain-model` artifact; brownfield path
  seeds from the CodeKB (`business-overview`, `component-inventory`); business approval gate with the
  product-lead reviewer bound to the model artifact.
* `ddd-conformance` (3.9, Construction) — hard gate after `build-and-test` via a real `requires_stage`
  edge (not the deferred `adds.requires_stage`); generates and RUNS the domain-conformance suite in
  the workspace (`workspace_requires: true`); adjudicates violations as code fixes or human-approved
  model amendments; emits `ddd-conformance-report.json`.

**Contributions (additive-only)** onto `units-generation` (bounded contexts bound decomposition),
`functional-design` (projection binding: `entities.md` entries trace to model element IDs, realized
invariants in `rules.md` trace to model rule IDs, `functional-spec.md` state machines must be subsets
of the owning aggregate's FSM), `code-generation` (runtime enforcement of invariants and guarded FSM
transitions), `build-and-test` (fold domain tests into the standing suite so they re-run in CI), and
`requirements-analysis` (`adds.scopes`, see below).

**Scope `ddd-modeling`** — a standalone modeling-only engagement: init → requirements-analysis →
ddd-domain-modeling, deliverable being the approved domain model (workshops, discovery, KB seeding).
The conformance gate deliberately stays out of this scope; the full path runs under
`enterprise`/`feature`/`mvp`/`workshop`.

**Sensor `aidlc-ddd-conformance`** — advisory; reads the conformance report. Candidate for gate-bound
blocking severity (#836) as a follow-up.

**Knowledge and docs** — `ddd-modeling-method.md` under the architect agent (additive, no-clobber);
plugin README; and `ddd-model-and-rule-schema.md`, the design spec covering the frontmatter schema
with a worked example, stable IDs, the four rule tiers and their compilation targets, the derived
rule-0 set, projection mapping into core artifacts, and the report shape.

**Release** — version 2.8.1 (`aidlc-version.ts`, README badge) + CHANGELOG entry, per the policy.

## User experience

**Before:** a team can capture entities, rules, and state machines per Unit, but nothing binds those
per-Unit artifacts to a single agreed domain model, and no gate verifies generated code against it.
Domain drift between Units is invisible until someone reads all the designs.

**After:** with the plugin installed and enabled, Inception gains a business-approved domain model
that bounds downstream decomposition and design, and Construction gains a hard gate that compiles
the model into executable tests (structural boundary/naming, invariant property tests, exhaustive FSM
transition matrices, example-based rules) and runs them. A violation stops the workflow for
adjudication rather than shipping. Teams that only want the model can run `--scope ddd-modeling` and
stop after Inception. Teams that do not enable the plugin see no change.

## Checklist

If an item does not apply, leave it unchecked.

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test plan

Per the current contributing checklist (post-#756, generated trees are ignored locally):

```bash
bun install --frozen-lockfile
bun core/tools/aidlc-plugin-validate.ts plugins/ddd   # 0 errors
bun scripts/package.ts                                # materializes dist/ + dist-release/
bun test plugins/ddd/tests/plugin.test.ts             # 7/7, includes a compose smoke
bun test tests/unit/t68-version-changelog-sync.test.ts # version/CHANGELOG/README agree on 2.8.1
```

The plugin validator reports one expected warning (no vendored `hooks/compose.ts`; the build injects
the bundled one). The compose smoke builds the claude projection into a disposable install and
asserts both stages land, all five contributions merge, the `ddd-modeling` scope join happens, and
the sensor/scope/knowledge files copy over.

The full L1 suite was run locally before rebasing. The only failures were environment-specific —
5-second budgets on git-heavy workspace-sync/dispatcher tests, one Windows-evaluator timeout, and the
native binary compile — and they **reproduce identically on a clean `main` checkout with no plugin
present**. The live-LLM sdk families are excluded from the PR gate by `--no-llm`.

**Dogfooded end to end.** The `ddd-modeling` scope was run against a real brownfield TypeScript
service (a Nova Sonic / Bedrock real-time translation service, ~240 components) on a Kiro IDE
install: install upgrade → plugin compose → scope join → 5-stage plan → both stages to completion,
with no plugin defects. Every enforcement seam held (summary-confirmation receipts, artifact-write
freshness against the audit ledger, two-phase adversarial review, a gate rejection/revision cycle,
human-presence minting). Two defects in the *modeling work* were caught by two different layers: the
adversarial reviewer refuted an FSM state that was unsatisfiable for one of two delivery directions
(it would have failed the conformance gate's transition-matrix test against correct code), and the
human business gate caught reverse-engineering documentation that had recorded a config default as
domain behavior. Two independent safety nets, each catching what the other missed.

## Known limitations / follow-ups

* The sensor is advisory (write-fired sensors carry no blocking severity); binding it gate-bound
  blocking per #836 is a natural follow-up.
* Inline mode with core reviewer agents keeps compose clean on every harness; a `mob` topology for
  live model-storming is a later enhancement.
* The ubiquitous-language glossary is a natural query vocabulary for semantic code search (model term
  → implementing components); out of scope here, noted in the plugin README.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
