### PR TITLE
fix: allow empty $Version so the Windows iex one-liner installs

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,7 +16,7 @@
 [CmdletBinding(PositionalBinding = $false)]
 param(
   [Parameter()]
-  [ValidatePattern('^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$')]
+  [ValidatePattern('^$|^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$')]
   [string]$Version,
 
   [Parameter()]

--- a/tests/unit/t244-install-management.test.ts
+++ b/tests/unit/t244-install-management.test.ts
@@ -1503,6 +1503,48 @@ describe("t244 Windows and completion release surfaces", () => {
     }
   });
 
+  test("PowerShell installer -Version pattern tolerates the empty iex default", () => {
+    // `irm .../install.ps1 | iex` pipes the script into Invoke-Expression,
+    // which binds the typed [string]$Version parameter to its empty-string
+    // default and eagerly runs [ValidatePattern]. A pattern that rejects the
+    // empty string throws a ValidationMetadataException before the body runs,
+    // breaking the documented one-liner on Windows PowerShell 5.1. The pattern
+    // must accept an empty string, mirroring install.sh's `[ -n "$VERSION" ]`
+    // guard that only validates an explicitly supplied version.
+    const script = readFileSync(INSTALL_PS1, "utf-8");
+    expect(script).toContain(
+      "[ValidatePattern('^$|^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$')]",
+    );
+    expect(script).not.toContain(
+      "[ValidatePattern('^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$')]",
+    );
+  });
+
+  test.skipIf(process.platform !== "win32")(
+    "PowerShell installer param block parses under iex with no arguments",
+    () => {
+      // A live guard on Windows: dot-piping the script into iex must not throw
+      // the ValidationMetadataException that the empty-string default produced.
+      // We stop before any network work by asserting only that the param block
+      // binds; the body's admin/network checks are out of scope here.
+      const script = readFileSync(INSTALL_PS1, "utf-8");
+      const paramBlock = script.slice(0, script.indexOf("$ErrorActionPreference"));
+      const probe = `${paramBlock}\nWrite-Output "PARAM_OK"\n`;
+      const result = spawnSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          "$input | Out-String | Invoke-Expression",
+        ],
+        { input: probe, encoding: "utf-8", timeout: 30_000 },
+      );
+      expect(result.stderr).not.toContain("ValidationMetadataException");
+      expect(result.stdout).toContain("PARAM_OK");
+    },
+  );
+
   test("doctor command-pointer text is grammatical without an active version", () => {
     const source = readFileSync(UTILITY, "utf-8");
     expect(source).toContain(


### PR DESCRIPTION
# Summary

The documented Windows one-liner `irm https://github.com/awslabs/aidlc-workflows/releases/latest/download/install.ps1 | iex` fails on Windows PowerShell 5.1 with a `ValidationMetadataException` before the installer body runs.

Piping `install.ps1` into `Invoke-Expression` binds the typed `[string]$Version` parameter to its empty-string default and eagerly runs `[ValidatePattern]`. The semver-only pattern rejected the empty string, so PowerShell threw the exception before the body ran, breaking the documented `irm ... install.ps1 | iex` one-liner. Running via `-File` is unaffected because unbound parameters skip validation.

Fixes #1102

## Changes

- `scripts/install.ps1`: widen the `$Version` `[ValidatePattern]` to also accept an empty string (`^$|^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`), mirroring `install.sh`'s `[ -n "$VERSION" ]` guard that only validates an explicitly supplied version. The empty path already routes to the latest-release branch, and validation of an explicit `-Version` stays strict.
- `tests/unit/t244-install-management.test.ts`: add regression tests — a content assertion on the tolerant pattern and a Windows-only live check that the param block parses under `iex`.

## User experience

Before: On Windows PowerShell 5.1, the documented one-liner aborts immediately with `The attribute cannot be added because variable Version with value  would no longer be valid.` (`ValidationMetadataException`), and `aidlc` is never installed.

After: The one-liner runs to completion — downloads and verifies the latest release, installs the native `aidlc` command, and prints `PASS installed AI-DLC <version>`. Explicitly passing an invalid `-Version` is still rejected as before.

## Checklist

If an item does not apply, leave it unchecked.

* [ ] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] If this change adds an input to any fingerprint, epoch, or receipt identity, the description names the human-visible change it detects

## Test plan

1. On Windows PowerShell 5.1, run the documented one-liner and confirm it completes with `PASS installed AI-DLC <version>` (no
`ValidationMetadataException`):
 ```powershell
 irm https://github.com/awslabs/aidlc-workflows/releases/latest/download/install.ps1 | iex

2. Confirm the installed command runs: aidlc version prints aidlc <version> (runtime <version>).
3. Confirm explicit-version validation stays strict: a valid -Version 1.2.3 is accepted; -Version 1.2 and -Version abc are rejected.
4. Run the new regression tests:
```
 bun test tests/unit/t244-install-management.test.ts -t "iex"
```
5. Confirm packaging still regenerates cleanly: bun scripts/package.ts.

Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).


A few notes:
- I left "I have reviewed the contributing guidelines" and "Changes are documented" unchecked — check the guidelines box once you've read
them; docs are unchanged since this is a behavior fix on an existing installer.
- I checked "self-review" and "tested" based on the verification we ran, but confirm before submitting since these are your attestations.
- Want me to write this to a `pr-body.md` file in the repo so you can pass `--body-file pr-body.md` to `gh pr create`?