### PR TITLE
fix: route native Cursor and Copilot hooks through the adapter dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.8.2] - 2026-09-09
+
+Restore native Cursor and GitHub Copilot hook dispatch after the 2.8.0 installer routed their adapters through the core-hook calling convention. **Upgrade:** `aidlc update` alone restores hooks in Cursor and Copilot projects configured by 2.8.0 because their existing `engine hook <harness>-adapter` wiring is now accepted; re-running `aidlc config` in the project rewrites the wiring to the canonical `aidlc engine adapter <harness> ...` spelling and replaces the old entry instead of duplicating it.
+
+* Cursor IDE `failClosed` `preToolUse` hooks now emit `{"permission":"allow"}` on allowed tools instead of returning no output and denying every tool; deny decisions continue to emit Cursor permission-deny JSON.
+* GitHub Copilot hooks no longer fail every event with `undefined is not an object (evaluating 'input.length')` and exit 1; adapter routing and its inner core-hook subprocesses now use the native dispatcher contracts.
+
 ## [2.8.1] - 2026-09-08
 
 Fix two defects found while exercising the 2.8.0 native install on Linux and Windows: the guided `aidlc config` setup cancelled itself when Enter was pressed to accept a default, and `aidlc update` on an already-current install failed its integrity check under a normal shell umask. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.1` / `install.ps1 -Version 2.8.1`; no project changes are required, and `aidlc config` refreshes projects when convenient.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.8.2] - 2026-09-09
 
-Restore native Cursor and GitHub Copilot hook dispatch after the 2.8.0 installer routed their adapters through the core-hook calling convention. **Upgrade:** `aidlc update` alone restores hooks in Cursor and Copilot projects configured by 2.8.0 because their existing `engine hook <harness>-adapter` wiring is now accepted; re-running `aidlc config` in the project rewrites the wiring to the canonical `aidlc engine adapter <harness> ...` spelling and replaces the old entry instead of duplicating it.
+Restore native Cursor and GitHub Copilot hook dispatch after the 2.8.0 installer routed their adapters through the core-hook calling convention. **Upgrade:** `aidlc update` alone restores hooks in Cursor and Copilot projects configured by 2.8.0 because their existing `engine hook <harness>-adapter` wiring is now accepted; re-running `aidlc config` rewrites the wiring to the canonical `aidlc engine adapter <harness> ...` spelling. Cursor's merged `.cursor/hooks.json` replaces the old entries instead of duplicating them, while Copilot's `.github/hooks/aidlc.json` is regenerated as an owned projection.
 
 * Cursor IDE `failClosed` `preToolUse` hooks now emit `{"permission":"allow"}` on allowed tools instead of returning no output and denying every tool; deny decisions continue to emit Cursor permission-deny JSON.
 * GitHub Copilot hooks no longer fail every event with `undefined is not an object (evaluating 'input.length')` and exit 1; adapter routing and its inner core-hook subprocesses now use the native dispatcher contracts.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ structured, verifiable software-delivery workflows. One harness-neutral core
 runs natively in Claude Code, Kiro CLI, Kiro IDE, Codex CLI, Cursor, opencode,
 and GitHub Copilot.
 
-![version](https://img.shields.io/badge/version-2.8.1-blue)
+![version](https://img.shields.io/badge/version-2.8.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 
 The Quick Start below installs the latest stable AI-DLC release.

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.8.1";
+export const AIDLC_VERSION = "2.8.2";

--- a/core/tools/aidlc.ts
+++ b/core/tools/aidlc.ts
@@ -1104,10 +1104,11 @@ function toolsDir(): string {
   return dispatcherDir();
 }
 
-type AdapterHarness = "codex" | "cursor" | "kiro" | "kiro-ide";
+type AdapterHarness = "codex" | "copilot" | "cursor" | "kiro" | "kiro-ide";
 
 const ADAPTER_HARNESS_LEAF: Record<AdapterHarness, string> = {
   codex: ".codex",
+  copilot: ".aidlc",
   cursor: ".cursor",
   kiro: ".kiro",
   "kiro-ide": ".kiro",
@@ -1119,6 +1120,7 @@ function isAdapterHarness(value: string): value is AdapterHarness {
 
 function adapterFile(harness: AdapterHarness): string {
   if (harness === "codex") return "aidlc-codex-adapter.ts";
+  if (harness === "copilot") return "aidlc-copilot-adapter.ts";
   if (harness === "cursor") return "aidlc-cursor-adapter.ts";
   return "aidlc-kiro-adapter.ts";
 }
@@ -1563,6 +1565,19 @@ function handleRouteOnly(route: Route, argv: string[]): Action {
     const name = argv[1];
     if (!name) return nounError("hook", undefined);
     if (!isSafeName(name)) return nounError("hook", name);
+    if (name === "cursor-adapter" || name === "copilot-adapter") {
+      const harness: AdapterHarness = name === "cursor-adapter" ? "cursor" : "copilot";
+      const target = argv[2];
+      if (!target) return nounError("adapter", undefined);
+      if (!isSafeName(target)) return nounError("adapter", target);
+      return {
+        type: "adapter",
+        harness,
+        target,
+        extraArgs: argv.slice(3),
+        path: resolveHookPath(adapterFile(harness), harness),
+      };
+    }
     return { type: "hook", name, path: resolveHookPath(`aidlc-${name}.ts`) };
   }
   if (route.routeOnly === "statusline") {

--- a/harness/copilot/hooks/aidlc-copilot-adapter.ts
+++ b/harness/copilot/hooks/aidlc-copilot-adapter.ts
@@ -241,7 +241,7 @@ export async function run(
   function runCore(hookFile: string, stdin: string): { stdout: string; code: number } {
     const executable = process.env.AIDLC_COMPILED_EXECUTABLE;
     const command = executable
-      ? [executable, "hook", hookFile.replace(/^aidlc-|\.ts$/g, "")]
+      ? [executable, "engine", "hook", hookFile.replace(/^aidlc-|\.ts$/g, "")]
       : [process.execPath, join(HOOKS_DIR, hookFile)];
     const r = Bun.spawnSync(command, {
       stdin: Buffer.from(stdin, "utf-8"),
@@ -262,7 +262,7 @@ export async function run(
   ): { stdout: string; stderr: string; code: number } {
     const executable = process.env.AIDLC_COMPILED_EXECUTABLE;
     const command = executable
-      ? [executable, "hook", hookFile.replace(/^aidlc-|\.ts$/g, "")]
+      ? [executable, "engine", "hook", hookFile.replace(/^aidlc-|\.ts$/g, "")]
       : [process.execPath, join(HOOKS_DIR, hookFile)];
     const r = Bun.spawnSync(command, {
       stdin: Buffer.from(stdin, "utf-8"),

--- a/harness/cursor/install.ts
+++ b/harness/cursor/install.ts
@@ -857,6 +857,23 @@ function stringArray(value: unknown, label: string): string[] {
   return value as string[];
 }
 
+function cursorAdapterTarget(command: string): string | null {
+  const normalized = command.trim();
+  const match = /\s([a-z0-9-]+)$/.exec(normalized);
+  if (!match) return null;
+  const invocation = normalized.slice(0, match.index);
+  if (
+    invocation === "aidlc engine hook cursor-adapter" ||
+    invocation === "aidlc engine adapter cursor" ||
+    /^bun\s+(?:"[^"]*\/hooks\/aidlc-cursor-adapter\.ts"|'[^']*\/hooks\/aidlc-cursor-adapter\.ts'|\S*\/hooks\/aidlc-cursor-adapter\.ts)$/.test(
+      invocation,
+    )
+  ) {
+    return match[1];
+  }
+  return null;
+}
+
 function mergeHooks(sourcePath: string, targetPath: string): string {
   const source = parseObject(sourcePath);
   const existing = existsSync(targetPath) ? parseObject(targetPath) : {};
@@ -889,15 +906,19 @@ function mergeHooks(sourcePath: string, targetPath: string): string {
     const merged = [...((projectEntries as unknown[] | undefined) ?? [])];
     for (const entry of shippedEntries) {
       const command = isObject(entry) && typeof entry.command === "string" ? entry.command : null;
+      const target = command === null ? null : cursorAdapterTarget(command);
       const existingIndex =
         command === null
           ? -1
           : merged.findIndex(
-              (candidate) => isObject(candidate) && candidate.command === command,
+              (candidate) => {
+                if (!isObject(candidate) || typeof candidate.command !== "string") return false;
+                return candidate.command === command ||
+                  (target !== null && cursorAdapterTarget(candidate.command) === target);
+              },
             );
-      // A command match identifies an AI-DLC-owned hook entry. Replace it with
-      // the refreshed shipped object so security metadata such as failClosed
-      // upgrades instead of being frozen at the first installed version.
+      // A command or adapter-target match identifies an AI-DLC-owned hook
+      // entry. Replace it so wiring and failClosed metadata upgrade together.
       if (existingIndex === -1) merged.push(entry);
       else merged[existingIndex] = entry;
     }

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -1503,6 +1503,49 @@ function cursorAdapterGate(artifact: string): GateResult {
   }
 }
 
+function copilotAdapterGate(artifact: string): GateResult {
+  const project = mkdtempSync(join(tmpdir(), "aidlc-binary-copilot-"));
+  try {
+    cpSync(join(REPO_ROOT, "dist-release", "copilot", ".aidlc"), join(project, ".aidlc"), {
+      recursive: true,
+    });
+    const input = JSON.stringify({
+      hook_event_name: "PreCompact",
+      cwd: project,
+      session_id: `binary-gate-${Date.now()}`,
+    });
+    const result = run(artifact, ["engine", "adapter", "copilot", "validate-state"], {
+      cwd: project,
+      env: { ...process.env, PATH: "" },
+      input,
+      timeoutMs: 30_000,
+    });
+    const output = `${result.stdout}\n${result.stderr}`;
+    const heartbeat = join(
+      project,
+      "aidlc",
+      "spaces",
+      "default",
+      "intents",
+      ".aidlc-hooks-health",
+      "validate-state.last",
+    );
+    return commandGate(
+      "adapter-copilot-validate-state",
+      result,
+      result.status === 0 &&
+        existsSync(heartbeat) &&
+        !/not available|Cannot find module|\/\$bunfs\/|unknown command/.test(output),
+      {
+        expected: "Copilot adapter invokes validate-state through the compiled dispatcher",
+        actual: existsSync(heartbeat) ? "heartbeat written" : result.stderr.trim(),
+      },
+    );
+  } finally {
+    rmSync(project, { recursive: true, force: true });
+  }
+}
+
 function routedProjectDirGate(artifact: string): GateResult {
   const cwdProject = mkdtempSync(join(tmpdir(), "aidlc-binary-route-cwd-"));
   const targetProject = installedProject("aidlc-binary-route-target-");
@@ -2232,6 +2275,7 @@ function buildTarget(target: TargetConfig): TargetResult {
     result.gates.push(planApprovalAdapterGate(actual.artifact, "codex"));
     result.gates.push(planApprovalAdapterGate(actual.artifact, "kiro"));
     result.gates.push(cursorAdapterGate(actual.artifact));
+    result.gates.push(copilotAdapterGate(actual.artifact));
     result.gates.push(routedProjectDirGate(actual.artifact));
     result.gates.push(dispatcherParityGate(actual.artifact));
     result.gates.push(...finalLayoutLifecycleGates(actual.artifact));

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -1139,7 +1139,7 @@ function rewriteNativeInvocations(
       (_match, delegate: string) => trustedCommand(delegate),
     );
     value = value.replace(hookPattern, (_match, hook: string) => {
-      if (hook === "kiro-adapter" || hook === "codex-adapter") {
+      if (hook.endsWith("-adapter")) {
         return trustedCommand(`adapter ${m.name}`);
       }
       if (hook === "statusline") return trustedCommand("statusline");

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -1094,6 +1094,12 @@ function rewriteNativeInvocations(
     "worktree",
     "workspace-sync",
   ].join("|");
+  const adapterHookNames = new Set([
+    "kiro-adapter",
+    "codex-adapter",
+    "cursor-adapter",
+    "copilot-adapter",
+  ]);
   const projectPrefix = String.raw`(?:"?(?:\$\{?CLAUDE_PROJECT_DIR\}?/)?`;
   const suffix = `"?)`;
   const toolPattern = new RegExp(
@@ -1139,7 +1145,7 @@ function rewriteNativeInvocations(
       (_match, delegate: string) => trustedCommand(delegate),
     );
     value = value.replace(hookPattern, (_match, hook: string) => {
-      if (hook.endsWith("-adapter")) {
+      if (adapterHookNames.has(hook)) {
         return trustedCommand(`adapter ${m.name}`);
       }
       if (hook === "statusline") return trustedCommand("statusline");

--- a/tests/unit/t230-dispatcher-routes.test.ts
+++ b/tests/unit/t230-dispatcher-routes.test.ts
@@ -2443,6 +2443,24 @@ describe("t230 dispatcher hook routing", () => {
     }
   });
 
+  test("Copilot adapter routing resolves its native adapter", () => {
+    const copilot = resolveAction([
+      "engine",
+      "adapter",
+      "copilot",
+      "guard-tool-call",
+    ]);
+    expect(copilot).toMatchObject({
+      type: "adapter",
+      harness: "copilot",
+      target: "guard-tool-call",
+      extraArgs: [],
+    });
+    if (copilot.type === "adapter") {
+      expect(copilot.path.endsWith("aidlc-copilot-adapter.ts")).toBe(true);
+    }
+  });
+
   test("hook validate-state dispatches to run(input) and writes heartbeat", () => {
     const projectDir = makeProject();
     const res = viaDispatcher( ["engine", "hook", "validate-state"], projectDir, {}, "{}");

--- a/tests/unit/t238-build-binaries.test.ts
+++ b/tests/unit/t238-build-binaries.test.ts
@@ -211,6 +211,7 @@ describe("t238 build-binaries release builder", () => {
       "statusline",
       "adapter-codex-validate-state",
       "adapter-cursor-validate-state",
+      "adapter-copilot-validate-state",
       "routed-project-dir",
       "bun-compiled-parity",
       "final-layout-config-dry-run",

--- a/tests/unit/t243-install-mechanism.test.ts
+++ b/tests/unit/t243-install-mechanism.test.ts
@@ -3953,13 +3953,13 @@ describe("t243 projection channel", () => {
       join(CURSOR_RELEASE, ".cursor", "hooks.json"),
       "utf-8",
     );
-    expect(cursorHooks).toContain(trustedCommand("hook cursor-adapter"));
+    expect(cursorHooks).toContain(trustedCommand("adapter cursor"));
     expect(cursorHooks).not.toContain("bun .cursor/hooks/");
     const copilotHooks = readFileSync(
       join(COPILOT_RELEASE, ".github", "hooks", "aidlc.json"),
       "utf-8",
     );
-    expect(copilotHooks).toContain(trustedCommand("hook copilot-adapter"));
+    expect(copilotHooks).toContain(trustedCommand("adapter copilot"));
     expect(copilotHooks).not.toContain("bun .aidlc/hooks/");
     const opencode = JSON.parse(
       readFileSync(join(OPENCODE_RELEASE, "opencode.json"), "utf-8"),

--- a/tests/unit/t275-cursor-packaging.test.ts
+++ b/tests/unit/t275-cursor-packaging.test.ts
@@ -46,6 +46,7 @@ import { REPO_ROOT } from "../harness/fixtures.ts";
 const PACKAGE_SCRIPT = join(REPO_ROOT, "scripts", "package.ts");
 const CLAUDE_SRC = join(REPO_ROOT, "dist", "claude", ".claude");
 const CURSOR_ROOT = join(REPO_ROOT, "dist", "cursor");
+const CURSOR_RELEASE_ROOT = join(REPO_ROOT, "dist-release", "cursor");
 const ENGINE = join(CURSOR_ROOT, ".cursor");
 const CURSOR_INSTALLER_SOURCE = join(REPO_ROOT, "harness", "cursor", "install.ts");
 
@@ -327,6 +328,47 @@ describe("t275 dist/cursor packaging parity + shell shape", () => {
       });
       expect(rerun.status, rerun.stderr).toBe(0);
       expect(readFileSync(join(cursorDir, "hooks.json"), "utf-8")).toBe(before);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("9b: native Cursor installer replaces legacy adapter wiring without duplication", () => {
+    const root = mkdtempSync(join(tmpdir(), "t275-cursor-native-hook-upgrade-"));
+    const project = join(root, "project");
+    try {
+      const cursorDir = join(project, ".cursor");
+      mkdirSync(cursorDir, { recursive: true });
+      writeFileSync(
+        join(cursorDir, "hooks.json"),
+        `${JSON.stringify({
+          version: 1,
+          hooks: {
+            preToolUse: [{
+              command: "aidlc engine hook cursor-adapter guards",
+              failClosed: true,
+            }],
+          },
+        }, null, 2)}\n`,
+      );
+
+      const install = spawnSync(
+        "bun",
+        [join(CURSOR_RELEASE_ROOT, "install.ts"), project],
+        {
+          cwd: REPO_ROOT,
+          encoding: "utf-8",
+        },
+      );
+      expect(install.status, install.stderr).toBe(0);
+
+      const hooks = JSON.parse(readFileSync(join(cursorDir, "hooks.json"), "utf-8")) as {
+        hooks: Record<string, Array<{ command: string; failClosed?: boolean }>>;
+      };
+      expect(hooks.hooks.preToolUse).toEqual([{
+        command: "aidlc engine adapter cursor guards",
+        failClosed: true,
+      }]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/unit/t276-cursor-adapter.test.ts
+++ b/tests/unit/t276-cursor-adapter.test.ts
@@ -417,6 +417,37 @@ describe("t276 cursor adapter payload conversion", () => {
     expectAllowJson(r);
   });
 
+  test("4b: dispatcher adapter and legacy hook routes both emit failClosed allow JSON", () => {
+    const proj = installedProject();
+    seedStateFile(proj, "state-construction.md");
+    const stdin = payload("preToolUseShell", proj, {
+      tool_input: { command: "true" },
+    });
+    for (const route of [
+      ["engine", "hook", "cursor-adapter", "guards"],
+      ["engine", "adapter", "cursor", "guards"],
+    ]) {
+      const r = spawnSync(
+        "bun",
+        [join(REPO_ROOT, "core", "tools", "aidlc.ts"), ...route],
+        {
+          cwd: proj,
+          input: stdin,
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            AIDLC_DISPATCH_TOOLS_DIR: join(REPO_ROOT, "core", "tools"),
+            AIDLC_PROJECT_DIR: proj,
+            AIDLC_HARNESS_DIR: ".cursor",
+          },
+        },
+      );
+      expect(r.status, `${route.join(" ")}: ${r.stderr}`).toBe(0);
+      expect(r.stderr, route.join(" ")).toBe("");
+      expect(r.stdout, route.join(" ")).toBe('{"permission":"allow"}\n');
+    }
+  });
+
   test("5: Task attribution binds unknown conversations only; registered mains are never conflated", () => {
     const proj = installedProject();
     seedStateFile(proj, "state-construction.md");


### PR DESCRIPTION
Closes #1058

## Problem

`aidlc config --harness cursor` on native 2.8.0 writes every `.cursor/hooks.json` command as `aidlc engine hook cursor-adapter <target>`. `scripts/package.ts` (`rewriteNativeInvocations`) special-cased only `kiro-adapter`/`codex-adapter` for the `engine adapter <harness>` route; `cursor-adapter` and `copilot-adapter` fell through to the generic `engine hook` route, whose `runHook` calls `mod.run(stdin)` (the one-arg core-hook contract) against the adapters' `run(target, input, extraArgs)`. `target` became the JSON payload and `input` was `undefined`.

- **Cursor**: the adapter's parse guard swallowed the TypeError and returned exit 0 with empty stdout. Under Cursor IDE `failClosed: true` that is not a permission decision, so every tool was denied (`Hook ... returned no output`). Every other Cursor event (session-start, mint, audit-and-sensors, stop, ...) was likewise a silent no-op.
- **Copilot** (same line, same root cause, reproduced on the stock 2.8.0 binary): `input.length` threw uncaught, so every native Copilot hook exited 1 with `undefined is not an object (evaluating 'input.length')`. Its inner core-hook subprocess also spelled `[executable, "hook", ...]`, a non-existent top-level command, latent until routing worked.

`tests/unit/t243-install-mechanism.test.ts` pinned both broken spellings.

## Fix

- `scripts/package.ts`: the four authored adapters (`kiro|codex|cursor|copilot-adapter`, explicit set) project to `aidlc engine adapter <harness> <target>`. Native `.cursor/hooks.json` now wires `aidlc engine adapter cursor guards` with `failClosed: true` intact.
- `core/tools/aidlc.ts`: `copilot` added to the adapter route (`.aidlc/hooks/aidlc-copilot-adapter.ts`). The shipped 2.8.0 spellings `engine hook cursor-adapter|copilot-adapter <target>` resolve to the same adapter action, so `aidlc update` alone restores hooks in projects configured by 2.8.0 (hook wiring is project-owned; `update` cannot rewrite it).
- `harness/copilot/hooks/aidlc-copilot-adapter.ts`: inner core-hook call is `[executable, "engine", "hook", <core>]`, matching the codex/cursor/kiro adapters.
- `harness/cursor/install.ts` `mergeHooks`: an existing entry is recognized as AI-DLC-owned by adapter target across the bun, 2.8.0-native, and canonical spellings, so re-running `aidlc config` replaces the stale entry instead of appending a second `preToolUse` hook.
- `scripts/build-binaries.ts`: new compiled gate `adapter-copilot-validate-state` (mirrors the codex/cursor gates); `t238` expects it.
- 2.8.2: `aidlc-version.ts`, README badge, CHANGELOG.

## Tests

- `t276` 4b: the reporter's exact preToolUse Shell payload through the dispatcher, both `engine hook cursor-adapter guards` and `engine adapter cursor guards` -> stdout exactly `{"permission":"allow"}\n`, exit 0 (fails pre-fix with empty stdout).
- `t243`: native projections carry `engine adapter cursor` / `engine adapter copilot`.
- `t230`: `engine adapter copilot <target>` resolves to the copilot adapter.
- `t275` 9b: native Cursor installer replaces a legacy `engine hook cursor-adapter guards` entry without duplication.
- `t238`: compiled binary runs the Copilot adapter through the real `engine adapter` -> inner `engine hook` path (heartbeat asserted).

## Verification

- Reproduced on the stock 2.8.0 binary with an `aidlc config --harness cursor` project: `engine hook cursor-adapter guards` -> exit 0, `''`; `engine adapter cursor guards` -> `{"permission":"allow"}`. Copilot: `engine hook copilot-adapter guard-tool-call` -> exit 1, `undefined is not an object (evaluating 'input.length')`.
- On this branch, same payload: untouched-main dispatcher -> `''`; fixed dispatcher via the old spelling -> `{"permission":"allow"}\n`. A real state-transition-guard refusal (direct `aidlc-state.ts approve` at construction stage) via the old spelling -> Cursor deny JSON with reason. `session-start` via the old spelling injects `additional_context`.
- `t238` 4/4 (compiled binary, includes the new Copilot gate); `t276 -t 4b`, `t275 -t 9b`, `t230` copilot route 1/1 each; `t68` 7/7; t230+t243+t68+t275 221/0 on the first commit; `bun scripts/package.ts --check` deterministic across 7 harnesses; typecheck clean.
- `t276` case 23 fails identically on untouched `origin/main` (`SUMMARY_QUESTIONS_MISSING` stage-fixture drift); pre-existing, not touched here.

**Limitations**: not exercised in a live Cursor IDE session. Copilot's `.github/hooks/aidlc.json` is a whole-file projection (verified with the stock 2.8.0 `config --force` dropping an injected foreign entry); this branch touches no Copilot install code, so 2.8.2 refresh behavior is inferred from the diff, not re-run on a 2.8.2 binary.

## Upgrade

`aidlc update`. Projects configured by 2.8.0 work immediately (old spelling accepted); `aidlc config` in the project rewrites the wiring to the canonical spelling.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
