### PR TITLE
fix: a thematic break before Assumption Confirmation no longer voids the summary receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@ All notable changes to this project will be documented in this file.
 
 ## [2.8.2] - 2026-09-10
 
-Improve review-findings table diagnostics so a missing cell no longer produces a misleading status error or guesses which column was omitted. Malformed rows report their cell count and the expected column order, with a repair hint when the last cell looks like a shifted status. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.2` / `install.ps1 -Version 2.8.2`. No migration is required.
+Preserve summary confirmations when an Assumption Confirmation section is appended with a decorative divider, and improve review-findings table diagnostics so malformed rows report their cell count and expected column order without guessing which column was omitted. The intended development release version is 2.8.2. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.2` / `install.ps1 -Version 2.8.2`. A summary receipt recorded before this fix over a body that already contained the newly excluded divider may need one fresh confirmation after upgrading; no other migration is required.
 
 * Short review-findings rows show the expected columns and, when applicable, suggest checking earlier cells for a missing value or `|` separator. Review completion remains refused until the row is corrected. Closes #1076.
 * Review-findings rows with surplus cells report the extra count. Well-formed rows, including escaped pipes and explicit blank cells, retain their existing behavior.
+* `aidlc version` reports `2.8.2`; the unpublished `2.8.6` development version is superseded.
+* Appending `## Assumption Confirmation` after a confirmed summary with an adjacent, blank-delimited `---`, `***`, or `___` no longer causes `SUMMARY_CONTENT_STALE` during stage completion. Code examples before the assumption heading and follow-up answers remain covered by the receipt, so substantive edits still require confirmation. Closes #1074.
+* Content appended under a `## ` heading is separated from the following `## ` heading by a blank line, keeping method files well-formed. Closes #1075.
 
 ## [2.8.6] - 2026-09-09
+
+**Superseded development entry:** No 2.8.6 release was published. The intended release version is 2.8.2, documented above; this entry is retained as development history.
 
 Fix a markdown-hygiene defect in the shared section writer: `appendUnderHeading` inserted new content flush against the following `## ` heading, so a bullet written under a section (for example a self-learning entry under `## Decided` in `project.md`) abutted the next heading with no separating blank line. The engine re-reads `project.md` every stage and the file is human-editable, so the malformed markdown could misgroup for a re-reading model or a stricter markdown tool. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.6` / `install.ps1 -Version 2.8.6`. No migration is required; existing files are corrected the next time content is appended to an affected section.
 

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -7580,6 +7580,27 @@ function visibleHeading(
 // Hash the normalized semantic questions content the human confirmed. The
 // shared protocol does not impose names on pre-checkpoint sections, while
 // follow-up Q<n> sections after an assumption decision remain hashable.
+// A thematic break (`---`, `***`, `___`) placed before the sanctioned
+// `## Assumption Confirmation` heading is presentation, not confirmed content.
+// It must fall inside the excluded range so appending that section — with or
+// without a leading rule — leaves the confirmed-content digest unchanged.
+const ASSUMPTION_THEMATIC_BREAK = /^ {0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/;
+
+function assumptionExclusionStart(lines: string[], headingLine: number): number {
+  let i = headingLine - 1;
+  while (i >= 0 && lines[i].trim() === "") i--;
+  // Only a blank-delimited rule is a thematic break; a rule immediately under
+  // text is a setext underline and must not be swept into the exclusion.
+  if (
+    i >= 0 &&
+    ASSUMPTION_THEMATIC_BREAK.test(lines[i]) &&
+    (i === 0 || lines[i - 1].trim() === "")
+  ) {
+    return i;
+  }
+  return headingLine;
+}
+
 export function summaryConfirmationContentHash(content: string): string {
   const normalized = content.replace(/\r\n?/g, "\n");
   const lines = normalized.split("\n");
@@ -7634,7 +7655,7 @@ export function summaryConfirmationContentHash(content: string): string {
         throw new Error('duplicate H2 section "Assumption Confirmation"');
       }
       postSummaryAssumptionSeen = true;
-      openExcludedAssumption = line;
+      openExcludedAssumption = assumptionExclusionStart(visibleLines, line);
       continue;
     }
 

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -7655,7 +7655,9 @@ export function summaryConfirmationContentHash(content: string): string {
         throw new Error('duplicate H2 section "Assumption Confirmation"');
       }
       postSummaryAssumptionSeen = true;
-      openExcludedAssumption = assumptionExclusionStart(visibleLines, line);
+      // Heading visibility blanks code blocks. Only actual source whitespace
+      // may be crossed when excluding an adjacent thematic break.
+      openExcludedAssumption = assumptionExclusionStart(lines, line);
       continue;
     }
 

