### PR TITLE
test: shard unit CI across isolated jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Run contract checks
         run: bun run check
 
-  test:
-    name: Tests (smoke + unit)
+  test_smoke:
+    name: Tests (smoke)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -70,16 +70,57 @@ jobs:
       - name: Build the harness projections
         run: bun scripts/package.ts
 
+      - name: Run smoke tier
+        run: bun tests/run-tests.ts --smoke
+
+  test_unit:
+    name: Tests (unit shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Each shard receives an independent checkout. Tests stay serial inside
+      # the shard, so packaging tests may regenerate dist/ without racing tests
+      # that read the generated trees.
+      - name: Build the harness projections
+        run: bun scripts/package.ts
+
       # t244 syntax-checks the generated zsh completion script with `zsh -n`;
       # ubuntu-latest does not ship zsh, so install it to keep that assertion
-      # exercising the real shell instead of skipping.
+      # exercising the real shell instead of skipping. Installing it in every
+      # shard keeps assignment changes independent of runner provisioning.
       - name: Install zsh (t244 completion syntax check)
         run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
 
-      # smoke + unit are the deterministic, credential-free tiers (no AWS /
-      # Bedrock / live Claude). The runner exits non-zero on any failed file.
-      - name: Run smoke + unit tiers
-        run: bun tests/run-tests.ts --smoke --unit --parallel 8
+      - name: Run unit shard
+        run: bun tests/run-tests.ts --unit --shard ${{ matrix.shard }}/4
+
+  # Preserve the existing required-check name while the work runs in isolated
+  # jobs. A matrix failure collapses test_unit.result to failure.
+  test:
+    name: Tests (smoke + unit)
+    if: ${{ always() }}
+    needs: [test_smoke, test_unit]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require smoke and every unit shard
+        env:
+          SMOKE_RESULT: ${{ needs.test_smoke.result }}
+          UNIT_RESULT: ${{ needs.test_unit.result }}
+        run: |
+          test "$SMOKE_RESULT" = "success"
+          test "$UNIT_RESULT" = "success"
 
   test-deep:
     name: Tests (integration + e2e, deterministic)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,14 +58,81 @@ jobs:
       # generator-determinism guard rather than a staleness check.
       - run: bun scripts/package.ts
       - run: bun run check
-      # TEMPORARY: the release tag already passed the PR CI suite. Keep this
-      # duplicate full-suite run disabled while the first native release ships.
-      # - run: bash tests/run-tests.sh --ci --parallel 8
       - name: ShellCheck installer
         run: shellcheck scripts/install.sh
 
+  test_smoke:
+    name: Release tests (smoke)
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - run: bun scripts/package.ts
+      - run: bun tests/run-tests.ts --smoke
+
+  test_unit:
+    name: Release tests (unit shard ${{ matrix.shard }}/4)
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      # Each shard owns an independent checkout. Tests remain serial inside
+      # the shard so package regeneration cannot race dist/ readers.
+      - run: bun scripts/package.ts
+      - name: Install zsh (t244 completion syntax check)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
+      - run: bun tests/run-tests.ts --unit --shard ${{ matrix.shard }}/4
+
+  test_deep:
+    name: Release tests (integration + e2e, deterministic)
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - run: bun scripts/package.ts
+      - run: bun tests/run-tests.ts --integration --e2e --no-llm --parallel 8
+
+  test:
+    name: Release tests
+    if: ${{ always() }}
+    needs: [test_smoke, test_unit, test_deep]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every release test tier
+        env:
+          SMOKE_RESULT: ${{ needs.test_smoke.result }}
+          UNIT_RESULT: ${{ needs.test_unit.result }}
+          DEEP_RESULT: ${{ needs.test_deep.result }}
+        run: |
+          test "$SMOKE_RESULT" = "success"
+          test "$UNIT_RESULT" = "success"
+          test "$DEEP_RESULT" = "success"
+
   native-smoke:
-    needs: [validate, verify]
+    needs: [validate, verify, test]
     strategy:
       fail-fast: false
       matrix:

--- a/docs/reference/09-testing.md
+++ b/docs/reference/09-testing.md
@@ -381,6 +381,8 @@ bash tests/run-tests.sh       # POSIX compatibility wrapper
 --filter PAT    # Only run tests whose filename matches extended regex PAT
 --parallel N    # Run up to N test files concurrently within a tier (alias: -P N).
                 # Default: 1 (serial). Smoke and unit tiers are always serial.
+--shard N/M     # Run one duration-balanced unit shard.
+                # Requires --unit with no other level or profile flags.
 ```
 
 `--no-llm` (or `AIDLC_NO_LLM=1`) closes the derived Claude gate and forces every
@@ -417,10 +419,28 @@ explicitly to keep those files on their in-test SKIP path.
 
 All 8 parallel calls observed `cache_read=73789` — Bedrock prompt caching stays warm across concurrent workers. No throttling or corruption observed at 8-way.
 
-**What stays serial.** Smoke and unit tiers ignore `--parallel` and run serially regardless. They already complete in seconds and their interleaved output would hurt debuggability for no wall-clock gain. The preflight gate (`tests/integration/t19.test.ts`) also runs serially because the LLM tiers depend on its exit status.
+**What stays serial.** Smoke and unit tiers ignore `--parallel` and run serially within one checkout. Unit CI reduces wall-clock time with isolated shards instead: each GitHub Actions job owns a fresh checkout and runs its assigned files serially, so packaging tests can regenerate `dist/` without racing readers. The preflight gate (`tests/integration/t19.test.ts`) also runs serially because the LLM tiers depend on its exit status.
 
 **Output under parallelism.** `START` markers stream live (several can appear back-to-back before the first `DONE` — that's the visible signal workers are concurrent). In normal/verbose mode, each worker's TAP body is buffered and flushed to stdout as one contiguous block under a directory-mutex (`mkdir $LOG_DIR/.stdout.lock`, atomic on POSIX — works on macOS bash 3.2 without `flock`). So `ok`/`not ok` lines from different files never interleave; stdout reads top-to-bottom like a serial run, just with the file completion order determined by how long each test took rather than dispatch order. In `--debug` mode, Bun stdout/stderr streams live while still being written to each per-test log; parallel debug output is prefixed by file basename so overlapping live workers remain attributable. SDK/TUI/Kiro-ACP driver traces are written beside the logs as `$LOG_DIR/sdk-drive-*.ndjson`, `$LOG_DIR/tui-drive-*.ndjson`, and `$LOG_DIR/kiro-acp-drive-*.ndjson`; their exact filenames depend on process IDs and TUI session names, so the runner prints the glob at startup and at each test start. The Kiro-ACP trace records the live `kiro-cli acp` turn event-by-event (spawn, prompt start, each `tool_call`/`tool_call_update` with its verbatim output preview, permission answers, the spawned process's stderr, and the terminal `result`/`timeout`/`end`), so a `session/prompt` timeout can be diagnosed after the fact — distinguishing a turn that was progressing (real tool calls firing) from one that stalled.
 
 **Worker coordination.** The parent backgrounds `run_bun_test_file` with `&` and holds a slot gate via `jobs -rp | wc -l`. Each worker writes an atomic `.meta` sidecar to `$LOG_DIR/_results/`; the parent reads them after `wait` to populate the summary tables. macOS ships bash 3.2.57 (no `wait -n`), so the gate polls every 200ms — negligible next to minute-long LLM calls.
 
 **Guidance.** Start with `--parallel 4`. Raise to `8` if Bedrock capacity and your bill tolerate it. Drop back to serial for debugging a single failing test — or use `--filter` to isolate it.
+
+## Unit Sharding
+
+`--unit --shard N/M` assigns every discovered unit file to exactly one of `M`
+duration-balanced shards. Assignment is deterministic and uses
+`tests/unit-shard-weights.json` for the slowest files. Unlisted files receive a
+one-second default weight, so new tests join the least-loaded shard without
+changing the command.
+
+Each shard remains serial. Run separate shards in separate checkouts or CI jobs.
+Do not run them concurrently against one repository tree because packaging
+tests regenerate `dist/` and can race tests that read generated files.
+
+The affinity list keeps cross-file prerequisites explicit. The native binary
+builder test currently runs before the Copilot compiled-adapter coverage in the
+same shard. The smoke runner contract verifies that all four CI shards are
+non-empty, disjoint, cover the complete unit inventory, and preserve this
+ordering.

--- a/docs/reference/09-testing.md
+++ b/docs/reference/09-testing.md
@@ -433,7 +433,9 @@ All 8 parallel calls observed `cache_read=73789` — Bedrock prompt caching stay
 duration-balanced shards. Assignment is deterministic and uses
 `tests/unit-shard-weights.json` for the slowest files. Unlisted files receive a
 one-second default weight, so new tests join the least-loaded shard without
-changing the command.
+changing the command. The runner exits 2 when `M` exceeds the number of
+assignable groups, so no valid shard command can report success after running
+zero files.
 
 Each shard remains serial. Run separate shards in separate checkouts or CI jobs.
 Do not run them concurrently against one repository tree because packaging
@@ -441,6 +443,8 @@ tests regenerate `dist/` and can race tests that read generated files.
 
 The affinity list keeps cross-file prerequisites explicit. The native binary
 builder test currently runs before the Copilot compiled-adapter coverage in the
-same shard. The smoke runner contract verifies that all four CI shards are
-non-empty, disjoint, cover the complete unit inventory, and preserve this
-ordering.
+same shard. Sharded unit execution requires that compiled coverage to resolve
+the producer's native build result, so a missing artifact fails instead of
+silently skipping the compiled cases. The smoke runner contract verifies that
+all four CI shards are non-empty, disjoint, cover the complete unit inventory,
+and preserve this ordering.

--- a/tests/README.md
+++ b/tests/README.md
@@ -101,6 +101,9 @@ bash tests/run-tests.sh --integration --filter "t25|t26"
 bash tests/run-tests.sh --all --parallel 4
 bash tests/run-tests.sh --integration -P 8
 
+# Run one deterministic unit shard. CI uses four isolated serial shards.
+bash tests/run-tests.sh --unit --shard 1/4
+
 # Verbose / debug output
 bash tests/run-tests.sh --verbose
 bash tests/run-tests.sh --debug   # streams output and writes SDK/TUI NDJSON traces

--- a/tests/README.md
+++ b/tests/README.md
@@ -112,6 +112,10 @@ bash tests/run-tests.sh --debug   # streams output and writes SDK/TUI NDJSON tra
 bun test tests/smoke/t01-file-structure.test.ts
 ```
 
+The runner rejects shard counts that exceed the number of assignable test
+groups. Sharded unit runs also require the native binary producer to make the
+compiled Copilot adapter cases executable.
+
 Live SDK and TUI drivers default to project-only Claude setting sources. That
 keeps the copied test `.claude/` tree authoritative while excluding developer
 user-level hooks/settings; focused calibration can opt the TUI back into CLI

--- a/tests/integration/t112.serial.test.ts
+++ b/tests/integration/t112.serial.test.ts
@@ -46,6 +46,7 @@ import { join } from "node:path";
 const REAL_RUNNER = join(import.meta.dir, "..", "run-tests.sh");
 const REAL_RUNNER_TS = join(import.meta.dir, "..", "run-tests.ts");
 const REAL_GLUE = join(import.meta.dir, "..", "lib", "bun-junit-to-meta.ts");
+const REAL_SHARDING = join(import.meta.dir, "..", "lib", "test-sharding.ts");
 
 const scratchRoots: string[] = [];
 
@@ -87,6 +88,7 @@ function driveRunner(nFail: number, nPass: number): { code: number; stdout: stri
   copyFileSync(REAL_RUNNER, join(testsDir, "run-tests.sh"));
   copyFileSync(REAL_RUNNER_TS, join(testsDir, "run-tests.ts"));
   copyFileSync(REAL_GLUE, join(libDir, "bun-junit-to-meta.ts"));
+  copyFileSync(REAL_SHARDING, join(libDir, "test-sharding.ts"));
 
   // Distinct numeric stems keep glob ordering deterministic and avoid collisions
   // between the fail/pass families.

--- a/tests/lib/test-sharding.ts
+++ b/tests/lib/test-sharding.ts
@@ -93,6 +93,12 @@ export function assignWeightedShards(
     });
   }
 
