### PR TITLE
fix: restore stable release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
 
   verify:
     needs: [validate, gate-result]
+    if: ${{ !cancelled() && needs.validate.result == 'success' && needs.gate-result.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -768,3 +769,24 @@ jobs:
           gh release view "$RELEASE_TAG" --json assets --jq ".assets[].name" |
             LC_ALL=C sort >"$RUNNER_TEMP/remote-assets.txt"
           diff -u "$RUNNER_TEMP/local-assets.txt" "$RUNNER_TEMP/remote-assets.txt"
+
+  release-result:
+    name: Release result
+    if: ${{ !cancelled() }}
+    needs: [validate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require publication or an intentional preview skip
+        env:
+          RELEASE_CHANNEL: ${{ needs.validate.outputs.channel }}
+          RELEASE_RESULT: ${{ needs.release.result }}
+          RELEASE_SKIP: ${{ needs.validate.outputs.skip }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+        run: |
+          set -euo pipefail
+          test "$VALIDATE_RESULT" = success
+          if [ "$RELEASE_CHANNEL" = preview ] && [ "$RELEASE_SKIP" = true ]; then
+            test "$RELEASE_RESULT" = skipped
+            exit 0
+          fi
+          test "$RELEASE_RESULT" = success

--- a/tests/unit/t332-preview-release-pipeline.test.ts
+++ b/tests/unit/t332-preview-release-pipeline.test.ts
@@ -1043,12 +1043,25 @@ describe("t332 preview publication pipeline", () => {
     expect(jobs["gate-result"].if).toContain("needs.gate.result == 'success'");
     expect(jobs["gate-result"].if).toContain("needs.validate.outputs.skip != 'true'");
     expect(jobs.verify.needs).toEqual(["validate", "gate-result"]);
+    expect(jobs.verify.if).toContain("!cancelled()");
+    expect(jobs.verify.if).toContain("needs.validate.result == 'success'");
+    expect(jobs.verify.if).toContain("needs.gate-result.result == 'success'");
     expect(jobs.publish.needs).toEqual(["validate", "musl-smoke", "windows-lifecycle", "unix-lifecycle"]);
     expect(jobs.release.needs).toEqual(["validate", "publish"]);
     expect(jobs.release.environment).toBe(
       `\${{ needs.validate.outputs.channel == 'preview' && 'preview' || 'release' }}`,
     );
     expect(jobs.release.permissions).toEqual({ contents: "write" });
+    expect(jobs["release-result"].needs).toEqual(["validate", "release"]);
+    expect(jobs["release-result"].if).toContain("!cancelled()");
+    const releaseResult = jobs["release-result"].steps?.find(
+      (step) => step.name === "Require publication or an intentional preview skip",
+    );
+    expect(releaseResult?.run).toContain('test "$VALIDATE_RESULT" = success');
+    expect(releaseResult?.run).toContain(
+      '[ "$RELEASE_CHANNEL" = preview ] && [ "$RELEASE_SKIP" = true ]',
+    );
+    expect(releaseResult?.run).toContain('test "$RELEASE_RESULT" = success');
 
     for (const key of ["channel", "tag", "sha", "skip", "preview_version", "preview_plan"]) {
       expect(jobs.validate.outputs?.[key], key).toBeDefined();


### PR DESCRIPTION
## Summary

- make `verify` explicitly run after the preview-only gate is skipped during a stable tag release
- add a terminal `Release result` job so a stable release cannot finish green without publishing
- allow the terminal job to pass without publication only for an intentional `preview` plan with `skip=true`
- extend the preview pipeline contract test to pin both protections

## Root cause

Run https://github.com/awslabs/aidlc-workflows/actions/runs/34570195172 validated `v2.8.2` and passed every release test tier, but the preview-only `gate` was skipped for the stable channel. GitHub propagated that skipped dependency through `gate-result` to `verify`, which had no explicit status condition. Every build and publication job was then skipped, while the workflow still concluded successfully.

## Validation

- release workflow parses successfully with Bun YAML
- `git diff --check`
- full local test execution was stopped at maintainer request; CI should provide the complete validation result

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).