### PR TITLE
fix: discover stage-level questions file for per-unit stages under stage-level scopes (#1105)

### DIFF
--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -7813,10 +7813,19 @@ function questionFilesInDir(
 function summaryQuestionFiles(
   projectDir: string,
   stage: SummaryConfirmationStage,
+  stateContent?: string | null,
 ): SummaryQuestionFile[] {
   const rec = recordDir(projectDir);
   if (rec === null) return [];
   if (!isPerUnitStage(stage)) {
+    return questionFilesInDir(join(rec, stage.phase, stage.slug), null);
+  }
+
+  if (
+    stateContent !== undefined &&
+    stateContent !== null &&
+    usesStageLevelPerUnitArtifacts(getField(stateContent, "Scope"), stateContent)
+  ) {
     return questionFilesInDir(join(rec, stage.phase, stage.slug), null);
   }
 
@@ -8257,7 +8266,7 @@ export function checkSummaryConfirmationEvidence(
     return { ok: true, required: false };
   }
 
-  let questions = summaryQuestionFiles(projectDir, stage);
+  let questions = summaryQuestionFiles(projectDir, stage, options.stateContent);
   if (options.unit !== undefined) {
     questions = questions.filter(
       (question) => question.unit === options.unit,

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -1721,6 +1721,10 @@
         {
           "file": "tests/unit/t335-change-control-review-summary.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t338-summary-questions-stage-level.test.ts",
+          "mechanism": "none"
         }
       ],
       "status": "covered"

--- a/tests/unit/t338-summary-questions-stage-level.test.ts
+++ b/tests/unit/t338-summary-questions-stage-level.test.ts
@@ -1,0 +1,125 @@
+// covers: function:summaryQuestionFiles function:checkSummaryConfirmationEvidence
+//
+// t338 - under a scope whose approved plan SKIPs units-generation (e.g. infra),
+// a per-unit construction stage keeps its artifacts at the STAGE level
+// (construction/<slug>/), not under per-unit subdirs. The completion guard
+// already consults usesStageLevelPerUnitArtifacts and skips the unit-set
+// requirement for this case, but its question-file discovery helper
+// (summaryQuestionFiles) did not, so it only looked under
+// construction/<unit>/<slug>/, found nothing, and fell through to
+// SUMMARY_QUESTIONS_MISSING forever (issue #1105). This pins that the helper
+// discovers the stage-level questions file in that mode while leaving the
+// per-unit lane (a scope that DOES run units-generation) untouched.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  checkSummaryConfirmationEvidence,
+  loadStageGraphAll,
+} from "../../dist/claude/.claude/tools/aidlc-lib.ts";
+import {
+  cleanupTestProject,
+  createTestProject,
+  seedAidlcMemory,
+  seededRecordDir,
+  seedStateFile,
+} from "../harness/fixtures.ts";
+
+const STAGE = "nfr-requirements";
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) cleanupTestProject(tempDirs.pop()!);
+});
+
+function withSummaryGuard<T>(fn: () => T): T {
+  const prior = process.env.AIDLC_SKIP_SUMMARY_CONFIRMATION_GUARD;
+  delete process.env.AIDLC_SKIP_SUMMARY_CONFIRMATION_GUARD;
+  try {
+    return fn();
+  } finally {
+    if (prior === undefined) {
+      delete process.env.AIDLC_SKIP_SUMMARY_CONFIRMATION_GUARD;
+    } else {
+      process.env.AIDLC_SKIP_SUMMARY_CONFIRMATION_GUARD = prior;
+    }
+  }
+}
+
+function stateFor(scope: string, unitsGeneration: "EXECUTE" | "SKIP"): string {
+  return `# AI-DLC State Tracking
+
+## Runtime State
+- **Project Type**: greenfield
+- **Scope**: ${scope}
+
+## Stage Progress
+- [x] units-generation \u2014 ${unitsGeneration}
+- [-] nfr-requirements \u2014 EXECUTE
+
+## Current Status
+- **Current Stage**: nfr-requirements
+`;
+}
+
+function project(): string {
+  const proj = createTestProject();
+  tempDirs.push(proj);
+  seedAidlcMemory(proj);
+  seedStateFile(proj, "state-construction.md");
+  return proj;
+}
+
+function stage() {
+  return loadStageGraphAll().find((entry) => entry.slug === STAGE)!;
+}
+
+function writeStageLevelQuestions(proj: string): void {
+  const dir = join(seededRecordDir(proj), "construction", STAGE);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${STAGE}-questions.md`),
+    [
+      "# NFR Questions",
+      "",
+      "## Consolidated Summary Confirmation",
+      "",
+      "- [Answer]: Looks correct",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+describe("t338 stage-level per-unit summary questions discovery", () => {
+  test("infra scope discovers a stage-level questions file (not SUMMARY_QUESTIONS_MISSING)", () => {
+    const proj = project();
+    writeStageLevelQuestions(proj);
+    const evidence = withSummaryGuard(() =>
+      checkSummaryConfirmationEvidence(proj, stage(), {
+        stateContent: stateFor("infra", "SKIP"),
+      }),
+    );
+    // The questions file is now discovered, so the guard advances past the
+    // missing-questions refusal to the receipt/answer checks.
+    if (!evidence.ok) {
+      expect(evidence.message).not.toContain("its question flow has no");
+    }
+  });
+
+  test("a scope that runs units-generation still discovers only per-unit questions", () => {
+    const proj = project();
+    // Stage-level file present, but this scope executes units-generation, so
+    // the per-unit lane applies and the stage-level file must be ignored.
+    writeStageLevelQuestions(proj);
+    const evidence = withSummaryGuard(() =>
+      checkSummaryConfirmationEvidence(proj, stage(), {
+        stateContent: stateFor("feature", "EXECUTE"),
+      }),
+    );
+    expect(evidence.ok).toBe(false);
+    if (evidence.ok) throw new Error("expected a refusal on the per-unit lane");
+    expect(evidence.message).toContain("its question flow has no");
+  });
+});


### PR DESCRIPTION
# Summary

Closes #1105. Under a scope whose approved plan **SKIPs** `units-generation` (e.g. **infra**), a per-unit construction stage keeps its artifacts at the **stage level** (`construction/<slug>/`) rather than under per-unit subdirs. The summary-confirmation completion guard already handles this, but its question-file discovery helper did not — so review/completion of such a stage was refused forever with `SUMMARY_QUESTIONS_MISSING`.

## Changes

In `core/tools/aidlc-lib.ts`:

- `summaryQuestionFiles()` now takes the `stateContent` and, for a per-unit stage under a scope where `usesStageLevelPerUnitArtifacts(...)` is true, looks for the `*-questions.md` file at the stage level (`construction/<slug>/`) — mirroring the check the completion guard already applies at line ~8277. Every other lane is unchanged: non-per-unit stages and per-unit stages under scopes that run `units-generation` still iterate `construction/<unit>/<slug>/`.
- `checkSummaryConfirmationEvidence()` threads `options.stateContent` into that helper.

The asymmetry root cause is exactly as described in the issue: the guard consulted `usesStageLevelPerUnitArtifacts`, the discovery helper did not.

## User experience

**Before:** Running an AI-DLC workflow under `infra` scope and reaching a per-unit stage such as `nfr-requirements` — with the questions/artifacts correctly written at `construction/nfr-requirements/` — every review-request and completion is refused with `SUMMARY_QUESTIONS_MISSING`, and no recovery clears it.

**After:** The stage-level questions file is discovered, so the guard advances normally to the receipt/answer checks and the stage can be reviewed and completed.

## Checklist

* [x] I have reviewed the contributing guidelines
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [ ] If this change adds an input to any fingerprint, epoch, or receipt identity, the description names the human-visible change it detects — N/A (no identity input added)

## Test plan

New unit test `tests/unit/t338-summary-questions-stage-level.test.ts`:

- **infra scope (units-generation SKIP)** with a stage-level questions file present → the guard no longer returns the "its question flow has no …" refusal.
- **a scope that runs units-generation (EXECUTE)** with the same stage-level file present → still refuses (the per-unit lane is untouched), proving the fix is scoped.

Verified locally with bun 1.4.2:

```
$ bun test tests/unit/t338-summary-questions-stage-level.test.ts
 2 pass  0 fail

# RED→GREEN: revert the source fix (keep the test) →
#   FAIL: Received "Refusing to complete \"nfr-requirements\": its question flow has no
#   nfr-requirements-questions.md file. …"  (the exact issue #1105 refusal)
# restore the fix → 2 pass.

$ bun run typecheck        # tsc across the 3 project configs → clean
$ bun x @biomejs/biome check core/tools/aidlc-lib.ts tests/unit/t338-...test.ts  # No fixes
$ bun tests/gen-coverage-registry.ts   # registry updated for the new test; --check gate green
```

Related summary/guard suites stay green with the change (t310, t320, t332, t335, t280). Two suites (`t188-human-presence-gate`, `t186-foreach-per-unit-iteration`) have pre-existing failures on a clean `main` checkout on my machine, unrelated to this diff — I confirmed they fail identically with the change stashed.

Happy to adjust naming or the test shape if you'd prefer it folded into an existing summary-confirmation suite.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
