### PR TITLE
fix: diagnose malformed review findings rows without guessing columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.8.2] - 2026-09-10
+
+Improve review-findings table diagnostics so a missing cell no longer produces a misleading status error or guesses which column was omitted. Malformed rows report their cell count and the expected column order, with a repair hint when the last cell looks like a shifted status. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.2` / `install.ps1 -Version 2.8.2`. No migration is required.
+
+* Short review-findings rows show the expected columns and, when applicable, suggest checking earlier cells for a missing value or `|` separator. Review completion remains refused until the row is corrected. Closes #1076.
+* Review-findings rows with surplus cells report the extra count. Well-formed rows, including escaped pipes and explicit blank cells, retain their existing behavior.
+
 ## [2.8.6] - 2026-09-09
 
 Fix a markdown-hygiene defect in the shared section writer: `appendUnderHeading` inserted new content flush against the following `## ` heading, so a bullet written under a section (for example a self-learning entry under `## Decided` in `project.md`) abutted the next heading with no separating blank line. The engine re-reads `project.md` every stage and the file is human-editable, so the malformed markdown could misgroup for a re-reading model or a stricter markdown tool. **Upgrade:** `aidlc update`, or `install.sh --version 2.8.6` / `install.ps1 -Version 2.8.6`. No migration is required; existing files are corrected the next time content is appended to an affected section.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ structured, verifiable software-delivery workflows. One harness-neutral core
 runs natively in Claude Code, Kiro CLI, Kiro IDE, Codex CLI, Cursor, opencode,
 and GitHub Copilot.
 
