### PR TITLE
fix(codex): allow rewritten PreToolUse input

### DIFF
--- a/harness/codex/hooks/aidlc-codex-adapter.ts
+++ b/harness/codex/hooks/aidlc-codex-adapter.ts
@@ -358,13 +358,37 @@ function wrapContext(coreStdout: string, eventName: string): string {
   return coreStdout;
 }
 
+function allowUpdatedInput(coreStdout: string): string {
+  try {
+    const parsed = JSON.parse(coreStdout) as {
+      hookSpecificOutput?: {
+        hookEventName?: unknown;
+        permissionDecision?: unknown;
+        updatedInput?: unknown;
+      };
+    };
+    const output = parsed.hookSpecificOutput;
+    if (
+      output?.hookEventName === "PreToolUse" &&
+      output.updatedInput !== undefined &&
+      output.permissionDecision === undefined
+    ) {
+      output.permissionDecision = "allow";
+      return `${JSON.stringify(parsed)}\n`;
+    }
+  } catch {
+    // Unparseable core output is not a successful input rewrite.
+  }
+  return coreStdout;
+}
+
 function wrapUpdatedInput(updatedInput: Record<string, unknown>): string {
-  return `${JSON.stringify({
+  return allowUpdatedInput(`${JSON.stringify({
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       updatedInput,
     },
-  })}\n`;
+  })}\n`);
 }
 
 // --- D-4: SESSION_ENDED reconcile-at-next-start ------------------------------
@@ -638,12 +662,14 @@ switch (target) {
 
   case "deliver-stage-rules": {
     // Codex 0.145 consumes the same PreToolUse hookSpecificOutput.updatedInput
-    // contract as Claude. The core hook recognizes spawn_agent and appends the
-    // exact active-stage bundle to message/items without adapter re-shaping.
+    // contract as Claude, plus an explicit allow decision for rewritten input.
+    // The core hook recognizes spawn_agent and appends the exact active-stage
+    // bundle to message/items; the adapter completes the Codex envelope.
     const r = runCoreWithStderr("aidlc-deliver-stage-rules.ts", rawInput);
     const answeredCode = r.code === 2 ? 2 : 0;
-    persistResponse(r.stdout, answeredCode, r.stderr);
-    if (r.stdout) process.stdout.write(r.stdout);
+    const stdout = r.code === 2 ? r.stdout : allowUpdatedInput(r.stdout);
+    persistResponse(stdout, answeredCode, r.stderr);
+    if (stdout) process.stdout.write(stdout);
     if (r.code === 2) {
       process.stderr.write(r.stderr);
       return 2;

--- a/tests/unit/t149-codex-hook-adapter.test.ts
+++ b/tests/unit/t149-codex-hook-adapter.test.ts
@@ -444,10 +444,12 @@ describe("t149 Codex hook adapter (live-captured payload fixtures)", () => {
       const output = JSON.parse(r.stdout) as {
         hookSpecificOutput?: {
           hookEventName?: string;
+          permissionDecision?: string;
           updatedInput?: { command?: string };
         };
       };
       expect(output.hookSpecificOutput?.hookEventName).toBe("PreToolUse");
+      expect(output.hookSpecificOutput?.permissionDecision).toBe("allow");
       expect(output.hookSpecificOutput?.updatedInput?.command).toBe(
         "export AIDLC_SESSION_OVERRIDE='codex-command-session' " +
           "AIDLC_SESSION_OVERRIDE_SOURCE='payload'; " +
@@ -542,9 +544,13 @@ describe("t149 Codex hook adapter (live-captured payload fixtures)", () => {
       expect(r.code, r.stderr).toBe(0);
       const out = JSON.parse(r.stdout) as {
         hookSpecificOutput?: {
+          hookEventName?: string;
+          permissionDecision?: string;
           updatedInput?: { message?: string };
         };
       };
+      expect(out.hookSpecificOutput?.hookEventName).toBe("PreToolUse");
+      expect(out.hookSpecificOutput?.permissionDecision).toBe("allow");
       const message = out.hookSpecificOutput?.updatedInput?.message ?? "";
       expect(message).toContain("first-class");
       expect(message).toContain("Given/When/Then");


### PR DESCRIPTION
## Summary

- add the explicit `permissionDecision: "allow"` required by Codex whenever a `PreToolUse` hook returns `updatedInput`
- normalize shared stage-rule rewrites in the Codex adapter without changing the Claude or other harness contracts
- cover both Bash session binding and spawned-agent stage-rule delivery with regression assertions

## Validation

- `bash tests/run-tests.sh --unit --filter '^t149-codex-hook-adapter\.test\.ts$' --no-llm`
- `bash tests/run-tests.sh --unit --filter '^(t150-codex-packaging|t228-hook-run-exports|t248-steering-content-delivery)\.test\.ts$' --no-llm`
- `bun scripts/package.ts --check`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

Fixes #1041

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