--- a/tests/unit/t332-summary-authorization.test.ts
+++ b/tests/unit/t332-summary-authorization.test.ts
@@ -41,6 +41,7 @@ import {
   reviewDraftRelativePath,
   reviewRecordRelativePath,
   SUMMARY_AUTHORIZATION_FIELD,
+  SUMMARY_CONFIRMATION_CHECKPOINT,
   SUMMARY_CONFIRMATION_HASH_SCOPE,
   summaryAttemptFloors,
   summaryAttemptIdentity,
@@ -477,6 +478,28 @@ describe("t332 summary authorization id", () => {
     expect(stale.refusal?.code).toBe("SUMMARY_ARTIFACT_UNAUTHORIZED");
     writeArtifact(proj, artifact, "# regenerated in the new attempt\n");
     expect(evidence(proj).ok).toBe(true);
+  });
+
+  test("a thematic break before the Assumption Confirmation section leaves the confirmed-content digest unchanged (#1074)", () => {
+    const summary = [
+      `## ${SUMMARY_CONFIRMATION_CHECKPOINT}`,
+      "",
+      "We will build the widget. Assumption: the tax number is present.",
+      "",
+    ].join("\n");
+    const assumption = ["## Assumption Confirmation", "", "Confirmed.", ""].join(
+      "\n",
+    );
+    // Appending the sanctioned section with a leading blank-delimited `---`
+    // (a thematic break, not a setext underline) must hash the same as without
+    // it — the rule is presentation, not confirmed content.
+    expect(
+      summaryConfirmationContentHash(`${summary}\n---\n\n${assumption}`),
+    ).toBe(summaryConfirmationContentHash(`${summary}${assumption}`));
+    // Control: a thematic break inside the CONFIRMED body still changes the digest.
+    expect(
+      summaryConfirmationContentHash(`a\n\n---\n\nb\n\n${summary}`),
+    ).not.toBe(summaryConfirmationContentHash(`a\n\nb\n\n${summary}`));
   });
 });
 

--- a/tests/unit/t332-summary-authorization.test.ts
+++ b/tests/unit/t332-summary-authorization.test.ts
@@ -493,14 +493,74 @@ describe("t332 summary authorization id", () => {
     // Appending the sanctioned section with a leading blank-delimited `---`
     // (a thematic break, not a setext underline) must hash the same as without
     // it — the rule is presentation, not confirmed content.
-    expect(
-      summaryConfirmationContentHash(`${summary}\n---\n\n${assumption}`),
-    ).toBe(summaryConfirmationContentHash(`${summary}${assumption}`));
+    for (const rule of ["---", "***", "___", "   ----   "]) {
+      const separated = `${summary}\n${rule}\n\n${assumption}`;
+      expect(summaryConfirmationContentHash(separated)).toBe(
+        summaryConfirmationContentHash(`${summary}${assumption}`),
+      );
+      expect(summaryConfirmationContentHash(separated.replaceAll("\n", "\r\n"))).toBe(
+        summaryConfirmationContentHash(`${summary}${assumption}`),
+      );
+    }
     // Control: a thematic break inside the CONFIRMED body still changes the digest.
     expect(
       summaryConfirmationContentHash(`a\n\n---\n\nb\n\n${summary}`),
     ).not.toBe(summaryConfirmationContentHash(`a\n\nb\n\n${summary}`));
+    expect(() => summaryConfirmationContentHash(
+      `${summary}\nSemantic heading\n---\n\n${assumption}`,
+    )).toThrow("unsupported Setext H2");
   });