-![version](https://img.shields.io/badge/version-2.8.6-blue)
+![version](https://img.shields.io/badge/version-2.8.2-blue)
 ![license](https://img.shields.io/badge/license-MIT--0-green)
 
 The Quick Start below installs the latest stable AI-DLC release.

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -10643,6 +10643,28 @@ export function parseReviewSection(
   const findings: ReviewFinding[] = [];
   for (const line of table.slice(2)) {
     const cells = splitMarkdownRow(line);
+    // Validate row arity against the header before reading positionally. A row
+    // with the wrong cell count shifts every later column, so a positional read
+    // would silently return "" for a missing cell and later throw a misdirecting
+    // "invalid finding status" that names the wrong cause. Name the offending
+    // column instead so the failure points at the fix.
+    if (cells.length !== headers.length) {
+      const rowId = cells[index.get("ID") ?? 0]?.trim() || "?";
+      if (cells.length < headers.length) {
+        const missing = headers
+          .slice(cells.length)
+          .map((name) => JSON.stringify(name))
+          .join(", ");
+        throw new Error(
+          `${artifact}#${rowId}: row has ${cells.length} cells, header declares ${headers.length}: missing ${missing}`,
+        );
+      }
+      throw new Error(
+        `${artifact}#${rowId}: row has ${cells.length} cells, header declares ${headers.length}: ${
+          cells.length - headers.length
+        } unexpected extra cell(s)`,
+      );
+    }
     const value = (name: string): string =>
       cells[index.get(name) ?? -1]?.trim() ?? "";
     const id = value("ID");

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -10643,20 +10643,19 @@ export function parseReviewSection(
   const findings: ReviewFinding[] = [];
   for (const line of table.slice(2)) {
     const cells = splitMarkdownRow(line);
-    // Validate row arity against the header before reading positionally. A row
-    // with the wrong cell count shifts every later column, so a positional read
-    // would silently return "" for a missing cell and later throw a misdirecting
-    // "invalid finding status" that names the wrong cause. Name the offending
-    // column instead so the failure points at the fix.
+    // Check arity before positional reads: a missing cell can shift later
+    // values left, but its intended column cannot be recovered reliably.
+    // Show the expected order and offer a hint when a trailing status fits.
     if (cells.length !== headers.length) {
       const rowId = cells[index.get("ID") ?? 0]?.trim() || "?";
       if (cells.length < headers.length) {
-        const missing = headers
-          .slice(cells.length)
-          .map((name) => JSON.stringify(name))
-          .join(", ");
+        const lastCell = cells.at(-1) ?? "";
+        const hint = headers.at(-1) === "Status" && validReviewFindingStatus(lastCell)
+          ? `The last cell ${JSON.stringify(lastCell)} looks like Status; check earlier cells for a missing value or "|" separator`
+          : 'Check for a missing cell or "|" separator';
         throw new Error(
-          `${artifact}#${rowId}: row has ${cells.length} cells, header declares ${headers.length}: missing ${missing}`,
+          `${artifact}#${rowId}: row has ${cells.length} cells, header declares ${headers.length}. ` +
+            `Expected columns: ${headers.join(" | ")}. ${hint}`,
         );
       }
       throw new Error(

--- a/core/tools/aidlc-version.ts
+++ b/core/tools/aidlc-version.ts
@@ -1,4 +1,4 @@
 // Hand-edited single source of truth for the AIDLC framework version.
 // Bumped in the same commit that adds the matching ## [N.N.N] heading
 // to CHANGELOG.md. Pinned by tests/unit/t68-version-changelog-sync.test.ts.
-export const AIDLC_VERSION = "2.8.6";
+export const AIDLC_VERSION = "2.8.2";

--- a/tests/unit/t304-review-brief.test.ts
+++ b/tests/unit/t304-review-brief.test.ts
@@ -23,6 +23,7 @@ import {
   auditBlockField,
   findStageBySlug,
   readAllAuditShards,
+  readAuditShardEvents,
   reviewArtifactEntries,
   sourcePathKey,
   writeUnitSourceSnapshot,
@@ -355,28 +356,58 @@ describe("t304 executable review brief scenarios", () => {
     );
   });
 
-  test("a findings row with the wrong cell count names the missing column, not a bogus status", () => {
-    // Header declares six columns; this row omits one so every later cell
-    // shifts left and Status resolves to "". The parser must name the missing
-    // column rather than throwing the misdirecting "invalid finding status \"\"".
-    const shortRow =
-      "| R-05 | Minor | aidlc/requirements.md > FR-1 | Deadline is missing | New |";
-    let thrown: Error | undefined;
-    try {
-      parseReviewArtifact(
-        reviewMarkdown("NOT-READY", [shortRow]),
-        "aidlc/requirements.md",
+  test.each(["New", "Unresolved", "Resolved", "Accepted risk", "Rejected: duplicate"])(
+    "a short findings row offers a repair hint for trailing status %s",
+    (status) => {
+      // Required action was omitted here, but the parser cannot identify
+      // that column reliably from the remaining positional values.
+      const shortRow =
+        `| R-05 | Minor | aidlc/requirements.md > FR-1 | Deadline is missing | ${status} |`;
+      expect(() =>
+        parseReviewArtifact(
+          reviewMarkdown("NOT-READY", [shortRow]),
+          "aidlc/requirements.md",
+        )
+      ).toThrow(
+        "aidlc/requirements.md#R-05: row has 5 cells, header declares 6. " +
+          "Expected columns: ID | Severity | Location | Finding | Required action | Status. " +
+          `The last cell ${JSON.stringify(status)} looks like Status; check earlier cells for a missing value or "|" separator`,
       );
-    } catch (error) {
-      thrown = error as Error;
-    }
-    expect(thrown).toBeInstanceOf(Error);
-    expect(thrown!.message).toContain("R-05");
-    expect(thrown!.message).toContain("row has 5 cells, header declares 6");
-    expect(thrown!.message).toContain('missing "Status"');
-    expect(thrown!.message).not.toContain("invalid finding status");
+    },
+  );
 
-    // A row with too many cells is refused just as clearly.
+  test.each([
+    ["| R-05 | Minor | aidlc/requirements.md > FR-1 | Deadline is missing | Fix it |", 5],
+    ["| R-05 | Minor | aidlc/requirements.md > FR-1 | Deadline is missing |", 4],
+    ["| R-05 | Minor | aidlc/requirements.md > FR-1 | Deadline is missing | |", 5],
+  ] satisfies [string, number][])("a short row without a recognizable trailing status shows the expected columns: %s", (row, count) => {
+    expect(() =>
+      parseReviewArtifact(
+        reviewMarkdown("NOT-READY", [row]),
+        "aidlc/requirements.md",
+      )
+    ).toThrow(
+      `aidlc/requirements.md#R-05: row has ${count} cells, header declares 6. ` +
+        "Expected columns: ID | Severity | Location | Finding | Required action | Status. " +
+        'Check for a missing cell or "|" separator',
+    );
+  });
+
+  test("reordered headers keep their declared order without treating a non-final Status as shifted", () => {
+    const review = reviewMarkdown("NOT-READY", [
+      "| R-05 | Resolved | Minor | aidlc/requirements.md > FR-1 | New |",
+    ]).replace(
+      "| ID | Severity | Location | Finding | Required action | Status |",
+      "| ID | Status | Severity | Location | Finding | Required action |",
+    );
+    expect(() => parseReviewArtifact(review, "aidlc/requirements.md")).toThrow(
+      "aidlc/requirements.md#R-05: row has 5 cells, header declares 6. " +
+        "Expected columns: ID | Status | Severity | Location | Finding | Required action. " +
+        'Check for a missing cell or "|" separator',
+    );
+  });
+
+  test("a findings row with extra cells reports the surplus", () => {
     const longRow =
       "| R-06 | Minor | aidlc/requirements.md > FR-1 | Extra | Fix it | New | surplus |";
     expect(() =>
@@ -384,15 +415,67 @@ describe("t304 executable review brief scenarios", () => {
         reviewMarkdown("NOT-READY", [longRow]),
         "aidlc/requirements.md",
       )
-    ).toThrow("row has 7 cells, header declares 6");
+    ).toThrow("row has 7 cells, header declares 6: 1 unexpected extra cell(s)");
+  });
 
-    // A well-formed row still parses.
+  test("valid findings preserve escaped pipes and explicit empty cells", () => {
     expect(
       parseReviewArtifact(
-        reviewMarkdown("NOT-READY", [ROW_NEW]),
+        reviewMarkdown("NOT-READY", [
+          ROW_NEW,
+          String.raw`| R-02 | Minor | aidlc/requirements.md > A\|B | A\|B is missing | | New |`,
+        ]).replace("|---|---|---|---|---|---|", "|:---|---:|:---:|---|---|---|"),
         "aidlc/requirements.md",
-      )!.findings.map((finding) => finding.id),
-    ).toEqual(["R-01"]);
+      )!.findings.map(({ id, location, finding, requiredAction, status }) =>
+        ({ id, location, finding, requiredAction, status })
+      ),
+    ).toEqual([
+      {
+        id: "R-01",
+        location: "aidlc/spaces/default/intents/fixture/inception/requirements-analysis/requirements.md > FR-1",
+        finding: "Deadline is missing",
+        requiredAction: "Add a delivery date",
+        status: "New",
+      },
+      {
+        id: "R-02",
+        location: "aidlc/requirements.md > A|B",
+        finding: "A|B is missing",
+        requiredAction: "",
+        status: "New",
+      },
+    ]);
+  });
+
+  test("review completion carries the short-row repair hint without recording a terminal receipt", () => {
+    const { proj, artifact } = requirementProject([]);
+    writeFileSync(artifact, "# Requirements\n\nFR-1: ship it.\n", "utf-8");
+    const base = [
+      "review",
+      "--stage",
+      "requirements-analysis",
+      "--reviewer",
+      "aidlc-product-lead-agent",
+      "--iteration",
+      "1",
+    ];
+    const requested = run(LOG, base, proj);
+    expect(requested.status, requested.out).toBe(0);
+    const draft = join(proj, JSON.parse(requested.stdout).reviewFile);
+    mkdirSync(dirname(draft), { recursive: true });
+    writeFileSync(draft, reviewMarkdown("NOT-READY", [
+      "| R-05 | Minor | aidlc/requirements.md > FR-1 | Deadline is missing | New |",
+    ]).replace(/^# Requirements\n\n/, ""), "utf-8");
+    const completed = run(LOG, [...base, "--verdict", "NOT-READY"], proj);
+    expect(completed.status).not.toBe(0);
+    const diagnostic = JSON.parse(completed.stderr).error;
+    expect(diagnostic).toContain('Refusing REVIEW_COMPLETED for "requirements-analysis"');
+    expect(diagnostic).toContain("row has 5 cells, header declares 6");
+    expect(diagnostic).toContain('The last cell "New" looks like Status');
+    expect(diagnostic).not.toContain('missing "Status"');
+    expect(
+      readAuditShardEvents(proj).filter((entry) => entry.event === "REVIEW_COMPLETED"),
+    ).toHaveLength(0);
   });
 
   test("the single per-Unit stage gate displays exactly the open findings approval dispositions cover", () => {

--- a/tests/unit/t304-review-brief.test.ts
+++ b/tests/unit/t304-review-brief.test.ts
@@ -355,6 +355,46 @@ describe("t304 executable review brief scenarios", () => {
     );
   });
 
+  test("a findings row with the wrong cell count names the missing column, not a bogus status", () => {
+    // Header declares six columns; this row omits one so every later cell
+    // shifts left and Status resolves to "". The parser must name the missing
+    // column rather than throwing the misdirecting "invalid finding status \"\"".
+    const shortRow =
+      "| R-05 | Minor | aidlc/requirements.md > FR-1 | Deadline is missing | New |";
+    let thrown: Error | undefined;
+    try {
+      parseReviewArtifact(
+        reviewMarkdown("NOT-READY", [shortRow]),
+        "aidlc/requirements.md",
+      );
+    } catch (error) {
+      thrown = error as Error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown!.message).toContain("R-05");
+    expect(thrown!.message).toContain("row has 5 cells, header declares 6");
+    expect(thrown!.message).toContain('missing "Status"');
+    expect(thrown!.message).not.toContain("invalid finding status");
+
+    // A row with too many cells is refused just as clearly.
+    const longRow =
+      "| R-06 | Minor | aidlc/requirements.md > FR-1 | Extra | Fix it | New | surplus |";
+    expect(() =>
+      parseReviewArtifact(
+        reviewMarkdown("NOT-READY", [longRow]),
+        "aidlc/requirements.md",
+      )
+    ).toThrow("row has 7 cells, header declares 6");
+
+    // A well-formed row still parses.
+    expect(
+      parseReviewArtifact(
+        reviewMarkdown("NOT-READY", [ROW_NEW]),
+        "aidlc/requirements.md",
+      )!.findings.map((finding) => finding.id),
+    ).toEqual(["R-01"]);
+  });
+
   test("the single per-Unit stage gate displays exactly the open findings approval dispositions cover", () => {
     const { proj, artifacts } = perUnitReviewProject(
       "functional-design",


### PR DESCRIPTION
## Summary

A findings row with too few cells previously failed with `invalid finding status ""`, even when a value such as `New` was present and an earlier cell had been omitted. Validate the row width before reading its values, report the expected column order, and give a conditional repair hint without claiming to know which field was omitted.

For example:

```text
requirements.md#R-05: row has 5 cells, header declares 6.
Expected columns: ID | Severity | Location | Finding | Required action | Status.
The last cell "New" looks like Status; check earlier cells for a missing value or "|" separator.
```

The trailing-status hint is shown only when `Status` is the final declared column and the last cell contains a recognized status. Other short rows receive a general missing-cell or separator hint; long rows report their surplus cells. Malformed reviews remain refused before `REVIEW_COMPLETED` is recorded. Valid tables, including escaped pipes and explicit blank cells, retain their existing behavior.

Closes #1076.

## Validation

- `bun run check` — projection generation, two-build packaging determinism, all three TypeScript configurations, and Biome passed.
- Focused `t304-review-brief` and `t68-version-changelog-sync` unit slice with `--debug -P 8 --no-llm` — 39 passed, 0 failed.
- TypeScript and Biome checks passed again after the final test assertion change.
- After setting the release target to `2.8.2`, `t68` passed all 7 checks, packaging remained deterministic, and the changelog guard confirmed that all existing entries were preserved.

## Checklist

- [x] I have reviewed the contributing guidelines.
- [x] I have performed a self-review of this change.
- [x] Regression coverage includes shifted statuses, missing status values, reordered headers, extra cells, escaped pipes, explicit blank cells, and refusal to record a malformed review.
- [x] No fingerprint, epoch, or receipt identity inputs change.
- [x] The version, README badge, and latest changelog entry target `2.8.2`; existing changelog entries are preserved.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
