### PR TITLE
test: bound cleanup hooks in t243 and t248

### DIFF
--- a/tests/unit/t243-install-mechanism.test.ts
+++ b/tests/unit/t243-install-mechanism.test.ts
@@ -1,7 +1,7 @@
 // covers: tool:aidlc-init, tool:aidlc-lifecycle, file:core/tools/aidlc-archive.ts
 // covers: file:core/tools/aidlc-transaction.ts, file:scripts/package.ts
 
-import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -104,10 +104,6 @@ const NEXT_VERSION = (() => {
 const temporary: string[] = [];
 const originalPath = process.env.PATH;
 
-// The default also governs afterAll removal of 128 staged roots, several of them
-// dist-sized, which exceeds bun's 5s hook default.
-setDefaultTimeout(120_000);
-
 beforeAll(() => {
   process.env.PATH = `${join(REPO_ROOT, "tests", "fixtures", "bin")}${delimiter}${
     originalPath ?? ""
@@ -118,11 +114,12 @@ function releaseBinaryName(): string {
   return `aidlc-${targetTriple()}${process.platform === "win32" ? ".exe" : ""}`;
 }
 
+// Removing the accumulated temporary trees can exceed bun's 5s hook default.
 afterAll(() => {
   if (originalPath === undefined) delete process.env.PATH;
   else process.env.PATH = originalPath;
   for (const path of temporary) rmSync(path, { recursive: true, force: true });
-});
+}, 120_000);
 
 // Production emits canonical project and machine paths, so fixtures live under
 // the canonical temp root (macOS aliases /var to /private/var).
@@ -1313,7 +1310,7 @@ describe("t243 project initialization", () => {
     };
     expect(merged.mcpServers.context7).toEqual(custom);
     expect(merged.projectSetting).toBe(true);
-  });
+  }, 60_000);
 
   test("MCP consent and managed AGENTS blocks preserve user-owned configuration", () => {
     const claudeProject = temp("aidlc-t240-mcp-matrix-");

--- a/tests/unit/t243-install-mechanism.test.ts
+++ b/tests/unit/t243-install-mechanism.test.ts
@@ -1,7 +1,7 @@
 // covers: tool:aidlc-init, tool:aidlc-lifecycle, file:core/tools/aidlc-archive.ts
 // covers: file:core/tools/aidlc-transaction.ts, file:scripts/package.ts
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -103,6 +103,10 @@ const NEXT_VERSION = (() => {
 })();
 const temporary: string[] = [];
 const originalPath = process.env.PATH;
+
+// The default also governs afterAll removal of 128 staged roots, several of them
+// dist-sized, which exceeds bun's 5s hook default.
+setDefaultTimeout(120_000);
 
 beforeAll(() => {
   process.env.PATH = `${join(REPO_ROOT, "tests", "fixtures", "bin")}${delimiter}${

--- a/tests/unit/t248-steering-content-delivery.test.ts
+++ b/tests/unit/t248-steering-content-delivery.test.ts
@@ -4,7 +4,7 @@
 // bounded load-steering directives before run-stage; optional persona/knowledge
 // remains path-loaded with actionable warnings.
 
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash, createHmac } from "node:crypto";
 import {
@@ -49,6 +49,10 @@ const REVIEWER_AGENTS = [
   "aidlc-architecture-reviewer-agent",
   "aidlc-product-lead-agent",
 ] as const;
+
+// The default also governs afterAll removal of every staged project, which
+// exceeds bun's 5s hook default.
+setDefaultTimeout(120_000);
 
 type RuleContent = { path: string; text: string };
 type WireDirective = {

--- a/tests/unit/t248-steering-content-delivery.test.ts
+++ b/tests/unit/t248-steering-content-delivery.test.ts
@@ -4,7 +4,7 @@
 // bounded load-steering directives before run-stage; optional persona/knowledge
 // remains path-loaded with actionable warnings.
 
-import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createHash, createHmac } from "node:crypto";
 import {
@@ -50,10 +50,6 @@ const REVIEWER_AGENTS = [
   "aidlc-product-lead-agent",
 ] as const;
 
-// The default also governs afterAll removal of every staged project, which
-// exceeds bun's 5s hook default.
-setDefaultTimeout(120_000);
-
 type RuleContent = { path: string; text: string };
 type WireDirective = {
   kind: string;
@@ -88,9 +84,10 @@ function project(): string {
   return proj;
 }
 
+// Removing every staged project can exceed bun's 5s hook default under load.
 afterAll(() => {
   for (const proj of projects) cleanupTestProject(proj);
-});
+}, 120_000);
 
 function invoke(
   proj: string,


### PR DESCRIPTION
## What

Two test files remove every temporary tree they staged in a single `afterAll`,
whose cost scales with the file rather than with any one case — so it outgrew
bun's 5s hook default and the file failed on cleanup alone. Both cleanup hooks
now carry an explicit `120_000` budget.

Test-only, so no version bump or CHANGELOG entry per the Changelog Policy.

## Measured

| File | Alone | Under load | Cleanup hook |
|---|---|---|---|
| `t243-install-mechanism` | fails **deterministically even alone** — 84 pass / 1 fail, `hook timed out` | same | 6464–6703 ms observed |
| `t248-steering-content-delivery` | **20 sequential runs, 20 pass / 0 fail** — clean at rest | **base 0/12, head 12/12** across 4 processes × 3 rounds, every base failure being 42 passing tests then the hook timeout | 8686 ms at `--parallel 8`; mean 3181 ms unloaded |

The `t248` pair of numbers is the useful one: the file is fine in isolation and
reliably broken under the conditions the suite actually runs in, so testing it
alone and concluding "passes for me" is the trap.

A timed-out hook does two kinds of damage: it fails the file for a reason
unrelated to anything under test, and it abandons whatever it had not yet
deleted. One `t243` run left 606 files / 6.5 MB behind in `$TMPDIR`. After the fix
only zero-byte dangling `*-alias` symlinks remain — `t243:573-574` creates that
symlink as a sibling of `machine` and never pushes it onto `temporary`, so
`rmSync` takes the target and leaves the link. Pre-existing; deliberately left
alone.

## Why the budget is on the hooks, not the file

An earlier revision used a file-wide `setDefaultTimeout(120_000)`. Scoping it to
the two `afterAll` hooks is better, and `t243` itself is the argument: the file
**already carries 39 explicit `}, 60_000)` case budgets**, so per-case budgets are
its local convention, and a file-wide default would let every unannotated case run
for two minutes before failing. The one case a load probe showed crossing the 5s
case default, `--force does not replace a pre-existing user-owned JSON entry`, gets
its own explicit budget instead.

## Known pre-existing failure this did not fix

`t243 release lifecycle > project pins require the retained OpenCode runtime
selected by project metadata` times out under macOS load — 8 of 12 runs at
5002–5019 ms. It sets its own budget at `t243:1900`
(`process.platform === "win32" ? 30_000 : 5_000`), and an explicit per-case value
overrides both a file-wide default and a hook budget, so no timeout mechanism in
this PR could reach it. Verified pre-existing: the same 4-way load against
unmodified `origin/main` fails 4/4 at 5004–5006 ms. Left for whoever owns that
budget.

## Verification

- `bun test` both files together — **126 pass / 0 fail / 1547 expects**.
- 4 concurrent processes × 3 rounds on macOS — **zero hook timeouts**; 125/1 in
  rounds 1–2 and 126/0 in round 3, the single failure being the pre-existing case
  above.
- `bun run typecheck` (3 projects), `bun run lint` (736 files), `git diff --check`
  — all exit 0.
- `bun scripts/package.ts --check` — deterministic across two independent builds,
  all seven harnesses.

Verified on macOS; CI covers Linux and Windows. Note that this class of failure
does not appear in Linux CI, so this fixes a failure developers hit locally rather
than a red pipeline.

## Relationship to #1043

#1043 is the umbrella effort for this failure class. It touches neither of these
two files, so this complements rather than overlaps it — happy to have it folded
in there instead.

An earlier revision also rewrote the `t298` live-holder launch. Dropped: #1043 and
#1025 both already fix it, and their one-line `>/dev/null 2>&1` redirect is the
better fix — detaching the holder's stdout is what lets `spawnSync` return while
the holder is still alive, and it keeps the `READY <pid>` line out of the buffer
the pid is parsed from.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