+
+  test("appending separated assumptions preserves the receipt and keeps follow-up answers confirmed", () => {
+    const proj = project();
+    const { questions, artifact } = paths(proj);
+    confirm(proj, questions);
+    writeArtifact(proj, artifact);
+    const confirmed = readFileSync(questions, "utf-8");
+    const appended = `${confirmed}\n---\n\n## Assumption Confirmation\n\nConfirmed.\n`;
+    writeFileSync(questions, appended);
+    expect(evidence(proj).ok).toBe(true);
+
+    writeFileSync(questions, `${appended}\n## Q2\n\n[Answer]: Disable TLS.\n`);
+    const stale = evidence(proj);
+    expect(stale.ok).toBe(false);
+    if (stale.ok) throw new Error("expected refusal");
+    expect(stale.refusal?.code).toBe("SUMMARY_CONTENT_STALE");
+  });
+
+  for (const { name, block } of [
+    { name: "fenced JSON", block: '```json\n{"tls_required":true}\n```' },
+    { name: "indented code", block: '    {"tls_required":true}' },
+    { name: "HTML preformatted text", block: '<pre>\n{"tls_required":true}\n</pre>' },
+  ]) {
+    test(`changes to ${name} before assumptions invalidate a real summary receipt`, () => {
+      const proj = project();
+      const { questions, artifact } = paths(proj);
+      const body = `${questionsBody("")}\n---\n\n${block}\n\n## Assumption Confirmation\n\nConfirmed.\n`;
+      writeFileSync(questions, body);
+      const decision = run(
+        [
+          "decision", "--stage", STAGE, "--checkpoint", "summary-confirmation",
+          "--questions-file", questions, "--decision", "Does this all look correct?",
+        ],
+        proj,
+      );
+      expect(decision.status, decision.stderr).toBe(0);
+      appendAuditEntry("HUMAN_TURN", {}, proj);
+      const confirmed = body.replace("[Answer]: \n", "[Answer]: Looks correct\n");
+      writeFileSync(questions, confirmed);
+      const recorded = answer(proj, questions, "Looks correct");
+      expect(recorded.status, recorded.stderr).toBe(0);
+      writeArtifact(proj, artifact);
+      expect(evidence(proj).ok).toBe(true);
+
+      writeFileSync(questions, confirmed.replace('"tls_required":true', '"tls_required":false'));
+      const stale = evidence(proj);
+      expect(stale.ok).toBe(false);
+      if (stale.ok) throw new Error("expected refusal");
+      expect(stale.refusal?.code).toBe("SUMMARY_CONTENT_STALE");
+    });
+  }
 });
 
 describe("t332 authorization scope resolution", () => {


### PR DESCRIPTION
## Summary

Appending `## Assumption Confirmation` after a confirmed summary can include a blank-delimited Markdown thematic break (`---`, `***`, or `___`) without invalidating the summary receipt and refusing stage completion with `SUMMARY_CONTENT_STALE`.

The exclusion scan uses the original normalized source lines, so it crosses only actual blank lines before an adjacent divider. Fenced code, indented code, and preformatted HTML between the divider and the assumption heading remain confirmed content: changing a JSON requirement such as `"tls_required":true` to `false` still requires a fresh confirmation. Setext headings remain invalid after the consolidated summary, and follow-up questions remain covered by the receipt.

Closes #1074.

## Compatibility

The hash scope remains `confirmed-content-v1`. A receipt recorded before this change over a body that already contained the newly excluded divider may need one fresh confirmation after upgrading. At the maintainer’s request, the version remains **2.8.2** after rebasing onto #1079: the version source, README badge, and current changelog heading agree. Both PRs’ release notes are preserved. The unpublished 2.8.6 development entry is explicitly marked superseded and retained as history.

## Validation

Verified on `ddde5285ece6d95b85eba1d0c412c951c4befed7`, based on `main` at `0c12f99ba6ce97485f77670e809e9fd5c57d4edb`:

- The repository test runner, with `--debug -P 8 --unit --integration --no-llm` and a filename filter, reran the receipt/version suites and the pre-existing CI failure. The receipt/version suites executed 32 tests with no failures or skips. Full output and per-file results were captured.
- `t332-summary-authorization.test.ts`: 25 tests, including a real receipt surviving a divider-only append, real receipts rejecting substantive edits in all three code formats, follow-up answer coverage, supported divider forms, CRLF normalization, and setext rejection.
- `t68-version-changelog-sync.test.ts`: 7 tests, including the shipped CLI reporting `2.8.2`.
- `bun scripts/ci-changelog-guard.ts origin/main`: all 278 existing changelog entries preserved.
- `t328-authority-rebinding.test.ts`: 19 pass, 3 fail in parking/resuming and Unit lifecycle approval checks. The identical three failures are present in [the already-merged #1079 CI run](https://github.com/awslabs/aidlc-workflows/actions/runs/34400168953/job/102630982764); they are not introduced by this PR.
- `bun scripts/package.ts --check`: deterministic output across all seven harnesses.
- `bun run typecheck` and `bun run lint`: passed.

Generated distributions were rebuilt for validation and are not committed.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