+  if (total > groups.length) {
+    throw new Error(
+      `--shard count ${total} exceeds ${groups.length} assignable unit-test groups`,
+    );
+  }
+
   groups.sort(
     (a, b) => b.weight - a.weight || a.files[0].localeCompare(b.files[0]),
   );

--- a/tests/lib/test-sharding.ts
+++ b/tests/lib/test-sharding.ts
@@ -1,0 +1,126 @@
+export interface ShardSpec {
+  index: number;
+  total: number;
+}
+
+export interface ShardConfig {
+  defaultSeconds: number;
+  weights: Record<string, number>;
+  affinityGroups: string[][];
+}
+
+interface WeightedGroup {
+  files: string[];
+  weight: number;
+}
+
+export function parseShardSpec(value: string): ShardSpec {
+  const match = /^([1-9][0-9]*)\/([1-9][0-9]*)$/.exec(value);
+  if (!match) {
+    throw new Error(`--shard requires N/M with positive integers (got: '${value || "<missing>"}')`);
+  }
+  const index = Number(match[1]);
+  const total = Number(match[2]);
+  if (index > total) {
+    throw new Error(`--shard index must be within 1..${total} (got: '${value}')`);
+  }
+  return { index, total };
+}
+
+export function validateShardConfig(files: string[], config: ShardConfig): void {
+  if (!Number.isFinite(config.defaultSeconds) || config.defaultSeconds <= 0) {
+    throw new Error("unit shard defaultSeconds must be a positive number");
+  }
+
+  const known = new Set(files);
+  for (const [file, weight] of Object.entries(config.weights)) {
+    if (!known.has(file)) {
+      throw new Error(`unit shard weight names missing test file: ${file}`);
+    }
+    if (!Number.isFinite(weight) || weight <= 0) {
+      throw new Error(`unit shard weight must be positive for ${file}`);
+    }
+  }
+
+  const grouped = new Set<string>();
+  for (const group of config.affinityGroups) {
+    if (group.length < 2) {
+      throw new Error("unit shard affinity groups must contain at least two files");
+    }
+    for (const file of group) {
+      if (!known.has(file)) {
+        throw new Error(`unit shard affinity group names missing test file: ${file}`);
+      }
+      if (grouped.has(file)) {
+        throw new Error(`unit shard affinity file appears more than once: ${file}`);
+      }
+      grouped.add(file);
+    }
+  }
+}
+
+export function assignWeightedShards(
+  files: string[],
+  total: number,
+  config: ShardConfig,
+): string[][] {
+  if (!Number.isInteger(total) || total < 1) {
+    throw new Error(`unit shard count must be a positive integer (got: ${total})`);
+  }
+
+  validateShardConfig(files, config);
+  const originalOrder = new Map(files.map((file, index) => [file, index]));
+  const assigned = new Set<string>();
+  const groups: WeightedGroup[] = [];
+
+  for (const affinity of config.affinityGroups) {
+    const members = affinity.filter((file) => originalOrder.has(file));
+    for (const file of members) assigned.add(file);
+    groups.push({
+      files: members,
+      weight: members.reduce(
+        (sum, file) => sum + (config.weights[file] ?? config.defaultSeconds),
+        0,
+      ),
+    });
+  }
+
+  for (const file of files) {
+    if (assigned.has(file)) continue;
+    groups.push({
+      files: [file],
+      weight: config.weights[file] ?? config.defaultSeconds,
+    });
+  }
+
+  groups.sort(
+    (a, b) => b.weight - a.weight || a.files[0].localeCompare(b.files[0]),
+  );
+
+  const shards = Array.from({ length: total }, (_, index) => ({
+    index,
+    weight: 0,
+    files: [] as string[],
+  }));
+  for (const group of groups) {
+    const target = [...shards].sort(
+      (a, b) => a.weight - b.weight || a.index - b.index,
+    )[0];
+    target.files.push(...group.files);
+    target.weight += group.weight;
+  }
+
+  return shards.map((shard) =>
+    shard.files.sort(
+      (a, b) => (originalOrder.get(a) ?? 0) - (originalOrder.get(b) ?? 0),
+    ),
+  );
+}
+
+export function selectShard(
+  files: string[],
+  spec: ShardSpec,
+  config: ShardConfig,
+): string[] {
+  return assignWeightedShards(files, spec.total, config)[spec.index - 1];
+}

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -35,6 +35,7 @@ const BUN = process.execPath;
 const PACKAGE_READY_ENV = "AIDLC_TEST_PACKAGE_READY";
 const PACKAGE_LOCK = join(REPO_ROOT, ".aidlc", "test-package.lock");
 const UNIT_SHARD_CONFIG = join(SCRIPT_DIR, "unit-shard-weights.json");
