### PR TITLE
feat: support transaction locking on mounts without hard links

### DIFF
--- a/core/tools/aidlc-init.ts
+++ b/core/tools/aidlc-init.ts
@@ -58,7 +58,7 @@ import { configureProjectPin } from "./aidlc-lifecycle.ts";
 import {
   type TransactionOperation,
   type TransactionPlan,
-  TransactionLockError,
+  TransactionFilesystemError,
   assertTransactionFilesystem,
   executePlan,
   transactionSourceHash,
@@ -4256,7 +4256,7 @@ function renderFirstRunFailure(error: unknown): void {
     `\n  Setup stopped: ${error instanceof Error ? error.message : String(error)}\n`,
   );
   if (
-    (error instanceof ConfigChildError || error instanceof TransactionLockError) &&
+    (error instanceof ConfigChildError || error instanceof TransactionFilesystemError) &&
     error.remediation
   ) {
     process.stdout.write(`  fix: ${error.remediation}\n`);
@@ -4940,7 +4940,7 @@ async function runFirstRunWizard(projectDir: string): Promise<boolean> {
   }
   return true;
   } catch (error) {
-    if (error instanceof TransactionLockError) {
+    if (error instanceof TransactionFilesystemError) {
       renderFirstRunFailure(error);
       process.stdout.write("  Nothing written.\n");
       process.exitCode = EXIT.failure;
@@ -6583,7 +6583,7 @@ export async function main(
       /pass (?:one )?--harness|--harness requires|multi-harness config/.test(message)
         ? EXIT.usage
         : EXIT.integrity,
-      error instanceof TransactionLockError
+      error instanceof TransactionFilesystemError
         ? error.remediation
         : copiedRefreshWithoutSource
         ? "re-copy the matching dist/<harness>/ tree, then rerun this command"

--- a/core/tools/aidlc-init.ts
+++ b/core/tools/aidlc-init.ts
@@ -58,6 +58,8 @@ import { configureProjectPin } from "./aidlc-lifecycle.ts";
 import {
   type TransactionOperation,
   type TransactionPlan,
+  TransactionLockError,
+  assertTransactionFilesystem,
   executePlan,
   transactionSourceHash,
   transactionState,
@@ -3745,7 +3747,9 @@ function mergeBlock(
       adoptedLegacy: true,
     };
   }
-  if (/\baidlc\b|AI-DLC/i.test(current)) {
+  // Ignore rules can remain user-owned even when they mention AI-DLC. Append
+  // our marked block without claiming or rewriting that existing prefix.
+  if (path !== ".gitignore" && /\baidlc\b|AI-DLC/i.test(current)) {
     return { error: "legacy root integration ambiguous; move or delete the unmarked AI-DLC content" };
   }
   const prefix = current.length === 0 || current.endsWith(newline) ? current : `${current}${newline}`;
@@ -4240,6 +4244,25 @@ type FirstRunMutationSnapshot = {
   cleanup: () => void;
 };
 
+class ConfigChildError extends Error {
+  constructor(message: string, readonly remediation?: string) {
+    super(message);
+    this.name = "ConfigChildError";
+  }
+}
+
+function renderFirstRunFailure(error: unknown): void {
+  process.stdout.write(
+    `\n  Setup stopped: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  if (
+    (error instanceof ConfigChildError || error instanceof TransactionLockError) &&
+    error.remediation
+  ) {
+    process.stdout.write(`  fix: ${error.remediation}\n`);
+  }
+}
+
 function runConfigChild(
   args: string[],
   cwd: string,
@@ -4259,7 +4282,24 @@ function runConfigChild(
     timeout: 120_000,
   });
   if (result.status !== 0) {
-    throw new Error((result.stdout || result.stderr || "configuration failed").trim());
+    let failure: Record<string, unknown> | undefined;
+    try {
+      const value: unknown = JSON.parse(result.stdout);
+      if (value && typeof value === "object") {
+        failure = value as Record<string, unknown>;
+      }
+    } catch {
+      // Startup/runtime errors may not use the command-result envelope.
+    }
+    if (failure?.ok === false && typeof failure.message === "string") {
+      throw new ConfigChildError(
+        failure.message,
+        typeof failure.remediation === "string" ? failure.remediation : undefined,
+      );
+    }
+    throw new Error(
+      (result.error?.message || result.stderr || result.stdout || "configuration failed").trim(),
+    );
   }
   const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
   snapshot.recordCommitted(parsed);
@@ -4781,6 +4821,7 @@ async function runFirstRunWizard(projectDir: string): Promise<boolean> {
   try {
   const candidates = installedSourceCandidates();
   if (candidates.length === 0) return false;
+  assertTransactionFilesystem(projectDir);
   const detection = detectFirstRun(projectDir, candidates);
   const detected = detectedCandidateChoices(candidates, detection);
   let candidate: InstalledSourceCandidate;
@@ -4891,9 +4932,7 @@ async function runFirstRunWizard(projectDir: string): Promise<boolean> {
         `setup failed and rollback was incomplete; recovery snapshot preserved at ${snapshot.recoveryPath}`,
       );
     }
-    process.stdout.write(
-      `\n  Setup stopped: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
+    renderFirstRunFailure(error);
     process.stdout.write("  No setup changes were kept.\n");
     process.exitCode = EXIT.failure;
   } finally {
@@ -4901,6 +4940,12 @@ async function runFirstRunWizard(projectDir: string): Promise<boolean> {
   }
   return true;
   } catch (error) {
+    if (error instanceof TransactionLockError) {
+      renderFirstRunFailure(error);
+      process.stdout.write("  Nothing written.\n");
+      process.exitCode = EXIT.failure;
+      return true;
+    }
     if (error instanceof FirstRunCancelled) {
       process.stdout.write("\n  Nothing written.\n");
       process.exitCode = EXIT.usage;
@@ -5091,7 +5136,16 @@ function planRootIntegrations(
       });
       continue;
     }
-    const current = targetRegular ? readFileSync(targetPath, "utf-8") : "";
+    const currentBytes = targetRegular ? readFileSync(targetPath) : Buffer.alloc(0);
+    const current = currentBytes.toString("utf-8");
+    if (integration.path === ".gitignore" && !Buffer.from(current, "utf-8").equals(currentBytes)) {
+      actions.push({
+        path: integration.path,
+        action: "conflict",
+        detail: "gitignore is not valid UTF-8; convert its encoding before config",
+      });
+      continue;
+    }
     const priorContribution = prior?.rootContributions[integration.path];
     if (integration.policy === "managed-block") {
       const merged = mergeBlock(
@@ -6265,7 +6319,9 @@ export async function main(
         ...failure(
           `${conflicts.length} config conflict(s): ${conflicts.map((item) => `${item.path} (${item.detail})`).join(", ")}`,
           EXIT.integrity,
-          configCommand("--dry-run --verbose"),
+          `Back up the conflicting files and reconcile the listed ownership or marker problems while preserving your custom content; then rerun ${
+            configCommand("--dry-run --verbose")
+          }.`,
         ),
         data: { projectDir, distribution: stamp.distribution, counts, actions },
       }, options);
@@ -6527,7 +6583,9 @@ export async function main(
       /pass (?:one )?--harness|--harness requires|multi-harness config/.test(message)
         ? EXIT.usage
         : EXIT.integrity,
-      copiedRefreshWithoutSource
+      error instanceof TransactionLockError
+        ? error.remediation
+        : copiedRefreshWithoutSource
         ? "re-copy the matching dist/<harness>/ tree, then rerun this command"
         : from
         ? configCommand("--from <valid-release-data>")

--- a/core/tools/aidlc-transaction.ts
+++ b/core/tools/aidlc-transaction.ts
@@ -9,6 +9,7 @@ import {
   lstatSync,
   linkSync,
   mkdirSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   readdirSync,
@@ -378,6 +379,75 @@ type HeldLock = {
   identity: string;
 };
 
+export class TransactionLockError extends Error {
+  readonly remediation =
+    "Use a filesystem that supports hard links, such as local ext4 or XFS storage on EC2/EBS, then rerun the command. " +
+    "For an S3-backed workspace, use a project directory outside that mount.";
+
+  constructor(
+    readonly root: string,
+    readonly code: string,
+    cause: unknown,
+  ) {
+    super(
+      `Cannot create an AI-DLC transaction lock in ${root}: the filesystem rejected hard-link creation (${code}).`,
+      { cause },
+    );
+    this.name = "TransactionLockError";
+  }
+}
+
+function linkTransactionLock(root: string, candidate: string, lockPath: string): void {
+  try {
+    linkSync(candidate, lockPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && ["EMLINK", "ENOTSUP", "EOPNOTSUPP", "ENOSYS"].includes(code)) {
+      throw new TransactionLockError(root, code, error);
+    }
+    throw error;
+  }
+}
+
+// Probe the operation on the destination filesystem without publishing a real
+// transaction lock or creating a missing project. A successful probe is only
+// an early diagnostic: acquisition and plan validation still run at apply time.
+export function assertTransactionFilesystem(path: string): void {
+  const root = canonicalRoot(path);
+  const probe = mkdtempSync(join(nearestExisting(root), ".aidlc-lock-probe-"));
+  const candidate = join(probe, "candidate");
+  let descriptor: number | null = null;
+  let failure: unknown;
+  try {
+    descriptor = openSync(candidate, "wx", 0o600);
+    writeSync(descriptor, "AI-DLC transaction lock capability check\n");
+    fsyncSync(descriptor);
+    linkTransactionLock(root, candidate, join(probe, "lock"));
+  } catch (error) {
+    failure = error;
+  }
+  // A close error must not skip removal or hide the original lock diagnostic.
+  let closeError: unknown;
+  try {
+    if (descriptor !== null) closeSync(descriptor);
+  } catch (error) {
+    closeError = error;
+  }
+  try {
+    rmSync(probe, { recursive: true, force: true });
+  } catch (cleanupError) {
+    const primary = failure instanceof Error ? `${failure.message} ` : "";
+    throw new AggregateError(
+      [failure, closeError, cleanupError].filter((error) => error !== undefined),
+      `${primary}Could not remove temporary transaction lock probe ${probe}: ${
+        cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+      }`,
+    );
+  }
+  if (failure !== undefined) throw failure;
+  if (closeError !== undefined) throw closeError;
+}
+
 function acquireLock(root: string, lockPath: string, staging: string): HeldLock {
   for (let attempt = 0; attempt < 2; attempt++) {
     const candidate = join(root, `.aidlc-lock-${randomUUID()}`);
@@ -387,7 +457,7 @@ function acquireLock(root: string, lockPath: string, staging: string): HeldLock 
       const identity = `${JSON.stringify({ pid: process.pid, staging: basename(staging) })}\n`;
       writeSync(descriptor, identity);
       fsyncSync(descriptor);
-      linkSync(candidate, lockPath);
+      linkTransactionLock(root, candidate, lockPath);
       rmSync(candidate, { force: true });
       return { descriptor, identity };
     } catch (error) {

--- a/core/tools/aidlc-transaction.ts
+++ b/core/tools/aidlc-transaction.ts
@@ -5,6 +5,7 @@ import {
   cpSync,
   copyFileSync,
   existsSync,
+  fstatSync,
   fsyncSync,
   lstatSync,
   linkSync,
@@ -21,6 +22,7 @@ import {
   writeFileSync,
   writeSync,
 } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 import { sha256Bytes } from "./aidlc-distribution.ts";
 import {
@@ -28,6 +30,7 @@ import {
   machineTransactionRoot,
   windowsUninstallFencePath,
 } from "./aidlc-install-paths.ts";
+import { runWithOwnerStampedLock, withAuditLock } from "./aidlc-lib.ts";
 
 export type TransactionOperation =
   | { kind: "write"; path: string; data: string; mode?: number; expected?: string | "absent" }
@@ -325,27 +328,54 @@ function failpoint(options: TransactionOptions, name: string): void {
 }
 
 function processIsAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid <= 0 || pid > 2_147_483_647) return true;
   try {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
+    // Only ESRCH proves death. Permission, range, or platform errors must not
+    // turn an unverifiable owner into permission to reclaim its lock.
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
   }
 }
 
 function clearStaleLock(lockPath: string): void {
+  const directory = pathExists(lockPath) && lstatSync(lockPath).isDirectory();
+  const ownerPath = directory ? join(lockPath, "owner.json") : lockPath;
   let raw: string;
   try {
-    raw = readFileSync(lockPath, "utf-8");
+    if (directory && !lstatSync(ownerPath).isFile()) {
+      throw new Error("directory owner is not a regular file");
+    }
+    raw = readFileSync(ownerPath, "utf-8");
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    if (!directory && (error as NodeJS.ErrnoException).code === "ENOENT") return;
     throw new Error(`cannot verify transaction lock ${lockPath}`);
   }
-  let lock: { pid?: unknown } = {};
+  let lock: { schemaVersion?: unknown; pid?: unknown; host?: unknown; token?: unknown } = {};
   try {
     lock = JSON.parse(raw) as typeof lock;
   } catch {
     // An empty lock can survive only if its process exited between open and write.
+  }
+  if (
+    directory &&
+    (
+      lock.schemaVersion !== 1 ||
+      !Number.isSafeInteger(lock.pid) ||
+      (lock.pid as number) <= 0 ||
+      (lock.pid as number) > 2_147_483_647 ||
+      typeof lock.token !== "string" ||
+      !lock.token
+    )
+  ) {
+    throw new Error(`cannot verify incomplete directory transaction lock ${lockPath}`);
+  }
+  if (directory && lock.host !== transactionHostIdentity()) {
+    throw new Error(
+      `transaction lock ${lockPath} belongs to another host or boot; ` +
+      "directory locking requires one host and one shared mount",
+    );
   }
   if (typeof lock.pid === "number" && processIsAlive(lock.pid)) {
     throw new Error(`another AI-DLC mutation holds ${lockPath}`);
@@ -359,7 +389,7 @@ function clearStaleLock(lockPath: string): void {
   }
   let movedRaw: string | null = null;
   try {
-    movedRaw = readFileSync(moved, "utf-8");
+    movedRaw = readFileSync(directory ? join(moved, "owner.json") : moved, "utf-8");
   } catch {
     // Restore below: ownership cannot be proved after the atomic move.
   }
@@ -371,60 +401,252 @@ function clearStaleLock(lockPath: string): void {
     }
     throw new Error(`another AI-DLC mutation holds ${lockPath}`);
   }
-  rmSync(moved, { force: true });
+  rmSync(moved, { recursive: directory, force: true });
 }
 
-type HeldLock = {
-  descriptor: number;
-  identity: string;
-};
+type HeldLock =
+  | { kind: "hardlink"; descriptor: number; identity: string }
+  | { kind: "directory"; identity: string };
 
-export class TransactionLockError extends Error {
+export class TransactionFilesystemError extends Error {
   readonly remediation =
-    "Use a filesystem that supports hard links, such as local ext4 or XFS storage on EC2/EBS, then rerun the command. " +
-    "For an S3-backed workspace, use a project directory outside that mount.";
+    "Use a mount that supports mutable files, exclusive creation, file synchronization, and file/directory rename, " +
+    "or use local storage such as ext4 or XFS on EC2/EBS. Directory locking supports cooperating processes on one host using one shared mount.";
 
   constructor(
     readonly root: string,
+    readonly operation: string,
     readonly code: string,
     cause: unknown,
   ) {
     super(
-      `Cannot create an AI-DLC transaction lock in ${root}: the filesystem rejected hard-link creation (${code}).`,
+      `Cannot use the filesystem at ${root}: ${operation} failed (${code}).`,
       { cause },
     );
+    this.name = "TransactionFilesystemError";
+  }
+}
+
+export class TransactionLockError extends TransactionFilesystemError {
+  constructor(root: string, code: string, cause: unknown) {
+    super(root, "transaction locking", code, cause);
+    this.message = `Cannot create an AI-DLC transaction lock in ${root}: hard-link and directory locking are unavailable (${code}).`;
     this.name = "TransactionLockError";
   }
 }
+
+const DIRECTORY_FALLBACK_CODES = new Set(["EMLINK", "ENOTSUP", "EOPNOTSUPP", "ENOSYS", "EPERM"]);
 
 function linkTransactionLock(root: string, candidate: string, lockPath: string): void {
   try {
     linkSync(candidate, lockPath);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code && ["EMLINK", "ENOTSUP", "EOPNOTSUPP", "ENOSYS"].includes(code)) {
+    if (code && DIRECTORY_FALLBACK_CODES.has(code)) {
       throw new TransactionLockError(root, code, error);
     }
     throw error;
   }
 }
 
-// Probe the operation on the destination filesystem without publishing a real
-// transaction lock or creating a missing project. A successful probe is only
-// an early diagnostic: acquisition and plan validation still run at apply time.
+let transactionHost: string | undefined;
+
+function transactionHostIdentity(): string {
+  if (transactionHost) return transactionHost;
+  let boot = "";
+  if (process.platform === "linux") {
+    try {
+      boot = readFileSync("/proc/sys/kernel/random/boot_id", "utf-8").trim();
+    } catch {
+      // Without a boot identifier, conservatively retain PID-based ownership.
+    }
+  }
+  transactionHost = sha256Bytes(`${process.platform}\0${hostname()}\0${boot}`);
+  return transactionHost;
+}
+
+function acquireDirectoryLock(root: string, lockPath: string, staging: string): HeldLock {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      mkdirSync(lockPath, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST" && attempt === 0) {
+        clearStaleLock(lockPath);
+        continue;
+      }
+      throw new TransactionLockError(root, (error as NodeJS.ErrnoException).code ?? "UNKNOWN", error);
+    }
+    const identity = `${JSON.stringify({
+      schemaVersion: 1,
+      pid: process.pid,
+      host: transactionHostIdentity(),
+      token: randomUUID(),
+      staging: basename(staging),
+    })}\n`;
+    let descriptor: number | null = null;
+    try {
+      descriptor = openSync(join(lockPath, "owner.json"), "wx", 0o600);
+      writeSync(descriptor, identity);
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = null;
+      return { kind: "directory", identity };
+    } catch (error) {
+      try {
+        if (descriptor !== null) closeSync(descriptor);
+      } finally {
+        // The local gate protects the incomplete-publication window. Older
+        // clients see a directory at their lock-file path and refuse it.
+        rmSync(lockPath, { recursive: true, force: true });
+      }
+      throw error;
+    }
+  }
+  throw new Error(`cannot acquire ${lockPath}`);
+}
+
+function releaseTransactionLock(lockPath: string, lock: HeldLock): void {
+  if (lock.kind === "hardlink") closeSync(lock.descriptor);
+  const ownerPath = lock.kind === "directory" ? join(lockPath, "owner.json") : lockPath;
+  try {
+    if (readFileSync(ownerPath, "utf-8") === lock.identity) {
+      rmSync(lockPath, { recursive: lock.kind === "directory", force: true });
+    }
+  } catch {
+    // A replacement lock is not ours. Leave uncertain ownership untouched.
+  }
+}
+
+function withTransactionLock(
+  root: string,
+  staging: string,
+  operation: (lock: HeldLock) => void,
+): void {
+  const canonical = process.platform === "win32" ? root.toLowerCase() : root;
+  const gate = join(realpathSync(tmpdir()), `.aidlc-transaction-${sha256Bytes(canonical).slice(7)}`);
+  const lockPath = join(root, ".aidlc-transaction.lock");
+  let entered = false;
+  try {
+    // Use the receipt-managed wrapper so a temporarily blocked release can be
+    // recovered before the next transaction in this same process.
+    withAuditLock(gate, () => {
+      entered = true;
+      const lock = acquireLock(root, lockPath, staging);
+      try {
+        operation(lock);
+      } finally {
+        releaseTransactionLock(lockPath, lock);
+      }
+    }, undefined, undefined, 0, 0);
+  } catch (error) {
+    if (entered) throw error;
+    throw new Error(
+      `another AI-DLC mutation holds ${lockPath}, or local transaction coordination is unavailable; ` +
+      "all processes must use the same local temporary directory",
+      { cause: error },
+    );
+  }
+}
+
+// Exercise required operations without touching the actual transaction lock
+// or creating a missing project. Passing checks do not certify a mount's
+// atomicity/durability contract or make independent mounts share a lock.
 export function assertTransactionFilesystem(path: string): void {
   const root = canonicalRoot(path);
   const probe = mkdtempSync(join(nearestExisting(root), ".aidlc-lock-probe-"));
   const candidate = join(probe, "candidate");
   let descriptor: number | null = null;
   let failure: unknown;
+  const check = (operation: string, action: () => void): void => {
+    try {
+      action();
+    } catch (error) {
+      if (error instanceof TransactionFilesystemError) throw error;
+      throw new TransactionFilesystemError(
+        root,
+        operation,
+        (error as NodeJS.ErrnoException).code ?? "UNKNOWN",
+        error,
+      );
+    }
+  };
   try {
-    descriptor = openSync(candidate, "wx", 0o600);
-    writeSync(descriptor, "AI-DLC transaction lock capability check\n");
-    fsyncSync(descriptor);
-    linkTransactionLock(root, candidate, join(probe, "lock"));
+    withTransactionLock(probe, join(probe, "staging"), () => {
+      check("exclusive file creation and synchronization", () => {
+        descriptor = openSync(candidate, "wx", 0o600);
+        writeSync(descriptor, "before");
+        fsyncSync(descriptor);
+        closeSync(descriptor);
+        descriptor = null;
+        let rejected = false;
+        try {
+          const duplicate = openSync(candidate, "wx", 0o600);
+          closeSync(duplicate);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+          rejected = true;
+        }
+        if (!rejected) throw new Error("exclusive creation replaced an existing file");
+      });
+      check("mutable file append and descriptor identity", () => {
+        descriptor = openSync(candidate, "a+");
+        writeSync(descriptor, "after");
+        fsyncSync(descriptor);
+        const opened = fstatSync(descriptor);
+        const current = lstatSync(candidate);
+        if (opened.dev !== current.dev || opened.ino !== current.ino || current.nlink !== 1) {
+          throw new Error("the open descriptor does not identify the published file");
+        }
+        closeSync(descriptor);
+        descriptor = null;
+        if (readFileSync(candidate, "utf-8") !== "beforeafter") {
+          throw new Error("appended content was not preserved");
+        }
+      });
+      check("file replacement by rename", () => {
+        const target = join(probe, "target");
+        writeFileSync(target, "old");
+        renameSync(candidate, target);
+        if (pathExists(candidate) || readFileSync(target, "utf-8") !== "beforeafter") {
+          throw new Error("rename did not publish the replacement");
+        }
+      });
+      check("directory rename", () => {
+        const source = join(probe, "source-tree");
+        const target = join(probe, "target-tree");
+        mkdirSync(source);
+        writeFileSync(join(source, "child"), "tree");
+        renameSync(source, target);
+        if (pathExists(source) || readFileSync(join(target, "child"), "utf-8") !== "tree") {
+          throw new Error("directory rename did not preserve its contents");
+        }
+      });
+      if (process.platform !== "win32") {
+        check("file permissions", () => {
+          const target = join(probe, "target");
+          chmodSync(target, 0o600);
+          if ((lstatSync(target).mode & 0o777) !== 0o600) {
+            throw new Error("file permissions are not retained");
+          }
+        });
+      }
+      check("workflow lock coordination", () => {
+        const locked = runWithOwnerStampedLock(join(probe, "workflow-lock"), 0, 0, () => undefined);
+        if (!locked.acquired) throw new Error("the mount cannot coordinate workflow locks");
+      });
+      check("directory synchronization", () => syncPath(probe));
+    });
   } catch (error) {
-    failure = error;
+    failure = error instanceof TransactionLockError
+      ? new TransactionLockError(root, error.code, error)
+      : error instanceof TransactionFilesystemError
+      ? error
+      : new TransactionFilesystemError(
+        root,
+        "transaction lock coordination",
+        (error as NodeJS.ErrnoException).code ?? "UNKNOWN",
+        error,
+      );
   }
   // A close error must not skip removal or hide the original lock diagnostic.
   let closeError: unknown;
@@ -459,10 +681,13 @@ function acquireLock(root: string, lockPath: string, staging: string): HeldLock 
       fsyncSync(descriptor);
       linkTransactionLock(root, candidate, lockPath);
       rmSync(candidate, { force: true });
-      return { descriptor, identity };
+      return { kind: "hardlink", descriptor, identity };
     } catch (error) {
       if (descriptor !== null) closeSync(descriptor);
       rmSync(candidate, { force: true });
+      if (error instanceof TransactionLockError) {
+        return acquireDirectoryLock(root, lockPath, staging);
+      }
       if ((error as NodeJS.ErrnoException).code !== "EEXIST" || attempt > 0) throw error;
       clearStaleLock(lockPath);
     }
@@ -527,7 +752,11 @@ function syncPath(path: string): void {
       process.platform === "win32" && code === "EPERM";
     if (
       !unsupportedWindowsSync &&
-      !["EINVAL", "ENOTSUP", "EISDIR", "EBADF"].includes(code ?? "")
+      !["EINVAL", "ENOTSUP", "EISDIR", "EBADF"].includes(code ?? "") &&
+      !(
+        ["ENOSYS", "EOPNOTSUPP"].includes(code ?? "") &&
+        lstatSync(path).isDirectory()
+      )
     ) {
       throw error;
     }
@@ -561,9 +790,8 @@ export function executePlan(
   verifyPlan(plan, root);
   if (plan.operations.length === 0) return;
   mkdirSync(root, { recursive: true, mode: 0o700 });
-  const lockPath = join(root, ".aidlc-transaction.lock");
   const staging = join(root, `.aidlc-txn-${randomUUID()}`);
-  let lock: HeldLock | null = null;
+  withTransactionLock(root, staging, (lock) => {
   let preserveStaging = false;
   const committed: Array<{
     rel: string;
@@ -572,8 +800,8 @@ export function executePlan(
     displaced: boolean;
   }> = [];
   try {
-    lock = acquireLock(root, lockPath, staging);
     failpoint(options, "after-lock");
+    if (lock.kind === "directory") assertTransactionFilesystem(root);
     if (
       !options.allowPendingWindowsUninstall &&
       pendingWindowsUninstallBlocks(root)
@@ -699,17 +927,8 @@ export function executePlan(
     throw error;
   } finally {
     if (!preserveStaging) rmSync(staging, { recursive: true, force: true });
-    if (lock !== null) {
-      closeSync(lock.descriptor);
-      try {
-        if (readFileSync(lockPath, "utf-8") === lock.identity) {
-          rmSync(lockPath, { force: true });
-        }
-      } catch {
-        // A safely reclaimed or already-removed lock is no longer ours.
-      }
-    }
   }
+  });
 }
 
 export function writeOperation(

--- a/docs/guide/15-troubleshooting.md
+++ b/docs/guide/15-troubleshooting.md
@@ -44,12 +44,14 @@ This chapter covers common issues and their solutions, organized by symptom.
 | `config plan changed after approval` | Rerun `aidlc config --dry-run --json`, review `data.actions`, and apply the new `data.planToken` with exactly the same source and behavior options. |
 | `locally modified` or `managed block was locally modified` from `aidlc config` | Run `aidlc config --dry-run --json` and review `data.actions`. Use `--force` only to replace baseline-owned framework bytes or managed blocks; it never authorizes unrelated root content. |
 | `unowned whole file` from `aidlc config` | Move or merge the existing file manually before config. Whole-file integrations such as OpenCode's `opencode.json` cannot be claimed with `--force`. |
-| `legacy root integration ambiguous; move or delete the unmarked AI-DLC content` | Move or delete the old unmarked AI-DLC block in the named root file, preserve any project-owned text elsewhere, then rerun `aidlc config`. This release intentionally refuses to guess ownership. |
+| `legacy root integration ambiguous; move or delete the unmarked AI-DLC content` | Reconcile the unmarked AI-DLC content in the named root file (such as `AGENTS.md`), preserving project-owned text, then rerun `aidlc config`. Ordinary unmarked `.gitignore` content is preserved and a fresh managed block appended; no rename or deletion is needed. See [Root Integrations and Ownership](18-install-and-lifecycle.md#root-integrations-and-ownership). |
 | `managed markers are missing, duplicated, or malformed` | Repair the named root file so it has exactly one matching `BEGIN AI-DLC` / `END AI-DLC` pair, or remove the broken AI-DLC block and rerun `aidlc config`. |
+| `gitignore is not valid UTF-8` | Back up `.gitignore` and convert it from its current encoding to UTF-8, preserving the ignore patterns, then rerun config. AI-DLC leaves the original bytes untouched when decoding would lose information. |
 | `project runtime <version> is incompatible with selected engine <version>` | Run `aidlc use <version>` to install and select the compatible version, or refresh the project intentionally with `aidlc config`. |
 | `this project requires <version>, which is not installed completely` | Install or reinstall the exact strict-semver pin with `aidlc config --pin <version>`. The dispatcher fails closed instead of falling back to the active machine version; use `aidlc config --unpin` only when the team intends to stop pinning the project. |
 | An update was interrupted and `aidlc version` still shows the prior release | This is the safe restored state: the old command remains active. Run `aidlc doctor`, then rerun the same `aidlc update --version <version>` command. |
 | `another AI-DLC mutation holds .../.aidlc-transaction.lock` | Let the active init/lifecycle command finish. If its process no longer exists, rerun the command; stale owner-private staging is swept only after the lock is safely reclaimed. |
+| `EMLINK` (`too many links`) or `Cannot create an AI-DLC transaction lock` during config | Use project storage that supports the required filesystem operations; see [Config fails with a hard-link error](#config-fails-with-a-hard-link-error). |
 | `existing aidlc is managed by Homebrew` / `Nix`, or the destination command is `not owned by the AI-DLC installer` | Upgrade through the reported owner. To keep a separate native install, set `AIDLC_BIN_DIR` explicitly to an empty user-owned directory. This release does not itself ship Homebrew or Nix packaging and never replaces a mixed-ownership command. |
 | `update cache is invalid` or machine settings are rejected | Run `aidlc system config global list`. Repair or remove only the named `%LOCALAPPDATA%\aidlc\aidlc.settings.json` (Windows) or `${XDG_DATA_HOME:-$HOME/.local/share}/aidlc/aidlc.settings.json` (macOS/Linux); unknown keys and stored credentials are rejected. |
 | `HTTPS_PROXY must use HTTP or HTTPS` or a release URL is rejected | Use an HTTP(S) proxy URL and an HTTPS release mirror without credentials, query, or fragment. The native client reads `HTTPS_PROXY` and `NO_PROXY`, not `HTTP_PROXY`, and redacts secret-like URL parts in errors. |
@@ -63,6 +65,28 @@ Native `aidlc doctor` also checks the active command pointer, rollback
 eligibility, retained pin completeness, stale pin registrations, abandoned
 transaction staging, project version skew, and whether binary-channel host
 hooks and permission/trust entries consistently select the native command.
+
+### Config fails with a hard-link error
+
+`aidlc config` creates a hard link to acquire its transaction lock. An
+`EMLINK` (`too many links`), `ENOTSUP`, `EOPNOTSUPP`, or `ENOSYS` error at this
+step means the filesystem rejected that operation. Compatibility depends on
+the mount's capabilities: S3-backed and FUSE mounts vary, so their names alone
+do not establish support.
+
+The first-run wizard checks lock creation before offering setup choices. It
+removes its temporary probe files and stops without persistent setup changes
+if the check fails. Human output names the failure and remediation;
+`--quiet` prints the remediation, and `--json` returns a structured failure.
+
+Move or clone the project onto storage that supports hard links, exclusive
+file creation, `fsync`, and atomic rename, then rerun `aidlc config` there.
+On EC2, ext4 or XFS on an EBS volume is a suitable choice. For a failing
+S3-backed workspace, use a project directory outside that mount. An alias or
+symlink to the same mount does not change its capabilities. Neither `--force`
+nor `--from` repairs the destination filesystem, and deleting transaction locks
+does not fix this error. Config requires the lock and does not fall back to
+unlocked writes. See [Transactions and Recovery](18-install-and-lifecycle.md#transactions-and-recovery).
 
 ---
 

--- a/docs/guide/15-troubleshooting.md
+++ b/docs/guide/15-troubleshooting.md
@@ -22,7 +22,7 @@ This chapter covers common issues and their solutions, organized by symptom.
 | Stuck at approval gate | Type your response; use `/aidlc --stage <target>` to jump past it |
 | Context compacted mid-session | Run `/aidlc` to resume from checkpoint |
 | Audit log too large | Rename to `audit-YYYY-MM.md`; a fresh one is created automatically |
-| Hooks appear to hang | Remove stale lock dirs from system temp directory (see below) |
+| Hooks appear to hang | Diagnose lock ownership with `/aidlc --doctor`; see [Lock Files Left Behind](#lock-files-left-behind) |
 | Statusline shows "ready" | Check `aidlc-state.md` has a `**Lifecycle Phase**` field |
 | Statusline not appearing | Run `aidlc doctor`; for a copy install, verify `bun` is on PATH |
 | Subagent timed out | Run `/aidlc` to retry or run the stage inline |
@@ -50,8 +50,8 @@ This chapter covers common issues and their solutions, organized by symptom.
 | `project runtime <version> is incompatible with selected engine <version>` | Run `aidlc use <version>` to install and select the compatible version, or refresh the project intentionally with `aidlc config`. |
 | `this project requires <version>, which is not installed completely` | Install or reinstall the exact strict-semver pin with `aidlc config --pin <version>`. The dispatcher fails closed instead of falling back to the active machine version; use `aidlc config --unpin` only when the team intends to stop pinning the project. |
 | An update was interrupted and `aidlc version` still shows the prior release | This is the safe restored state: the old command remains active. Run `aidlc doctor`, then rerun the same `aidlc update --version <version>` command. |
-| `another AI-DLC mutation holds .../.aidlc-transaction.lock` | Let the active init/lifecycle command finish. If its process no longer exists, rerun the command; stale owner-private staging is swept only after the lock is safely reclaimed. |
-| `EMLINK` (`too many links`) or `Cannot create an AI-DLC transaction lock` during config | Use project storage that supports the required filesystem operations; see [Config fails with a hard-link error](#config-fails-with-a-hard-link-error). |
+| `another AI-DLC mutation holds .../.aidlc-transaction.lock`, `cannot verify` a lock, or `belongs to another host or boot` | Let an active owner finish; otherwise follow [Transaction lock ownership](#transaction-lock-ownership). |
+| `EMLINK` (`too many links`), `Cannot create an AI-DLC transaction lock`, or `Cannot use the filesystem at ...` during config | Hard links have an automatic fallback; other filesystem requirements still apply. See [Config fails with a hard-link error](#config-fails-with-a-hard-link-error). |
 | `existing aidlc is managed by Homebrew` / `Nix`, or the destination command is `not owned by the AI-DLC installer` | Upgrade through the reported owner. To keep a separate native install, set `AIDLC_BIN_DIR` explicitly to an empty user-owned directory. This release does not itself ship Homebrew or Nix packaging and never replaces a mixed-ownership command. |
 | `update cache is invalid` or machine settings are rejected | Run `aidlc system config global list`. Repair or remove only the named `%LOCALAPPDATA%\aidlc\aidlc.settings.json` (Windows) or `${XDG_DATA_HOME:-$HOME/.local/share}/aidlc/aidlc.settings.json` (macOS/Linux); unknown keys and stored credentials are rejected. |
 | `HTTPS_PROXY must use HTTP or HTTPS` or a release URL is rejected | Use an HTTP(S) proxy URL and an HTTPS release mirror without credentials, query, or fragment. The native client reads `HTTPS_PROXY` and `NO_PROXY`, not `HTTP_PROXY`, and redacts secret-like URL parts in errors. |
@@ -68,25 +68,41 @@ hooks and permission/trust entries consistently select the native command.
 
 ### Config fails with a hard-link error
 
-`aidlc config` creates a hard link to acquire its transaction lock. An
-`EMLINK` (`too many links`), `ENOTSUP`, `EOPNOTSUPP`, or `ENOSYS` error at this
-step means the filesystem rejected that operation. Compatibility depends on
-the mount's capabilities: S3-backed and FUSE mounts vary, so their names alone
-do not establish support.
+`aidlc config` first attempts a hard-link transaction lock. If the mount rejects
+it with `EMLINK`, `ENOTSUP`, `EOPNOTSUPP`, `ENOSYS`, or `EPERM`, config automatically
+tries a directory lock at the same `.aidlc-transaction.lock` path. No flag is
+needed, and config never proceeds with unlocked writes.
 
-The first-run wizard checks lock creation before offering setup choices. It
-removes its temporary probe files and stops without persistent setup changes
-if the check fails. Human output names the failure and remediation;
-`--quiet` prints the remediation, and `--json` returns a structured failure.
+The first-run wizard probes the required filesystem operations before offering
+setup choices, then removes its temporary probe files. A failed probe stops
+setup without persistent setup changes. Human output names the failure and
+remediation; `--quiet` prints the remediation, and `--json` returns a structured
+failure. Passing probes cannot certify atomicity or crash durability. See the
+capabilities and support matrix in [Transactions and Recovery](18-install-and-lifecycle.md#transactions-and-recovery).
+An S3 mount name or hard-link error alone does not identify its driver, version,
+or options.
 
-Move or clone the project onto storage that supports hard links, exclusive
-file creation, `fsync`, and atomic rename, then rerun `aidlc config` there.
-On EC2, ext4 or XFS on an EBS volume is a suitable choice. For a failing
-S3-backed workspace, use a project directory outside that mount. An alias or
-symlink to the same mount does not change its capabilities. Neither `--force`
-nor `--from` repairs the destination filesystem, and deleting transaction locks
-does not fix this error. Config requires the lock and does not fall back to
-unlocked writes. See [Transactions and Recovery](18-install-and-lifecycle.md#transactions-and-recovery).
+For an incompatible mount, move or clone the project onto compatible local
+storage, such as ext4 or XFS on an EC2 EBS volume, and rerun `aidlc config` there.
+Keep the working project outside the S3 mount; any later upload is a separate
+publication, without an atomic multi-file guarantee. An alias or symlink to the
+same mount does not change its capabilities. Neither `--force`, `--from`, nor
+deleting locks repairs missing filesystem semantics.
+
+### Transaction lock ownership
+
+Let a live init/lifecycle owner finish before retrying. A directory lock can be
+reclaimed on retry when its recorded host/boot identity matches and its owner
+PID is dead. Foreign, incomplete, or unverifiable directory owners are retained;
+a PID absent on this host is not proof that a foreign owner has stopped.
+
+For manual diagnosis, preserve the error, lock, and named staging/recovery
+paths. Inspect `.aidlc-transaction.lock/owner.json` (the lock file itself for a
+legacy file lock), and establish the owner process, host/boot, and mount history
+with the operator. All participants must share the same local temporary
+directory (`TMPDIR` on Unix) and PID namespace. Stop writers before corrective
+work and retain the evidence while ownership is uncertain. Do not blindly
+delete the project lock or its local coordination gate to make a retry proceed.
 
 ---
 
@@ -352,18 +368,13 @@ generation, a reused PID whose creation generation no longer matches, or an old
 lock whose owner stamp is genuinely missing. Matching/unknown live generations,
 malformed stamps, and unreadable stamps are reported but not removed.
 
-```bash
-# macOS / Linux
-rm -rf /tmp/.aidlc-audit-*.lock /tmp/.aidlc-subagent-*.lock
-
-# Windows (PowerShell)
-Remove-Item "$env:TEMP\.aidlc-audit-*.lock", "$env:TEMP\.aidlc-subagent-*.lock" -Recurse -Force
-```
-
-Manual removal is safe only after stopping all AI-DLC processes and confirming
-the project is quiescent. Locks and their owner-stamped `.reap` recovery gates
-are transient and recreated as needed. `.gate-mutex` files are persistent
-advisory-lock anchors and may remain empty in the temp directory.
+Before any manual cleanup, stop all AI-DLC processes using the affected locks,
+confirm ownership and that the projects are quiescent, and preserve diagnostic
+evidence. Investigate only the named lock; do not bulk-delete lock directories.
+Locks and their owner-stamped `.reap` recovery gates are transient and recreated
+as needed. `.gate-mutex` files are persistent advisory-lock anchors and may
+remain empty in the temp directory; an empty file is not evidence of a stale
+owner. Project transaction locks use the [ownership checks above](#transaction-lock-ownership).
 
 ---
 

--- a/docs/guide/18-install-and-lifecycle.md
+++ b/docs/guide/18-install-and-lifecycle.md
@@ -236,9 +236,14 @@ customization, or exit without persistent setup changes. Multiple detected
 harnesses get a numbered harness picker first; no detected harness gets the
 complete picker without a default.
 
-Before any setup choices, the wizard probes transaction-lock creation on the
-project filesystem using temporary files, then removes them. A failed probe
-stops setup with storage remediation and no persistent setup changes; see
+Before any setup choices, the wizard probes the project filesystem using
+temporary files and directories, then removes them. It checks transaction
+locking, exclusive file creation, regular-file `fsync`, mutable append and
+readback, descriptor/path identity, file replacement by rename, directory
+rename, Unix `chmod`, and runtime workflow-lock coordination. Unsupported
+directory `fsync` is tolerated. These checks detect unavailable operations;
+success cannot certify atomicity or crash durability. A failed probe stops
+setup with storage remediation and no persistent setup changes; see
 [Config fails with a hard-link error](15-troubleshooting.md#config-fails-with-a-hard-link-error).
 
 Recommended defaults state the bundle on the option line. Customization walks
@@ -877,18 +882,43 @@ no public completion-generation verb.
 ## Transactions and Recovery
 
 Project and machine mutations stage on the destination filesystem, validate
-the candidate, and commit through atomic renames. Concurrent changes detected
-against planned state abort instead of overwriting new bytes. Abandoned
-owner-private staging is swept only after lock and ownership checks.
+the candidate, and commit through rename boundaries. The filesystem remains
+responsible for coherent file identity and append behavior, atomic file
+replacement and directory rename, exclusive creation, and meaningful regular-file
+`fsync`. AI-DLC adds no copy-and-delete fallback for rename. Concurrent changes
+detected against planned state abort instead of overwriting new bytes.
+Abandoned owner-private staging is swept only after lock and ownership checks.
+Unsupported directory `fsync` is tolerated, so a successful command alone
+cannot promise metadata durability after a crash.
 
-The destination filesystem must support hard links for the transaction lock,
-exclusive file creation, `fsync`, and atomic rename within the same filesystem.
-The first-run lock probe is an early check; it does not replace validation and
-lock acquisition when applying changes or certify every filesystem operation.
-S3-backed and FUSE mounts must provide these operations to be usable. If a
-mount rejects lock creation, use compatible project storage, such as ext4 or
-XFS on EBS for EC2, and rerun config. An alias or symlink to the same mount does
-not help; config never proceeds with unlocked writes.
+Transaction locking prefers hard links and automatically falls back to an
+owner-stamped directory. Both occupy `.aidlc-transaction.lock`, preserving
+exclusion with live legacy file owners. A dedicated owner-stamped gate in the
+local temporary directory serializes transactions and ownership changes.
+This supports only cooperating processes on **one continuously running mount
+on one host**, sharing the same canonical project path, local temporary
+directory (`TMPDIR` on Unix), and PID namespace. It is not distributed locking
+across hosts or independent mounts, even when they access the same bucket.
+
+The first-run probe is an early capability check; directory-lock transactions
+also probe before applying changes. Neither replaces validation or real lock
+acquisition, and passing calls cannot prove atomic rename or crash durability.
+Compatibility depends on the driver and its actual semantics:
+
+| Storage | Compatibility boundary |
+| --- | --- |
+| Local ext4 or XFS, including EC2 EBS volumes | Suitable project storage for the required filesystem operations. |
+| POSIX-like mount without hard links | Config and transactions can run with directory locking if all remaining requirements hold, within the single-mount scope above. |
+| Mountpoint for Amazon S3 | Full workflows remain incompatible: directory rename and general mutable-file updates are unavailable. S3 Express single-file rename does not remove those limits. See [Mountpoint filesystem semantics](https://github.com/awslabs/mountpoint-s3/blob/5e400f788f8cbca028f3314d84ef2df2c7fcf536/doc/SEMANTICS.md). |
+| s3fs-fuse | Rename uses copy then delete and is not atomic. Passing probes does not establish support for general crash-safe AI-DLC transactions. See [s3fs limitations](https://github.com/s3fs-fuse/s3fs-fuse/blob/fc5778fe83b533a9beed9383f3ce99de76207ef9/README.md#L153-L163). |
+
+The fallback removes the transaction lock's hard-link requirement; separate
+operations can still require hard links, including workspace sync when it
+publishes generated files. Upstream semantics and simulated failures are not
+live validation of a particular S3 mount. Use compatible local/EBS project
+storage when a mount cannot meet these requirements; see [filesystem troubleshooting](15-troubleshooting.md#config-fails-with-a-hard-link-error).
+For foreign or incomplete lock owners, follow [Transaction lock ownership](15-troubleshooting.md#transaction-lock-ownership)
+before any manual recovery.
 
 If rollback of an interrupted commit cannot be completed safely, evidence is
 retained in a named `.aidlc-recovery-*` quarantine under the machine install

--- a/docs/guide/18-install-and-lifecycle.md
+++ b/docs/guide/18-install-and-lifecycle.md
@@ -232,18 +232,23 @@ On a human TTY, a bare first run starts with detection rather than questions:
 installed harness CLIs on `PATH`, project state, local AWS credentials and
 regions, and the non-interactive hook runtime. With one detected harness, the
 wizard names it and offers three choices: recommended defaults, six-step
-customization, or exit with nothing written. Multiple detected harnesses get a
-numbered harness picker first; no detected harness gets the complete picker
-without a default.
+customization, or exit without persistent setup changes. Multiple detected
+harnesses get a numbered harness picker first; no detected harness gets the
+complete picker without a default.
+
+Before any setup choices, the wizard probes transaction-lock creation on the
+project filesystem using temporary files, then removes them. A failed probe
+stops setup with storage remediation and no persistent setup changes; see
+[Config fails with a hard-link error](15-troubleshooting.md#config-fails-with-a-hard-link-error).
 
 Recommended defaults state the bundle on the option line. Customization walks
 Harness, Model provider, Model effort preset, Plugins, MCP servers, and settings
 layer. Every numbered prompt has a bracketed default, invalid input re-asks in
 place, and each answer is echoed. A check-your-answers table accepts Enter to
-apply or a step number to edit. No files are written before that final gate.
-After apply, gerund receipts name the project files and settings layer,
-genuinely blocking actions follow, then the wizard prints the exact harness
-launch and first workflow command.
+apply or a step number to edit. No persistent setup files are written before
+that final gate. After apply, gerund receipts name the project files and
+settings layer, genuinely blocking actions follow, then the wizard prints the
+exact harness launch and first workflow command.
 
 An existing-project rerun keeps the seven-row map for Harnesses, Models,
 Runtime, Flags, Project, Providers, and Trust. Rows are lowercase `[ok]` or
@@ -629,8 +634,13 @@ project content.
 | `opencode.json` | OpenCode | Whole-file ownership; an unknown existing file is a conflict |
 
 Known unmarked files and JSON entries from historical shipped projections are
-adopted only when their exact recorded SHA-256 signature matches. Modified
-lookalikes remain ambiguous and are refused.
+adopted only when their exact recorded SHA-256 signature matches. Unknown or
+modified unmarked `.gitignore` content remains user-owned, including `aidlc/`
+rules and AI-DLC comments. Config preserves that content as a prefix and
+appends a fresh managed block; no rename or deletion is needed. Other modified
+legacy lookalikes, including ambiguous AI-DLC content in `AGENTS.md`, remain
+refused. A `.gitignore` that is not valid UTF-8 also remains untouched and
+requires an encoding conversion before config can merge it safely.
 
 `--force` can replace a modified, baseline-owned managed block or managed
 harness file. It cannot adopt ambiguous unmarked content, overwrite a
@@ -870,6 +880,15 @@ Project and machine mutations stage on the destination filesystem, validate
 the candidate, and commit through atomic renames. Concurrent changes detected
 against planned state abort instead of overwriting new bytes. Abandoned
 owner-private staging is swept only after lock and ownership checks.
+
+The destination filesystem must support hard links for the transaction lock,
+exclusive file creation, `fsync`, and atomic rename within the same filesystem.
+The first-run lock probe is an early check; it does not replace validation and
+lock acquisition when applying changes or certify every filesystem operation.
+S3-backed and FUSE mounts must provide these operations to be usable. If a
+mount rejects lock creation, use compatible project storage, such as ext4 or
+XFS on EBS for EC2, and rerun config. An alias or symlink to the same mount does
+not help; config never proceeds with unlocked writes.
 
 If rollback of an interrupted commit cannot be completed safely, evidence is
 retained in a named `.aidlc-recovery-*` quarantine under the machine install

--- a/docs/reference/01-architecture.md
+++ b/docs/reference/01-architecture.md
@@ -502,6 +502,34 @@ preserves recovery evidence, and the next transaction quarantines abandoned
 staging rather than deleting it. Project init/refresh, machine lifecycle,
 project pins, plugin selection, and plugin sync all build plans for this engine.
 
+The root lock prefers hard-link publication and falls back automatically to an
+owner-stamped directory when hard links are unavailable. Both use
+`.aidlc-transaction.lock`, so a live legacy file owner still blocks the directory
+fallback. The receipt-managed `withAuditLock` helper supplies a dedicated local
+gate in the temporary directory, keyed by canonical root, around transaction
+execution, including
+acquisition, stale-owner recovery, and ownership-checked release. Directory
+recovery requires a matching host/boot identity and a dead owner PID; unknown,
+foreign, or incomplete directory owners are retained for manual diagnosis.
+
+The coordination contract covers cooperating processes on one continuously
+running mount on one host with a common local temporary directory (`TMPDIR` on
+Unix), canonical root, and PID namespace. It provides no distributed locking
+between hosts or independent mounts. Moving the gate locally does not change
+the data contract: workflow append and descriptor identity must remain coherent,
+and transaction publication still depends on atomic file replacement and
+directory rename supplied by the filesystem. No copy-and-delete rename
+fallback is added.
+
+`assertTransactionFilesystem` probes exclusive creation, regular-file `fsync`,
+mutable append/readback and descriptor identity, file/directory rename, Unix
+`chmod`, and transaction and runtime workflow locking. The first-run wizard and
+transactions using the directory fallback invoke it; unsupported directory
+`fsync` is tolerated. Successful probes cannot establish crash durability or
+rename atomicity, nor certify a driver through simulated failures. Mountpoint's
+missing directory rename/mutable-file support and s3fs's non-atomic rename
+remain outside the full transaction contract. See the [storage compatibility matrix](../guide/18-install-and-lifecycle.md#transactions-and-recovery).
+
 ### Release assembly and provenance
 
 `scripts/build-binaries.ts` regenerates projections, compiles the dispatcher

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -810,6 +810,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     "unit/t304-codekb-cumulative-merge.test.ts",
     "unit/t306-learnings-cid-collision-followup.test.ts",
     "unit/t324-doctor-hooks-disabled.test.ts",
+    "unit/t330-transaction-filesystem.test.ts",
     "unit/t240-opencode-packaging.test.ts",
     "unit/t244-install-management.test.ts",
     "unit/t242-plugin-state.test.ts",

--- a/tests/unit/t243-install-mechanism.test.ts
+++ b/tests/unit/t243-install-mechanism.test.ts
@@ -1202,7 +1202,7 @@ describe("t243 project initialization", () => {
     expect(readFileSync(target, "utf-8")).toContain("// active refresh marker");
   }, 60_000);
 
-  test("exact legacy root signatures are adopted while modified lookalikes still refuse", () => {
+  test("exact legacy root signatures are adopted", () => {
     const project = temp("aidlc-t240-legacy-adopt-");
     mkdirSync(join(project, ".git"));
     cpSync(join(CLAUDE_COPY, ".gitignore"), join(project, ".gitignore"));
@@ -1231,6 +1231,11 @@ describe("t243 project initialization", () => {
     const gitignore = readFileSync(join(project, ".gitignore"), "utf-8");
     expect(gitignore.match(/BEGIN AI-DLC:gitignore/g)).toHaveLength(1);
     expect(gitignore.match(/END AI-DLC:gitignore/g)).toHaveLength(1);
+    expect(gitignore).toBe(
+      `# BEGIN AI-DLC:gitignore\n${
+        readFileSync(join(CLAUDE_RELEASE, ".gitignore"), "utf-8").trim()
+      }\n# END AI-DLC:gitignore\n`,
+    );
 
     const baseline = JSON.parse(
       readFileSync(join(project, ".claude", "tools", "data", "aidlc-manifest.json"), "utf-8"),
@@ -1260,26 +1265,208 @@ describe("t243 project initialization", () => {
     expect(disabled.status, disabled.stdout + disabled.stderr).toBe(0);
     expect(JSON.parse(readFileSync(join(project, ".mcp.json"), "utf-8")).mcpServers)
       .toBeUndefined();
+  }, 60_000);
 
-    const ambiguous = temp("aidlc-t240-legacy-ambiguous-");
-    mkdirSync(join(ambiguous, ".git"));
-    writeFileSync(
-      join(ambiguous, ".gitignore"),
-      `${readFileSync(join(CLAUDE_COPY, ".gitignore"), "utf-8")}# local AI-DLC rule\n`,
-    );
+  for (const fixture of [
+    {
+      name: "ordinary ignore rules",
+      contents: () => "# Project build output\nnode_modules/\nbuild/\n\n",
+      newline: "\n",
+    },
+    {
+      name: "aidlc rules and an AI-DLC comment",
+      contents: () => "# AI-DLC output owned by this project\naidlc/\n!aidlc/README.md\n",
+      newline: "\n",
+    },
+    {
+      name: "CRLF rules without a final newline",
+      contents: () => "# AI-DLC output — project rules\r\naidlc/\r\nlocal-cache/",
+      newline: "\r\n",
+    },
+    {
+      name: "a locally edited shipped gitignore",
+      contents: () =>
+        `${readFileSync(join(CLAUDE_COPY, ".gitignore"), "utf-8")}# local AI-DLC rule\naidlc/custom/\n`,
+      newline: "\n",
+    },
+  ]) {
+    test(`unmarked gitignore preserves ${fixture.name} through dry-run, apply, and refresh`, () => {
+      const project = temp("aidlc-t243-user-gitignore-");
+      mkdirSync(join(project, ".git"));
+      const path = join(project, ".gitignore");
+      const original = Buffer.from(fixture.contents());
+      writeFileSync(path, original);
+      const args = [
+        "config",
+        "--project-dir",
+        project,
+        "--from",
+        CLAUDE_RELEASE,
+        "--harness",
+        "claude",
+        "--json",
+      ];
+      type ConfigPlan = {
+        data: { actions: Array<{ path: string; action: string; detail?: string }> };
+      };
+
+      const dry = run(INIT, [...args, "--dry-run", "--verbose"], project);
+      expect(dry.status, dry.stdout + dry.stderr).toBe(0);
+      const dryPlan = JSON.parse(dry.stdout) as ConfigPlan;
+      expect(dryPlan.data.actions.find((action) => action.path === ".gitignore"))
+        .toEqual({ path: ".gitignore", action: "merge" });
+      expect(readFileSync(path)).toEqual(original);
+      expect(readdirSync(project).sort()).toEqual([".git", ".gitignore"]);
+      expect(readdirSync(join(project, ".git"))).toEqual([]);
+
+      const applied = run(INIT, args, project);
+      expect(applied.status, applied.stdout + applied.stderr).toBe(0);
+      const installed = readFileSync(path);
+      expect(installed.subarray(0, original.length)).toEqual(original);
+      const block = [
+        "# BEGIN AI-DLC:gitignore",
+        readFileSync(join(CLAUDE_RELEASE, ".gitignore"), "utf-8")
+          .trim().replace(/\r?\n/g, fixture.newline),
+        "# END AI-DLC:gitignore",
+      ].join(fixture.newline);
+      const appended = installed.subarray(original.length).toString();
+      expect(appended).toStartWith(fixture.newline);
+      expect(appended.trim()).toBe(block);
+      expect(appended).toEndWith(fixture.newline);
+      expect(installed.toString().match(/# BEGIN AI-DLC:gitignore/g)).toHaveLength(1);
+      expect(installed.toString().match(/# END AI-DLC:gitignore/g)).toHaveLength(1);
+
+      const manifestPath = join(project, ".claude", "tools", "data", "aidlc-manifest.json");
+      const contribution = {
+        policy: "managed-block",
+        marker: "gitignore",
+        hash: sha256Bytes(block),
+      };
+      const baseline = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+        files: Record<string, string>;
+        rootContributions: Record<string, unknown>;
+      };
+      expect(baseline.files[".gitignore"]).toBeUndefined();
+      expect(baseline.rootContributions[".gitignore"]).toEqual(contribution);
+
+      // An unchanged refresh is idempotent; subsequent user-prefix edits remain unowned.
+      for (const userEdit of ["", `# Later AI-DLC project rule${fixture.newline}`]) {
+        const beforeRefresh = Buffer.concat([Buffer.from(userEdit), installed]);
+        if (userEdit) writeFileSync(path, beforeRefresh);
+        const refreshed = run(INIT, args, project);
+        expect(refreshed.status, refreshed.stdout + refreshed.stderr).toBe(0);
+        const refreshPlan = JSON.parse(refreshed.stdout) as ConfigPlan;
+        expect(refreshPlan.data.actions.find((action) => action.path === ".gitignore"))
+          .toEqual({ path: ".gitignore", action: "preserve" });
+        expect(readFileSync(path)).toEqual(beforeRefresh);
+        const refreshedBaseline = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+          files: Record<string, string>;
+          rootContributions: Record<string, unknown>;
+        };
+        expect(refreshedBaseline.files[".gitignore"]).toBeUndefined();
+        expect(refreshedBaseline.rootContributions[".gitignore"]).toEqual(contribution);
+      }
+    }, 60_000);
+  }
+
+  test("unmarked gitignore with invalid UTF-8 refuses without changing its bytes even with --force", () => {
+    const project = temp("aidlc-t243-gitignore-encoding-");
+    mkdirSync(join(project, ".git"));
+    const path = join(project, ".gitignore");
+    const original = Buffer.concat([
+      Buffer.from("# AI-DLC\n"),
+      Buffer.from([0x63, 0x61, 0x66, 0xe9, 0x2f, 0x0a]),
+    ]);
+    writeFileSync(path, original);
+    for (const flags of [["--dry-run", "--verbose"], ["--force"]]) {
+      const refused = run(INIT, [
+        "config",
+        "--project-dir",
+        project,
+        "--from",
+        CLAUDE_RELEASE,
+        "--harness",
+        "claude",
+        ...flags,
+      ], project);
+      expect(refused.status, refused.stdout + refused.stderr).toBe(4);
+      expect(refused.stdout).toContain(
+        "gitignore is not valid UTF-8; convert its encoding before config",
+      );
+      expect(readFileSync(path)).toEqual(original);
+      expect(readdirSync(project).sort()).toEqual([".git", ".gitignore"]);
+      expect(readdirSync(join(project, ".git"))).toEqual([]);
+    }
+  }, 60_000);
+
+  for (const fixture of [
+    {
+      name: "missing end marker",
+      contents: "# BEGIN AI-DLC:gitignore\naidlc/\n",
+      error: "managed markers are missing, duplicated, or malformed",
+    },
+    {
+      name: "missing begin marker",
+      contents: "aidlc/\n# END AI-DLC:gitignore\n",
+      error: "managed markers are missing, duplicated, or malformed",
+    },
+    {
+      name: "duplicate blocks",
+      contents: "# BEGIN AI-DLC:gitignore\naidlc/\n# END AI-DLC:gitignore\n".repeat(2),
+      error: "managed markers are missing, duplicated, or malformed",
+    },
+    {
+      name: "reversed markers",
+      contents: "# END AI-DLC:gitignore\naidlc/\n# BEGIN AI-DLC:gitignore\n",
+      error: "managed end marker precedes its begin marker",
+    },
+  ]) {
+    test(`gitignore with ${fixture.name} still refuses even with --force`, () => {
+      const project = temp("aidlc-t243-gitignore-markers-");
+      mkdirSync(join(project, ".git"));
+      const path = join(project, ".gitignore");
+      writeFileSync(path, fixture.contents);
+      for (const flags of [["--dry-run", "--verbose"], ["--force"]]) {
+        const refused = run(INIT, [
+          "config",
+          "--project-dir",
+          project,
+          "--from",
+          CLAUDE_RELEASE,
+          "--harness",
+          "claude",
+          ...flags,
+        ], project);
+        expect(refused.status, refused.stdout + refused.stderr).toBe(4);
+        expect(refused.stdout).toContain(fixture.error);
+        expect(readFileSync(path, "utf-8")).toBe(fixture.contents);
+        expect(readdirSync(project).sort()).toEqual([".git", ".gitignore"]);
+        expect(readdirSync(join(project, ".git"))).toEqual([]);
+      }
+    }, 60_000);
+  }
+
+  test("modified unmarked AGENTS.md still refuses as ambiguous even with --force", () => {
+    const project = temp("aidlc-t243-agents-ambiguous-");
+    mkdirSync(join(project, ".git"));
+    const path = join(project, "AGENTS.md");
+    const original = `${readFileSync(join(KIRO_RELEASES[0], "AGENTS.md"), "utf-8")}\n# Local AI-DLC instructions\n`;
+    writeFileSync(path, original);
     const refused = run(INIT, [
       "config",
       "--project-dir",
-      ambiguous,
+      project,
       "--from",
-      CLAUDE_RELEASE,
+      KIRO_RELEASES[0],
       "--harness",
-      "claude",
+      "kiro",
       "--force",
-    ], ambiguous);
-    expect(refused.status).toBe(4);
+    ], project);
+    expect(refused.status, refused.stdout + refused.stderr).toBe(4);
     expect(refused.stdout).toContain("legacy root integration ambiguous");
-    expect(existsSync(join(ambiguous, ".claude"))).toBe(false);
+    expect(readFileSync(path, "utf-8")).toBe(original);
+    expect(readdirSync(project).sort()).toEqual([".git", "AGENTS.md"]);
+    expect(readdirSync(join(project, ".git"))).toEqual([]);
   }, 60_000);
 
   test("--force does not replace a pre-existing user-owned JSON entry", () => {

--- a/tests/unit/t299-first-run-wizard.test.ts
+++ b/tests/unit/t299-first-run-wizard.test.ts
@@ -1,6 +1,7 @@
 // covers: tool:aidlc-init, function:readTerminalLine
 
 import { afterAll, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   closeSync,
   existsSync,
@@ -118,34 +119,225 @@ function detection(
 // explicit AIDLC_RUNTIME_ROOT plus the active machine runtime).
 function isolatedMachineEnv(): NodeJS.ProcessEnv {
   const machine = temp("aidlc-t299-machine-");
+  const isolatedHome = join(machine, "home");
+  const scratch = join(machine, "tmp");
+  mkdirSync(isolatedHome);
+  mkdirSync(scratch);
   return {
     AIDLC_INSTALL_ROOT: join(machine, "share", "aidlc"),
     AIDLC_BIN_DIR: join(machine, "bin"),
+    HOME: isolatedHome,
+    USERPROFILE: isolatedHome,
+    XDG_CONFIG_HOME: join(isolatedHome, ".config"),
+    XDG_CACHE_HOME: join(isolatedHome, ".cache"),
+    CLAUDE_CONFIG_DIR: join(isolatedHome, ".claude"),
+    CODEX_HOME: undefined,
+    AWS_CONFIG_FILE: join(isolatedHome, ".aws", "config"),
+    AWS_SHARED_CREDENTIALS_FILE: join(isolatedHome, ".aws", "credentials"),
+    AWS_ACCESS_KEY_ID: undefined,
+    AWS_SECRET_ACCESS_KEY: undefined,
+    AWS_SESSION_TOKEN: undefined,
+    AWS_PROFILE: undefined,
+    AWS_DEFAULT_PROFILE: undefined,
+    AWS_WEB_IDENTITY_TOKEN_FILE: undefined,
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: undefined,
+    AWS_CONTAINER_CREDENTIALS_FULL_URI: undefined,
+    AWS_EC2_METADATA_DISABLED: "true",
+    AWS_AIDLC_DEFAULT_SCOPE: undefined,
+    AIDLC_SESSION_OVERRIDE: undefined,
+    AIDLC_SKIP_SOURCE_FRESHNESS: undefined,
+    TMPDIR: scratch,
+    TMP: scratch,
+    TEMP: scratch,
   };
 }
 
-// Run the real CLI with an isolated filesystem mock. The trace proves that a
-// failure reached linkSync, rather than stopping at a missing runtime or stdin.
-function hardLinkFailurePreload(): { preload: string; trace: string } {
+const REQUIRED_FILESYSTEM_FAILURES = [
+  { operation: "file-rename", code: "ENOTSUP", diagnostic: "file replacement by rename" },
+  { operation: "directory-rename", code: "EOPNOTSUPP", diagnostic: "directory rename" },
+  { operation: "append", code: "ENOSYS", diagnostic: "mutable file append" },
+] as const;
+type FilesystemFailure = (typeof REQUIRED_FILESYSTEM_FAILURES)[number];
+type FilesystemTrace = {
+  event: string;
+  pid: number;
+  args?: string[];
+  childPid?: number;
+  status?: number;
+  path?: string;
+  source?: string;
+  destination?: string;
+  code?: string;
+  flags?: string | number;
+  owner?: { schemaVersion: number; pid: number; host: string; token: string };
+};
+
+// These faults model only API availability on the project filesystem. Local
+// temp storage, release sources, credentials, and the test runner are untouched.
+// Passing them says nothing about a real S3 driver's atomicity or durability.
+function filesystemPreload(failure?: FilesystemFailure): { preload: string; trace: string } {
   const directory = temp("aidlc-t299-filesystem-mock-");
-  const preload = join(directory, "reject-hard-links.ts");
-  const trace = join(directory, "links.ndjson");
+  const preload = join(directory, "project-filesystem.ts");
+  const trace = join(directory, "filesystem.ndjson");
   writeFileSync(preload, `
     import { mock } from "bun:test";
+    import { basename, resolve, sep } from "node:path";
+    import { fileURLToPath } from "node:url";
     const actual = { ...await import("node:fs") };
+    const children = { ...await import("node:child_process") };
+    const root = actual.realpathSync(process.env.AIDLC_T299_PROJECT_DIR);
+    const fault = ${JSON.stringify(failure ?? null)};
+    const record = (event, fields = {}) => actual.appendFileSync(
+      ${JSON.stringify(trace)}, JSON.stringify({ event, pid: process.pid, ...fields }) + "\\n",
+    );
+    const pathOf = (path) => resolve(path instanceof URL ? fileURLToPath(path) : String(path));
+    const inProject = (path) => {
+      if (typeof path === "number") return false;
+      const absolute = pathOf(path);
+      return absolute === root || absolute.startsWith(root + sep);
+    };
+    const reject = (operation, fields, code) => {
+      record("refused", { operation, ...fields, code });
+      throw Object.assign(new Error("simulated project filesystem " + operation + " failure"), { code });
+    };
+    const observeMutation = (method, pathIndex = 0) => (...args) => {
+      const path = args[pathIndex];
+      if (inProject(path)) record(method, { path: pathOf(path) });
+      return actual[method](...args);
+    };
+    record("preload", { args: process.argv.slice(1) });
     mock.module("node:fs", () => ({
       ...actual,
+      chmodSync: observeMutation("chmodSync"),
+      copyFileSync: observeMutation("copyFileSync", 1),
+      cpSync: observeMutation("cpSync", 1),
+      symlinkSync: observeMutation("symlinkSync", 1),
+      unlinkSync: observeMutation("unlinkSync"),
+      rmdirSync: observeMutation("rmdirSync"),
       linkSync(source, destination) {
-        actual.appendFileSync(${JSON.stringify(trace)}, JSON.stringify({ source, destination }) + "\\n");
-        throw Object.assign(new Error("simulated hard-link failure"), { code: "EMLINK" });
+        if (inProject(source) || inProject(destination)) {
+          record("link", { source: pathOf(source), destination: pathOf(destination), code: "EMLINK" });
+          throw Object.assign(new Error("simulated project hard-link failure"), { code: "EMLINK" });
+        }
+        return actual.linkSync(source, destination);
+      },
+      openSync(path, flags, ...rest) {
+        if (inProject(path)) {
+          const append = typeof flags === "string"
+            ? flags.includes("a")
+            : Boolean(flags & actual.constants.O_APPEND);
+          const write = typeof flags === "string"
+            ? /[wa+]/.test(flags)
+            : Boolean(flags & (actual.constants.O_WRONLY | actual.constants.O_RDWR | actual.constants.O_CREAT));
+          if (write) record("open", { path: pathOf(path), flags });
+          if (fault?.operation === "append" && append && actual.existsSync(path)) {
+            reject("append", { path: pathOf(path), flags }, fault.code);
+          }
+        }
+        return actual.openSync(path, flags, ...rest);
+      },
+      renameSync(source, destination) {
+        if (inProject(source) || inProject(destination)) {
+          const fields = { source: pathOf(source), destination: pathOf(destination) };
+          record("rename", fields);
+          const directory = actual.lstatSync(source).isDirectory();
+          if ((fault?.operation === "file-rename" && !directory) ||
+              (fault?.operation === "directory-rename" && directory)) {
+            reject(fault.operation, fields, fault.code);
+          }
+        }
+        return actual.renameSync(source, destination);
+      },
+      mkdirSync(path, ...rest) {
+        if (inProject(path)) record("mkdir", { path: pathOf(path) });
+        return actual.mkdirSync(path, ...rest);
+      },
+      mkdtempSync(path, ...rest) {
+        if (inProject(path)) record("mkdtemp", { path: pathOf(path) });
+        return actual.mkdtempSync(path, ...rest);
+      },
+      writeFileSync(path, ...rest) {
+        if (inProject(path)) record("write", { path: pathOf(path) });
+        return actual.writeFileSync(path, ...rest);
+      },
+      appendFileSync(path, ...rest) {
+        if (inProject(path)) {
+          record("append", { path: pathOf(path) });
+          if (fault?.operation === "append" && actual.existsSync(path)) {
+            reject("append", { path: pathOf(path) }, fault.code);
+          }
+        }
+        return actual.appendFileSync(path, ...rest);
+      },
+      rmSync(path, ...rest) {
+        if (inProject(path)) {
+          record("remove", { path: pathOf(path) });
+          if (basename(pathOf(path)) === ".aidlc-transaction.lock" &&
+              actual.existsSync(path) && actual.lstatSync(path).isDirectory() &&
+              actual.existsSync(resolve(String(path), "owner.json"))) {
+            record("directory-lock", {
+              path: pathOf(path),
+              owner: JSON.parse(actual.readFileSync(resolve(String(path), "owner.json"), "utf-8")),
+            });
+          }
+        }
+        return actual.rmSync(path, ...rest);
+      },
+    }));
+    // runConfigChild launches process.execPath without the parent's CLI flags.
+    // Propagate the preload explicitly and prove each child loaded it below.
+    mock.module("node:child_process", () => ({
+      ...children,
+      spawnSync(command, args, options) {
+        if (command !== process.execPath || !Array.isArray(args)) {
+          return children.spawnSync(command, args, options);
+        }
+        const forwarded = args.includes(${JSON.stringify(preload)})
+          ? args : ["--preload", ${JSON.stringify(preload)}, ...args];
+        const result = children.spawnSync(command, forwarded, options);
+        record("spawn", { args, childPid: result.pid, status: result.status });
+        return result;
       },
     }));
   `);
   return { preload, trace };
 }
 
-function linkTrace(trace: string): Array<{ source: string; destination: string }> {
+function filesystemTrace(trace: string): FilesystemTrace[] {
   return readFileSync(trace, "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+}
+
+type CliResult = { status: number; stdout: string; stderr: string; pid: number };
+type CliContext = { project: string; env: NodeJS.ProcessEnv; preload?: string };
+
+function runCli(context: CliContext, tool: string, args: string[], input = ""): CliResult {
+  const result = spawnSync(BUN, [
+    ...(context.preload ? ["--preload", context.preload] : []),
+    tool,
+    ...args,
+    "--project-dir",
+    context.project,
+  ], {
+    cwd: context.project,
+    env: context.env,
+    input,
+    encoding: "utf-8",
+    timeout: 60_000,
+  });
+  if (result.error) throw result.error;
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    pid: result.pid,
+  };
+}
+
+function runConfig(context: CliContext, args: string[]): CliResult {
+  return runCli({
+    ...context,
+    env: { ...context.env, AIDLC_TEST_CONFIG_TTY: undefined },
+  }, INIT, ["config", ...args]);
 }
 
 function runWizard(
@@ -159,8 +351,8 @@ function runWizard(
     preload?: string;
     configArgs?: string[];
   } = {},
-): { project: string; status: number; stdout: string; stderr: string } {
-  const project = temp("aidlc-t299-project-");
+): CliContext & CliResult {
+  const project = realpathSync(temp("aidlc-t299-project-"));
   const bin = temp("aidlc-t299-bin-");
   mkdirSync(join(project, ".git"));
   executable(join(bin, "claude"), "claude 2.1.220");
@@ -174,42 +366,164 @@ function runWizard(
   executable(join(bin, "getconf"), bin);
   if (options.aidlc !== false) executable(join(bin, "aidlc"));
   options.prepare?.(project);
-  const result = spawnSync(
-    BUN,
-    [
-      ...(options.preload ? ["--preload", options.preload] : []),
-      INIT,
-      "config",
-      "--project-dir",
-      project,
-      ...(options.configArgs ?? []),
-    ],
-    {
-      cwd: project,
-      env: {
-        ...process.env,
-        ...isolatedMachineEnv(),
-        PATH: bin,
-        AIDLC_RUNTIME_ROOT: RUNTIME,
-        AIDLC_TEST_CONFIG_TTY: "1",
-        AIDLC_TEST_CONFIG_DETECTION_JSON: detection(
-          bin,
-          options.harnesses,
-          options.runtimeIssue,
-        ),
-        ...options.env,
-      },
-      input,
-      encoding: "utf-8",
-      timeout: 60_000,
-    },
-  );
-  return {
+  const context: CliContext = {
     project,
-    status: result.status ?? -1,
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
+    preload: options.preload,
+    env: {
+      ...process.env,
+      ...isolatedMachineEnv(),
+      PATH: bin,
+      NO_COLOR: "1",
+      AIDLC_RUNTIME_ROOT: RUNTIME,
+      AIDLC_TEST_CONFIG_TTY: "1",
+      AIDLC_TEST_CONFIG_DETECTION_JSON: detection(
+        bin,
+        options.harnesses,
+        options.runtimeIssue,
+      ),
+      ...options.env,
+      AIDLC_T299_PROJECT_DIR: project,
+    },
   };
+  return { ...context, ...runCli(context, INIT, ["config", ...(options.configArgs ?? [])], input) };
+}
+
+function expectConfiguredProject(project: string, mcp: "defaults" | "none"): void {
+  const settings = JSON.parse(readFileSync(join(project, "aidlc.settings.json"), "utf-8"));
+  expect(settings).toEqual(expect.objectContaining({
+    schemaVersion: 1,
+    models: expect.objectContaining({ schemaVersion: 1, preset: "balanced" }),
+  }));
+  const data = join(project, ".claude", "tools", "data");
+  const harness = JSON.parse(readFileSync(join(data, "harness.json"), "utf-8"));
+  expect(harness.providers).toEqual(expect.objectContaining({
+    schemaVersion: 1,
+    provider: "amazon-bedrock",
+    region: "us-east-2",
+    pendingActions: expect.arrayContaining([
+      expect.objectContaining({ id: "bedrock-model-access", status: "done" }),
+    ]),
+  }));
+  const nativeSettings = JSON.parse(
+    readFileSync(join(project, ".claude", "settings.json"), "utf-8"),
+  );
+  expect(nativeSettings.env).toEqual(expect.objectContaining({
+    CLAUDE_CODE_USE_BEDROCK: "1",
+    AWS_REGION: "us-east-2",
+  }));
+  expect(readFileSync(join(project, ".claude", "agents", "aidlc-product-lead-agent.md"), "utf-8"))
+    .toContain("effort: medium");
+  const baseline = JSON.parse(readFileSync(join(data, "aidlc-manifest.json"), "utf-8"));
+  expect(baseline).toEqual(expect.objectContaining({
+    schemaVersion: 1,
+    distribution: "claude",
+    harnessDir: ".claude",
+    mcpMode: mcp,
+  }));
+  // planManagedFiles excludes mutable harness data from baseline ownership;
+  // its provider content is checked above. Other regenerated surfaces stay hashed.
+  expect(Object.hasOwn(baseline.files, ".claude/tools/data/harness.json")).toBe(false);
+  for (const path of [
+    ".claude/settings.json",
+    ".claude/tools/data/agent-tiers.json",
+    ".claude/agents/aidlc-product-lead-agent.md",
+  ]) {
+    const hash = createHash("sha256").update(readFileSync(join(project, path))).digest("hex");
+    expect(baseline.files[path], path).toBe(`sha256:${hash}`);
+  }
+  expect(readdirSync(project).filter((name) =>
+    /^\.aidlc-(?:transaction\.lock|lock-|txn-|recovery-)/.test(name)
+  )).toEqual([]);
+}
+
+function expectDirectoryTransaction(
+  events: FilesystemTrace[],
+  project: string,
+  pid: number,
+): void {
+  const lock = join(project, ".aidlc-transaction.lock");
+  expect(events).toContainEqual(expect.objectContaining({
+    event: "link", pid, destination: lock, code: "EMLINK",
+  }));
+  expect(events).toContainEqual(expect.objectContaining({
+    event: "directory-lock",
+    pid,
+    path: lock,
+    owner: expect.objectContaining({
+      schemaVersion: 1,
+      pid,
+      host: expect.any(String),
+      token: expect.any(String),
+    }),
+  }));
+}
+
+function expectFilesystemRemediation(message: string, remediation: string, fault: FilesystemFailure): void {
+  expect(message).toContain("Cannot use the filesystem at");
+  expect(message).toContain(fault.diagnostic);
+  expect(message).toContain(`(${fault.code})`);
+  expect(remediation).toMatch(/mutable files/i);
+  expect(remediation).toMatch(/rename/i);
+  expect(remediation).toMatch(/local storage|ext4|XFS/i);
+  expect(remediation).toMatch(/one host/i);
+  expect(message + remediation).not.toContain("<valid-release-data>");
+  expect(message + remediation).not.toContain("hard-link creation");
+}
+
+function expectInstalledWorkflowWrites(context: CliContext, trace: string): void {
+  const run = (tool: string, args: string[]): CliResult => {
+    const result = runCli({
+      ...context,
+      env: {
+        ...context.env,
+        AIDLC_TEST_CONFIG_TTY: undefined,
+        AIDLC_HARNESS_DIR: ".claude",
+        AIDLC_PROJECT_DIR: context.project,
+      },
+    }, join(context.project, ".claude", "tools", tool), args);
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(filesystemTrace(trace)).toContainEqual(expect.objectContaining({
+      event: "preload", pid: result.pid,
+    }));
+    return result;
+  };
+  // These installed utilities execute locally; no agent or provider is called.
+  const next = run("aidlc-orchestrate.ts", ["next", "--scope", "bugfix"]);
+  const directive = JSON.parse(next.stdout);
+  expect(directive.kind).toBe("print");
+  expect(directive.message).toContain("intent create --scope bugfix");
+  run("aidlc-utility.ts", [
+    "intent-create", "--scope", "bugfix", "--depth", "minimal",
+    "--label", "Filesystem regression", "--arguments", "Exercise mutable project storage",
+  ]);
+  const workspace = join(context.project, "aidlc");
+  const space = readFileSync(join(workspace, "active-space"), "utf-8").trim();
+  const intents = join(workspace, "spaces", space, "intents");
+  const record = join(intents, readFileSync(join(intents, "active-intent"), "utf-8").trim());
+  const statePath = join(record, "aidlc-state.md");
+  expect(readFileSync(statePath, "utf-8")).toContain("- **Scope**: bugfix");
+  expect(existsSync(join(workspace, "spaces", space, "knowledge"))).toBe(true);
+  expect(run("aidlc-state.ts", ["get", "Depth"]).stdout.trim()).toBe("Minimal");
+
+  const auditDir = join(record, "audit");
+  const readAudit = (): string => readdirSync(auditDir).filter((name) => name.endsWith(".md"))
+    .sort().map((name) => readFileSync(join(auditDir, name), "utf-8")).join("\n");
+  const before = readAudit();
+  expect(before).toContain("**Event**: WORKFLOW_STARTED");
+  const changed = run("aidlc-utility.ts", ["config-change", "--depth", "comprehensive"]);
+  expect(run("aidlc-state.ts", ["get", "Depth"]).stdout.trim()).toBe("Comprehensive");
+  expect(readFileSync(statePath, "utf-8")).toContain("- **Depth**: Comprehensive");
+  const after = readAudit();
+  expect(after.length).toBeGreaterThan(before.length);
+  expect(after).toContain("**Event**: DEPTH_CHANGED");
+  expect(after).toContain("**New Depth**: Comprehensive");
+  const events = filesystemTrace(trace).filter((event) => event.pid === changed.pid);
+  expect(events.some((event) =>
+    event.event === "rename" && event.destination === statePath
+  )).toBe(true);
+  expect(events.some((event) =>
+    event.event === "open" && event.path && dirname(event.path) === auditDir
+  )).toBe(true);
 }
 
 describe("t299 first-run setup wizard", () => {
@@ -355,95 +669,225 @@ describe("t299 first-run setup wizard", () => {
     expect(treeSnapshot(result.project)).toEqual(before);
   }, 60_000);
 
-  for (const [label, harnesses] of [
-    ["one detected CLI", { claude: { found: true } }],
-    ["multiple detected CLIs", { claude: { found: true }, codex: { found: true } }],
-    ["no detected CLI", { claude: { found: false } }],
-  ] as const) {
-    test(`filesystem rejection stops the wizard before selection with ${label}`, () => {
-      const { preload, trace } = hardLinkFailurePreload();
-      let before: Record<string, string> = {};
-      // Empty stdin cannot answer either the harness picker or the setup gate.
-      const result = runWizard("", {
-        preload,
-        harnesses,
-        prepare: (project) => {
-          writeFileSync(join(project, "README.md"), "existing project\n");
-          before = treeSnapshot(project);
-        },
-      });
-      const output = result.stdout + result.stderr;
-      expect(result.status, output).toBe(1);
-      expect(output).toContain("Setup stopped:");
-      expect(output).toContain("Cannot create an AI-DLC transaction lock in");
-      expect(output).toContain("(EMLINK)");
-      expect(output).toMatch(/fix:/i);
-      expect(output).toMatch(/hard[- ]links?/i);
-      expect(output).toMatch(/S3|FUSE/i);
-      expect(output).toContain("Nothing written.");
-      expect(output).not.toContain("Choose the harness for this project first.");
-      expect(output).not.toContain("Choose one to configure:");
-      expect(output).not.toContain("Set up AI-DLC for");
-      expect(output).not.toContain("Customize setup");
-      expect(output).not.toContain('"schemaVersion"');
-      expect(output).not.toContain('"actions"');
-      expect(output).not.toContain("<valid-release-data>");
-      const links = linkTrace(trace);
-      expect(links).toHaveLength(1);
-      expect(basename(dirname(links[0].source))).toMatch(/^\.aidlc-lock-probe-/);
-      expect(dirname(links[0].source)).toBe(dirname(links[0].destination));
-      expect(links[0].destination).not.toBe(join(result.project, ".aidlc-transaction.lock"));
-      expect(treeSnapshot(result.project)).toEqual(before);
-    }, 60_000);
-  }
+  test("recommended first-run and installed workflow writes succeed with project hardlinks refused in every config child", () => {
+    const { preload, trace } = filesystemPreload();
+    const result = runWizard("\n", { preload });
+    const output = result.stdout + result.stderr;
+    expect(result.status, output).toBe(0);
+    expect(output).toContain("Writing project files ... done");
+    expect(output).toContain("Recording your choices ... done");
+    expect(output).toContain("Setup complete. Start your first workflow:");
+    expect(output).not.toContain("Setup stopped:");
+    expectConfiguredProject(result.project, "defaults");
 
-  for (const mode of ["json", "quiet", "human"] as const) {
-    test(`noninteractive ${mode} config preserves filesystem remediation on apply failure`, () => {
-      const { preload, trace } = hardLinkFailurePreload();
-      let before: Record<string, string> = {};
-      const result = runWizard("", {
-        preload,
-        configArgs: [
-          "--from", join(RUNTIME, "claude"),
-          "--harness", "claude",
-          "--mcp", "none",
-          "--yes",
-          ...(mode === "human" ? [] : [`--${mode}`]),
-        ],
-        env: { AIDLC_TEST_CONFIG_TTY: undefined, NO_COLOR: "1" },
-        prepare: (project) => {
-          writeFileSync(join(project, "README.md"), "existing project\n");
-          writeFileSync(join(project, ".gitignore"), "# user-owned\n");
-          before = treeSnapshot(project);
-        },
-      });
-      const output = result.stdout + result.stderr;
-      expect(result.status, output).toBeGreaterThan(0);
-      expect(output).not.toContain("<valid-release-data>");
-      if (mode === "json") {
-        const error = JSON.parse(result.stdout);
-        expect(error.ok).toBe(false);
-        expect(error.code).toBe(result.status);
-        expect(error.message).toContain("Cannot create an AI-DLC transaction lock in");
-        expect(error.message).toContain("(EMLINK)");
-        expect(error.remediation).toMatch(/hard[- ]links?/i);
-        expect(error.remediation).toMatch(/S3|FUSE/i);
-      } else {
-        expect(output).toMatch(/hard[- ]links?/i);
-        expect(output).toMatch(/S3|FUSE/i);
+    const events = filesystemTrace(trace);
+    const probeLinks = events.filter((event) => event.event === "link" && event.pid === result.pid);
+    expect(probeLinks.length).toBeGreaterThan(0);
+    for (const link of probeLinks) {
+      expect(basename(dirname(link.destination!))).toMatch(/^\.aidlc-lock-probe-/);
+    }
+    const children = events.filter((event) =>
+      event.event === "spawn" && event.pid === result.pid && event.args?.includes("config")
+    );
+    // Scaffold, models, project choices, and provider setup all mutate through
+    // separate Bun processes. A parent-only preload cannot satisfy this check.
+    expect(children.map((child) => {
+      const args = child.args!;
+      const section = args[args.indexOf("config") + 1];
+      return section.startsWith("--") ? "config" : section;
+    })).toEqual(["config", "models", "project", "providers"]);
+    for (const child of children) {
+      expect(child.status).toBe(0);
+      expect(events).toContainEqual(expect.objectContaining({
+        event: "preload", pid: child.childPid,
+      }));
+      expectDirectoryTransaction(events, result.project, child.childPid!);
+    }
+    expectInstalledWorkflowWrites(result, trace);
+  }, 120_000);
+
+  test("noninteractive JSON apply and refresh keep settings, models, providers, and baseline valid without hardlinks", () => {
+    const { preload, trace } = filesystemPreload();
+    const result = runWizard("", {
+      preload,
+      configArgs: [
+        "--from", join(RUNTIME, "claude"),
+        "--harness", "claude",
+        "--mcp", "none",
+        "--yes", "--json",
+      ],
+      env: {
+        AIDLC_TEST_CONFIG_TTY: undefined,
+        // The providers --check command performs offline credential detection.
+        // Synthetic values satisfy that check without reading host credentials.
+        AWS_ACCESS_KEY_ID: "aidlc-t299-offline-access",
+        AWS_SECRET_ACCESS_KEY: "aidlc-t299-offline-secret",
+      },
+    });
+    const expectApplied = (applied: CliResult): void => {
+      expect(applied.status, applied.stdout + applied.stderr).toBe(0);
+      const payload = JSON.parse(applied.stdout);
+      expect(payload.ok).toBe(true);
+      expect(payload.code).toBe(0);
+      expect(payload.data.distribution).toBe("claude");
+      expect(payload.data.counts.conflict).toBe(0);
+      expectDirectoryTransaction(filesystemTrace(trace), result.project, applied.pid);
+    };
+    expectApplied(result);
+    expectApplied(runConfig(result, [
+      "models", "--project", "--preset", "balanced", "--yes", "--json",
+    ]));
+    expectApplied(runConfig(result, [
+      "providers", "--provider", "amazon-bedrock", "--region", "us-east-2",
+      "--mark-done", "bedrock-model-access", "--yes", "--json",
+    ]));
+    expectConfiguredProject(result.project, "none");
+    const settingsBefore = readFileSync(join(result.project, "aidlc.settings.json"), "utf-8");
+    const userFile = join(result.project, ".claude", "user-notes.txt");
+    writeFileSync(userFile, "keep this unowned file\n");
+
+    expectApplied(runConfig(result, ["--yes", "--json"]));
+    expectConfiguredProject(result.project, "none");
+    expect(readFileSync(join(result.project, "aidlc.settings.json"), "utf-8")).toBe(settingsBefore);
+    expect(readFileSync(userFile, "utf-8")).toBe("keep this unowned file\n");
+    for (const section of ["models", "providers"]) {
+      const checked = runConfig(result, [section, "--check", "--json"]);
+      expect(checked.status, checked.stdout + checked.stderr).toBe(0);
+      expect(JSON.parse(checked.stdout).ok).toBe(true);
+    }
+  }, 120_000);
+
+  for (const fault of REQUIRED_FILESYSTEM_FAILURES) {
+    for (const [label, harnesses] of [
+      ["one detected CLI", { claude: { found: true } }],
+      ["multiple detected CLIs", { claude: { found: true }, codex: { found: true } }],
+      ["no detected CLI", { claude: { found: false } }],
+    ] as const) {
+      test(`${fault.operation} rejection stops the wizard before selection with ${label}`, () => {
+        const { preload, trace } = filesystemPreload(fault);
+        let before: Record<string, string> = {};
+        // Empty stdin cannot answer either the harness picker or the setup gate.
+        const result = runWizard("", {
+          preload,
+          harnesses,
+          prepare: (project) => {
+            writeFileSync(join(project, "README.md"), "existing project\n");
+            writeFileSync(join(project, ".gitignore"), "# user-owned\n");
+            before = treeSnapshot(project);
+          },
+        });
+        const output = result.stdout + result.stderr;
+        expect(result.status, output).toBe(1);
+        expect(output).toContain("Setup stopped:");
+        expectFilesystemRemediation(output, output, fault);
+        expect(output).toMatch(/fix:/i);
+        expect(output).toContain("Nothing written.");
+        expect(output).not.toContain("Choose the harness for this project first.");
+        expect(output).not.toContain("Choose one to configure:");
+        expect(output).not.toContain("Set up AI-DLC for");
+        expect(output).not.toContain("Customize setup");
         expect(output).not.toContain('"schemaVersion"');
         expect(output).not.toContain('"actions"');
-        if (mode === "human") {
-          expect(output).toContain("Cannot create an AI-DLC transaction lock in");
-          expect(output).toContain("(EMLINK)");
-          expect(output).toMatch(/fix:/i);
+        expect(output.trim().split("\n").length).toBeLessThanOrEqual(4);
+        const events = filesystemTrace(trace);
+        expect(events).toContainEqual(expect.objectContaining({
+          event: "refused", code: fault.code,
+        }));
+        const links = events.filter((event) => event.event === "link");
+        expect(links).toHaveLength(1);
+        expect(basename(dirname(links[0].source!))).toMatch(/^\.aidlc-lock-probe-/);
+        expect(dirname(links[0].source!)).toBe(dirname(links[0].destination!));
+        expect(links[0].destination).not.toBe(join(result.project, ".aidlc-transaction.lock"));
+        expect(events.some((event) => event.event === "spawn")).toBe(false);
+        expect(treeSnapshot(result.project)).toEqual(before);
+      }, 60_000);
+    }
+
+    for (const mode of ["json", "quiet", "human"] as const) {
+      test(`noninteractive ${mode} config preserves ${fault.operation} remediation without persistent writes`, () => {
+        const { preload, trace } = filesystemPreload(fault);
+        let before: Record<string, string> = {};
+        const result = runWizard("", {
+          preload,
+          configArgs: [
+            "--from", join(RUNTIME, "claude"),
+            "--harness", "claude",
+            "--mcp", "none",
+            "--yes",
+            ...(mode === "human" ? [] : [`--${mode}`]),
+          ],
+          env: { AIDLC_TEST_CONFIG_TTY: undefined },
+          prepare: (project) => {
+            writeFileSync(join(project, "README.md"), "existing project\n");
+            writeFileSync(join(project, ".gitignore"), "# user-owned\n");
+            before = treeSnapshot(project);
+          },
+        });
+        const output = result.stdout + result.stderr;
+        expect(result.status, output).toBeGreaterThan(0);
+        expect(output).not.toContain("<valid-release-data>");
+        if (mode === "json") {
+          const error = JSON.parse(result.stdout);
+          expect(error.ok).toBe(false);
+          expect(error.code).toBe(result.status);
+          expectFilesystemRemediation(error.message, error.remediation, fault);
+          expect(error).not.toHaveProperty("data");
+          expect(result.stderr).toBe("");
+        } else {
+          expect(output).toMatch(/mutable files/i);
+          expect(output).toMatch(/local storage|ext4|XFS/i);
+          expect(output).not.toContain('"schemaVersion"');
+          expect(output).not.toContain('"actions"');
+          expect(output.trim().split("\n").length).toBeLessThanOrEqual(3);
+          if (mode === "human") {
+            expectFilesystemRemediation(output, output, fault);
+            expect(output).toMatch(/fix:/i);
+          }
         }
-      }
-      expect(linkTrace(trace)).toEqual([expect.objectContaining({
-        destination: join(realpathSync(result.project), ".aidlc-transaction.lock"),
-      })]);
-      expect(treeSnapshot(result.project)).toEqual(before);
-    }, 60_000);
+        const events = filesystemTrace(trace);
+        expect(events).toContainEqual(expect.objectContaining({
+          event: "refused", code: fault.code,
+        }));
+        expectDirectoryTransaction(events, result.project, result.pid);
+        expect(treeSnapshot(result.project)).toEqual(before);
+      }, 60_000);
+    }
+  }
+
+  for (const fault of [undefined, ...REQUIRED_FILESYSTEM_FAILURES]) {
+    for (const mode of ["human", "json"] as const) {
+      test(`${mode} dry-run does not probe or write with ${fault?.operation ?? "hardlinks"} refused`, () => {
+        const { preload, trace } = filesystemPreload(fault);
+        let before: Record<string, string> = {};
+        const result = runWizard("", {
+          preload,
+          configArgs: [
+            "--from", join(RUNTIME, "claude"), "--harness", "claude",
+            "--mcp", "none", "--dry-run", ...(mode === "json" ? ["--json"] : []),
+          ],
+          prepare: (project) => {
+            writeFileSync(join(project, "README.md"), "existing project\n");
+            writeFileSync(join(project, ".gitignore"), "# user-owned\n");
+            before = treeSnapshot(project);
+          },
+        });
+        expect(result.status, result.stdout + result.stderr).toBe(0);
+        expect(result.stdout).toContain("config plan for");
+        expect(result.stdout).not.toContain("Set up AI-DLC for");
+        if (mode === "json") {
+          const payload = JSON.parse(result.stdout);
+          expect(payload.ok).toBe(true);
+          expect(payload.data.counts.create).toBeGreaterThan(0);
+          expect(payload.data.planToken).toMatch(/^sha256:[0-9a-f]{64}$/);
+        }
+        // A trace containing only startup proves the mock was loaded without
+        // ever calling a project mutation, including a disposable probe.
+        expect(filesystemTrace(trace)).toEqual([
+          expect.objectContaining({ event: "preload", pid: result.pid }),
+        ]);
+        expect(treeSnapshot(result.project)).toEqual(before);
+      }, 60_000);
+    }
   }
 
   test("late first-run failure restores every wizard-owned path", () => {

--- a/tests/unit/t299-first-run-wizard.test.ts
+++ b/tests/unit/t299-first-run-wizard.test.ts
@@ -9,12 +9,13 @@ import {
   openSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { REPO_ROOT } from "../harness/fixtures.ts";
 import { binRoot } from "../../core/tools/aidlc-install-paths.ts";
@@ -123,6 +124,30 @@ function isolatedMachineEnv(): NodeJS.ProcessEnv {
   };
 }
 
+// Run the real CLI with an isolated filesystem mock. The trace proves that a
+// failure reached linkSync, rather than stopping at a missing runtime or stdin.
+function hardLinkFailurePreload(): { preload: string; trace: string } {
+  const directory = temp("aidlc-t299-filesystem-mock-");
+  const preload = join(directory, "reject-hard-links.ts");
+  const trace = join(directory, "links.ndjson");
+  writeFileSync(preload, `
+    import { mock } from "bun:test";
+    const actual = { ...await import("node:fs") };
+    mock.module("node:fs", () => ({
+      ...actual,
+      linkSync(source, destination) {
+        actual.appendFileSync(${JSON.stringify(trace)}, JSON.stringify({ source, destination }) + "\\n");
+        throw Object.assign(new Error("simulated hard-link failure"), { code: "EMLINK" });
+      },
+    }));
+  `);
+  return { preload, trace };
+}
+
+function linkTrace(trace: string): Array<{ source: string; destination: string }> {
+  return readFileSync(trace, "utf-8").trim().split("\n").map((line) => JSON.parse(line));
+}
+
 function runWizard(
   input: string,
   options: {
@@ -131,6 +156,8 @@ function runWizard(
     runtimeIssue?: boolean;
     env?: NodeJS.ProcessEnv;
     prepare?: (project: string) => void;
+    preload?: string;
+    configArgs?: string[];
   } = {},
 ): { project: string; status: number; stdout: string; stderr: string } {
   const project = temp("aidlc-t299-project-");
@@ -149,7 +176,14 @@ function runWizard(
   options.prepare?.(project);
   const result = spawnSync(
     BUN,
-    [INIT, "config", "--project-dir", project],
+    [
+      ...(options.preload ? ["--preload", options.preload] : []),
+      INIT,
+      "config",
+      "--project-dir",
+      project,
+      ...(options.configArgs ?? []),
+    ],
     {
       cwd: project,
       env: {
@@ -297,6 +331,120 @@ describe("t299 first-run setup wizard", () => {
       opencodeDefault: true,
     }));
   }, 60_000);
+
+  test("a preexisting settings conflict renders the child's message and fix without its JSON plan", () => {
+    let before: Record<string, string> = {};
+    const result = runWizard("\n", {
+      prepare: (project) => {
+        mkdirSync(join(project, ".claude"));
+        writeFileSync(join(project, ".claude", "settings.json"), '{"userOwned":true}\n');
+        writeFileSync(join(project, ".gitignore"), "# keep my ignores\nnode_modules/\n");
+        before = treeSnapshot(project);
+      },
+    });
+    const output = result.stdout + result.stderr;
+    expect(result.status, output).toBe(1);
+    expect(output).toContain("Setup stopped:");
+    expect(output).toContain("config conflict(s)");
+    expect(output).toContain(".claude/settings.json");
+    expect(output).toContain("locally modified or unowned");
+    expect(output).toMatch(/fix:/i);
+    expect(output).toContain("--dry-run --verbose");
+    expect(output).not.toContain('"schemaVersion"');
+    expect(output).not.toContain('"actions"');
+    expect(treeSnapshot(result.project)).toEqual(before);
+  }, 60_000);
+
+  for (const [label, harnesses] of [
+    ["one detected CLI", { claude: { found: true } }],
+    ["multiple detected CLIs", { claude: { found: true }, codex: { found: true } }],
+    ["no detected CLI", { claude: { found: false } }],
+  ] as const) {
+    test(`filesystem rejection stops the wizard before selection with ${label}`, () => {
+      const { preload, trace } = hardLinkFailurePreload();
+      let before: Record<string, string> = {};
+      // Empty stdin cannot answer either the harness picker or the setup gate.
+      const result = runWizard("", {
+        preload,
+        harnesses,
+        prepare: (project) => {
+          writeFileSync(join(project, "README.md"), "existing project\n");
+          before = treeSnapshot(project);
+        },
+      });
+      const output = result.stdout + result.stderr;
+      expect(result.status, output).toBe(1);
+      expect(output).toContain("Setup stopped:");
+      expect(output).toContain("Cannot create an AI-DLC transaction lock in");
+      expect(output).toContain("(EMLINK)");
+      expect(output).toMatch(/fix:/i);
+      expect(output).toMatch(/hard[- ]links?/i);
+      expect(output).toMatch(/S3|FUSE/i);
+      expect(output).toContain("Nothing written.");
+      expect(output).not.toContain("Choose the harness for this project first.");
+      expect(output).not.toContain("Choose one to configure:");
+      expect(output).not.toContain("Set up AI-DLC for");
+      expect(output).not.toContain("Customize setup");
+      expect(output).not.toContain('"schemaVersion"');
+      expect(output).not.toContain('"actions"');
+      expect(output).not.toContain("<valid-release-data>");
+      const links = linkTrace(trace);
+      expect(links).toHaveLength(1);
+      expect(basename(dirname(links[0].source))).toMatch(/^\.aidlc-lock-probe-/);
+      expect(dirname(links[0].source)).toBe(dirname(links[0].destination));
+      expect(links[0].destination).not.toBe(join(result.project, ".aidlc-transaction.lock"));
+      expect(treeSnapshot(result.project)).toEqual(before);
+    }, 60_000);
+  }
+
+  for (const mode of ["json", "quiet", "human"] as const) {
+    test(`noninteractive ${mode} config preserves filesystem remediation on apply failure`, () => {
+      const { preload, trace } = hardLinkFailurePreload();
+      let before: Record<string, string> = {};
+      const result = runWizard("", {
+        preload,
+        configArgs: [
+          "--from", join(RUNTIME, "claude"),
+          "--harness", "claude",
+          "--mcp", "none",
+          "--yes",
+          ...(mode === "human" ? [] : [`--${mode}`]),
+        ],
+        env: { AIDLC_TEST_CONFIG_TTY: undefined, NO_COLOR: "1" },
+        prepare: (project) => {
+          writeFileSync(join(project, "README.md"), "existing project\n");
+          writeFileSync(join(project, ".gitignore"), "# user-owned\n");
+          before = treeSnapshot(project);
+        },
+      });
+      const output = result.stdout + result.stderr;
+      expect(result.status, output).toBeGreaterThan(0);
+      expect(output).not.toContain("<valid-release-data>");
+      if (mode === "json") {
+        const error = JSON.parse(result.stdout);
+        expect(error.ok).toBe(false);
+        expect(error.code).toBe(result.status);
+        expect(error.message).toContain("Cannot create an AI-DLC transaction lock in");
+        expect(error.message).toContain("(EMLINK)");
+        expect(error.remediation).toMatch(/hard[- ]links?/i);
+        expect(error.remediation).toMatch(/S3|FUSE/i);
+      } else {
+        expect(output).toMatch(/hard[- ]links?/i);
+        expect(output).toMatch(/S3|FUSE/i);
+        expect(output).not.toContain('"schemaVersion"');
+        expect(output).not.toContain('"actions"');
+        if (mode === "human") {
+          expect(output).toContain("Cannot create an AI-DLC transaction lock in");
+          expect(output).toContain("(EMLINK)");
+          expect(output).toMatch(/fix:/i);
+        }
+      }
+      expect(linkTrace(trace)).toEqual([expect.objectContaining({
+        destination: join(realpathSync(result.project), ".aidlc-transaction.lock"),
+      })]);
+      expect(treeSnapshot(result.project)).toEqual(before);
+    }, 60_000);
+  }
 
   test("late first-run failure restores every wizard-owned path", () => {
     const result = runWizard("\n", {

--- a/tests/unit/t330-transaction-filesystem.test.ts
+++ b/tests/unit/t330-transaction-filesystem.test.ts
@@ -1,480 +1,514 @@
 // covers: function:assertTransactionFilesystem, function:executePlan
-
+// Real local IO with selected mount operations unavailable; this does not
+// certify the atomicity/durability of S3 drivers or exercise a live S3 mount.
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  realpathSync,
-  rmSync,
-  statSync,
-  writeFileSync,
+  existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync,
+  realpathSync, rmSync, statSync, symlinkSync, writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
-import {
-  assertTransactionFilesystem,
-  executePlan,
-  TransactionLockError,
-  transactionState,
-  type TransactionPlan,
-} from "../../core/tools/aidlc-transaction.ts";
-import { REPO_ROOT } from "../harness/fixtures.ts";
 
+const REPO_ROOT = join(import.meta.dir, "..", "..");
 const TRANSACTION = pathToFileURL(join(REPO_ROOT, "core/tools/aidlc-transaction.ts")).href;
+const LOCK = ".aidlc-transaction.lock";
 const temporary: string[] = [];
-const ORIGINAL = "existing project content\n";
-
 afterAll(() => {
   for (const path of temporary) rmSync(path, { recursive: true, force: true });
 });
 
 function project(): string {
-  const root = realpathSync(mkdtempSync(join(tmpdir(), "aidlc-t330-filesystem-")));
-  temporary.push(root);
-  writeFileSync(join(root, "existing.txt"), ORIGINAL);
+  const container = realpathSync(mkdtempSync(join(tmpdir(), "aidlc-t330-")));
+  temporary.push(container);
+  const root = join(container, "project");
+  mkdirSync(root);
+  writeFileSync(join(root, "existing.txt"), "original\n", { mode: 0o640 });
+  writeFileSync(join(root, "remove.txt"), "keep until commit\n");
   return root;
 }
 
-function plan(root: string): TransactionPlan {
-  return {
-    schemaVersion: 1,
-    root,
-    operations: [
-      {
-        kind: "write",
-        path: "existing.txt",
-        data: Buffer.from("updated\n").toString("base64"),
-        expected: transactionState(join(root, "existing.txt")),
-      },
-      {
-        kind: "write",
-        path: "new.txt",
-        data: Buffer.from("created\n").toString("base64"),
-        expected: "absent",
-      },
-    ],
-  };
+function expectProject(root: string, committed = false, extra: string[] = []): void {
+  expect(readFileSync(join(root, "existing.txt"), "utf-8"))
+    .toBe(committed ? "updated\n" : "original\n");
+  const second = committed ? "new.txt" : "remove.txt";
+  expect(readFileSync(join(root, second), "utf-8"))
+    .toBe(committed ? "created\n" : "keep until commit\n");
+  expect(readdirSync(root).sort()).toEqual(["existing.txt", second, ...extra].sort());
+  if (process.platform !== "win32") {
+    expect(statSync(join(root, "existing.txt")).mode & 0o777).toBe(committed ? 0o600 : 0o640);
+  }
 }
 
-function expectUntouched(root: string, entries = ["existing.txt"]): void {
-  expect(readFileSync(join(root, "existing.txt"), "utf-8")).toBe(ORIGINAL);
-  // Exact entries also catch leaked candidates, probe directories, staging,
-  // recovery directories, and accidentally published transaction locks.
-  expect(readdirSync(root).sort()).toEqual([...entries].sort());
-}
-
-type FilesystemObservation = {
-  error: {
-    name: string;
-    message: string;
-    code?: string;
-    root?: string;
-    remediation?: string;
-    transactionLockError: boolean;
-    aggregateError: boolean;
-    sameAsInjected: boolean;
-    sameAsCloseError: boolean;
-  } | null;
-  events: Array<{
-    operation: string;
-    path: string;
-    destination?: string;
-    exclusive?: boolean;
-    directoryMode?: number;
-    closed?: boolean;
-  }>;
-  preflightCompleted: boolean;
+type Fault = "append" | "append-lost" | "read" | "identity" | "exclusive"
+  | "file-rename" | "directory-rename" | "chmod" | "workflow" | "lock-mkdir"
+  | "directory-fsync" | "file-fsync" | "commit-fsync" | "commit-rename";
+type Options = {
+  fallback?: string; fault?: Fault; code?: string; mode?: "probe" | "apply";
+  failAfter?: number; warmup?: boolean; closeError?: boolean; cleanupError?: boolean;
+  replaceOwner?: boolean; requestedRoot?: string; contender?: boolean; releaseRetry?: boolean;
+  pause?: "acquire" | "locked" | "release";
 };
-
-// node:fs mocks must never enter the unit runner's module cache. Capture the
-// actual exports before registering the mock, then import the transaction
-// module in a fresh Bun process; wrappers still exercise real IO and cleanup.
-function filesystemFailure(
-  root: string,
-  mode: "probe" | "apply",
-  code: string | null,
-  operation: "open" | "write" | "fsync" | "link" = "link",
-  afterHealthyProbe = false,
-  cleanup: { closeCode?: string; removeCode?: string } = {},
-): FilesystemObservation {
-  const script = `
-    import { mock } from "bun:test";
-    import { basename, dirname } from "node:path";
-    const actual = { ...await import("node:fs") };
-    const root = ${JSON.stringify(root)};
-    const cleanup = ${JSON.stringify(cleanup)};
-    const injected = Object.assign(new Error("simulated " + ${JSON.stringify(operation)} + " failure"), {
-      code: ${JSON.stringify(code)},
-    });
-    const closeError = Object.assign(new Error("simulated close failure"), { code: cleanup.closeCode });
-    const removeError = Object.assign(new Error("simulated probe removal failure"), { code: cleanup.removeCode });
-    const events = [];
-    const descriptors = new Map();
-    let active = false;
-    let reject = ${JSON.stringify(code !== null && !afterHealthyProbe)};
-    function record(operation, path, extra = {}) {
-      if (!active) return;
-      events.push({ operation, path, ...extra });
-      if (reject && operation === ${JSON.stringify(operation)}) throw injected;
-    }
-    mock.module("node:fs", () => ({
-      ...actual,
-      openSync(path, flags, ...rest) {
-        const exclusive = typeof flags === "string"
-          ? flags.includes("x")
-          : Boolean((flags & actual.constants.O_EXCL) && (flags & actual.constants.O_CREAT));
-        record("open", path, { exclusive });
-        const fd = actual.openSync(path, flags, ...rest);
-        descriptors.set(fd, path);
-        return fd;
-      },
-      writeSync(fd, ...rest) {
-        record("write", descriptors.get(fd));
-        return actual.writeSync(fd, ...rest);
-      },
-      fsyncSync(fd) {
-        record("fsync", descriptors.get(fd));
-        return actual.fsyncSync(fd);
-      },
-      linkSync(source, destination) {
-        record("link", source, {
-          destination,
-          directoryMode: actual.statSync(dirname(source)).mode & 0o777,
-        });
-        return actual.linkSync(source, destination);
-      },
-      closeSync(fd) {
-        const path = descriptors.get(fd);
-        const result = actual.closeSync(fd);
-        descriptors.delete(fd);
-        record("close", path, { closed: true });
-        if (active && cleanup.closeCode) throw closeError;
-        return result;
-      },
-      rmSync(path, ...rest) {
-        if (active && basename(path).startsWith(".aidlc-lock-probe-")) {
-          record("remove", path);
-          if (cleanup.removeCode) throw removeError;
-        }
-        return actual.rmSync(path, ...rest);
-      },
-    }));
-    const transaction = await import(${JSON.stringify(TRANSACTION)});
-    active = true;
-    let preflightCompleted = false;
-    if (${JSON.stringify(afterHealthyProbe)}) {
-      transaction.assertTransactionFilesystem(root);
-      preflightCompleted = true;
-      events.length = 0;
-      reject = ${JSON.stringify(code !== null)};
-    }
-    let failure = null;
-    try {
-      if (${JSON.stringify(mode)} === "probe") {
-        transaction.assertTransactionFilesystem(root);
-      } else {
-        transaction.executePlan({
-          schemaVersion: 1,
-          root,
-          operations: [
-            {
-              kind: "write",
-              path: "existing.txt",
-              data: Buffer.from("updated\\n").toString("base64"),
-              expected: transaction.transactionState(root + "/existing.txt"),
-            },
-            {
-              kind: "write",
-              path: "new.txt",
-              data: Buffer.from("created\\n").toString("base64"),
-              expected: "absent",
-            },
-          ],
-        });
-      }
-    } catch (error) {
-      failure = {
-        name: error.name,
-        message: error.message,
-        code: error.code,
-        root: error.root,
-        remediation: error.remediation,
-        transactionLockError: error instanceof transaction.TransactionLockError,
-        aggregateError: error instanceof AggregateError,
-        sameAsInjected: error === injected,
-        sameAsCloseError: error === closeError,
-      };
-    }
-    process.stdout.write(JSON.stringify({ error: failure, events, preflightCompleted }));
-  `;
+type Owner = { schemaVersion: number; pid: number; host: string; token: string; staging: string };
+type Observation = {
+  error: null | {
+    name: string; message: string; root?: string; operation?: string; code?: string;
+    remediation?: string; filesystem: boolean; lock: boolean; causeInjected: boolean;
+    sameInjected: boolean; causes?: string[];
+  };
+  backend?: "directory" | "hardlink"; owner?: Owner; replacement?: string;
+  faultHits: number; fallbackHits: number; probes: string[]; gates: string[];
+  publicationCopies: number; preflightCompleted: boolean; pendingGate?: boolean;
+};
+function childEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
   delete env.AIDLC_ROUTE_MUTATION_SCOPE;
-  const result = spawnSync(process.execPath, ["--eval", script], {
-    cwd: REPO_ROOT,
-    env,
-    encoding: "utf-8",
-    timeout: 30_000,
+  return env;
+}
+
+// Isolate mocks from the runner's module cache. Every wrapper delegates to real
+// IO except its selected fault, scoped to the project mount. In particular,
+// hardlink rejection must never affect the dedicated local tmpdir gate.
+function childSource(root: string, options: Options): string {
+  return `
+    import { mock } from "bun:test";
+    import { basename, dirname, join, sep } from "node:path";
+    const fs = { ...await import("node:fs") };
+    const root = ${JSON.stringify(root)}, cfg = ${JSON.stringify(options)};
+    const lock = join(root, ${JSON.stringify(LOCK)});
+    const onMount = p => typeof p === "string" && (p === root || p.startsWith(root + sep));
+    const inProbe = p => onMount(p) && p.split(sep).some(s => s.startsWith(".aidlc-lock-probe-"));
+    const injected = Object.assign(new Error("simulated " + (cfg.fault ?? "link") + " failure"),
+      { code: cfg.code ?? cfg.fallback ?? "EOPNOTSUPP" });
+    const linkError = cfg.fault
+      ? Object.assign(new Error("simulated link failure"), { code: cfg.fallback }) : injected;
+    const closeError = Object.assign(new Error("simulated close failure"), { code: "EIO" });
+    const cleanupError = Object.assign(new Error("simulated cleanup failure"), { code: "EACCES" });
+    const out = { error: null, faultHits: 0, fallbackHits: 0, probes: [], gates: [],
+      publicationCopies: 0, preflightCompleted: false };
+    const fds = new Map();
+    let armed = !cfg.warmup, paused = false;
+    const fail = () => { out.faultHits++; throw injected; };
+    function pause(phase) {
+      if (cfg.pause !== phase || paused) return;
+      paused = true;
+      fs.writeFileSync(join(dirname(root), "ready"), phase);
+      const deadline = performance.now() + 20000;
+      while (!fs.existsSync(join(dirname(root), "continue"))) {
+        if (performance.now() > deadline) throw new Error("holder rendezvous timed out");
+        Bun.sleepSync(10);
+      }
+    }
+    mock.module("node:fs", () => ({
+      ...fs,
+      mkdtempSync(p, ...args) {
+        const result = fs.mkdtempSync(p, ...args);
+        if (inProbe(result)) out.probes.push(result);
+        return result;
+      },
+      linkSync(source, destination) {
+        if (armed && cfg.fallback && onMount(source) && onMount(destination)) {
+          out.fallbackHits++;
+          throw linkError;
+        }
+        return fs.linkSync(source, destination);
+      },
+      mkdirSync(p, ...args) {
+        if (!onMount(p) && /^\\.aidlc-.*\\.lock$/.test(basename(p)))
+          out.gates.push(p);
+        if (armed && onMount(p) && cfg.fault === "lock-mkdir" && basename(p) === ${JSON.stringify(LOCK)}) fail();
+        if (armed && inProbe(p) && cfg.fault === "workflow" && basename(p) === "workflow-lock") fail();
+        return fs.mkdirSync(p, ...args);
+      },
+      openSync(p, flags, ...args) {
+        if (dirname(String(p)) === root && basename(String(p)).startsWith(".aidlc-lock-")) pause("acquire");
+        if (armed && inProbe(p) && cfg.fault === "append" && flags === "a+") fail();
+        if (armed && inProbe(p) && cfg.fault === "exclusive" && flags === "wx" && fs.existsSync(p)) {
+          out.faultHits++;
+          flags = "w";
+        }
+        const fd = fs.openSync(p, flags, ...args);
+        fds.set(fd, { path: p, flags });
+        return fd;
+      },
+      writeSync(fd, ...args) {
+        if (armed && inProbe(fds.get(fd)?.path) && cfg.fault === "append-lost" && fds.get(fd)?.flags === "a+") {
+          out.faultHits++;
+          return Buffer.byteLength(args[0]);
+        }
+        return fs.writeSync(fd, ...args);
+      },
+      fstatSync(fd, ...args) {
+        const stat = fs.fstatSync(fd, ...args);
+        if (armed && inProbe(fds.get(fd)?.path) && cfg.fault === "identity" && fds.get(fd)?.flags === "a+") {
+          out.faultHits++;
+          return { ...stat, ino: stat.ino + 1 };
+        }
+        return stat;
+      },
+      fsyncSync(fd) {
+        const p = fds.get(fd)?.path;
+        if (armed && onMount(p)) {
+          const directory = fs.fstatSync(fd).isDirectory();
+          if (cfg.fault === "directory-fsync" && directory) fail();
+          if (cfg.fault === "file-fsync" && inProbe(p) && basename(p) === "candidate") fail();
+          if (cfg.fault === "commit-fsync" && !inProbe(p) && p.includes(sep + "candidates" + sep)) fail();
+        }
+        return fs.fsyncSync(fd);
+      },
+      readFileSync(p, ...args) {
+        if (armed && cfg.fault === "read" && inProbe(p) && basename(p) === "candidate") fail();
+        return fs.readFileSync(p, ...args);
+      },
+      renameSync(source, destination) {
+        if (armed && inProbe(source) && fs.existsSync(source)) {
+          if (cfg.fault === "directory-rename" && fs.lstatSync(source).isDirectory()) fail();
+          if (cfg.fault === "file-rename" && !fs.lstatSync(source).isDirectory()) fail();
+        }
+        if (armed && cfg.fault === "commit-rename" && destination === join(root, "new.txt")) fail();
+        return fs.renameSync(source, destination);
+      },
+      chmodSync(p, ...args) {
+        if (armed && cfg.fault === "chmod" && inProbe(p)) fail();
+        return fs.chmodSync(p, ...args);
+      },
+      closeSync(fd) {
+        const p = fds.get(fd)?.path;
+        const result = fs.closeSync(fd);
+        fds.delete(fd);
+        if (cfg.closeError && inProbe(p) && basename(p) === "candidate") throw closeError;
+        return result;
+      },
+      rmSync(p, ...args) {
+        if (p === lock) pause("release");
+        if (cfg.cleanupError && onMount(p) && basename(p).startsWith(".aidlc-lock-probe-")) throw cleanupError;
+        return fs.rmSync(p, ...args);
+      },
+      cpSync(source, destination, ...args) {
+        if (dirname(destination) === root) out.publicationCopies++;
+        return fs.cpSync(source, destination, ...args);
+      },
+      copyFileSync(source, destination, ...args) {
+        if (dirname(destination) === root) out.publicationCopies++;
+        return fs.copyFileSync(source, destination, ...args);
+      },
+    }));
+    const tx = await import(${JSON.stringify(TRANSACTION)});
+    const lib = cfg.releaseRetry ? await import(new URL("./aidlc-lib.ts", ${JSON.stringify(TRANSACTION)}).href) : null;
+    lib?._setAuditLockFaultHooksForTests({ failReleaseRename: () => { out.faultHits++; return true; } });
+    const requested = cfg.requestedRoot ?? root;
+    try {
+      if (cfg.warmup) {
+        tx.assertTransactionFilesystem(requested);
+        out.preflightCompleted = true;
+        armed = true;
+      }
+      if (cfg.mode === "probe") tx.assertTransactionFilesystem(requested);
+      else tx.executePlan({ schemaVersion: 1, root: requested, operations: [
+        tx.writeOperation("existing.txt", cfg.contender ? "contender\\n" : "updated\\n",
+          tx.transactionState(join(root, "existing.txt")), 0o600),
+        ...(cfg.contender ? [] : [
+          tx.writeOperation("new.txt", "created\\n", "absent"),
+          { kind: "remove", path: "remove.txt", expected: tx.transactionState(join(root, "remove.txt")) },
+        ]),
+      ] }, {
+        failAfter: cfg.failAfter,
+        validateLocked() {
+          out.backend = fs.statSync(lock).isDirectory() ? "directory" : "hardlink";
+          out.owner = JSON.parse(fs.readFileSync(out.backend === "directory" ? join(lock, "owner.json") : lock, "utf8"));
+          pause("locked");
+        },
+        validateCandidates() {
+          if (!cfg.replaceOwner) return;
+          fs.rmSync(lock, { recursive: true, force: true });
+          fs.mkdirSync(lock);
+          out.replacement = JSON.stringify({ ...out.owner, token: "replacement-owner" });
+          fs.writeFileSync(join(lock, "owner.json"), out.replacement);
+          throw new Error("replacement installed");
+        },
+      });
+      if (cfg.releaseRetry) {
+        out.pendingGate = out.gates.some(p => fs.existsSync(p));
+        lib._setAuditLockFaultHooksForTests(null);
+        tx.executePlan({ schemaVersion: 1, root: requested,
+          operations: [tx.writeOperation("second.txt", "second commit\\n", "absent")] });
+      }
+    } catch (e) {
+      out.error = { name: e.name, message: e.message, root: e.root, operation: e.operation,
+        code: e.code, remediation: e.remediation, filesystem: e instanceof tx.TransactionFilesystemError,
+        lock: e instanceof tx.TransactionLockError, causeInjected: e.cause === injected,
+        sameInjected: e === injected, causes: e.errors?.map(c => c?.message) };
+    } finally {
+      lib?._setAuditLockFaultHooksForTests(null);
+    }
+    process.stdout.write(JSON.stringify(out));
+  `;
+}
+
+function observe(root: string, options: Options = {}): Observation {
+  const result = spawnSync(process.execPath, ["--eval", childSource(root, options)], {
+    cwd: REPO_ROOT, env: childEnv(), encoding: "utf-8", timeout: 30_000,
   });
   expect(result.error, result.stderr).toBeUndefined();
   expect(result.status, result.stdout + result.stderr).toBe(0);
-  return JSON.parse(result.stdout) as FilesystemObservation;
+  const out = JSON.parse(result.stdout) as Observation;
+  if (!options.contender) {
+    for (const gate of out.gates) expect(existsSync(gate), gate).toBe(false);
+  }
+  if (!options.cleanupError) {
+    for (const probe of out.probes) expect(existsSync(probe), probe).toBe(false);
+  }
+  return out;
 }
 
-function expectLockFailure(
-  result: FilesystemObservation,
-  root: string,
-  code: string,
-): void {
-  expect(result.error).toEqual(expect.objectContaining({
-    name: "TransactionLockError",
-    code,
-    root,
-    message: `Cannot create an AI-DLC transaction lock in ${root}: the filesystem rejected hard-link creation (${code}).`,
-    transactionLockError: true,
-    sameAsInjected: false,
-  }));
-  expect(result.error?.remediation).toMatch(/hard[- ]links?/i);
-  expect(result.error?.remediation).toMatch(/S3|FUSE/i);
+function expectFilesystem(out: Observation, root: string, code: string, operation: RegExp): void {
+  expect(out.error).toMatchObject({
+    name: "TransactionFilesystemError", root, code, filesystem: true, lock: false,
+  });
+  expect(out.error?.operation).toMatch(operation);
+  expect(out.error?.message).toContain(root);
+  expect(out.error?.message).toContain(code);
+  expect(out.error?.remediation).toMatch(/mount|local storage/i);
 }
 
-describe("t330 transaction filesystem diagnostics", () => {
-  for (const code of ["EMLINK", "ENOTSUP", "EOPNOTSUPP", "ENOSYS"]) {
-    test(`probe explains ${code}, exercises durable exclusive creation, and removes its private files`, () => {
+describe("t330 transaction filesystem contract", () => {
+  for (const fallback of [undefined, "EMLINK", "ENOTSUP", "EOPNOTSUPP", "ENOSYS", "EPERM"]) {
+    test(`${fallback ?? "native"} supports probe, update/create/remove, rollback and cleanup`, () => {
       const root = project();
-      const result = filesystemFailure(root, "probe", code);
-      expectLockFailure(result, root, code);
-      expect(result.events.map((event) => event.operation))
-        .toEqual(["open", "write", "fsync", "link", "close", "remove"]);
-      expect(result.events[0].exclusive).toBe(true);
-      const link = result.events.find((event) => event.operation === "link")!;
-      const probe = dirname(link.path);
-      expect(dirname(probe)).toBe(root);
-      expect(basename(probe)).toMatch(/^\.aidlc-lock-probe-/);
-      expect(dirname(link.destination!)).toBe(probe);
-      expect(link.destination).not.toBe(join(root, ".aidlc-transaction.lock"));
-      if (process.platform !== "win32") {
-        expect(link.directoryMode! & 0o077).toBe(0);
-      }
-      expectUntouched(root);
-    });
-
-    test(`apply explains ${code} before changing existing or new project files`, () => {
-      const root = project();
-      const result = filesystemFailure(root, "apply", code);
-      expectLockFailure(result, root, code);
-      expect(result.events.filter((event) => event.operation === "link"))
-        .toEqual([expect.objectContaining({
-          destination: join(root, ".aidlc-transaction.lock"),
-        })]);
-      expectUntouched(root);
+      expect(observe(root, { fallback, mode: "probe" }).error).toBeNull();
+      expectProject(root);
+      const rolledBack = observe(root, { fallback, failAfter: 3 });
+      expect(rolledBack.error?.message).toContain("injected transaction failure after operation 3");
+      expectProject(root);
+      const applied = observe(root, { fallback });
+      expect(applied.error).toBeNull();
+      expect(applied.backend).toBe(fallback ? "directory" : "hardlink");
+      if (fallback) {
+        expect(applied.fallbackHits).toBeGreaterThan(0);
+        expect(applied.owner).toMatchObject({ pid: expect.any(Number),
+          host: expect.any(String), token: expect.any(String), staging: expect.stringMatching(/^\.aidlc-txn-/) });
+      } else expect(applied.probes).toHaveLength(0);
+      expectProject(root, true);
     });
   }
 
-  test("apply still diagnoses a hard-link failure after a successful early probe", () => {
+  for (const [fault, operation, code] of [
+    ["append", /append/, "EOPNOTSUPP"], ["append-lost", /append/, "UNKNOWN"],
+    ["read", /append/, "EIO"], ["identity", /descriptor/, "UNKNOWN"],
+    ["exclusive", /exclusive/, "UNKNOWN"], ["file-rename", /file replacement/, "EXDEV"],
+    ["directory-rename", /directory rename/, "EOPNOTSUPP"],
+    ["workflow", /workflow lock/, "UNKNOWN"],
+    ...(process.platform === "win32" ? [] : [["chmod", /permissions/, "EPERM"]]),
+  ] as [Fault, RegExp, string][]) {
+    test(`fallback preflight rejects ${fault} before any project mutation`, () => {
+      const root = project();
+      const out = observe(root, { fallback: "EMLINK", fault, code });
+      expect(out.faultHits).toBeGreaterThan(0);
+      expectFilesystem(out, root, code, operation);
+      expectProject(root);
+    });
+  }
+
+  test("execute rechecks the full probe when hardlinks become unavailable after preflight", () => {
     const root = project();
-    const result = filesystemFailure(root, "apply", "EMLINK", "link", true);
-    expect(result.preflightCompleted).toBe(true);
-    expectLockFailure(result, root, "EMLINK");
-    expectUntouched(root);
+    const out = observe(root, { warmup: true, fallback: "EMLINK", fault: "append", code: "ENOSYS" });
+    expect(out.preflightCompleted).toBe(true);
+    expect(out.probes).toHaveLength(2);
+    expectFilesystem(out, root, "ENOSYS", /append/);
+    expectProject(root);
   });
 
   for (const mode of ["probe", "apply"] as const) {
-    for (const code of ["EACCES", "EPERM", "EIO", "EXDEV"]) {
-      test(`${mode} preserves the original ${code} link error and cleans temporary files`, () => {
-        const root = project();
-        const result = filesystemFailure(root, mode, code);
-        expect(result.error).toEqual(expect.objectContaining({
-          code,
-          message: "simulated link failure",
-          transactionLockError: false,
-          sameAsInjected: true,
-        }));
-        expect(result.error?.remediation).toBeUndefined();
-        expectUntouched(root);
-      });
-    }
-  }
-
-  for (const [operation, code] of [
-    ["open", "EACCES"],
-    ["write", "ENOSPC"],
-    ["fsync", "EIO"],
-    ["fsync", "ENOTSUP"],
-  ] as const) {
-    test(`probe preserves ${operation} ${code} errors and cleans up before attempting a link`, () => {
+    test(`${mode} diagnoses unavailable hardlink AND directory locking at the project root`, () => {
       const root = project();
-      const result = filesystemFailure(root, "probe", code, operation);
-      expect(result.error).toEqual(expect.objectContaining({
-        code,
-        transactionLockError: false,
-        sameAsInjected: true,
-      }));
-      expect(result.events.some((event) => event.operation === "link")).toBe(false);
-      expect(result.events.filter((event) => event.operation === "close"))
-        .toHaveLength(operation === "open" ? 0 : 1);
-      expectUntouched(root);
+      const out = observe(root, { mode, fallback: "EMLINK", fault: "lock-mkdir", code: "EACCES" });
+      expect(out.error).toMatchObject({
+        name: "TransactionLockError", root, code: "EACCES", filesystem: true, lock: true,
+      });
+      expect(out.error?.message).toMatch(/hard-link and directory locking/);
+      expectProject(root);
     });
   }
 
-  test("a close error after a healthy probe is preserved after removing every probe file", () => {
-    const root = project();
-    const result = filesystemFailure(root, "probe", null, "link", false, { closeCode: "EIO" });
-    expect(result.error).toEqual(expect.objectContaining({
-      name: "Error",
-      message: "simulated close failure",
-      code: "EIO",
-      transactionLockError: false,
-      aggregateError: false,
-      sameAsCloseError: true,
-    }));
-    expect(result.events.map((event) => event.operation))
-      .toEqual(["open", "write", "fsync", "link", "close", "remove"]);
-    const close = result.events.find((event) => event.operation === "close")!;
-    expect(close.closed).toBe(true);
-    expect(result.events.find((event) => event.operation === "remove")?.path)
-      .toBe(dirname(close.path));
-    expectUntouched(root);
-  });
-
-  test("EMLINK remains the primary diagnostic when closing fails but probe removal succeeds", () => {
-    const root = project();
-    const result = filesystemFailure(root, "probe", "EMLINK", "link", false, { closeCode: "EIO" });
-    expectLockFailure(result, root, "EMLINK");
-    expect(result.error?.aggregateError).toBe(false);
-    expect(result.events.map((event) => event.operation))
-      .toEqual(["open", "write", "fsync", "link", "close", "remove"]);
-    const close = result.events.find((event) => event.operation === "close")!;
-    expect(close.closed).toBe(true);
-    expect(result.events.find((event) => event.operation === "remove")?.path)
-      .toBe(dirname(close.path));
-    expectUntouched(root);
-  });
-
-  for (const [label, code, closeCode] of [
-    ["a healthy probe", null, undefined],
-    ["EMLINK", "EMLINK", undefined],
-    ["EMLINK and a close error", "EMLINK", "EIO"],
-  ] as const) {
-    test(`probe removal failure after ${label} reports an aggregate diagnostic and retained evidence`, () => {
+  for (const code of ["EACCES", "EIO", "EXDEV"]) {
+    test(`unexpected native hardlink ${code} is preserved without attempting directory mode`, () => {
       const root = project();
-      const result = filesystemFailure(root, "probe", code, "link", false, {
-        closeCode,
-        removeCode: "EACCES",
-      });
-      const remove = result.events.find((event) => event.operation === "remove")!;
-      expect(remove).toBeDefined();
-      const probe = remove.path;
-      try {
-        expect(result.error).toEqual(expect.objectContaining({
-          name: "AggregateError",
-          aggregateError: true,
-          transactionLockError: false,
-        }));
-        expect(result.error?.message).toContain(probe);
-        expect(result.error?.message).toMatch(/cleanup|clean up|remov/i);
-        expect(result.error?.message).toMatch(/fail|could not|cannot|unable/i);
-        if (code !== null) {
-          expect(result.error?.message).toContain(
-            `Cannot create an AI-DLC transaction lock in ${root}: the filesystem rejected hard-link creation (EMLINK).`,
-          );
-        }
-        const link = result.events.find((event) => event.operation === "link")!;
-        expect(dirname(probe)).toBe(root);
-        expect(basename(probe)).toMatch(/^\.aidlc-lock-probe-/);
-        expect(dirname(link.path)).toBe(probe);
-        expect(readFileSync(link.path, "utf-8").length).toBeGreaterThan(0);
-        expect(existsSync(link.destination!)).toBe(code === null);
-        expect(result.events.find((event) => event.operation === "close")?.closed).toBe(true);
-        expectUntouched(root, ["existing.txt", basename(probe)]);
-      } finally {
-        // The child intentionally leaves evidence behind; cleanup here uses
-        // the parent's unmocked filesystem, including on assertion failure.
-        rmSync(probe, { recursive: true, force: true });
-      }
-      expectUntouched(root);
+      const out = observe(root, { fallback: code });
+      expect(out.error).toMatchObject({ code, sameInjected: true, filesystem: false, lock: false });
+      expectProject(root);
     });
   }
 
-  test("a healthy probe leaves an existing live transaction lock and project files untouched", () => {
+  for (const code of ["ENOSYS", "EOPNOTSUPP"]) {
+    test(`${code} directory fsync is tolerated but file fsync is required`, () => {
+      const root = project();
+      const probe = observe(root, { fallback: "EMLINK", fault: "file-fsync", code });
+      expectFilesystem(probe, root, code, /synchronization/);
+      expectProject(root);
+      const stage = observe(root, { fallback: "EMLINK", fault: "commit-fsync", code });
+      expect(stage.error).toMatchObject({ code, sameInjected: true });
+      expectProject(root);
+      const dirs = observe(root, { fallback: "EMLINK", fault: "directory-fsync", code });
+      expect(dirs.faultHits).toBeGreaterThan(0);
+      expect(dirs.error).toBeNull();
+      expectProject(root, true);
+    });
+  }
+
+  test("a failed publication rename rolls back earlier changes without copy/delete publication", () => {
     const root = project();
-    const lock = join(root, ".aidlc-transaction.lock");
-    const identity = `${JSON.stringify({ pid: process.pid, staging: ".aidlc-txn-live" })}\n`;
-    writeFileSync(lock, identity);
-    const before = statSync(lock);
-    expect(assertTransactionFilesystem(root)).toBeUndefined();
-    expect(readFileSync(lock, "utf-8")).toBe(identity);
-    const after = statSync(lock);
-    expect({ ino: after.ino, mtimeMs: after.mtimeMs, nlink: after.nlink })
-      .toEqual({ ino: before.ino, mtimeMs: before.mtimeMs, nlink: before.nlink });
-    expectUntouched(root, [".aidlc-transaction.lock", "existing.txt"]);
+    const out = observe(root, { fallback: "EMLINK", fault: "commit-rename", code: "EXDEV" });
+    expect(out.error).toMatchObject({ code: "EXDEV", sameInjected: true });
+    expect(out.publicationCopies).toBe(0);
+    expectProject(root);
   });
 
-  test("a healthy probe uses the nearest existing ancestor without creating the project", () => {
-    const parent = project();
-    const root = join(parent, "missing", "nested-project");
-    expect(assertTransactionFilesystem(root)).toBeUndefined();
-    expect(existsSync(join(parent, "missing"))).toBe(false);
-    expectUntouched(parent);
-  });
-
-  test("a rejected probe names the missing destination and cleans its nearest existing ancestor", () => {
-    const parent = project();
-    const root = join(parent, "missing", "nested-project");
-    const result = filesystemFailure(root, "probe", "EMLINK");
-    expectLockFailure(result, root, "EMLINK");
-    const link = result.events.find((event) => event.operation === "link")!;
-    expect(dirname(dirname(link.path))).toBe(parent);
-    expect(existsSync(join(parent, "missing"))).toBe(false);
-    expectUntouched(parent);
-  });
-
-  test("a rejected probe preserves an existing live lock as well as the project files", () => {
+  test("probe cleanup survives close failure and retains the original diagnostic", () => {
     const root = project();
-    const lock = join(root, ".aidlc-transaction.lock");
-    const identity = `${JSON.stringify({ pid: process.pid, staging: ".aidlc-txn-live" })}\n`;
-    writeFileSync(lock, identity);
-    const before = statSync(lock);
-    const result = filesystemFailure(root, "probe", "EMLINK");
-    expectLockFailure(result, root, "EMLINK");
-    expect(result.events.some((event) => event.path === lock || event.destination === lock))
-      .toBe(false);
-    expect(readFileSync(lock, "utf-8")).toBe(identity);
-    expect(statSync(lock).ino).toBe(before.ino);
-    expect(statSync(lock).mtimeMs).toBe(before.mtimeMs);
-    expectUntouched(root, [".aidlc-transaction.lock", "existing.txt"]);
+    const out = observe(root, { mode: "probe", fault: "file-fsync", code: "ENOSPC", closeError: true });
+    expectFilesystem(out, root, "ENOSPC", /synchronization/);
+    expect(out.error?.causeInjected).toBe(true);
+    expectProject(root);
+    const close = observe(root, { mode: "probe", closeError: true });
+    expectFilesystem(close, root, "EIO", /synchronization/);
+    expectProject(root);
   });
 
-  test("EEXIST from a live lock retains normal ownership protection and the original lock", () => {
+  test("failed probe cleanup reports retained evidence and the primary diagnostic together", () => {
     const root = project();
-    const lock = join(root, ".aidlc-transaction.lock");
-    const identity = `${JSON.stringify({ pid: process.pid, staging: ".aidlc-txn-live" })}\n`;
-    writeFileSync(lock, identity);
-    let caught: unknown;
-    try {
-      executePlan(plan(root));
-    } catch (error) {
-      caught = error;
-    }
-    expect(caught).toBeInstanceOf(Error);
-    expect(caught).not.toBeInstanceOf(TransactionLockError);
-    expect((caught as Error).message).toContain("another AI-DLC mutation holds");
-    expect(readFileSync(lock, "utf-8")).toBe(identity);
-    expectUntouched(root, [".aidlc-transaction.lock", "existing.txt"]);
+    const out = observe(root, { mode: "probe", fault: "file-fsync", code: "ENOSPC",
+      closeError: true, cleanupError: true });
+    expect(out.error?.name).toBe("AggregateError");
+    expect(out.error?.message).toContain(out.probes[0]);
+    expect(out.error?.message).toContain("ENOSPC");
+    expect(out.error?.causes).toEqual(expect.arrayContaining(["simulated close failure", "simulated cleanup failure"]));
+    expect(existsSync(out.probes[0])).toBe(true);
+    rmSync(out.probes[0], { recursive: true, force: true });
+    expectProject(root);
   });
 
-  test("EEXIST from a dead owner still permits recovery and a normal transaction", () => {
-    const root = project();
-    writeFileSync(join(root, ".aidlc-transaction.lock"), `${JSON.stringify({
-      pid: 2_147_483_647,
-      staging: ".aidlc-txn-dead",
-    })}\n`);
-    executePlan(plan(root));
-    expect(readFileSync(join(root, "existing.txt"), "utf-8")).toBe("updated\n");
-    expect(readFileSync(join(root, "new.txt"), "utf-8")).toBe("created\n");
-    expect(readdirSync(root).sort()).toEqual(["existing.txt", "new.txt"]);
+  test("a missing project is probed in its ancestor and diagnostics name the requested root", () => {
+    const root = project(), requestedRoot = join(root, "missing", "nested");
+    expect(observe(root, { mode: "probe", fallback: "EMLINK", requestedRoot }).error).toBeNull();
+    const out = observe(root, { mode: "probe", fault: "read", code: "EIO", requestedRoot });
+    expectFilesystem(out, requestedRoot, "EIO", /append/);
+    expectProject(root);
   });
 });
+
+describe("t330 lock ownership", () => {
+  test("a pending local-gate release is recovered before another native transaction in the same process", () => {
+    const root = project(), out = observe(root, { releaseRetry: true });
+    expect(out.faultHits).toBeGreaterThan(0);
+    expect(out.pendingGate).toBe(true);
+    expect(out.error).toBeNull();
+    expect(out.backend).toBe("hardlink");
+    expect(out.probes).toHaveLength(0);
+    expect(readFileSync(join(root, "second.txt"), "utf8")).toBe("second commit\n");
+    expectProject(root, true, ["second.txt"]);
+  });
+
+  let deadOwner: Owner;
+  function owner(): Owner {
+    if (!deadOwner) {
+      const root = project();
+      const out = observe(root, { fallback: "EMLINK", failAfter: 3 });
+      expect(out.error?.message).toContain("injected transaction failure");
+      expectProject(root);
+      deadOwner = out.owner!;
+      expect(() => process.kill(deadOwner.pid, 0)).toThrow();
+    }
+    return { ...deadOwner };
+  }
+  for (const state of ["live", "dead", "foreign", "missing", "malformed", "unknown-schema", "no-token", "invalid-pid", "out-of-range-pid"]) {
+    test(`directory owner ${state} is reclaimed only with proof of same-host death`, () => {
+      const root = project(), lock = join(root, LOCK), stamp = owner();
+      if (state === "live") stamp.pid = process.pid;
+      if (state === "foreign") stamp.host = `other-boot:${stamp.host}`;
+      if (state === "unknown-schema") stamp.schemaVersion = 2;
+      if (state === "no-token") stamp.token = "";
+      if (state === "invalid-pid") stamp.pid = 0;
+      if (state === "out-of-range-pid") stamp.pid = Number.MAX_SAFE_INTEGER;
+      mkdirSync(lock);
+      const raw = state === "malformed" ? "{" : JSON.stringify(stamp);
+      if (state !== "missing") writeFileSync(join(lock, "owner.json"), raw);
+      const before = statSync(lock);
+      const out = observe(root, { fallback: "EMLINK" });
+      if (state === "dead") {
+        expect(out.error).toBeNull();
+        expectProject(root, true);
+      } else {
+        expect(out.error?.message).toMatch(/another AI-DLC mutation|cannot verify|another host or boot/);
+        expect(statSync(lock).ino).toBe(before.ino);
+        expect(readdirSync(lock)).toEqual(state === "missing" ? [] : ["owner.json"]);
+        if (state !== "missing") expect(readFileSync(join(lock, "owner.json"), "utf8")).toBe(raw);
+        expectProject(root, false, [LOCK]);
+      }
+    });
+  }
+
+  test("fallback probe and acquisition preserve a live legacy file lock", () => {
+    const root = project(), lock = join(root, LOCK);
+    const raw = JSON.stringify({ pid: process.pid, staging: ".aidlc-txn-live" });
+    writeFileSync(lock, raw);
+    const before = statSync(lock);
+    expect(observe(root, { fallback: "EMLINK", mode: "probe" }).error).toBeNull();
+    expect(observe(root, { fallback: "EMLINK" }).error?.message).toContain("another AI-DLC mutation");
+    expect(readFileSync(lock, "utf8")).toBe(raw);
+    expect(statSync(lock).ino).toBe(before.ino);
+    expect(statSync(lock).mtimeMs).toBe(before.mtimeMs);
+    expectProject(root, false, [LOCK]);
+  });
+
+  test("directory release preserves a replacement owner's directory", () => {
+    const root = project();
+    const out = observe(root, { fallback: "EMLINK", replaceOwner: true });
+    expect(out.error?.message).toBe("replacement installed");
+    expect(readFileSync(join(root, LOCK, "owner.json"), "utf8")).toBe(out.replacement!);
+    expectProject(root, false, [LOCK]);
+  });
+});
+
+// Rendezvous with actual processes, not a guessed sleep: contender uses an
+// alias and the other backend while the holder is inside the local gate.
+for (const [pause, fallback, crash] of [
+  ["acquire", "EMLINK", false], ["locked", "EMLINK", true],
+  ["release", "EMLINK", false], ["locked", undefined, false],
+] as const) {
+  test(`local gate spans ${pause} (${fallback ?? "native"})${crash ? " and recovers after SIGKILL" : ""}`, async () => {
+    const root = project(), alias = join(dirname(root), "alias");
+    symlinkSync(root, alias, process.platform === "win32" ? "junction" : "dir");
+    const child = Bun.spawn([process.execPath, "--eval", childSource(root, { pause, fallback })], {
+      cwd: REPO_ROOT, env: childEnv(), stdout: "pipe", stderr: "pipe",
+    });
+    const stdout = new Response(child.stdout).text(), stderr = new Response(child.stderr).text();
+    try {
+      const ready = join(dirname(root), "ready"), deadline = performance.now() + 10_000;
+      while (!existsSync(ready) && child.exitCode === null && performance.now() < deadline) await Bun.sleep(10);
+      expect(existsSync(ready), "holder must reach the synchronized lock boundary").toBe(true);
+      expect(readFileSync(ready, "utf8")).toBe(pause);
+      const before = readdirSync(root).sort(), content = readFileSync(join(root, "existing.txt"), "utf8");
+      const blocked = observe(root, { requestedRoot: alias, contender: true, fallback: fallback ? undefined : "EMLINK" });
+      expect(blocked.error?.message).toContain("another AI-DLC mutation");
+      expect(blocked.backend).toBeUndefined();
+      expect(readdirSync(root).sort()).toEqual(before);
+      expect(readFileSync(join(root, "existing.txt"), "utf8")).toBe(content);
+      if (crash) {
+        child.kill("SIGKILL");
+        await child.exited;
+        expect(observe(root, { fallback: "EMLINK" }).error).toBeNull();
+      } else {
+        writeFileSync(join(dirname(root), "continue"), "");
+        expect(await child.exited, await stderr).toBe(0);
+        const completed = JSON.parse(await stdout) as Observation;
+        expect(completed.error).toBeNull();
+        for (const gate of completed.gates) expect(existsSync(gate)).toBe(false);
+      }
+      expectProject(root, true);
+    } finally {
+      if (child.exitCode === null) child.kill("SIGKILL");
+      await Promise.all([child.exited, stdout, stderr]);
+    }
+  }, 40_000);
+}

--- a/tests/unit/t330-transaction-filesystem.test.ts
+++ b/tests/unit/t330-transaction-filesystem.test.ts
@@ -1,0 +1,480 @@
+// covers: function:assertTransactionFilesystem, function:executePlan
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  assertTransactionFilesystem,
+  executePlan,
+  TransactionLockError,
+  transactionState,
+  type TransactionPlan,
+} from "../../core/tools/aidlc-transaction.ts";
+import { REPO_ROOT } from "../harness/fixtures.ts";
+
+const TRANSACTION = pathToFileURL(join(REPO_ROOT, "core/tools/aidlc-transaction.ts")).href;
+const temporary: string[] = [];
+const ORIGINAL = "existing project content\n";
+
+afterAll(() => {
+  for (const path of temporary) rmSync(path, { recursive: true, force: true });
+});
+
+function project(): string {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "aidlc-t330-filesystem-")));
+  temporary.push(root);
+  writeFileSync(join(root, "existing.txt"), ORIGINAL);
+  return root;
+}
+
+function plan(root: string): TransactionPlan {
+  return {
+    schemaVersion: 1,
+    root,
+    operations: [
+      {
+        kind: "write",
+        path: "existing.txt",
+        data: Buffer.from("updated\n").toString("base64"),
+        expected: transactionState(join(root, "existing.txt")),
+      },
+      {
+        kind: "write",
+        path: "new.txt",
+        data: Buffer.from("created\n").toString("base64"),
+        expected: "absent",
+      },
+    ],
+  };
+}
+
+function expectUntouched(root: string, entries = ["existing.txt"]): void {
+  expect(readFileSync(join(root, "existing.txt"), "utf-8")).toBe(ORIGINAL);
+  // Exact entries also catch leaked candidates, probe directories, staging,
+  // recovery directories, and accidentally published transaction locks.
+  expect(readdirSync(root).sort()).toEqual([...entries].sort());
+}
+
+type FilesystemObservation = {
+  error: {
+    name: string;
+    message: string;
+    code?: string;
+    root?: string;
+    remediation?: string;
+    transactionLockError: boolean;
+    aggregateError: boolean;
+    sameAsInjected: boolean;
+    sameAsCloseError: boolean;
+  } | null;
+  events: Array<{
+    operation: string;
+    path: string;
+    destination?: string;
+    exclusive?: boolean;
+    directoryMode?: number;
+    closed?: boolean;
+  }>;
+  preflightCompleted: boolean;
+};
+
+// node:fs mocks must never enter the unit runner's module cache. Capture the
+// actual exports before registering the mock, then import the transaction
+// module in a fresh Bun process; wrappers still exercise real IO and cleanup.
+function filesystemFailure(
+  root: string,
+  mode: "probe" | "apply",
+  code: string | null,
+  operation: "open" | "write" | "fsync" | "link" = "link",
+  afterHealthyProbe = false,
+  cleanup: { closeCode?: string; removeCode?: string } = {},
+): FilesystemObservation {
+  const script = `
+    import { mock } from "bun:test";
+    import { basename, dirname } from "node:path";
+    const actual = { ...await import("node:fs") };
+    const root = ${JSON.stringify(root)};
+    const cleanup = ${JSON.stringify(cleanup)};
+    const injected = Object.assign(new Error("simulated " + ${JSON.stringify(operation)} + " failure"), {
+      code: ${JSON.stringify(code)},
+    });
+    const closeError = Object.assign(new Error("simulated close failure"), { code: cleanup.closeCode });
+    const removeError = Object.assign(new Error("simulated probe removal failure"), { code: cleanup.removeCode });
+    const events = [];
+    const descriptors = new Map();
+    let active = false;
+    let reject = ${JSON.stringify(code !== null && !afterHealthyProbe)};
+    function record(operation, path, extra = {}) {
+      if (!active) return;
+      events.push({ operation, path, ...extra });
+      if (reject && operation === ${JSON.stringify(operation)}) throw injected;
+    }
+    mock.module("node:fs", () => ({
+      ...actual,
+      openSync(path, flags, ...rest) {
+        const exclusive = typeof flags === "string"
+          ? flags.includes("x")
+          : Boolean((flags & actual.constants.O_EXCL) && (flags & actual.constants.O_CREAT));
+        record("open", path, { exclusive });
+        const fd = actual.openSync(path, flags, ...rest);
+        descriptors.set(fd, path);
+        return fd;
+      },
+      writeSync(fd, ...rest) {
+        record("write", descriptors.get(fd));
+        return actual.writeSync(fd, ...rest);
+      },
+      fsyncSync(fd) {
+        record("fsync", descriptors.get(fd));
+        return actual.fsyncSync(fd);
+      },
+      linkSync(source, destination) {
+        record("link", source, {
+          destination,
+          directoryMode: actual.statSync(dirname(source)).mode & 0o777,
+        });
+        return actual.linkSync(source, destination);
+      },
+      closeSync(fd) {
+        const path = descriptors.get(fd);
+        const result = actual.closeSync(fd);
+        descriptors.delete(fd);
+        record("close", path, { closed: true });
+        if (active && cleanup.closeCode) throw closeError;
+        return result;
+      },
+      rmSync(path, ...rest) {
+        if (active && basename(path).startsWith(".aidlc-lock-probe-")) {
+          record("remove", path);
+          if (cleanup.removeCode) throw removeError;
+        }
+        return actual.rmSync(path, ...rest);
+      },
+    }));
+    const transaction = await import(${JSON.stringify(TRANSACTION)});
+    active = true;
+    let preflightCompleted = false;
+    if (${JSON.stringify(afterHealthyProbe)}) {
+      transaction.assertTransactionFilesystem(root);
+      preflightCompleted = true;
+      events.length = 0;
+      reject = ${JSON.stringify(code !== null)};
+    }
+    let failure = null;
+    try {
+      if (${JSON.stringify(mode)} === "probe") {
+        transaction.assertTransactionFilesystem(root);
+      } else {
+        transaction.executePlan({
+          schemaVersion: 1,
+          root,
+          operations: [
+            {
+              kind: "write",
+              path: "existing.txt",
+              data: Buffer.from("updated\\n").toString("base64"),
+              expected: transaction.transactionState(root + "/existing.txt"),
+            },
+            {
+              kind: "write",
+              path: "new.txt",
+              data: Buffer.from("created\\n").toString("base64"),
+              expected: "absent",
+            },
+          ],
+        });
+      }
+    } catch (error) {
+      failure = {
+        name: error.name,
+        message: error.message,
+        code: error.code,
+        root: error.root,
+        remediation: error.remediation,
+        transactionLockError: error instanceof transaction.TransactionLockError,
+        aggregateError: error instanceof AggregateError,
+        sameAsInjected: error === injected,
+        sameAsCloseError: error === closeError,
+      };
+    }
+    process.stdout.write(JSON.stringify({ error: failure, events, preflightCompleted }));
+  `;
+  const env = { ...process.env };
+  delete env.AIDLC_ROUTE_MUTATION_SCOPE;
+  const result = spawnSync(process.execPath, ["--eval", script], {
+    cwd: REPO_ROOT,
+    env,
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+  expect(result.error, result.stderr).toBeUndefined();
+  expect(result.status, result.stdout + result.stderr).toBe(0);
+  return JSON.parse(result.stdout) as FilesystemObservation;
+}
+
+function expectLockFailure(
+  result: FilesystemObservation,
+  root: string,
+  code: string,
+): void {
+  expect(result.error).toEqual(expect.objectContaining({
+    name: "TransactionLockError",
+    code,
+    root,
+    message: `Cannot create an AI-DLC transaction lock in ${root}: the filesystem rejected hard-link creation (${code}).`,
+    transactionLockError: true,
+    sameAsInjected: false,
+  }));
+  expect(result.error?.remediation).toMatch(/hard[- ]links?/i);
+  expect(result.error?.remediation).toMatch(/S3|FUSE/i);
+}
+
+describe("t330 transaction filesystem diagnostics", () => {
+  for (const code of ["EMLINK", "ENOTSUP", "EOPNOTSUPP", "ENOSYS"]) {
+    test(`probe explains ${code}, exercises durable exclusive creation, and removes its private files`, () => {
+      const root = project();
+      const result = filesystemFailure(root, "probe", code);
+      expectLockFailure(result, root, code);
+      expect(result.events.map((event) => event.operation))
+        .toEqual(["open", "write", "fsync", "link", "close", "remove"]);
+      expect(result.events[0].exclusive).toBe(true);
+      const link = result.events.find((event) => event.operation === "link")!;
+      const probe = dirname(link.path);
+      expect(dirname(probe)).toBe(root);
+      expect(basename(probe)).toMatch(/^\.aidlc-lock-probe-/);
+      expect(dirname(link.destination!)).toBe(probe);
+      expect(link.destination).not.toBe(join(root, ".aidlc-transaction.lock"));
+      if (process.platform !== "win32") {
+        expect(link.directoryMode! & 0o077).toBe(0);
+      }
+      expectUntouched(root);
+    });
+
+    test(`apply explains ${code} before changing existing or new project files`, () => {
+      const root = project();
+      const result = filesystemFailure(root, "apply", code);
+      expectLockFailure(result, root, code);
+      expect(result.events.filter((event) => event.operation === "link"))
+        .toEqual([expect.objectContaining({
+          destination: join(root, ".aidlc-transaction.lock"),
+        })]);
+      expectUntouched(root);
+    });
+  }
+
+  test("apply still diagnoses a hard-link failure after a successful early probe", () => {
+    const root = project();
+    const result = filesystemFailure(root, "apply", "EMLINK", "link", true);
+    expect(result.preflightCompleted).toBe(true);
+    expectLockFailure(result, root, "EMLINK");
+    expectUntouched(root);
+  });
+
+  for (const mode of ["probe", "apply"] as const) {
+    for (const code of ["EACCES", "EPERM", "EIO", "EXDEV"]) {
+      test(`${mode} preserves the original ${code} link error and cleans temporary files`, () => {
+        const root = project();
+        const result = filesystemFailure(root, mode, code);
+        expect(result.error).toEqual(expect.objectContaining({
+          code,
+          message: "simulated link failure",
+          transactionLockError: false,
+          sameAsInjected: true,
+        }));
+        expect(result.error?.remediation).toBeUndefined();
+        expectUntouched(root);
+      });
+    }
+  }
+
+  for (const [operation, code] of [
+    ["open", "EACCES"],
+    ["write", "ENOSPC"],
+    ["fsync", "EIO"],
+    ["fsync", "ENOTSUP"],
+  ] as const) {
+    test(`probe preserves ${operation} ${code} errors and cleans up before attempting a link`, () => {
+      const root = project();
+      const result = filesystemFailure(root, "probe", code, operation);
+      expect(result.error).toEqual(expect.objectContaining({
+        code,
+        transactionLockError: false,
+        sameAsInjected: true,
+      }));
+      expect(result.events.some((event) => event.operation === "link")).toBe(false);
+      expect(result.events.filter((event) => event.operation === "close"))
+        .toHaveLength(operation === "open" ? 0 : 1);
+      expectUntouched(root);
+    });
+  }
+
+  test("a close error after a healthy probe is preserved after removing every probe file", () => {
+    const root = project();
+    const result = filesystemFailure(root, "probe", null, "link", false, { closeCode: "EIO" });
+    expect(result.error).toEqual(expect.objectContaining({
+      name: "Error",
+      message: "simulated close failure",
+      code: "EIO",
+      transactionLockError: false,
+      aggregateError: false,
+      sameAsCloseError: true,
+    }));
+    expect(result.events.map((event) => event.operation))
+      .toEqual(["open", "write", "fsync", "link", "close", "remove"]);
+    const close = result.events.find((event) => event.operation === "close")!;
+    expect(close.closed).toBe(true);
+    expect(result.events.find((event) => event.operation === "remove")?.path)
+      .toBe(dirname(close.path));
+    expectUntouched(root);
+  });
+
+  test("EMLINK remains the primary diagnostic when closing fails but probe removal succeeds", () => {
+    const root = project();
+    const result = filesystemFailure(root, "probe", "EMLINK", "link", false, { closeCode: "EIO" });
+    expectLockFailure(result, root, "EMLINK");
+    expect(result.error?.aggregateError).toBe(false);
+    expect(result.events.map((event) => event.operation))
+      .toEqual(["open", "write", "fsync", "link", "close", "remove"]);
+    const close = result.events.find((event) => event.operation === "close")!;
+    expect(close.closed).toBe(true);
+    expect(result.events.find((event) => event.operation === "remove")?.path)
+      .toBe(dirname(close.path));
+    expectUntouched(root);
+  });
+
+  for (const [label, code, closeCode] of [
+    ["a healthy probe", null, undefined],
+    ["EMLINK", "EMLINK", undefined],
+    ["EMLINK and a close error", "EMLINK", "EIO"],
+  ] as const) {
+    test(`probe removal failure after ${label} reports an aggregate diagnostic and retained evidence`, () => {
+      const root = project();
+      const result = filesystemFailure(root, "probe", code, "link", false, {
+        closeCode,
+        removeCode: "EACCES",
+      });
+      const remove = result.events.find((event) => event.operation === "remove")!;
+      expect(remove).toBeDefined();
+      const probe = remove.path;
+      try {
+        expect(result.error).toEqual(expect.objectContaining({
+          name: "AggregateError",
+          aggregateError: true,
+          transactionLockError: false,
+        }));
+        expect(result.error?.message).toContain(probe);
+        expect(result.error?.message).toMatch(/cleanup|clean up|remov/i);
+        expect(result.error?.message).toMatch(/fail|could not|cannot|unable/i);
+        if (code !== null) {
+          expect(result.error?.message).toContain(
+            `Cannot create an AI-DLC transaction lock in ${root}: the filesystem rejected hard-link creation (EMLINK).`,
+          );
+        }
+        const link = result.events.find((event) => event.operation === "link")!;
+        expect(dirname(probe)).toBe(root);
+        expect(basename(probe)).toMatch(/^\.aidlc-lock-probe-/);
+        expect(dirname(link.path)).toBe(probe);
+        expect(readFileSync(link.path, "utf-8").length).toBeGreaterThan(0);
+        expect(existsSync(link.destination!)).toBe(code === null);
+        expect(result.events.find((event) => event.operation === "close")?.closed).toBe(true);
+        expectUntouched(root, ["existing.txt", basename(probe)]);
+      } finally {
+        // The child intentionally leaves evidence behind; cleanup here uses
+        // the parent's unmocked filesystem, including on assertion failure.
+        rmSync(probe, { recursive: true, force: true });
+      }
+      expectUntouched(root);
+    });
+  }
+
+  test("a healthy probe leaves an existing live transaction lock and project files untouched", () => {
+    const root = project();
+    const lock = join(root, ".aidlc-transaction.lock");
+    const identity = `${JSON.stringify({ pid: process.pid, staging: ".aidlc-txn-live" })}\n`;
+    writeFileSync(lock, identity);
+    const before = statSync(lock);
+    expect(assertTransactionFilesystem(root)).toBeUndefined();
+    expect(readFileSync(lock, "utf-8")).toBe(identity);
+    const after = statSync(lock);
+    expect({ ino: after.ino, mtimeMs: after.mtimeMs, nlink: after.nlink })
+      .toEqual({ ino: before.ino, mtimeMs: before.mtimeMs, nlink: before.nlink });
+    expectUntouched(root, [".aidlc-transaction.lock", "existing.txt"]);
+  });
+
+  test("a healthy probe uses the nearest existing ancestor without creating the project", () => {
+    const parent = project();
+    const root = join(parent, "missing", "nested-project");
+    expect(assertTransactionFilesystem(root)).toBeUndefined();
+    expect(existsSync(join(parent, "missing"))).toBe(false);
+    expectUntouched(parent);
+  });
+
+  test("a rejected probe names the missing destination and cleans its nearest existing ancestor", () => {
+    const parent = project();
+    const root = join(parent, "missing", "nested-project");
+    const result = filesystemFailure(root, "probe", "EMLINK");
+    expectLockFailure(result, root, "EMLINK");
+    const link = result.events.find((event) => event.operation === "link")!;
+    expect(dirname(dirname(link.path))).toBe(parent);
+    expect(existsSync(join(parent, "missing"))).toBe(false);
+    expectUntouched(parent);
+  });
+
+  test("a rejected probe preserves an existing live lock as well as the project files", () => {
+    const root = project();
+    const lock = join(root, ".aidlc-transaction.lock");
+    const identity = `${JSON.stringify({ pid: process.pid, staging: ".aidlc-txn-live" })}\n`;
+    writeFileSync(lock, identity);
+    const before = statSync(lock);
+    const result = filesystemFailure(root, "probe", "EMLINK");
+    expectLockFailure(result, root, "EMLINK");
+    expect(result.events.some((event) => event.path === lock || event.destination === lock))
+      .toBe(false);
+    expect(readFileSync(lock, "utf-8")).toBe(identity);
+    expect(statSync(lock).ino).toBe(before.ino);
+    expect(statSync(lock).mtimeMs).toBe(before.mtimeMs);
+    expectUntouched(root, [".aidlc-transaction.lock", "existing.txt"]);
+  });
+
+  test("EEXIST from a live lock retains normal ownership protection and the original lock", () => {
+    const root = project();
+    const lock = join(root, ".aidlc-transaction.lock");
+    const identity = `${JSON.stringify({ pid: process.pid, staging: ".aidlc-txn-live" })}\n`;
+    writeFileSync(lock, identity);
+    let caught: unknown;
+    try {
+      executePlan(plan(root));
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(TransactionLockError);
+    expect((caught as Error).message).toContain("another AI-DLC mutation holds");
+    expect(readFileSync(lock, "utf-8")).toBe(identity);
+    expectUntouched(root, [".aidlc-transaction.lock", "existing.txt"]);
+  });
+
+  test("EEXIST from a dead owner still permits recovery and a normal transaction", () => {
+    const root = project();
+    writeFileSync(join(root, ".aidlc-transaction.lock"), `${JSON.stringify({
+      pid: 2_147_483_647,
+      staging: ".aidlc-txn-dead",
+    })}\n`);
+    executePlan(plan(root));
+    expect(readFileSync(join(root, "existing.txt"), "utf-8")).toBe("updated\n");
+    expect(readFileSync(join(root, "new.txt"), "utf-8")).toBe("created\n");
+    expect(readdirSync(root).sort()).toEqual(["existing.txt", "new.txt"]);
+  });
+});


### PR DESCRIPTION
# Summary

Stacked on #1107; the base is `fix/config-filesystem-lock`.

Config can now proceed when a compatible mounted filesystem rejects hard links. Transaction locking automatically falls back to an owner-stamped directory, while a local process gate serializes acquisition, recovery, execution, and release.

This removes the reported hard-link blocker. It is bounded compatibility support, not certification of arbitrary S3 filesystem drivers: the mount must still provide the file semantics required by AI-DLC.

## Changes

- Coordinate native and directory transaction locks through a dedicated local, receipt-managed gate keyed by the canonical project root.
- Keep `.aidlc-transaction.lock` as the destination lock path so existing file-lock owners remain protected.
- Recover directory owners only with valid same-host/boot metadata and a provably dead PID. Preserve live, foreign, incomplete, invalid, and replacement owners.
- Probe exclusive creation, mutable append/readback, descriptor identity, file replacement, directory rename, Unix file permissions, workflow locking, and synchronization.
- Recheck capabilities before directory-lock transactions apply changes. Report the failed operation and storage remediation; retain the existing rename-based transaction and rollback logic.
- Document storage requirements, driver limits, and the single-host/single-mount coordination boundary.

## User experience

For a mount whose missing hard-link operation was the blocker, first-run config, refresh, and workflow writes can use directory locking without a new flag.

All cooperating processes must use one continuously running mount on one host, a common local temporary directory, and the same PID namespace. This is not a distributed lock across independent mounts or hosts.

The filesystem still supplies coherent identity/append behavior and atomic replacement/rename semantics. Successful probes cannot prove crash durability or atomicity. Mountpoint lacks operations needed for full workflows; s3fs implements rename through copy/delete and does not establish the full atomic-rename contract. Those limitations are documented explicitly, and this PR adds no copy/delete emulation of a failed rename.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Test plan

- `bun scripts/package.ts`
- `bun scripts/package.ts --check`
- `bun run typecheck`
- `bun run lint`
- Targeted unit slices with `bash tests/run-tests.sh --debug -P 8 --unit --filter ...`: **215 passed, 0 failed** across installation/configuration (94), transaction filesystems and concurrency (43), first-run/installed-workflow behavior (41), and coverage registry (37).

Tests disable hard links throughout all setup subprocesses and then exercise config, refresh, installed intent creation, state changes, and audit writes. They also cover multiprocess exclusion, interrupted-owner recovery, rollback, capability rejection without project changes, and local-gate release recovery.

Validation uses isolated filesystem fault injection around real file operations. No live S3 mount was exercised, and the reporting user's mount driver remains unknown.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
