### PR TITLE
fix: separate appended section content from the following heading with a blank line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.8.6] - 2026-09-09
+
+Fix a markdown-hygiene defect in the shared section writer: `appendUnderHeading` inserted new content flush against the following `## ` heading, so a bullet written under a section (for example a self-learning entry under `## Decided` in `project.md`) abutted the next heading with no separating blank line. The engine re-reads `project.md` every stage and the file is human-editable, so the malformed markdown could misgroup for a re-reading model or a stricter markdown tool. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.6` / `install.ps1 -Version 2.8.6`. No migration is required; existing files are corrected the next time content is appended to an affected section.
+
+* Content appended under a `## ` heading is now separated from the following `## ` heading by exactly one blank line, keeping method files (`memory/project.md`, `project-guardrails.md`) well-formed. The terminal end-of-file append is unchanged — no spurious trailing blank line is added. Closes #1075.
+
 ## [2.8.1] - 2026-09-08
 
 Fix defects found while exercising the 2.8.0 native install: the guided `aidlc config` setup cancelled itself when Enter was pressed to accept a default, `aidlc update` on an already-current install failed its integrity check under a normal shell umask, and every native GitHub Copilot and Cursor hook was dead because the 2.8.0 packager projected those adapters onto the one-argument core-hook route. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.1` / `install.ps1 -Version 2.8.1`. Copilot and Cursor projects configured by 2.8.0 work as soon as the binary is updated: their existing `aidlc engine hook <harness>-adapter ...` wiring is accepted, and the 2.8.0 Copilot adapter still installed in the project (whose core-hook calls are the bare `aidlc hook <name>`) is accepted too. `aidlc config` in the project then rewrites the wiring to the canonical `aidlc engine adapter <harness> ...` spelling and installs the current adapter — Cursor's merged `.cursor/hooks.json` collapses every earlier AI-DLC spelling of an entry (bun-era and 2.8.0) into the one shipped entry instead of leaving duplicates that keep executing, and Copilot's `.github/hooks/aidlc.json` is regenerated.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ structured, verifiable software-delivery workflows. One harness-neutral core
 runs natively in Claude Code, Kiro CLI, Kiro IDE, Codex CLI, Cursor, opencode,
 and GitHub Copilot.
 
-![version](https://img.shields.io/badge/version-2.8.1-blue)
+![version](https://img.shields.io/badge/version-2.8.6-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 
 The Quick Start below installs the latest stable AI-DLC release.

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -27866,7 +27866,17 @@ export function appendUnderHeading(
   const remainder = content.slice(bodyStart);
   const nextMatch = nextHeading.exec(remainder);
   const insertAt = nextMatch ? bodyStart + nextMatch.index : content.length;
-  return content.slice(0, insertAt) + newContent + content.slice(insertAt);
+  // When the insertion point is a following `## ` heading, callers that pass
+  // single-`\n`-terminated content would abut the heading with no separating
+  // blank line, producing malformed markdown (e.g. a bullet directly above
+  // `## Scope Overrides` in project.md). Add exactly one blank line in that
+  // case — but only when a heading actually follows (never in the terminal
+  // end-of-file append) and the content does not already end with a blank line.
+  const separator =
+    nextMatch && newContent.endsWith("\n") && !newContent.endsWith("\n\n")
+      ? "\n"
+      : "";
+  return content.slice(0, insertAt) + newContent + separator + content.slice(insertAt);
 }
 
 export function replaceSection(

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.8.1";
+export const AIDLC_VERSION = "2.8.6";

--- a/tests/unit/t71.test.ts
+++ b/tests/unit/t71.test.ts
@@ -53,8 +53,10 @@ describe("appendUnderHeading", () => {
   // .sh #5: Inserts new content before the next ## heading
   test("inserts content before the next ## heading", () => {
     const c = "## Mandated\n\n## Forbidden\n";
+    // A blank line separates the inserted content from the following heading:
+    // single-`\n`-terminated content must not abut the next `## ` heading.
     expect(appendUnderHeading(c, "## Mandated", "ALWAYS test\n")).toBe(
-      "## Mandated\n\nALWAYS test\n## Forbidden\n",
+      "## Mandated\n\nALWAYS test\n\n## Forbidden\n",
     );
   });
 
@@ -80,6 +82,24 @@ describe("appendUnderHeading", () => {
     c = appendUnderHeading(c, "## Mandated", "rule\n");
     const count = c.split("\n").filter((l) => l === "rule").length;
     expect(count).toBe(2);
+  });
+
+  // Regression (#1075): a bullet written under `## Decided` in the shipped
+  // project.md shape must be separated from the following `## Scope Overrides`
+  // heading by a blank line — the section writer must not abut the heading.
+  test("separates an inserted bullet from the following heading with a blank line", () => {
+    const projectMd =
+      "## Decided\n\n<!-- decisions -->\n\n## Scope Overrides\n\n<!-- overrides -->\n";
+    const out = appendUnderHeading(
+      projectMd,
+      "## Decided",
+      "- DECIDED: use Result<T,E> (learned 2026-09-09) <!-- cid:x -->\n",
+    );
+    expect(out).toContain(
+      "- DECIDED: use Result<T,E> (learned 2026-09-09) <!-- cid:x -->\n\n## Scope Overrides",
+    );
+    // No spurious double-blank (only one blank line separates them).
+    expect(out).not.toContain("<!-- cid:x -->\n\n\n## Scope Overrides");
   });
 });
 


### PR DESCRIPTION
# Summary

`appendUnderHeading` inserted new content flush against the next `## ` heading. Callers pass single-`\n`-terminated content, so a bullet (e.g. a self-learning entry under `## Decided` in `project.md`) abutted the following heading with no separating blank line — malformed markdown in a file the engine re-reads every stage.

Closes #1075.

## Changes

- `appendUnderHeading` (`core/tools/aidlc-lib.ts`): insert exactly one blank line when the insertion point is a following `## ` heading and the content is single-newline-terminated. The terminal end-of-file append is unchanged (no spurious trailing blank).
- Updated the `t71` flush-output pin to the blank-line-separated form; added a regression test for the `## Decided` → `## Scope Overrides` adjacency.

## User experience

**Before:** appended content produced `- bullet\n## Scope Overrides` (no blank line). **After:** `- bullet\n\n## Scope Overrides` — well-formed markdown.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] If this change adds an input to any fingerprint, epoch, or receipt identity, the description names the human-visible change it detects — **N/A:** markdown hygiene only; changes no digest/receipt identity (fields are read by regex, unaffected).

## Test plan

- `bun test tests/unit/t71.test.ts tests/integration/t75.test.ts tests/unit/t68-version-changelog-sync.test.ts` — pass (t71 pin updated + new regression test; t75/t266 checked, unaffected).
- `bun scripts/package.ts --check` — no drift.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