+const REQUIRE_COMPILED_COVERAGE_ENV = "AIDLC_REQUIRE_COMPILED_COVERAGE";
 
 // Platform null device, used for the system config after the protected
 // safe.directory entries have been copied into the suite's isolated config.
@@ -868,8 +869,15 @@ function levelFiles(level: Level, excludes: string[] = []): string[] {
   if (level === "unit" && args.shard) {
     const config = JSON.parse(readFileSync(UNIT_SHARD_CONFIG, "utf8")) as ShardConfig;
     const names = files.map((file) => basename(file));
-    const selected = new Set(selectShard(names, args.shard, config));
-    return files.filter((file) => selected.has(basename(file)));
+    try {
+      const selected = new Set(selectShard(names, args.shard, config));
+      return files.filter((file) => selected.has(basename(file)));
+    } catch (error) {
+      process.stderr.write(
+        `ERROR: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      process.exit(2);
+    }
   }
   return files;
 }
@@ -928,6 +936,7 @@ async function runTier(level: Level, label: string): Promise<void> {
   if (effectiveParallel > 1) modifiers.push(`parallel=${effectiveParallel}`);
   if (level === "unit" && args.shard) {
     modifiers.push(`shard=${args.shard.index}/${args.shard.total}`);
+    process.env[REQUIRE_COMPILED_COVERAGE_ENV] = "1";
   }
   process.stdout.write("\n");
   process.stdout.write(

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -22,12 +22,19 @@ import { homedir, tmpdir } from "node:os";
 import { basename, delimiter, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildMeta, renderMeta, type MetaCounts } from "./lib/bun-junit-to-meta.ts";
+import {
+  parseShardSpec,
+  selectShard,
+  type ShardConfig,
+  type ShardSpec,
+} from "./lib/test-sharding.ts";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const BUN = process.execPath;
 const PACKAGE_READY_ENV = "AIDLC_TEST_PACKAGE_READY";
 const PACKAGE_LOCK = join(REPO_ROOT, ".aidlc", "test-package.lock");
+const UNIT_SHARD_CONFIG = join(SCRIPT_DIR, "unit-shard-weights.json");
 
 // Platform null device, used for the system config after the protected
 // safe.directory entries have been copied into the suite's isolated config.
@@ -56,6 +63,7 @@ interface ParsedArgs {
   debug: boolean;
   filter: string;
   parallel: number;
+  shard: ShardSpec | null;
   fullProfile: boolean;
   // Force every live-model gate closed so deterministic tests in integration
   // and e2e still run. Also via AIDLC_NO_LLM=1.
@@ -96,6 +104,8 @@ OUTPUT MODIFIERS (combinable with any tier/profile):
   --parallel N    Run up to N test files concurrently within a tier (alias: -P N).
                   Default: 1 (serial). Smoke and unit tiers always run serially.
                   Recommended range: 1-8. See docs/reference/09-testing.md.
+  --shard N/M     Run one deterministic, duration-balanced unit-test shard.
+                  Requires --unit with no other level or profile flags.
 
   -h, --help      Show this help and exit
 
@@ -109,6 +119,7 @@ EXAMPLES:
   bash tests/run-tests.sh --all --debug          # Everything with traces
   bash tests/run-tests.sh --integration --filter "t25|t26" --debug
   bash tests/run-tests.sh --all --parallel 4     # 4-way parallel for larger levels
+  bash tests/run-tests.sh --unit --shard 1/4    # CI-style isolated unit shard
 `;
 }
 
@@ -127,6 +138,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     debug: false,
     filter: "",
     parallel: 1,
+    shard: null,
     fullProfile: false,
     noLlm: process.env.AIDLC_NO_LLM === "1",
   };
@@ -193,6 +205,16 @@ function parseArgs(argv: string[]): ParsedArgs {
         out.parallel = Number(value);
         break;
       }
+      case "--shard": {
+        const value = argv[++i] ?? "";
+        try {
+          out.shard = parseShardSpec(value);
+        } catch (error) {
+          process.stderr.write(`ERROR: ${error instanceof Error ? error.message : String(error)}\n`);
+          process.exit(2);
+        }
+        break;
+      }
       case "--help":
         process.stdout.write(usage());
         process.exit(0);
@@ -210,6 +232,13 @@ function parseArgs(argv: string[]): ParsedArgs {
     out.runSmoke = true;
     out.runUnit = true;
     out.runIntegration = true;
+  }
+  if (
+    out.shard &&
+    (!out.runUnit || out.runSmoke || out.runIntegration || out.runE2e)
+  ) {
+    process.stderr.write("ERROR: --shard requires --unit with no other level or profile flags\n");
+    process.exit(2);
   }
   return out;
 }
@@ -836,6 +865,12 @@ function levelFiles(level: Level, excludes: string[] = []): string[] {
       return !excludeSet.has(qualified);
     }));
   }
