### PR TITLE
fix: make compiled dispatch exhaustive over TOOLS so native review briefs route (#1070)

### DIFF
--- a/core/tools/aidlc-init.ts
+++ b/core/tools/aidlc-init.ts
@@ -6582,7 +6582,7 @@ export async function main(
 
 if (import.meta.main) {
   main(process.argv.slice(2)).catch((error) => {
-    process.stderr.write(`aidlc config: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.stderr.write(`${JSON.stringify({ error: error instanceof Error ? error.message : String(error) })}\n`);
     process.exitCode = EXIT.failure;
   });
 }

--- a/core/tools/aidlc-lifecycle.ts
+++ b/core/tools/aidlc-lifecycle.ts
@@ -2143,7 +2143,7 @@ export async function main(input: string[]): Promise<void> {
 
 if (import.meta.main) {
   main(process.argv.slice(2)).catch((error) => {
-    process.stderr.write(`aidlc lifecycle: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.stderr.write(`${JSON.stringify({ error: error instanceof Error ? error.message : String(error) })}\n`);
     process.exitCode = EXIT.failure;
   });
 }

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -9392,9 +9392,10 @@ if (import.meta.main) {
     main(process.argv.slice(2));
   } catch (e) {
     // Any uncaught read error (missing graph, malformed state) surfaces as a
-    // non-zero exit with the message on stderr — never a half-emitted
-    // directive on stdout.
-    console.error(`aidlc-orchestrate: ${errorMessage(e)}`);
+    // non-zero exit with JSON on stderr — never a half-emitted directive on
+    // stdout. The shape matches the compiled dispatcher when main throws
+    // in-process, so the copy and native channels agree.
+    process.stderr.write(`${JSON.stringify({ error: errorMessage(e) })}\n`);
     process.exit(1);
   }
 }

--- a/core/tools/aidlc-review-brief.ts
+++ b/core/tools/aidlc-review-brief.ts
@@ -991,7 +991,7 @@ if (import.meta.main) {
   try {
     main(process.argv.slice(2));
   } catch (error) {
-    process.stderr.write(`aidlc-review-brief: ${String(error)}\n`);
+    process.stderr.write(`${JSON.stringify({ error: error instanceof Error ? error.message : String(error) })}\n`);
     process.exit(1);
   }
 }

--- a/core/tools/aidlc.ts
+++ b/core/tools/aidlc.ts
@@ -2043,6 +2043,8 @@ async function loadDelegate(tool: string): Promise<DelegateModule | null> {
       return import("./aidlc-orchestrate.ts");
     case TOOLS.plugin:
       return import("./aidlc-plugin.ts");
+    case TOOLS.reviewBrief:
+      return import("./aidlc-review-brief.ts");
     case TOOLS.runnerGen:
       return import("./aidlc-runner-gen.ts");
     case TOOLS.runtime:

--- a/core/tools/aidlc.ts
+++ b/core/tools/aidlc.ts
@@ -2005,81 +2005,56 @@ function runDelegateDev(tool: string, args: string[]): number {
   }
 }
 
+type ToolFile = (typeof TOOLS)[keyof typeof TOOLS];
+
 type DelegateModule = {
   main(argv: string[]): void | Promise<void>;
 };
 
-async function loadDelegate(tool: string): Promise<DelegateModule | null> {
-  switch (tool) {
-    case TOOLS.attest:
-      return import("./aidlc-attest.ts");
-    case TOOLS.audit:
-      return import("./aidlc-audit.ts");
-    case TOOLS.bolt:
-      return import("./aidlc-bolt.ts");
-    case TOOLS.graph:
-      return import("./aidlc-graph.ts");
-    case TOOLS.doctor:
-      return import("./aidlc-doctor.ts");
-    case TOOLS.init:
-      return import("./aidlc-init.ts");
-    case TOOLS.jump:
-      return import("./aidlc-jump.ts");
-    case TOOLS.knowledge:
-      return import("./aidlc-knowledge.ts");
-    case TOOLS.testingPosture:
-      return import("./aidlc-testing-posture.ts");
-    case TOOLS.learnings:
-      return import("./aidlc-learnings.ts");
-    case TOOLS.log:
-      return import("./aidlc-log.ts");
-    case TOOLS.lifecycle:
-      return import("./aidlc-lifecycle.ts");
-    case TOOLS.machineConfig:
-      return import("./aidlc-machine-config.ts");
-    case TOOLS.completions:
-      return import("./aidlc-completions.ts");
-    case TOOLS.orchestrate:
-      return import("./aidlc-orchestrate.ts");
-    case TOOLS.plugin:
-      return import("./aidlc-plugin.ts");
-    case TOOLS.reviewBrief:
-      return import("./aidlc-review-brief.ts");
-    case TOOLS.runnerGen:
-      return import("./aidlc-runner-gen.ts");
-    case TOOLS.runtime:
-      return import("./aidlc-runtime.ts");
-    case TOOLS.sensor:
-      return import("./aidlc-sensor.ts");
-    case TOOLS.sensorClaimSources:
-      return import("./aidlc-sensor-claim-sources.ts");
-    case TOOLS.sensorLinter:
-      return import("./aidlc-sensor-linter.ts");
-    case TOOLS.sensorRequiredSections:
-      return import("./aidlc-sensor-required-sections.ts");
-    case TOOLS.sensorTraceability:
-      return import("./aidlc-sensor-traceability.ts");
-    case TOOLS.sensorTypeCheck:
-      return import("./aidlc-sensor-type-check.ts");
-    case TOOLS.sensorUpstreamCoverage:
-      return import("./aidlc-sensor-upstream-coverage.ts");
-    case TOOLS.state:
-      return import("./aidlc-state.ts");
-    case TOOLS.unit:
-      return import("./aidlc-unit.ts");
-    case TOOLS.swarm:
-      return import("./aidlc-swarm.ts");
-    case TOOLS.utility:
-      return import("./aidlc-utility.ts");
-    case TOOLS.validate:
-      return import("./aidlc-validate.ts");
-    case TOOLS.worktree:
-      return import("./aidlc-worktree.ts");
-    case TOOLS.workspaceSync:
-      return import("./aidlc-workspace-sync.ts");
-    default:
-      return null;
-  }
+// Issue #1070 shipped in 2.8.0-2.8.2 because reviewBrief was added to TOOLS and
+// routed, but this loader's switch never got its arm. Dev mode spawns
+// `bun <tool>`, so every test that ran the tool passed; only the compiled binary
+// walks this table. The Record<ToolFile, ...> annotation makes a missing loader
+// OR a delegate without `export main` a tsc error under `bun run check`. Keep
+// import specifiers literal so `bun build --compile` bundles every delegate.
+const DELEGATES: Record<ToolFile, () => Promise<DelegateModule>> = {
+  "aidlc-attest.ts": () => import("./aidlc-attest.ts"),
+  "aidlc-audit.ts": () => import("./aidlc-audit.ts"),
+  "aidlc-bolt.ts": () => import("./aidlc-bolt.ts"),
+  "aidlc-completions.ts": () => import("./aidlc-completions.ts"),
+  "aidlc-doctor.ts": () => import("./aidlc-doctor.ts"),
+  "aidlc-graph.ts": () => import("./aidlc-graph.ts"),
+  "aidlc-init.ts": () => import("./aidlc-init.ts"),
+  "aidlc-jump.ts": () => import("./aidlc-jump.ts"),
+  "aidlc-knowledge.ts": () => import("./aidlc-knowledge.ts"),
+  "aidlc-learnings.ts": () => import("./aidlc-learnings.ts"),
+  "aidlc-lifecycle.ts": () => import("./aidlc-lifecycle.ts"),
+  "aidlc-log.ts": () => import("./aidlc-log.ts"),
+  "aidlc-machine-config.ts": () => import("./aidlc-machine-config.ts"),
+  "aidlc-orchestrate.ts": () => import("./aidlc-orchestrate.ts"),
+  "aidlc-plugin.ts": () => import("./aidlc-plugin.ts"),
+  "aidlc-review-brief.ts": () => import("./aidlc-review-brief.ts"),
+  "aidlc-runner-gen.ts": () => import("./aidlc-runner-gen.ts"),
+  "aidlc-runtime.ts": () => import("./aidlc-runtime.ts"),
+  "aidlc-sensor-claim-sources.ts": () => import("./aidlc-sensor-claim-sources.ts"),
+  "aidlc-sensor-linter.ts": () => import("./aidlc-sensor-linter.ts"),
+  "aidlc-sensor-required-sections.ts": () => import("./aidlc-sensor-required-sections.ts"),
+  "aidlc-sensor-traceability.ts": () => import("./aidlc-sensor-traceability.ts"),
+  "aidlc-sensor-type-check.ts": () => import("./aidlc-sensor-type-check.ts"),
+  "aidlc-sensor-upstream-coverage.ts": () => import("./aidlc-sensor-upstream-coverage.ts"),
+  "aidlc-sensor.ts": () => import("./aidlc-sensor.ts"),
+  "aidlc-state.ts": () => import("./aidlc-state.ts"),
+  "aidlc-swarm.ts": () => import("./aidlc-swarm.ts"),
+  "aidlc-testing-posture.ts": () => import("./aidlc-testing-posture.ts"),
+  "aidlc-unit.ts": () => import("./aidlc-unit.ts"),
+  "aidlc-utility.ts": () => import("./aidlc-utility.ts"),
+  "aidlc-validate.ts": () => import("./aidlc-validate.ts"),
+  "aidlc-workspace-sync.ts": () => import("./aidlc-workspace-sync.ts"),
+  "aidlc-worktree.ts": () => import("./aidlc-worktree.ts"),
+};
+
+function loadDelegate(tool: string): Promise<DelegateModule> | null {
+  return Object.hasOwn(DELEGATES, tool) ? DELEGATES[tool as ToolFile]() : null;
 }
 
 async function runDelegateInProcess(tool: string, args: string[]): Promise<number> {
@@ -2087,11 +2062,12 @@ async function runDelegateInProcess(tool: string, args: string[]): Promise<numbe
   const projectDir = delegatedProjectDir(args);
   if (projectDir) process.env.AIDLC_PROJECT_DIR = projectDir;
   try {
-    const mod = await loadDelegate(tool);
-    if (mod === null || typeof mod.main !== "function") {
-      text(2, `${JSON.stringify({ error: `${tool} does not export main(argv)` })}\n`);
+    const delegate = loadDelegate(tool);
+    if (delegate === null) {
+      text(2, `${JSON.stringify({ error: `${tool} has no in-process delegate; DELEGATES in aidlc.ts is out of step with TOOLS` })}\n`);
       return 1;
     }
+    const mod = await delegate;
     await mod.main(args);
     const code = process.exitCode;
     if (typeof code === "number") return code;

--- a/docs/reference/06-hooks-and-tools.md
+++ b/docs/reference/06-hooks-and-tools.md
@@ -848,6 +848,9 @@ for debugging.
 
 ### `aidlc-review-brief.ts` — Decision-context renderer
 
+Native installs invoke this tool through `aidlc engine review-brief`, followed
+by `summary`, `review`, or `context` and the mode's flags, including `--stage <slug>`.
+
 `summary` renders the pre-generation confirmation context from the stage graph
 and questions-file path. `review` renders a reviewer-backed gate with hydrated
 finding dispositions and optional stale-path detail. `context` emits only the

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -93,7 +93,7 @@ import {
   TRUSTED_ROUTE_NAMESPACE,
   trustedCommand,
 } from "../core/tools/aidlc-command.ts";
-import { ROUTES } from "../core/tools/aidlc.ts";
+import { ROUTES, TOOLS } from "../core/tools/aidlc.ts";
 import { AIDLC_VERSION } from "../core/tools/aidlc-version.ts";
 import { BUILD_VERSION_ENV, releaseBuildVersion } from "../core/tools/aidlc-channel.ts";
 import { sha256Bytes } from "../core/tools/aidlc-distribution.ts";
@@ -1096,31 +1096,13 @@ function rewriteNativeInvocations(
 ): void {
   projectNativeRootIntegrations(outRoot, m);
   const harnessDir = escapeRegExp(m.harnessDir);
-  const delegateNames = [
-    "audit",
-    "bolt",
-    "graph",
-    "init",
-    "jump",
-    "learnings",
-    "lifecycle",
-    "log",
-    "orchestrate",
-    "runner-gen",
-    "runtime",
-    "sensor",
-    "sensor-claim-sources",
-    "sensor-linter",
-    "sensor-required-sections",
-    "sensor-type-check",
-    "sensor-upstream-coverage",
-    "state",
-    "swarm",
-    "utility",
-    "validate",
-    "worktree",
-    "workspace-sync",
-  ].join("|");
+  // The hand-maintained list had drifted to 23 of 33 tools, omitting review-brief.
+  // Deriving it from TOOLS keeps new delegates' bare bun aidlc-<name>.ts forms
+  // covered by both the rewrite and bareToolCheck. The leftover checks below
+  // still reject a rewrite to a non-route.
+  const delegateNames = Object.values(TOOLS)
+    .map((file) => escapeRegExp(file.slice("aidlc-".length, -".ts".length)))
+    .join("|");
   // The authored subprocess adapters, each backed by an `aidlc engine adapter
   // <harness>` dispatcher route. Only these project onto that route; any other
   // hook file keeps the generic one-argument `engine hook <name>` rewrite.

--- a/tests/unit/t230-dispatcher-routes.test.ts
+++ b/tests/unit/t230-dispatcher-routes.test.ts
@@ -60,6 +60,7 @@ const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const BUN = process.execPath;
 const CORE_TOOLS_DIR = join(REPO_ROOT, "core", "tools");
 const DIST_TOOLS_DIR = join(REPO_ROOT, "dist", "claude", ".claude", "tools");
+const RELEASE_TOOLS_DIR = join(REPO_ROOT, "dist-release", "claude", ".claude", "tools");
 const DISPATCHER = join(CORE_TOOLS_DIR, "aidlc.ts");
 
 type RunResult = {
@@ -1613,11 +1614,12 @@ describe("t230 native review-brief dispatch", () => {
     const root = mkdtempSync(join(tmpdir(), "aidlc-t230-native-"));
     tempProjects.add(root);
     executable = join(root, process.platform === "win32" ? "aidlc.exe" : "aidlc");
-    // Compile the actual dispatcher once; the $bunfs import fixture above
-    // cannot establish that the native executable reaches its bundled delegate.
+    // Compile the release projection that build-binaries.ts ships once; the
+    // $bunfs import fixture above cannot establish that the native executable
+    // reaches its bundled delegate.
     const built = spawnSync(
       BUN,
-      ["build", "--compile", join(DIST_TOOLS_DIR, "aidlc.ts"), "--outfile", executable],
+      ["build", "--compile", join(RELEASE_TOOLS_DIR, "aidlc.ts"), "--outfile", executable],
       { cwd: REPO_ROOT, encoding: "utf-8", timeout: 60_000 },
     );
     if (built.error) throw built.error;

--- a/tests/unit/t230-dispatcher-routes.test.ts
+++ b/tests/unit/t230-dispatcher-routes.test.ts
@@ -1,5 +1,5 @@
 // covers: tool:aidlc, function:renderCommandHelp, tool:aidlc-sensor, tool:aidlc-swarm, hook:aidlc-validate-state, hook:aidlc-review-freeze, hook:aidlc-statusline
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
@@ -49,8 +49,10 @@ import { AIDLC_VERSION } from "../../core/tools/aidlc-version.ts";
 import {
   cleanupTestProject,
   createTestProject,
+  seedAidlcMemory,
   seededRecordDir,
   seededStateFile,
+  seedStateFile,
 } from "../harness/fixtures.ts";
 import { setupTuiProject } from "../harness/tui-fixtures.ts";
 
@@ -1596,6 +1598,121 @@ describe("t230 dispatcher dev and compiled in-process modes", () => {
     expect(directive.ask_type).toBe("new-work-routing");
     expect(directive.available_intents).toHaveLength(2);
   });
+});
+
+describe("t230 native review-brief dispatch", () => {
+  let executable: string;
+  let projectDir: string;
+  let otherCwd: string;
+  let artifact: string;
+  let questions: string;
+  let finding: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeAll(() => {
+    const root = mkdtempSync(join(tmpdir(), "aidlc-t230-native-"));
+    tempProjects.add(root);
+    executable = join(root, process.platform === "win32" ? "aidlc.exe" : "aidlc");
+    // Compile the actual dispatcher once; the $bunfs import fixture above
+    // cannot establish that the native executable reaches its bundled delegate.
+    const built = spawnSync(
+      BUN,
+      ["build", "--compile", join(DIST_TOOLS_DIR, "aidlc.ts"), "--outfile", executable],
+      { cwd: REPO_ROOT, encoding: "utf-8", timeout: 60_000 },
+    );
+    if (built.error) throw built.error;
+    expect(built.status, `${built.stdout}\n${built.stderr}`).toBe(0);
+
+    projectDir = makeProject();
+    seedAidlcMemory(projectDir);
+    seedStateFile(projectDir, "state-mid-inception.md");
+    const stageDir = join(seededRecordDir(projectDir), "inception", "requirements-analysis");
+    mkdirSync(stageDir, { recursive: true });
+    const artifactPath = join(stageDir, "requirements.md");
+    const questionsPath = join(stageDir, "requirements-analysis-questions.md");
+    artifact = relative(projectDir, artifactPath).replaceAll("\\", "/");
+    questions = relative(projectDir, questionsPath).replaceAll("\\", "/");
+    finding = `| R-01 | Minor | ${artifact} > FR-1 | Deadline is missing | Add a delivery date | New |`;
+    writeFileSync(artifactPath, [
+      "# Requirements",
+      "",
+      "## Review",
+      "",
+      "**Verdict:** NOT-READY",
+      "**Reviewer:** aidlc-product-lead-agent",
+      "**Iteration:** 1",
+      "",
+      "### Findings",
+      "",
+      "| ID | Severity | Location | Finding | Required action | Status |",
+      "|---|---|---|---|---|---|",
+      finding,
+      "",
+    ].join("\n"));
+    writeFileSync(questionsPath, "# Questions\n\n## Q1: Delivery scope\n[Answer]: A command-line application.\n");
+
+    otherCwd = join(root, "unrelated-cwd");
+    mkdirSync(otherCwd);
+    env = {
+      // Both forms read the same generated graph; project content must still
+      // resolve from --project-dir despite both project envs pointing at cwd.
+      AIDLC_RUNTIME_HARNESS_ROOT: dirname(DIST_TOOLS_DIR),
+      AIDLC_PROJECT_DIR: otherCwd,
+      PATH: "",
+    };
+  }, 65_000);
+
+  function native(args: string[]): RunResult {
+    return run(
+      [executable, "engine", "review-brief", ...args, "--project-dir", projectDir],
+      otherCwd,
+      { ...env, AIDLC_DISPATCH_TOOLS_DIR: "" },
+    );
+  }
+
+  for (const command of ["review", "context", "summary"]) {
+    test(`${command} matches Bun output from another cwd without Bun on PATH`, () => {
+      const args = [command, "--stage", "requirements-analysis"];
+      if (command === "review") args.push("--why", "first");
+      if (command === "summary") args.push("--questions-file", questions);
+      const source = viaDispatcher(
+        ["engine", "review-brief", ...args, "--project-dir", projectDir],
+        otherCwd,
+        env,
+      );
+      expect(source.exitCode, source.stderr.toString()).toBe(0);
+      expect(source.stderr.toString()).toBe("");
+      const result = native(args);
+      expectSameRun(result, source, `native review-brief ${command}`);
+      const output = result.stdout.toString();
+      if (command === "summary") {
+        expect(output).toContain("**Stage:** Requirements Analysis");
+        expect(output).toContain(`**Confirming:** Consolidated answers in \`${questions}\``);
+        expect(output).toContain(`before generating \`${artifact}\``);
+        expect(output).toContain("**Looks correct**");
+        expect(output).toContain("**Request changes**");
+      } else {
+        expect(output).toContain(`**Review artifact:** \`${artifact}\``);
+        expect(output).toContain(finding);
+        if (command === "review") {
+          expect(output).toContain("**Stage:** Requirements Analysis");
+          expect(output).toContain("**Review outcome:** Concerns remain for your decision.");
+          expect(output).toContain("**Why now:** First review completed.");
+          expect(output).toContain("**Approve**");
+          expect(output).toContain("**Request Changes**");
+        }
+      }
+    }, 35_000);
+  }
+
+  test("missing --stage reaches the native renderer's argument error", () => {
+    const result = native(["review", "--why", "first"]);
+    expect(result.exitCode, result.stderr.toString()).toBe(1);
+    expect(result.stdout.toString()).toBe("");
+    expect(JSON.parse(result.stderr.toString())).toEqual({
+      error: "Missing --stage <slug>.",
+    });
+  }, 20_000);
 });
 
 describe("t230 dispatcher route completeness", () => {

--- a/tests/unit/t230-dispatcher-routes.test.ts
+++ b/tests/unit/t230-dispatcher-routes.test.ts
@@ -1469,6 +1469,43 @@ describe("t230 dispatcher global flag translation", () => {
   });
 });
 
+const UNEXERCISED_DELEGATES: Partial<Record<string, string>> = {
+  "aidlc-doctor.ts": "The only route has networkPolicy 'interactive-bounded'.",
+  "aidlc-init.ts": "The only route has networkPolicy 'explicit-only'.",
+  "aidlc-workspace-sync.ts": "The only route has networkPolicy 'required'.",
+};
+
+// Generalize the former four-case list: #1070's review-brief was routed and tested
+// directly, yet unreachable through the compiled dispatcher. Per-command lists
+// only guard what someone remembered to list.
+function compiledParityCases(): Array<{ tool: string; routeId: string; argv: string[] }> {
+  const cases: Array<{ tool: string; routeId: string; argv: string[] }> = [];
+  tools: for (const tool of Object.values(TOOLS)) {
+    for (const route of ROUTES) {
+      if (
+        (route.tool !== tool && route.kind !== "custom") ||
+        route.networkPolicy !== "forbidden"
+      ) continue;
+
+      const nsPrefix = route.namespace === "public" ? [] : [route.namespace];
+      const top = route.kind === "top-passthrough" ||
+        route.kind === "top-prefix" || route.kind === "top-help";
+      for (const verb of route.verbs) {
+        const argv = [
+          ...nsPrefix,
+          ...(top ? [] : [route.group]),
+          ...(verb.startsWith("<") ? [] : verb.split(" ")),
+        ];
+        const action = resolveAction(argv);
+        if (action.type !== "delegate" || action.tool !== tool) continue;
+        cases.push({ tool, routeId: route.id, argv });
+        continue tools;
+      }
+    }
+  }
+  return cases;
+}
+
 describe("t230 dispatcher dev and compiled in-process modes", () => {
   test("compiled URL detection recognizes Bun virtual roots on Unix and Windows", () => {
     expect(isCompiledModuleUrl("file:///$bunfs/root/aidlc.ts")).toBe(true);
@@ -1477,19 +1514,33 @@ describe("t230 dispatcher dev and compiled in-process modes", () => {
     expect(isCompiledModuleUrl("file:///workspace/core/tools/aidlc.ts")).toBe(false);
   });
 
-  const cases = [
-    { name: "version", args: ["version"] },
-    { name: "graph artifacts", args: ["engine", "graph", "artifacts", "--help"] },
-    { name: "sensor list", args: ["engine", "sensor", "list"] },
-    { name: "state get", args: ["engine", "state", "get"] },
-  ];
+  const cases = compiledParityCases();
 
-  for (const item of cases) {
-    test(`${item.name} imported compiled main matches spawned dev dispatcher`, () => {
+  test("every delegate is exercised or explicitly excused", () => {
+    expect(new Set([
+      ...cases.map((item) => item.tool),
+      ...Object.keys(UNEXERCISED_DELEGATES),
+    ])).toEqual(new Set(Object.values(TOOLS)));
+    expect(cases.filter((item) => UNEXERCISED_DELEGATES[item.tool])).toEqual([]);
+  });
+
+  for (const { tool, routeId, argv } of cases) {
+    const title = `${tool} via ${routeId}: imported compiled main matches spawned dev dispatcher`;
+    test(title, () => {
+      expect(resolveAction(argv)).toMatchObject({ type: "delegate", tool });
       const projectDir = makeProject();
-      const dev = viaDispatcher(item.args, projectDir, { AIDLC_DISPATCH_TOOLS_DIR: DIST_TOOLS_DIR });
-      const compiled = viaImportedCompiledMain(item.args, projectDir);
-      expectSameRun(compiled, dev, item.name);
+      const root = mkdtempSync(join(tmpdir(), "aidlc-t230-compiled-sandbox-"));
+      tempProjects.add(root);
+      const env = {
+        AIDLC_INSTALL_ROOT: join(root, "install"),
+        AIDLC_BIN_DIR: join(root, "bin"),
+        AIDLC_OFFLINE: "1",
+      };
+      const dev = viaDispatcher(argv, projectDir, { AIDLC_DISPATCH_TOOLS_DIR: DIST_TOOLS_DIR, ...env });
+      const compiled = viaImportedCompiledMain(argv, projectDir, env);
+      expect(compiled.stderr.toString()).not.toContain("has no in-process delegate");
+      expect(compiled.stderr.toString()).not.toContain("does not export main");
+      expectSameRun(compiled, dev, title);
     });
   }
 

--- a/tests/unit/t299-first-run-wizard.test.ts
+++ b/tests/unit/t299-first-run-wizard.test.ts
@@ -178,6 +178,15 @@ function runWizard(
   };
 }
 
+function wizardStderrMessage(stderr: string): string {
+  try {
+    const parsed = JSON.parse(stderr) as { error?: unknown };
+    return typeof parsed.error === "string" ? parsed.error : stderr;
+  } catch {
+    return stderr;
+  }
+}
+
 describe("t299 first-run setup wizard", () => {
   test("recommended defaults render detection, trichotomy, receipts, blocker, and next commands", () => {
     const result = runWizard("\n", { aidlc: false, runtimeIssue: true });
@@ -344,7 +353,7 @@ describe("t299 first-run setup wizard", () => {
     });
     expect(result.status).toBe(1);
     expect(readFileSync(join(result.project, "aidlc.settings.json"), "utf-8")).toBe(newer);
-    const output = `${result.stdout}${result.stderr}`;
+    const output = `${result.stdout}${wizardStderrMessage(result.stderr)}`;
     expect(output).toContain("rollback was incomplete");
     const recovery = /recovery snapshot preserved at ([^\r\n]+)/.exec(output)?.[1];
     expect(recovery).toBeDefined();
@@ -394,7 +403,7 @@ describe("t299 first-run setup wizard", () => {
     });
     expect(result.status, result.stdout + result.stderr).toBe(1);
     expect(readFileSync(settings, "utf-8")).toBe(newer);
-    const output = `${result.stdout}${result.stderr}`;
+    const output = `${result.stdout}${wizardStderrMessage(result.stderr)}`;
     expect(output).toContain("rollback was incomplete");
     const recovery = /recovery snapshot preserved at ([^\r\n]+)/.exec(output)?.[1];
     expect(recovery).toBeDefined();
@@ -464,7 +473,7 @@ describe("t299 first-run setup wizard", () => {
         timeout: 60_000,
       },
     );
-    const output = `${result.stdout}${result.stderr}`;
+    const output = `${result.stdout}${wizardStderrMessage(result.stderr)}`;
     expect(result.status, output).toBe(0);
     expect(output).toContain("Choice [1]:");
     expect(output).not.toContain("Nothing written.");

--- a/tests/unit/t312-orchestrate-session-binding.test.ts
+++ b/tests/unit/t312-orchestrate-session-binding.test.ts
@@ -187,7 +187,8 @@ describe("t312 orchestrate session binding", () => {
     });
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stderr.toString()).toContain(
+    const diagnostic = JSON.parse(result.stderr.toString()) as { error: string };
+    expect(diagnostic.error).toContain(
       'Session override "session-b" conflicts with the owning conversation "session-a"',
     );
     expect(readFileSync(statePath(firstDir), "utf-8")).toBe(firstBefore);


### PR DESCRIPTION
# Summary

Closes #1070. Native `aidlc engine review-brief` commands failed with `aidlc-review-brief.ts does not export main(argv)` even though the renderer exported the required entry point. The dispatcher declared the route but its compiled-mode delegate table omitted the tool, and the error text pointed at the wrong layer.

This is the same defect class as the earlier knowledge-verb miss documented in the route table: a tool that works when invoked as `bun <tool>.ts` (the copy channel every test and every e2e journey runs) but is unreachable through the compiled binary, which is the only path that consults the delegate table. Rather than add one arm, the PR closes the class: the table is typed so drift fails typecheck, t230 drives every delegate through the simulated compiled dispatcher so drift also fails a unit test, the packager's last hand-maintained tool list is derived from `TOOLS`, and the copy-channel CLI wrappers emit uncaught errors in the shape the compiled dispatcher already uses.

## Changes

**Dispatcher (`core/tools/aidlc.ts`)**
- Replace the `loadDelegate` `switch` with `DELEGATES: Record<ToolFile, () => Promise<DelegateModule>>`. `DelegateModule.main` is required, so a `TOOLS` entry without a loader **or** a delegate module without `export main` fails `tsc` under `bun run check`. Import specifiers stay literal so `bun build --compile` still bundles every delegate.
- Split the error: an unrouted tool reports `has no in-process delegate; DELEGATES in aidlc.ts is out of step with TOOLS` instead of the misleading missing-export message.

**Tests (`tests/unit/t230-dispatcher-routes.test.ts`)**
- Replace the hand-listed four compiled-vs-dev parity cases with a generator over `TOOLS` × `ROUTES`. For each of the 33 tools it picks the first route/verb whose `resolveAction` yields a delegate to that tool (two modes agreeing on a routing error can never pass vacuously), runs it in a fresh sandboxed project (`AIDLC_INSTALL_ROOT`, `AIDLC_BIN_DIR`, `AIDLC_OFFLINE=1`) through both `viaDispatcher` and `viaImportedCompiledMain`, and asserts identical output. 30 tools exercised; `doctor`, `init`, `workspace-sync` are excused by an explicit map quoting their non-`forbidden` `networkPolicy`; a completeness test fails if a tool is neither exercised nor excused. No `bun build`; ~12 s.
- Add a regression that compiles the **release projection** (`dist-release/claude/.claude/tools/aidlc.ts`, the entry `build-binaries.ts` ships) into a real executable and exercises `review`, `context`, and `summary` from another cwd with an empty `PATH`.

**Packager (`scripts/package.ts`)**
- `delegateNames`, the list driving the bare `bun aidlc-<name>.ts` native rewrite and its leftover check, had drifted to 23 of 33 tools (review-brief among the missing). It is now derived from `TOOLS`. Output-neutral: `dist-release` hashes identically before and after (the only bare form in any prose is `aidlc-directive.ts`, not a delegate); the existing leftover checks still reject a rewrite to a non-route.

**Copy-channel CLI wrappers**
- `aidlc-review-brief.ts`, `aidlc-orchestrate.ts`, `aidlc-init.ts`, `aidlc-lifecycle.ts`: the `import.meta.main` catch now writes `{"error":"<message>"}` to stderr, the shape the compiled dispatcher's in-process catch and `aidlc-lib` `die()` already use, so `bun <tool>.ts` and `aidlc engine <tool>` agree. The parity test found the review-brief case on its first run (`aidlc-review-brief: Error: Missing --stage <slug>.` vs `{"error":"Missing --stage <slug>."}`); the other three had the same latent divergence. In-`main` diagnostics are untouched. t299 and t312 decoded that stderr as raw text and now read `JSON.parse(stderr).error` first; every state, rollback, and audit assertion in them is unchanged.

**Docs**
- Document the native invocation in the tool reference.

## Evidence the guards work

Rebasing onto `main` (which added `attest` to `TOOLS` in #1052) with the map lacking that entry:

```
core/tools/aidlc.ts(2020,7): error TS2741: Property '"aidlc-attest.ts"' is missing in type '{ ... }' but required in type 'Record<ToolFile, () => Promise<DelegateModule>>'.
```

Deleting only the `"aidlc-review-brief.ts"` line from `DELEGATES` and running `bun test tests/unit/t230-dispatcher-routes.test.ts -t 'aidlc-review-brief.ts via'`:

```
Expected to not contain: "has no in-process delegate"
Received: "{\"error\":\"aidlc-review-brief.ts has no in-process delegate; DELEGATES in aidlc.ts is out of step with TOOLS\"}\n"
```

Both are the drift that shipped #1070, caught before a user could.

## Test plan

- Reproduced the reported error with a native executable compiled from unchanged `main`: exit code 1 and the exact missing-export message.
- `bash tests/run-tests.sh --debug -P 8 --unit --filter '^(t230-dispatcher-routes|t304-review-brief|t299-first-run-wizard|t312-orchestrate-session-binding|t215-bolt-dag-selfheal)[.]test[.]ts$' --no-llm`: **215 passed, 0 failed** (t230 147, t304 32, t215 15, t299 12, t312 9).
- `bun scripts/package.ts`, `bun scripts/package.ts --check` (deterministic across two builds, all seven harnesses), `bun run typecheck`, `bun run lint`, `git diff --check` passed.

Native execution was verified on Linux. No live-model tests were needed for this deterministic dispatcher change.

## Checklist

* [x] I have reviewed the contributing guidelines.
* [x] I have performed a self-review of this change.
* [x] Changes have been tested.
* [x] Changes are documented.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).