+  if (level === "unit" && args.shard) {
+    const config = JSON.parse(readFileSync(UNIT_SHARD_CONFIG, "utf8")) as ShardConfig;
+    const names = files.map((file) => basename(file));
+    const selected = new Set(selectShard(names, args.shard, config));
+    return files.filter((file) => selected.has(basename(file)));
+  }
   return files;
 }
 
@@ -889,9 +924,14 @@ async function runFilesPartitioned(
 
 async function runTier(level: Level, label: string): Promise<void> {
   const effectiveParallel = level === "smoke" || level === "unit" ? 1 : args.parallel;
+  const modifiers: string[] = [];
+  if (effectiveParallel > 1) modifiers.push(`parallel=${effectiveParallel}`);
+  if (level === "unit" && args.shard) {
+    modifiers.push(`shard=${args.shard.index}/${args.shard.total}`);
+  }
   process.stdout.write("\n");
   process.stdout.write(
-    effectiveParallel > 1 ? `## ${label} (parallel=${effectiveParallel})\n` : `## ${label}\n`,
+    modifiers.length > 0 ? `## ${label} (${modifiers.join(", ")})\n` : `## ${label}\n`,
   );
   await runFilesPartitioned(level, effectiveParallel);
   await withStdoutLock(() => undefined);

--- a/tests/smoke/t05-run-tests-parallel.test.ts
+++ b/tests/smoke/t05-run-tests-parallel.test.ts
@@ -86,12 +86,20 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { REPO_ROOT } from "../harness/fixtures.ts";
+import {
+  assignWeightedShards,
+  parseShardSpec,
+  type ShardConfig,
+} from "../lib/test-sharding.ts";
 
 // The runner lives at <repo>/tests/run-tests.sh. We invoke it with `bash` to
 // match how the suite (and the .sh) ran it — the runner is not chmod-dependent
 // in the test path, and `bash <script>` is the runner's documented entrypoint.
 const TESTS_ROOT = join(REPO_ROOT, "tests");
 const RUNNER = join(TESTS_ROOT, "run-tests.sh");
+const UNIT_SHARD_CONFIG = JSON.parse(
+  readFileSync(join(TESTS_ROOT, "unit-shard-weights.json"), "utf-8"),
+) as ShardConfig;
 
 interface RunResult {
   status: number;
@@ -191,6 +199,87 @@ describe("t05 run-tests.sh --parallel flag (migrated from t05-run-tests-parallel
     // (run-tests.sh:90 `${PARALLEL:-<missing>}`). STRONGER than the .sh, which
     // only checked rc==2 here.
     expect(r.out).toContain("ERROR: --parallel requires a positive integer");
+  }, PER_TEST_TIMEOUT);
+
+  test("rejects malformed and out-of-range --shard values", () => {
+    for (const bad of ["0/4", "1/0", "5/4", "abc"]) {
+      const r = run(["--unit", "--shard", bad]);
+      expect(r.status).toBe(2);
+      expect(r.out).toContain("ERROR: --shard");
+    }
+    const missing = run(["--unit", "--shard"]);
+    expect(missing.status).toBe(2);
+    expect(missing.out).toContain("ERROR: --shard");
+  }, PER_TEST_TIMEOUT);
+
+  test("--shard is restricted to a unit-only invocation", () => {
+    const smoke = run(["--smoke", "--shard", "1/4"]);
+    expect(smoke.status).toBe(2);
+    expect(smoke.out).toContain(
+      "ERROR: --shard requires --unit with no other level or profile flags",
+    );
+
+    const profile = run(["--ci", "--shard", "1/4"]);
+    expect(profile.status).toBe(2);
+    expect(profile.out).toContain(
+      "ERROR: --shard requires --unit with no other level or profile flags",
+    );
+  }, PER_TEST_TIMEOUT);
+
+  test("four weighted unit shards cover every file once and preserve binary affinity", () => {
+    const files = readdirSync(join(TESTS_ROOT, "unit"))
+      .filter((file) => file.endsWith(".test.ts"))
+      .sort();
+    const shards = assignWeightedShards(files, 4, UNIT_SHARD_CONFIG);
+    const flattened = shards.flat();
+
+    expect(shards.every((shard) => shard.length > 0)).toBe(true);
+    expect(flattened.length).toBe(files.length);
+    expect(new Set(flattened).size).toBe(files.length);
+    expect([...flattened].sort()).toEqual(files);
+
+    const producer = shards.findIndex((shard) =>
+      shard.includes("t238-build-binaries.test.ts"),
+    );
+    const consumer = shards.findIndex((shard) =>
+      shard.includes("t249-copilot-adapter.test.ts"),
+    );
+    expect(producer).toBeGreaterThanOrEqual(0);
+    expect(consumer).toBe(producer);
+    expect(
+      shards[producer].indexOf("t238-build-binaries.test.ts"),
+    ).toBeLessThan(
+      shards[producer].indexOf("t249-copilot-adapter.test.ts"),
+    );
+  }, PER_TEST_TIMEOUT);
+
+  test("unit shard CLI runs only the selected deterministic shard", () => {
+    const file = "t68-version-changelog-sync.test.ts";
+    const files = readdirSync(join(TESTS_ROOT, "unit"))
+      .filter((entry) => entry.endsWith(".test.ts"))
+      .sort();
+    const shards = assignWeightedShards(files, 4, UNIT_SHARD_CONFIG);
+    const selected = shards.findIndex((shard) => shard.includes(file)) + 1;
+    expect(selected).toBeGreaterThan(0);
+    expect(parseShardSpec(`${selected}/4`)).toEqual({
+      index: selected,
+      total: 4,
+    });
+
+    const r = run([
+      "--unit",
+      "--shard",
+      `${selected}/4`,
+      "--filter",
+      "t68-version-changelog-sync",
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.out).toContain(
+      `## Unit Tests (single-component isolation) (shard=${selected}/4)`,
+    );
+    expect(r.out).toContain(`=== START ${file} ===`);
+    expect(r.out).toContain("Test files: 1");
+    expect(r.out).toContain("RESULT: PASS");
   }, PER_TEST_TIMEOUT);
 
   // --- 3. --parallel 1 ≡ serial on the smoke tier --------------------------

--- a/tests/smoke/t05-run-tests-parallel.test.ts
+++ b/tests/smoke/t05-run-tests-parallel.test.ts
@@ -226,6 +226,32 @@ describe("t05 run-tests.sh --parallel flag (migrated from t05-run-tests-parallel
     );
   }, PER_TEST_TIMEOUT);
 
+  test("rejects shard counts that create empty shards", () => {
+    const files = readdirSync(join(TESTS_ROOT, "unit"))
+      .filter((file) => file.endsWith(".test.ts"))
+      .sort();
+    const affinityFiles = new Set(UNIT_SHARD_CONFIG.affinityGroups.flat());
+    const assignableGroups =
+      files.length - affinityFiles.size + UNIT_SHARD_CONFIG.affinityGroups.length;
+    const invalidCount = assignableGroups + 1;
+
+    expect(() =>
+      assignWeightedShards(files, invalidCount, UNIT_SHARD_CONFIG)
+    ).toThrow(
+      `--shard count ${invalidCount} exceeds ${assignableGroups} assignable unit-test groups`,
+    );
+
+    const r = run(
+      ["--unit", "--shard", `${invalidCount}/${invalidCount}`],
+      { AIDLC_TEST_PACKAGE_READY: "1" },
+    );
+    expect(r.status).toBe(2);
+    expect(r.out).toContain(
+      `ERROR: --shard count ${invalidCount} exceeds ${assignableGroups} assignable unit-test groups`,
+    );
+    expect(r.out).not.toContain("RESULT: PASS");
+  }, PER_TEST_TIMEOUT);
+
   test("four weighted unit shards cover every file once and preserve binary affinity", () => {
     const files = readdirSync(join(TESTS_ROOT, "unit"))
       .filter((file) => file.endsWith(".test.ts"))

--- a/tests/unit-shard-weights.json
+++ b/tests/unit-shard-weights.json
@@ -1,0 +1,26 @@
+{
+  "defaultSeconds": 1,
+  "weights": {
+    "t115.test.ts": 19.1,
+    "t218-kiro-ide-hook-adapter.test.ts": 60,
+    "t238-build-binaries.test.ts": 93.1,
+    "t243-install-mechanism.test.ts": 48.3,
+    "t244-install-management.test.ts": 49.5,
+    "t249-copilot-adapter.test.ts": 64,
+    "t255-workspace-sync.test.ts": 15.7,
+    "t272-unit-major-code-gen.test.ts": 15.9,
+    "t276-cursor-adapter.test.ts": 39.4,
+    "t293-knowledge-journey.test.ts": 14.5,
+    "t294-document-extractors-seam.test.ts": 56,
+    "t298-knowledge-transaction.test.ts": 24.9,
+    "t305-per-unit-attribution-receipts.test.ts": 59.3,
+    "t314-source-freshness-receipts.test.ts": 102.9,
+    "t324-team-unit-progress-gates.test.ts": 69.3
+  },
+  "affinityGroups": [
+    [
+      "t238-build-binaries.test.ts",
+      "t249-copilot-adapter.test.ts"
+    ]
+  ]
+}

--- a/tests/unit-shard-weights.json
+++ b/tests/unit-shard-weights.json
@@ -6,7 +6,7 @@
     "t238-build-binaries.test.ts": 93.1,
     "t243-install-mechanism.test.ts": 48.3,
     "t244-install-management.test.ts": 49.5,
-    "t249-copilot-adapter.test.ts": 64,
+    "t249-copilot-adapter.test.ts": 110,
     "t255-workspace-sync.test.ts": 15.7,
     "t272-unit-major-code-gen.test.ts": 15.9,
     "t276-cursor-adapter.test.ts": 39.4,

--- a/tests/unit/t244-install-management.test.ts
+++ b/tests/unit/t244-install-management.test.ts
@@ -166,7 +166,7 @@ function writeVerifierCandidate(root: string): void {
 
 function workflowJob(workflow: string, name: string): string {
   const match = new RegExp(
-    `\\n  ${name}:\\n[\\s\\S]*?(?=\\n  [a-z][a-z0-9-]*:\\n|$)`,
+    `\\n  ${name}:\\n[\\s\\S]*?(?=\\n  [a-z][a-z0-9_-]*:\\n|$)`,
   ).exec(workflow);
   if (!match) throw new Error(`release workflow has no ${name} job`);
   return match[0];
@@ -1836,6 +1836,7 @@ describe("t244 Windows and completion release surfaces", () => {
       }>;
     };
     expect(parsed.permissions).toEqual({ contents: "read" });
+    expect(parsed.jobs.test_unit.strategy?.["fail-fast"]).toBe(false);
     expect(parsed.jobs["native-smoke"].strategy?.["fail-fast"]).toBe(false);
     expect(parsed.jobs["musl-smoke"].strategy?.["fail-fast"]).toBe(false);
     expect(workflow).toContain("name: Validate release tag and source");
@@ -1874,6 +1875,7 @@ describe("t244 Windows and completion release surfaces", () => {
     expect(workflow).toContain(`build-results-\${{ matrix.directory }}.json`);
     expect(workflow).not.toContain("python3 -m http.server");
     expect(workflow).toContain('env PATH="/usr/bin:/bin"');
+    expect(workflow).not.toContain("duplicate full-suite run disabled");
 
     // Release artifacts must build from projections regenerated ON the runner,
     // never from checkout residue: every dist-consuming job regenerates
@@ -1886,12 +1888,40 @@ describe("t244 Windows and completion release surfaces", () => {
     );
     expect(verifyJob).toContain(regen);
     expect(verifyJob.indexOf(regen)).toBeLessThan(verifyJob.indexOf("- run: bun run check"));
+    const smokeTests = workflowJob(workflow, "test_smoke");
+    expect(smokeTests).toContain("needs: validate");
+    expect(smokeTests).toContain(`ref: \${{ needs.validate.outputs.sha }}`);
+    expect(smokeTests).toContain(regen);
+    expect(smokeTests).toContain("bun tests/run-tests.ts --smoke");
+    const unitTests = workflowJob(workflow, "test_unit");
+    expect(unitTests).toContain("needs: validate");
+    expect(unitTests).toContain("shard: [1, 2, 3, 4]");
+    expect(unitTests).toContain(`ref: \${{ needs.validate.outputs.sha }}`);
+    expect(unitTests).toContain(regen);
+    expect(unitTests).toContain("sudo apt-get install -y -qq zsh");
+    expect(unitTests).toContain(
+      `bun tests/run-tests.ts --unit --shard \${{ matrix.shard }}/4`,
+    );
+    const deepTests = workflowJob(workflow, "test_deep");
+    expect(deepTests).toContain("needs: validate");
+    expect(deepTests).toContain("timeout-minutes: 90");
+    expect(deepTests).toContain(`ref: \${{ needs.validate.outputs.sha }}`);
+    expect(deepTests).toContain(regen);
+    expect(deepTests).toContain(
+      "bun tests/run-tests.ts --integration --e2e --no-llm --parallel 8",
+    );
+    const releaseTests = workflowJob(workflow, "test");
+    expect(releaseTests).toContain(`if: \${{ always() }}`);
+    expect(releaseTests).toContain("needs: [test_smoke, test_unit, test_deep]");
+    expect(releaseTests).toContain('test "$SMOKE_RESULT" = "success"');
+    expect(releaseTests).toContain('test "$UNIT_RESULT" = "success"');
+    expect(releaseTests).toContain('test "$DEEP_RESULT" = "success"');
     const nativeSmokeJob = workflow.slice(
       workflow.indexOf("  native-smoke:"),
       workflow.indexOf("  build:"),
     );
     expect(nativeSmokeJob).toContain(regen);
-    expect(nativeSmokeJob).toContain("needs: [validate, verify]");
+    expect(nativeSmokeJob).toContain("needs: [validate, verify, test]");
     expect(nativeSmokeJob).toContain(`ref: \${{ needs.validate.outputs.sha }}`);
     expect(nativeSmokeJob.indexOf(regen))
       .toBeLessThan(nativeSmokeJob.indexOf("t238-build-binaries.test.ts"));

--- a/tests/unit/t249-copilot-adapter.test.ts
+++ b/tests/unit/t249-copilot-adapter.test.ts
@@ -179,13 +179,15 @@ function orchestrationProject(): string {
 function compiledBinary(): string | null {
   const explicit = process.env.AIDLC_TEST_COMPILED_EXECUTABLE;
   if (explicit && existsSync(explicit)) return realpathSync(explicit);
-  const results = join(REPO_ROOT, "build", "binaries", "build-results.json");
+  const results = join(REPO_ROOT, "build", "binaries", "build-results-native.json");
   if (!existsSync(results)) return null;
   const doc = JSON.parse(readFileSync(results, "utf-8")) as { results?: Array<{ name?: string; artifact?: string }> };
   const artifact = doc.results?.find((entry) => entry.name === "native")?.artifact;
   return artifact && existsSync(artifact) ? realpathSync(artifact) : null;
 }
 const COMPILED_BINARY = compiledBinary();
+const COMPILED_COVERAGE_REQUIRED =
+  process.env.AIDLC_REQUIRE_COMPILED_COVERAGE === "1";
 
 function readAudit(dir: string): string {
   const auditDir = seededAuditDir(dir);
@@ -385,6 +387,10 @@ function driveToRunStage(dir: string, session: string) {
 }
 
 describe("t249 Copilot hook adapter (live-captured payload fixtures)", () => {
+  test("0a: sharded unit execution has compiled dispatcher coverage", () => {
+    expect(!COMPILED_COVERAGE_REQUIRED || COMPILED_BINARY !== null).toBe(true);
+  });
+
   test("0: native write, shell, and Agent paths enforce Plan Approval", () => {
     const dir = scratchProject(true);
     seedUnapprovedCodeGeneration(dir);


### PR DESCRIPTION
Closes #1066

## Summary

- Split smoke into its own CI job.
- Run unit tests in four isolated GitHub Actions jobs while keeping each shard serial.
- Assign every unit file exactly once using measured duration weights.
- Keep the native binary producer and compiled Copilot adapter consumer in the same ordered shard.
- Reject shard counts that create an empty shard.
- Require compiled coverage in sharded unit runs instead of silently skipping it.
- Preserve the required `Tests (smoke + unit)` check through an aggregate job.

## Why

The measured smoke and unit gate took 20 minutes and 30 seconds for 285 files and 8,097 assertions. Direct `--parallel 8` execution in one checkout reproduced `dist/` races, fixed-timeout failures, and skipped compiled coverage. Isolated weighted shards reduce wall time without weakening coverage or running packaging tests concurrently in one tree.

## Review fixes

- `t249` now reads the producer output `build/binaries/build-results-native.json`.
- Sharded unit execution sets `AIDLC_REQUIRE_COMPILED_COVERAGE=1`, so a missing native artifact fails the suite.
- `assignWeightedShards` rejects `M` above the number of assignable groups, and the runner exits 2 without reporting `RESULT: PASS`.
- The t249 weight was recalibrated after enabling the compiled cases.
- The Copilot native dispatcher correction is already present in the current base through #1065.

## Validation

- `t238-build-binaries`: 4 passed, 0 failed.
- `t249-copilot-adapter` with compiled coverage required: 58 passed, 0 failed, 0 skipped, including 11a, 21b, and 26b.
- Focused smoke, version sync, and Copilot packaging tests: 41 passed, 0 failed.
- `bun scripts/package.ts --check`.
- `bun run typecheck`.
- `bun run lint`.
- `git diff --check`.

No version or changelog bump. This PR changes CI, test infrastructure, and test documentation only.

## Checklist

- [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).