### PR TITLE
fix: isolate stable and preview release pipelines

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,16 +1,17 @@
-name: Release
+name: Preview Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-      - "!v*-preview.*"
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *"
 
 permissions:
   contents: read
 
+# Scheduled and manual preview runs share one repository-wide slot. A later run
+# observes the prior publication before allocating another retry-safe build id.
 concurrency:
-  group: release-stable
+  group: release-preview
   cancel-in-progress: false
 
 jobs:
@@ -19,36 +20,72 @@ jobs:
     permissions:
       contents: read
     outputs:
-      tag: ${{ steps.validate.outputs.tag }}
+      tag: ${{ steps.plan.outputs.tag }}
       sha: ${{ steps.validate.outputs.sha }}
+      skip: ${{ steps.plan.outputs.skip == 'true' }}
+      preview_version: ${{ steps.plan.outputs.preview_version }}
+      preview_plan: ${{ steps.plan.outputs.preview_plan }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
-      - name: Validate release tag and source
+      - name: Validate preview source
         id: validate
         shell: bash
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
-          test "$GITHUB_EVENT_NAME" = "push"
-          test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
-          git fetch --force origin \
-            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG" main
-          tag_sha="$(git rev-parse "$RELEASE_TAG^{commit}")"
-          main_sha="$(git rev-parse origin/main^{commit})"
-          test "$GITHUB_SHA" = "$tag_sha"
-          test "$(git rev-parse HEAD^{commit})" = "$tag_sha"
-          git merge-base --is-ancestor "$tag_sha" "$main_sha"
-          version="$(awk -F'"' '/^export const AIDLC_VERSION = "/ { print $2 }' core/tools/aidlc-version.ts)"
-          test "$RELEASE_TAG" = "v$version"
-          printf 'tag=%s\nsha=%s\n' "$RELEASE_TAG" "$tag_sha" >> "$GITHUB_OUTPUT"
+          case "$GITHUB_EVENT_NAME" in
+            schedule | workflow_dispatch) ;;
+            *) exit 1 ;;
+          esac
+          test "$GITHUB_REF" = "refs/heads/main"
+          git fetch --no-tags origin main
+          # A queued run may no longer be the tip. Let it observe today's
+          # publication and skip before requiring current main for a build.
+          source_sha="$GITHUB_SHA"
+          test "$(git rev-parse HEAD^{commit})" = "$source_sha"
+          git merge-base --is-ancestor "$source_sha" origin/main
+          printf 'sha=%s\n' "$source_sha" >> "$GITHUB_OUTPUT"
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - name: Plan preview publication
+        id: plan
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTHORIZED_SHA: ${{ steps.validate.outputs.sha }}
+        run: |
+          set -euo pipefail
+          plan="$RUNNER_TEMP/aidlc-preview-plan.json"
+          bun scripts/plan-preview-release.ts \
+            --repository "$GITHUB_REPOSITORY" \
+            --source-repository "$GITHUB_REPOSITORY" \
+            --source-digest "$AUTHORIZED_SHA" \
+            --output "$plan"
+          if [ "$(jq -r 'type' "$plan")" != null ]; then
+            test "$AUTHORIZED_SHA" = "$(git rev-parse origin/main^{commit})"
+          fi
+          {
+            printf 'preview_plan='
+            jq -c . "$plan"
+          } >> "$GITHUB_OUTPUT"
+      - name: Require immutable preview releases
+        if: steps.plan.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$(gh api "repos/$GITHUB_REPOSITORY/immutable-releases" --jq .enabled)" = true
+
+  gate:
+    needs: validate
+    if: needs.validate.outputs.skip != 'true'
+    uses: ./.github/workflows/ci.yml
 
   verify:
-    needs: validate
+    needs: [validate, gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -68,7 +105,7 @@ jobs:
 
   test_smoke:
     name: Release tests (smoke)
-    needs: validate
+    needs: [validate, gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -83,7 +120,7 @@ jobs:
 
   test_unit:
     name: Release tests (unit shard ${{ matrix.shard }}/4)
-    needs: validate
+    needs: [validate, gate]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -106,7 +143,7 @@ jobs:
 
   test_deep:
     name: Release tests (integration + e2e, deterministic)
-    needs: validate
+    needs: [validate, gate]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -122,8 +159,8 @@ jobs:
 
   test:
     name: Release tests
-    if: ${{ always() }}
-    needs: [test_smoke, test_unit, test_deep]
+    if: ${{ !cancelled() && needs.validate.outputs.skip != 'true' }}
+    needs: [validate, test_smoke, test_unit, test_deep]
     runs-on: ubuntu-latest
     steps:
       - name: Require every release test tier
@@ -154,7 +191,11 @@ jobs:
       # t238 builds the native binary from dist-release/; regenerate first so
       # the smoke proves CI-built bytes on every OS in the matrix.
       - run: bun scripts/package.ts
+        env:
+          AIDLC_BUILD_VERSION: ${{ needs.validate.outputs.preview_version }}
       - run: bun test tests/unit/t238-build-binaries.test.ts
+        env:
+          AIDLC_BUILD_VERSION: ${{ needs.validate.outputs.preview_version }}
       - if: runner.os == 'Windows'
         run: bun test tests/unit/t244-install-management.test.ts -t "t244 Windows and completion release surfaces"
       - name: PSScriptAnalyzer installer
@@ -195,6 +236,8 @@ jobs:
             target: bun-windows-x64
             directory: windows-x64
     runs-on: ${{ matrix.runner }}
+    env:
+      AIDLC_BUILD_VERSION: ${{ needs.validate.outputs.preview_version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -246,6 +289,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      AIDLC_BUILD_VERSION: ${{ needs.validate.outputs.preview_version }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -291,7 +336,7 @@ jobs:
           $ghFixture = Join-Path $env:RUNNER_TEMP 'aidlc-gh.ps1'
           $env:AIDLC_TEST_GH_MARKER = Join-Path $env:RUNNER_TEMP 'aidlc-gh-verified'
           $env:AIDLC_TEST_GH_REPOSITORY = 'awslabs/aidlc-workflows'
-          $env:AIDLC_TEST_GH_WORKFLOW = 'awslabs/aidlc-workflows/.github/workflows/release.yml'
+          $env:AIDLC_TEST_GH_WORKFLOW = 'awslabs/aidlc-workflows/.github/workflows/preview-release.yml'
           $manifest = Get-Content -Raw -LiteralPath (Join-Path $releaseRoot 'version.json') |
             ConvertFrom-Json
           $env:AIDLC_TEST_GH_SOURCE_REF = $manifest.sourceRef
@@ -394,7 +439,7 @@ jobs:
           & ./build/release/install.ps1 -From $releaseRoot -Offline -Quiet
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $pointer = Get-Content -Raw (Join-Path $env:AIDLC_INSTALL_ROOT 'active-executable')
-          if ($pointer.Trim() -notmatch '\\versions\\[0-9]+\.[0-9]+\.[0-9]+\\aidlc\.exe$') {
+          if ($pointer.Trim() -notmatch '\\versions\\[0-9]+\.[0-9]+\.[0-9]+(-preview\.[0-9]{8}\.[1-9][0-9]*)?\\aidlc\.exe$') {
             throw "invalid active executable pointer: $pointer"
           }
           $env:COPILOT_HOME = Join-Path $env:RUNNER_TEMP 'aidlc-copilot-home'
@@ -453,7 +498,7 @@ jobs:
           gh_bin="$RUNNER_TEMP/aidlc-gh"
           gh_marker="$RUNNER_TEMP/aidlc-gh-verified"
           manifest_version="$(
-            sed -n 's/.*"version":[[:space:]]*"\([0-9][0-9.]*\)".*/\1/p' \
+            sed -n 's/.*"version":[[:space:]]*"\([0-9][0-9A-Za-z.-]*\)".*/\1/p' \
               "$release/version.json" | head -n 1
           )"
           test -n "$manifest_version"
@@ -461,7 +506,11 @@ jobs:
             sed -n 's/.*"sourceRef":[[:space:]]*"\([^"]*\)".*/\1/p' \
               "$release/version.json" | head -n 1
           )"
-          test "$manifest_source_ref" = "refs/tags/v$manifest_version"
+          case "$manifest_version" in
+            *-preview.*) expected_source_ref=refs/heads/main ;;
+            *) expected_source_ref="refs/tags/v$manifest_version" ;;
+          esac
+          test "$manifest_source_ref" = "$expected_source_ref"
           if command -v sha256sum >/dev/null 2>&1; then
             checksums_sha="$(sha256sum "$release/checksums.txt" | awk '{print $1}')"
           else
@@ -513,7 +562,7 @@ jobs:
             AIDLC_GH_BIN="$gh_bin" \
             AIDLC_TEST_GH_MARKER="$gh_marker" \
             AIDLC_TEST_GH_REPOSITORY="awslabs/aidlc-workflows" \
-            AIDLC_TEST_GH_WORKFLOW="awslabs/aidlc-workflows/.github/workflows/release.yml" \
+            AIDLC_TEST_GH_WORKFLOW="awslabs/aidlc-workflows/.github/workflows/preview-release.yml" \
             AIDLC_TEST_GH_SOURCE_REF="$manifest_source_ref" \
             AIDLC_TEST_GH_SOURCE_DIGEST="$(
               sed -n 's/.*"sourceDigest":[[:space:]]*"\([a-f0-9]*\)".*/\1/p' \
@@ -555,14 +604,13 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
-      - name: Recheck release source
+      - name: Recheck preview source
         env:
           AUTHORIZED_SHA: ${{ needs.validate.outputs.sha }}
-          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          git fetch --force origin \
-            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-          test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$AUTHORIZED_SHA"
+          set -euo pipefail
+          git fetch --no-tags origin main
+          test "$(git rev-parse origin/main^{commit})" = "$AUTHORIZED_SHA"
           test "$(git rev-parse HEAD)" = "$AUTHORIZED_SHA"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -603,7 +651,7 @@ jobs:
   release:
     needs: [validate, publish]
     runs-on: ubuntu-latest
-    environment: release
+    environment: preview
     permissions:
       contents: write
     steps:
@@ -615,27 +663,42 @@ jobs:
         with:
           name: attested-release
           path: build/release
-      - name: Recheck release source
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - name: Recheck preview source
         env:
           AUTHORIZED_SHA: ${{ needs.validate.outputs.sha }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail
-          git fetch --force origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-          test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$AUTHORIZED_SHA"
+          git fetch --no-tags origin main
+          test "$(git rev-parse origin/main^{commit})" = "$AUTHORIZED_SHA"
           test "$(git rev-parse HEAD)" = "$AUTHORIZED_SHA"
           test "$RELEASE_TAG" = "v$(jq -r .version build/release/version.json)"
           (cd build/release && sha256sum -c checksums.txt)
-      - name: Create GitHub Release
+      - name: Create preview GitHub Release
         env:
+          AUTHORIZED_SHA: ${{ needs.validate.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
+          PREVIEW_PLAN: ${{ needs.validate.outputs.preview_plan }}
           RELEASE_TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail
-          gh release create "$RELEASE_TAG" build/release/* \
-            --verify-tag \
-            --title "AI-DLC ${RELEASE_TAG#v}" \
-            --generate-notes
+          plan="$RUNNER_TEMP/aidlc-preview-plan.json"
+          printf '%s\n' "$PREVIEW_PLAN" >"$plan"
+          test "$RELEASE_TAG" = "$(jq -r .tag "$plan")"
+          test "$AUTHORIZED_SHA" = "$(jq -r .sourceDigest "$plan")"
+          bun scripts/publish-release.ts \
+            --directory build/release \
+            --tag "$RELEASE_TAG" \
+            --channel preview \
+            --preview-plan "$plan" \
+            --staging-tag "aidlc-staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --target "$AUTHORIZED_SHA" \
+            --repository "$GITHUB_REPOSITORY" \
+            --changelog "$PWD/CHANGELOG.md" \
+            --expected-assets 13
       - name: Verify uploaded asset inventory
         env:
           GH_TOKEN: ${{ github.token }}
@@ -654,11 +717,16 @@ jobs:
     needs: [validate, release]
     runs-on: ubuntu-latest
     steps:
-      - name: Require stable publication
+      - name: Require publication or an intentional preview skip
         env:
           RELEASE_RESULT: ${{ needs.release.result }}
+          RELEASE_SKIP: ${{ needs.validate.outputs.skip }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
         run: |
           set -euo pipefail
           test "$VALIDATE_RESULT" = success
+          if [ "$RELEASE_SKIP" = true ]; then
+            test "$RELEASE_RESULT" = skipped
+            exit 0
+          fi
           test "$RELEASE_RESULT" = success

--- a/core/tools/aidlc-release.ts
+++ b/core/tools/aidlc-release.ts
@@ -66,12 +66,15 @@ const GITHUB_API_HEADERS = {
   "X-GitHub-Api-Version": "2022-11-28",
 };
 
-function releaseTrust(): { repository: string; workflow: string } {
+function releaseTrust(version: string): { repository: string; workflow: string } {
   const repository =
     process.env.AIDLC_RELEASE_REPOSITORY ?? DEFAULT_RELEASE_REPOSITORY;
+  const workflowName = parseVersion(version).channel === PREVIEW_CHANNEL
+    ? "preview-release.yml"
+    : "release.yml";
   const workflow =
     process.env.AIDLC_RELEASE_WORKFLOW ??
-    `${repository}/.github/workflows/release.yml`;
+    `${repository}/.github/workflows/${workflowName}`;
   return { repository, workflow };
 }
 
@@ -169,7 +172,7 @@ export function verifyReleaseProvenance(
     throw new Error(`release is missing ${PROVENANCE_BUNDLE}`);
   }
   assertMetadataSize(bundle, PROVENANCE_BUNDLE);
-  const trust = releaseTrust();
+  const trust = releaseTrust(manifest.version);
   const configuredGh = process.env.AIDLC_GH_BIN?.trim();
   const gh = configuredGh || "gh";
   let capabilityAvailable = false;

--- a/docs/guide/18-install-and-lifecycle.md
+++ b/docs/guide/18-install-and-lifecycle.md
@@ -125,14 +125,16 @@ the same binary plus all harness runtimes.
 explicit options win. `AIDLC_RELEASE_REPOSITORY` selects both the GitHub
 repository used for default downloads and the repository trusted by provenance
 verification. It defaults to `awslabs/aidlc-workflows`.
-`AIDLC_RELEASE_WORKFLOW` selects the trusted signer workflow and defaults to
-`<AIDLC_RELEASE_REPOSITORY>/.github/workflows/release.yml`. Set these explicitly
-for a fork or mirror, together with its release base URL; changing the download
-URL alone does not change the provenance trust root. `AIDLC_GH_BIN` selects an
-explicit GitHub CLI executable for both installers. If that executable is
-missing or lacks `--signer-workflow`, `--source-ref`, or `--source-digest`,
-provenance verification is skipped while checksum verification remains
-mandatory.
+`AIDLC_RELEASE_WORKFLOW` overrides the trusted signer workflow. By default,
+installers select `<AIDLC_RELEASE_REPOSITORY>/.github/workflows/release.yml`
+for stable versions and
+`<AIDLC_RELEASE_REPOSITORY>/.github/workflows/preview-release.yml` for preview
+versions. Set the override explicitly for a fork or mirror whose workflow path
+differs, together with its release base URL; changing the download URL alone
+does not change the provenance trust root. `AIDLC_GH_BIN` selects an explicit
+GitHub CLI executable for both installers. If that executable is missing or
+lacks `--signer-workflow`, `--source-ref`, or `--source-digest`, provenance
+verification is skipped while checksum verification remains mandatory.
 
 Fork releases need no GitHub App or additional repository. The tag workflow
 publishes to the same repository with its short-lived `GITHUB_TOKEN`. Its final

--- a/docs/reference/09-testing.md
+++ b/docs/reference/09-testing.md
@@ -57,9 +57,9 @@ Distribution coverage is split by contract:
   the cap of at most one published preview per UTC day even after `main`
   advances or a later manual run starts, including overnight publication
   timestamps. Unchanged sources skip; drafts and orphan tags permit retry
-  planning with unoccupied ids. Workflow assertions cover scheduled/manual
-  triggers sharing `release-preview` concurrency, CI gate ordering, and build
-  stamping.
+  planning with unoccupied ids. Workflow assertions cover isolation of stable
+  tags from scheduled/manual previews, shared `release-preview` concurrency,
+  CI gate ancestry, channel-specific provenance signers, and build stamping.
 
 The test runner regenerates all projections under a process lock before test
 discovery, so a fresh clone has no dependency on pre-existing `dist/` bytes.

--- a/docs/reference/11-contributing.md
+++ b/docs/reference/11-contributing.md
@@ -88,15 +88,16 @@ the GitHub Release in this repository with `GITHUB_TOKEN`, and verifies the
 uploaded asset inventory. Never rebuild, repackage, or substitute the
 candidate.
 
-Stable releases start from pushed version tags. The same workflow schedules
-or manually dispatches preview builds from `main`, gates them through callable
-CI, stamps `AIDLC_BUILD_VERSION`, and publishes an annotated-tag prerelease
-that is never "latest". Previews publish at most once per UTC day. Scheduled
-and manual runs share `release-preview` workflow concurrency; each later run
-re-reads releases and skips if that day already has a published preview, even
-if `main` advanced. Unchanged sources also skip. Drafts and orphan tags do not
-consume the daily allowance: the planner can retry with an unoccupied id,
-whose `.N` counter does not authorize extra public releases that day.
+Stable releases start from pushed version tags in `.github/workflows/release.yml`.
+The isolated `.github/workflows/preview-release.yml` workflow schedules or
+manually dispatches preview builds from `main`, gates them through callable CI,
+stamps `AIDLC_BUILD_VERSION`, and publishes an annotated-tag prerelease that is
+never "latest". Previews publish at most once per UTC day. Scheduled and manual
+runs share `release-preview` workflow concurrency; each later run re-reads
+releases and skips if that day already has a published preview, even if `main`
+advanced. Unchanged sources also skip. Drafts and orphan tags do not consume
+the daily allowance: the planner can retry with an unoccupied id, whose `.N`
+counter does not authorize extra public releases that day.
 
 Stable and preview publication use the `release` and `preview` environments
 respectively and serialize independently. The full trust design, including

--- a/docs/reference/19-supply-chain-security.md
+++ b/docs/reference/19-supply-chain-security.md
@@ -1,9 +1,11 @@
 # Release supply chain
 
-AI-DLC releases are created in `awslabs/aidlc-workflows` by
-`.github/workflows/release.yml`. The workflow uses the repository-provided
-`GITHUB_TOKEN`. It does not require a GitHub App, a personal access token, a
-second repository, or repository secrets.
+AI-DLC releases are created in `awslabs/aidlc-workflows` by two isolated
+workflows: `.github/workflows/release.yml` for stable tags and
+`.github/workflows/preview-release.yml` for scheduled or manually dispatched
+previews. Both use the repository-provided `GITHUB_TOKEN`. Neither requires a
+GitHub App, a personal access token, a second repository, or repository
+secrets.
 
 ## Release trigger
 
@@ -45,7 +47,7 @@ after the build and lifecycle jobs pass. GitHub generates build provenance for
 the staged assets. The exported provenance bundle is included as
 `aidlc-release.intoto.jsonl`.
 
-The preview channel schedules `main` daily and accepts manual dispatch, with
+The preview workflow schedules `main` daily and accepts manual dispatch, with
 publication at most once per UTC day for both triggers combined. Scheduled
 and manual runs serialize through the `release-preview` workflow concurrency
 group without cancelling the active run. Each later run re-reads the release
@@ -71,17 +73,20 @@ creates an annotated tag that records the source repository and commit, then
 publishes the draft as a prerelease with `make_latest: false`; stable
 `latest/download` discovery therefore remains unchanged.
 
-The final publication job selects the protected `release` environment for
-stable tags and the unattended `preview` environment for preview runs. The
-preview environment must keep the same `main` deployment policy but no
-required reviewers; merge approval plus callable CI are its human and
-deterministic gates. Stable runs use a separate concurrency group.
+Stable and preview publication use the protected `release` and unattended
+`preview` environments respectively. The preview environment must keep the
+same `main` deployment policy but no required reviewers; merge approval plus
+callable CI are its human and deterministic gates. Stable runs use a separate
+concurrency group. Preview publication also requires immutable releases to be
+enabled for the repository; the preview workflow fails before the expensive
+gate and build jobs when that repository setting is disabled.
 
 When a compatible GitHub CLI is available, installers verify `checksums.txt`
 against that bundle and bind verification to:
 
 - `awslabs/aidlc-workflows`;
-- `.github/workflows/release.yml`;
+- `.github/workflows/release.yml` for stable versions or
+  `.github/workflows/preview-release.yml` for preview versions;
 - the version tag for stable releases or `refs/heads/main` for previews;
 - the exact source commit from `version.json`.
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,11 +65,7 @@ $releaseRepository = if ($env:AIDLC_RELEASE_REPOSITORY) {
 } else {
   'awslabs/aidlc-workflows'
 }
-$releaseWorkflow = if ($env:AIDLC_RELEASE_WORKFLOW) {
-  $env:AIDLC_RELEASE_WORKFLOW
-} else {
-  "$releaseRepository/.github/workflows/release.yml"
-}
+$releaseWorkflow = $env:AIDLC_RELEASE_WORKFLOW
 
 function Write-Result {
   [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
@@ -277,6 +273,14 @@ try {
   if ($manifest.schemaVersion -ne 1 -or $manifest.version -cnotmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-preview\.[0-9]{8}\.[1-9][0-9]*)?(?![\s\S])') {
     Stop-Install -Code 4 -Status 'failed' `
       -Message 'version.json has an invalid schema or version'
+  }
+  if (-not $releaseWorkflow) {
+    $workflowName = if ($manifest.version -match '-preview\.') {
+      'preview-release.yml'
+    } else {
+      'release.yml'
+    }
+    $releaseWorkflow = "$releaseRepository/.github/workflows/$workflowName"
   }
   $ghPath = $env:AIDLC_GH_BIN
   if (-not $ghPath) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 RELEASE_REPOSITORY=${AIDLC_RELEASE_REPOSITORY:-awslabs/aidlc-workflows}
 BASE_URL=${AIDLC_RELEASE_BASE_URL:-https://github.com/$RELEASE_REPOSITORY/releases}
-RELEASE_WORKFLOW=${AIDLC_RELEASE_WORKFLOW:-$RELEASE_REPOSITORY/.github/workflows/release.yml}
+RELEASE_WORKFLOW=${AIDLC_RELEASE_WORKFLOW:-}
 GH_BIN=${AIDLC_GH_BIN:-}
 PROVENANCE_VERIFIER_AVAILABLE=0
 VERSION=
@@ -352,6 +352,16 @@ for metadata in version.json checksums.txt aidlc-release.intoto.jsonl; do
     fail 4 failed "$metadata exceeds the 1 MiB metadata limit"
 done
 
+candidate_version=$(sed -n 's/.*"version":[[:space:]]*"\([0-9][0-9A-Za-z.-]*\)".*/\1/p' "$TMP/version.json" | head -n 1)
+printf '%s\n' "$candidate_version" |
+  grep -Eq "$VERSION_PATTERN" ||
+  fail 4 failed "version.json has no valid version."
+if [ -z "$RELEASE_WORKFLOW" ]; then
+  case "$candidate_version" in
+    *-preview.*) RELEASE_WORKFLOW="$RELEASE_REPOSITORY/.github/workflows/preview-release.yml" ;;
+    *) RELEASE_WORKFLOW="$RELEASE_REPOSITORY/.github/workflows/release.yml" ;;
+  esac
+fi
 requested_version=$VERSION
 if [ -z "$GH_BIN" ]; then
   GH_BIN=$(command -v gh 2>/dev/null || true)
@@ -384,10 +394,6 @@ actual_manifest=$(sha256_file "$TMP/version.json")
 [ "$actual_manifest" = "$expected_manifest" ] || {
   fail 4 failed "Checksum mismatch for version.json."
 }
-candidate_version=$(sed -n 's/.*"version":[[:space:]]*"\([0-9][0-9A-Za-z.-]*\)".*/\1/p' "$TMP/version.json" | head -n 1)
-printf '%s\n' "$candidate_version" |
-  grep -Eq "$VERSION_PATTERN" ||
-  fail 4 failed "version.json has no valid version."
 source_ref=$(sed -n 's/.*"sourceRef":[[:space:]]*"\([^"]*\)".*/\1/p' "$TMP/version.json" | head -n 1)
 source_digest=$(sed -n 's/.*"sourceDigest":[[:space:]]*"\([a-f0-9]*\)".*/\1/p' "$TMP/version.json" | head -n 1)
 case "$candidate_version" in

--- a/scripts/plan-preview-release.ts
+++ b/scripts/plan-preview-release.ts
@@ -154,6 +154,7 @@ function newestPublishedPreviewVersion(releases: readonly unknown[]): string | n
 export async function previewSourceDigest(
   client: ApiClient,
   repository: string,
+  sourceRepository: string,
   version: string,
 ): Promise<string | null> {
   const ref = await client.json(`repos/${repository}/git/ref/tags/v${version}`);
@@ -174,7 +175,9 @@ export async function previewSourceDigest(
   const message = tag.value && typeof tag.value === "object" && "message" in tag.value
     ? tag.value.message
     : null;
-  return typeof message === "string" ? parsePreviewTagSource(message)?.digest ?? null : null;
+  if (typeof message !== "string") return null;
+  const source = parsePreviewTagSource(message);
+  return source?.repository === sourceRepository ? source.digest : null;
 }
 
 export function nextPreviewVersion(
@@ -304,7 +307,12 @@ export async function planPreviewRelease(options: {
   }
   const newest = newestPublishedPreviewVersion(releases);
   const previousSourceDigest = newest
-    ? await previewSourceDigest(options.client, options.repository, newest)
+    ? await previewSourceDigest(
+        options.client,
+        options.repository,
+        options.sourceRepository,
+        newest,
+      )
     : null;
   if (previousSourceDigest && previousSourceDigest === options.sourceDigest) {
     return { skip: true, reason: "unchanged-source", version: null, previousSourceDigest, plan: null };

--- a/tests/fixtures/bin/gh.ts
+++ b/tests/fixtures/bin/gh.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 const args = process.argv.slice(2);
 if (
@@ -27,9 +28,16 @@ const repository = valueAfter("--repo");
 const signerWorkflow = valueAfter("--signer-workflow");
 const expectedRepository =
   process.env.AIDLC_RELEASE_REPOSITORY?.trim() || "awslabs/aidlc-workflows";
+const manifestPath = join(dirname(args[2]), "version.json");
+const manifestVersion = existsSync(manifestPath)
+  ? (JSON.parse(readFileSync(manifestPath, "utf-8")) as { version?: string }).version
+  : undefined;
+const expectedWorkflowName = manifestVersion?.includes("-preview.")
+  ? "preview-release.yml"
+  : "release.yml";
 const expectedWorkflow =
   process.env.AIDLC_RELEASE_WORKFLOW?.trim() ||
-  `${expectedRepository}/.github/workflows/release.yml`;
+  `${expectedRepository}/.github/workflows/${expectedWorkflowName}`;
 if (
   !existsSync(args[2]) ||
   !bundle ||

--- a/tests/unit/t244-install-management.test.ts
+++ b/tests/unit/t244-install-management.test.ts
@@ -54,6 +54,12 @@ const LIFECYCLE = join(REPO_ROOT, "core", "tools", "aidlc-lifecycle.ts");
 const INSTALL_SH = join(REPO_ROOT, "scripts", "install.sh");
 const INSTALL_PS1 = join(REPO_ROOT, "scripts", "install.ps1");
 const RELEASE_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "release.yml");
+const PREVIEW_RELEASE_WORKFLOW = join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "preview-release.yml",
+);
 const V1_RELEASE_DISPATCH_WORKFLOW = join(
   REPO_ROOT,
   ".github",
@@ -1908,6 +1914,7 @@ describe("t244 Windows and completion release surfaces", () => {
 
   test("release workflow keeps actions pinned, lints installers, and regenerates before consumers", () => {
     const workflow = readFileSync(RELEASE_WORKFLOW, "utf-8");
+    const previewWorkflow = readFileSync(PREVIEW_RELEASE_WORKFLOW, "utf-8");
     const parsed = Bun.YAML.parse(workflow) as {
       permissions?: Record<string, string>;
       jobs: Record<string, {
@@ -1939,9 +1946,11 @@ describe("t244 Windows and completion release surfaces", () => {
     // Third-party actions are pinned to a full commit SHA. A same-repository
     // reusable workflow (`./.github/workflows/...`) is referenced by path and
     // resolves to the commit already being run, so it carries no ref to pin.
-    const actionRefs = [...workflow.matchAll(
-      /^\s*(?:-\s+)?uses:\s+([^\s#]+)(?:\s+#.*)?$/gm,
-    )].map((match) => match[1]);
+    const actionRefs = [workflow, previewWorkflow].flatMap(
+      (workflowText) =>
+        [...workflowText.matchAll(/^\s*(?:-\s+)?uses:\s+([^\s#]+)(?:\s+#.*)?$/gm)]
+          .map((match) => match[1]),
+    );
     expect(actionRefs.length).toBeGreaterThan(0);
     for (const ref of actionRefs) {
       if (ref.startsWith("./.github/workflows/")) continue;
@@ -2329,9 +2338,7 @@ describe("t244 Windows and completion release surfaces", () => {
     };
     expect(parsed.jobs.release.needs).toEqual(["validate", "publish"]);
     expect(parsed.jobs.release.permissions).toEqual({ contents: "write" });
-    expect(parsed.jobs.release.environment).toBe(
-      `\${{ needs.validate.outputs.channel == 'preview' && 'preview' || 'release' }}`,
-    );
+    expect(parsed.jobs.release.environment).toBe("release");
     const release = workflowJob(workflow, "release");
     expect(release).toContain(`GH_TOKEN: \${{ github.token }}`);
     expect(release).toContain('gh release create "$RELEASE_TAG" build/release/*');

--- a/tests/unit/t330-release-channel-grammar.test.ts
+++ b/tests/unit/t330-release-channel-grammar.test.ts
@@ -38,8 +38,8 @@ const LIFECYCLE = join(REPO_ROOT, "core", "tools", "aidlc-lifecycle.ts");
 const INSTALL_SH = readFileSync(join(REPO_ROOT, "scripts", "install.sh"), "utf-8");
 const INSTALL_PS1 = readFileSync(join(REPO_ROOT, "scripts", "install.ps1"), "utf-8");
 const RUNTIME_PATHS = readFileSync(join(REPO_ROOT, "core", "tools", "aidlc-runtime-paths.ts"), "utf-8");
-const RELEASE_WORKFLOW = readFileSync(
-  join(REPO_ROOT, ".github", "workflows", "release.yml"),
+const PREVIEW_RELEASE_WORKFLOW = readFileSync(
+  join(REPO_ROOT, ".github", "workflows", "preview-release.yml"),
   "utf-8",
 );
 const [MAJOR, MINOR, PATCH] = AIDLC_VERSION.split(".").map(Number);
@@ -241,13 +241,13 @@ describe("t330 release version-id grammar", () => {
         expect(regex.test(value), `install.ps1 ${context} ${JSON.stringify(value)}`).toBe(false);
       }
     }
-    const lifecycle = /\\\\versions\\\\([^']+)\\\\aidlc\\\.exe\$'/.exec(RELEASE_WORKFLOW)?.[1];
+    const lifecycle = /\\\\versions\\\\([^']+)\\\\aidlc\\\.exe\$'/.exec(PREVIEW_RELEASE_WORKFLOW)?.[1];
     expect(lifecycle).toBeDefined();
     const pointer = new RegExp(`^${lifecycle}$`);
     expect(pointer.test("2.7.2")).toBe(true);
     expect(pointer.test("2.7.2-preview.20260903.1")).toBe(true);
     expect(pointer.test("2.7.2-rc.1")).toBe(false);
-    expect(RELEASE_WORKFLOW).toContain(
+    expect(PREVIEW_RELEASE_WORKFLOW).toContain(
       `sed -n 's/.*"version":[[:space:]]*"\\([0-9][0-9A-Za-z.-]*\\)".*/\\1/p'`,
     );
   });

--- a/tests/unit/t332-preview-release-pipeline.test.ts
+++ b/tests/unit/t332-preview-release-pipeline.test.ts
@@ -30,7 +30,8 @@ import {
 import { publishRelease } from "../../scripts/publish-release.ts";
 
 const REPO_ROOT = join(fileURLToPath(new URL("../..", import.meta.url)));
-const RELEASE_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "release.yml");
+const STABLE_RELEASE_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "release.yml");
+const PREVIEW_RELEASE_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "preview-release.yml");
 const CI_WORKFLOW = join(REPO_ROOT, ".github", "workflows", "ci.yml");
 
 const [MAJOR, MINOR, PATCH] = AIDLC_VERSION.split(".").map(Number);
@@ -239,7 +240,7 @@ function servePublishMock(
 type PlanMockOptions = {
   releases: MockRelease[];
   tags: string[];
-  annotated: Record<string, { source: string } | "lightweight">;
+  annotated: Record<string, { source: string; repository?: string } | "lightweight">;
   requests?: string[];
 };
 
@@ -276,7 +277,7 @@ function servePlanMock(options: PlanMockOptions): string {
         return json({
           message: previewTagMessage({
             version: entry[0].slice(1),
-            sourceRepository: "owner/source",
+            sourceRepository: entry[1].repository ?? "owner/source",
             sourceDigest: entry[1].source,
           }),
           object: { type: "commit", sha: TARGET },
@@ -877,37 +878,44 @@ describe("t332 preview publication pipeline", () => {
     });
   });
 
-  test("a lightweight or foreign previous preview never triggers a skip", async () => {
-    const history = sourceHistory();
-    const previous = `v${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260902.1`;
-    const baseUrl = servePlanMock({
-      releases: [{ tag_name: previous, prerelease: true, draft: false }],
-      tags: [previous],
-      annotated: { [previous]: "lightweight" },
-    });
-    const planned = await planPreviewRelease({
-      client: githubApiClient(baseUrl, undefined),
-      repository: "owner/repo",
-      sourceRepository: "owner/source",
-      sourceDigest: history.first,
-      cwd: history.cwd,
-      date: "20260904",
-    });
-    expect(planned.skip).toBe(false);
-    expect(planned.version).toBe(`${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260904.1`);
-    expect(planned.plan?.previousSourceDigest).toBeNull();
-    expect(nextPreviewVersion([], AIDLC_VERSION, "20260904")).toBe(
-      `${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260904.1`,
-    );
-    expect(nextPreviewVersion(
-      [`${NEXT_STABLE}-${PREVIEW_CHANNEL}.20260904.3`, `${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260903.7`],
-      AIDLC_VERSION,
-      "20260904",
-    )).toBe(`${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260904.4`);
-  });
+  test.each(["lightweight", "foreign"] as const)(
+    "a %s previous preview never triggers a skip",
+    async (kind) => {
+      const history = sourceHistory();
+      const previous = `v${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260902.1`;
+      const baseUrl = servePlanMock({
+        releases: [{ tag_name: previous, prerelease: true, draft: false }],
+        tags: [previous],
+        annotated: {
+          [previous]: kind === "lightweight"
+            ? "lightweight"
+            : { source: history.first, repository: "other/source" },
+        },
+      });
+      const planned = await planPreviewRelease({
+        client: githubApiClient(baseUrl, undefined),
+        repository: "owner/repo",
+        sourceRepository: "owner/source",
+        sourceDigest: history.first,
+        cwd: history.cwd,
+        date: "20260904",
+      });
+      expect(planned.skip).toBe(false);
+      expect(planned.version).toBe(`${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260904.1`);
+      expect(planned.plan?.previousSourceDigest).toBeNull();
+      expect(nextPreviewVersion([], AIDLC_VERSION, "20260904")).toBe(
+        `${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260904.1`,
+      );
+      expect(nextPreviewVersion(
+        [`${NEXT_STABLE}-${PREVIEW_CHANNEL}.20260904.3`, `${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260903.7`],
+        AIDLC_VERSION,
+        "20260904",
+      )).toBe(`${AIDLC_VERSION}-${PREVIEW_CHANNEL}.20260904.4`);
+    },
+  );
 
   test("a queued older checkout can skip today's preview but cannot become a new publication candidate", async () => {
-    const workflow = Bun.YAML.parse(readFileSync(RELEASE_WORKFLOW, "utf-8")) as {
+    const workflow = Bun.YAML.parse(readFileSync(PREVIEW_RELEASE_WORKFLOW, "utf-8")) as {
       jobs: { validate: { steps: Array<{ id?: string; run?: string }> } };
     };
     const validateScript = workflow.jobs.validate.steps.find((step) => step.id === "validate")?.run;
@@ -949,7 +957,7 @@ describe("t332 preview publication pipeline", () => {
     });
     expect(validated.status, validated.stdout + validated.stderr).toBe(0);
     const validationRows = readFileSync(validationOutput, "utf-8");
-    expect(validationRows).toBe(`channel=preview\ntag=\nsha=${history.first}\n`);
+    expect(validationRows).toBe(`sha=${history.first}\n`);
     const authorizedSha = /^sha=(.+)$/m.exec(validationRows)?.[1];
     expect(git(history.cwd, ["rev-parse", "HEAD"])).toBe(history.first);
     expect(git(history.cwd, ["rev-parse", "origin/main"])).toBe(history.third);
@@ -984,109 +992,158 @@ describe("t332 preview publication pipeline", () => {
     }
   }, 45_000);
 
-  test("the release workflow schedules previews, gates them on CI, and stamps the build", () => {
-    const workflow = readFileSync(RELEASE_WORKFLOW, "utf-8");
-    const ci = Bun.YAML.parse(readFileSync(CI_WORKFLOW, "utf-8")) as { on: Record<string, unknown> };
-    expect(Object.keys(ci.on)).toContain("workflow_call");
-    const parsed = Bun.YAML.parse(workflow) as {
-      on: {
-        push: { tags: string[] };
-        schedule?: Array<{ cron: string }>;
-        workflow_dispatch: unknown;
-      };
-      concurrency?: { group?: string; "cancel-in-progress"?: boolean };
-      jobs: Record<string, {
-        needs?: string | string[];
+  test("stable and preview releases use isolated, fully gated DAGs", () => {
+    type WorkflowJob = {
+      needs?: string | string[];
+      if?: string;
+      environment?: string;
+      permissions?: Record<string, string>;
+      uses?: string;
+      env?: Record<string, string>;
+      outputs?: Record<string, string>;
+      steps?: Array<{
+        name?: string;
         if?: string;
-        environment?: string;
-        permissions?: Record<string, string>;
-        uses?: string;
+        run?: string;
         env?: Record<string, string>;
-        outputs?: Record<string, string>;
-        steps?: Array<{ name?: string; if?: string; run?: string; env?: Record<string, string> }>;
       }>;
     };
-    const cron = parsed.on.schedule?.[0]?.cron ?? "";
+    type Workflow = {
+      on: Record<string, unknown> & {
+        push?: { tags: string[] };
+        schedule?: Array<{ cron: string }>;
+      };
+      concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+      jobs: Record<string, WorkflowJob>;
+    };
+    const stableText = readFileSync(STABLE_RELEASE_WORKFLOW, "utf-8");
+    const previewText = readFileSync(PREVIEW_RELEASE_WORKFLOW, "utf-8");
+    const stable = Bun.YAML.parse(stableText) as Workflow;
+    const preview = Bun.YAML.parse(previewText) as Workflow;
+    const ci = Bun.YAML.parse(readFileSync(CI_WORKFLOW, "utf-8")) as {
+      on: Record<string, unknown>;
+    };
+
+    expect(Object.keys(ci.on)).toContain("workflow_call");
+    expect(Object.keys(stable.on)).toEqual(["push"]);
+    expect(stable.on.push?.tags).toEqual(["v*.*.*", "!v*-preview.*"]);
+    expect(stable.concurrency).toEqual({
+      group: "release-stable",
+      "cancel-in-progress": false,
+    });
+    expect(stable.jobs.gate).toBeUndefined();
+    expect(stable.jobs.verify.needs).toBe("validate");
+    expect(stable.jobs.validate.outputs).toEqual({
+      tag: `\${{ steps.validate.outputs.tag }}`,
+      sha: `\${{ steps.validate.outputs.sha }}`,
+    });
+    expect(stable.jobs.release.environment).toBe("release");
+    expect(stable.jobs["release-result"].needs).toEqual(["validate", "release"]);
+    expect(stableText).not.toContain("plan-preview-release.ts");
+    expect(stableText).not.toContain("AIDLC_BUILD_VERSION");
+    expect(stableText).not.toContain("./.github/workflows/ci.yml");
+
+    expect(Object.keys(preview.on).sort()).toEqual(["schedule", "workflow_dispatch"]);
+    const cron = preview.on.schedule?.[0]?.cron ?? "";
     expect(cron).toMatch(/^\d{1,2} \d{1,2} \* \* \*$/);
     expect(cron.split(" ")[0]).not.toBe("0");
-    expect(parsed.on.workflow_dispatch).toBeDefined();
-    expect(parsed.on.push.tags).toContain("v*.*.*");
-    expect(parsed.on.push.tags).toContain("!v*-preview.*");
-    expect(parsed.concurrency?.group).toBe(
-      `release-\${{ github.event_name == 'push' && 'stable' || 'preview' }}`,
-    );
-    expect(parsed.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(preview.concurrency).toEqual({
+      group: "release-preview",
+      "cancel-in-progress": false,
+    });
+    expect(preview.jobs.gate).toMatchObject({
+      needs: "validate",
+      uses: "./.github/workflows/ci.yml",
+    });
+    expect(preview.jobs.gate.if).toContain("needs.validate.outputs.skip");
+    expect(preview.jobs.verify.needs).toEqual(["validate", "gate"]);
+    expect(preview.jobs.test_smoke.needs).toEqual(["validate", "gate"]);
+    expect(preview.jobs.test_unit.needs).toEqual(["validate", "gate"]);
+    expect(preview.jobs.test_deep.needs).toEqual(["validate", "gate"]);
+    expect(preview.jobs.test.needs).toEqual([
+      "validate",
+      "test_smoke",
+      "test_unit",
+      "test_deep",
+    ]);
+    expect(preview.jobs.test.if).toContain("needs.validate.outputs.skip");
+    expect(preview.jobs.release.environment).toBe("preview");
+    expect(preview.jobs.release.permissions).toEqual({ contents: "write" });
 
-    const jobs = parsed.jobs;
-    for (const [name, job] of Object.entries(jobs)) {
-      const needs = job.needs === undefined ? [] : Array.isArray(job.needs) ? job.needs : [job.needs];
-      for (const dependency of needs) expect(jobs[dependency], `${name} needs ${dependency}`).toBeDefined();
+    const dependencies = (job: WorkflowJob): string[] =>
+      job.needs === undefined ? [] : Array.isArray(job.needs) ? job.needs : [job.needs];
+    for (const [name, job] of Object.entries(preview.jobs)) {
+      for (const dependency of dependencies(job)) {
+        expect(preview.jobs[dependency], `${name} needs ${dependency}`).toBeDefined();
+      }
     }
-    const visiting = new Set<string>();
-    const done = new Set<string>();
-    const visit = (name: string): void => {
-      if (done.has(name)) return;
-      expect(visiting.has(name), `cycle through ${name}`).toBe(false);
-      visiting.add(name);
-      const needs = jobs[name].needs;
-      for (const dependency of needs === undefined ? [] : Array.isArray(needs) ? needs : [needs]) visit(dependency);
-      visiting.delete(name);
-      done.add(name);
+    const ancestors = (name: string, seen = new Set<string>()): Set<string> => {
+      for (const dependency of dependencies(preview.jobs[name])) {
+        if (seen.has(dependency)) continue;
+        seen.add(dependency);
+        ancestors(dependency, seen);
+      }
+      return seen;
     };
-    for (const name of Object.keys(jobs)) visit(name);
-
-    expect(jobs.gate.uses).toBe("./.github/workflows/ci.yml");
-    expect(jobs.gate.needs).toBe("validate");
-    expect(jobs.gate.if).toContain(`needs.validate.outputs.channel == '${PREVIEW_CHANNEL}'`);
-    expect(jobs.gate.if).toContain("needs.validate.outputs.skip != 'true'");
-    expect(jobs["gate-result"].needs).toEqual(["validate", "gate"]);
-    expect(jobs["gate-result"].if).toContain("needs.gate.result == 'success'");
-    expect(jobs["gate-result"].if).toContain("needs.validate.outputs.skip != 'true'");
-    expect(jobs.verify.needs).toEqual(["validate", "gate-result"]);
-    expect(jobs.verify.if).toContain("!cancelled()");
-    expect(jobs.verify.if).toContain("needs.validate.result == 'success'");
-    expect(jobs.verify.if).toContain("needs.gate-result.result == 'success'");
-    expect(jobs.publish.needs).toEqual(["validate", "musl-smoke", "windows-lifecycle", "unix-lifecycle"]);
-    expect(jobs.release.needs).toEqual(["validate", "publish"]);
-    expect(jobs.release.environment).toBe(
-      `\${{ needs.validate.outputs.channel == 'preview' && 'preview' || 'release' }}`,
-    );
-    expect(jobs.release.permissions).toEqual({ contents: "write" });
-    expect(jobs["release-result"].needs).toEqual(["validate", "release"]);
-    expect(jobs["release-result"].if).toContain("!cancelled()");
-    const releaseResult = jobs["release-result"].steps?.find(
-      (step) => step.name === "Require publication or an intentional preview skip",
-    );
-    expect(releaseResult?.run).toContain('test "$VALIDATE_RESULT" = success');
-    expect(releaseResult?.run).toContain(
-      '[ "$RELEASE_CHANNEL" = preview ] && [ "$RELEASE_SKIP" = true ]',
-    );
-    expect(releaseResult?.run).toContain('test "$RELEASE_RESULT" = success');
-
-    for (const key of ["channel", "tag", "sha", "skip", "preview_version", "preview_plan"]) {
-      expect(jobs.validate.outputs?.[key], key).toBeDefined();
+    for (const name of [
+      "verify",
+      "test_smoke",
+      "test_unit",
+      "test_deep",
+      "test",
+      "native-smoke",
+      "build",
+      "musl-smoke",
+      "stage-release",
+      "windows-lifecycle",
+      "unix-lifecycle",
+      "publish",
+      "release",
+    ]) {
+      expect(ancestors(name).has("gate"), `${name} must descend from the CI gate`).toBe(true);
     }
-    const plan = jobs.validate.steps?.find((step) => step.name === "Plan preview publication");
-    expect(plan?.if).toBe(`steps.validate.outputs.channel == '${PREVIEW_CHANNEL}'`);
+
+    for (const key of ["tag", "sha", "skip", "preview_version", "preview_plan"]) {
+      expect(preview.jobs.validate.outputs?.[key], key).toBeDefined();
+    }
+    expect(preview.jobs.validate.outputs?.channel).toBeUndefined();
+    const plan = preview.jobs.validate.steps?.find(
+      (step) => step.name === "Plan preview publication",
+    );
     expect(plan?.run).toContain("bun scripts/plan-preview-release.ts");
-    expect(plan?.run).toContain('--source-digest "$AUTHORIZED_SHA"');
+    expect(plan?.run).toContain("--source-digest \"$AUTHORIZED_SHA\"");
+    const immutable = preview.jobs.validate.steps?.find(
+      (step) => step.name === "Require immutable preview releases",
+    );
+    expect(immutable?.if).toContain("steps.plan.outputs.skip");
+    expect(immutable?.run).toContain("immutable-releases");
 
     const stamp = `\${{ needs.validate.outputs.preview_version }}`;
-    expect(jobs.build.env?.AIDLC_BUILD_VERSION).toBe(stamp);
-    expect(jobs["stage-release"].env?.AIDLC_BUILD_VERSION).toBe(stamp);
-    const smoke = jobs["native-smoke"].steps ?? [];
-    expect(smoke.find((step) => step.run === "bun scripts/package.ts")?.env?.AIDLC_BUILD_VERSION).toBe(stamp);
-    expect(smoke.find((step) => step.run?.includes("t238-build-binaries"))?.env?.AIDLC_BUILD_VERSION).toBe(stamp);
-    expect(jobs.verify.env).toBeUndefined();
+    expect(preview.jobs.build.env?.AIDLC_BUILD_VERSION).toBe(stamp);
+    expect(preview.jobs["stage-release"].env?.AIDLC_BUILD_VERSION).toBe(stamp);
+    const smoke = preview.jobs["native-smoke"].steps ?? [];
+    expect(smoke.find((step) => step.run === "bun scripts/package.ts")?.env?.AIDLC_BUILD_VERSION)
+      .toBe(stamp);
+    expect(smoke.find((step) => step.run?.includes("t238-build-binaries"))?.env?.AIDLC_BUILD_VERSION)
+      .toBe(stamp);
+    expect(preview.jobs.verify.env).toBeUndefined();
 
-    const preview = jobs.release.steps?.find((step) => step.name === "Create preview GitHub Release");
-    expect(preview?.if).toBe(`needs.validate.outputs.channel == '${PREVIEW_CHANNEL}'`);
-    expect(preview?.run).toContain("bun scripts/publish-release.ts");
-    expect(preview?.run).toContain("--channel preview");
-    expect(preview?.run).toContain('--preview-plan "$plan"');
-    expect(preview?.run).toContain("--expected-assets 13");
-    const stable = jobs.release.steps?.find((step) => step.name === "Create stable GitHub Release");
-    expect(stable?.if).toBe(`needs.validate.outputs.channel == '${STABLE_CHANNEL}'`);
-    expect(stable?.run).toContain("--generate-notes");
+    const publish = preview.jobs.release.steps?.find(
+      (step) => step.name === "Create preview GitHub Release",
+    );
+    expect(publish?.if).toBeUndefined();
+    expect(publish?.run).toContain("bun scripts/publish-release.ts");
+    expect(publish?.run).toContain("--channel preview");
+    expect(publish?.run).toContain("--preview-plan \"$plan\"");
+    expect(publish?.run).toContain("--expected-assets 13");
+    expect(previewText).toContain(
+      "awslabs/aidlc-workflows/.github/workflows/preview-release.yml",
+    );
+    expect(preview.jobs["release-result"].needs).toEqual(["validate", "release"]);
+    const result = preview.jobs["release-result"].steps?.find(
+      (step) => step.name === "Require publication or an intentional preview skip",
+    );
+    expect(result?.run).toContain("[ \"$RELEASE_SKIP\" = true ]");
+    expect(result?.run).toContain("test \"$RELEASE_RESULT\" = success");
   });
 });


### PR DESCRIPTION
## Summary

- restore `.github/workflows/release.yml` to a stable-tag-only DAG based on the proven v2.8.1 release structure, while retaining strict tag/source validation, the full build and lifecycle gates, provenance, protected publication, and a terminal result check
- move scheduled and manually dispatched previews into `.github/workflows/preview-release.yml`, preserving daily planning, retry-safe counters, unchanged-source deduplication, callable CI, every release test/build/lifecycle gate, `AIDLC_BUILD_VERSION`, main-source rechecks, attestations, and the custom preview publisher
- select the trusted provenance signer from the closed stable/preview version grammar in both installers and the runtime release client; foreign annotated preview tags can no longer suppress a publication
- document the isolated workflows and extend regression coverage for gate ancestry, skip behavior, signer selection, and repository-bound preview deduplication

This is an internal release-pipeline correction, so it intentionally does not bump the product version or changelog.

## Repository setup required for previews

Before a preview can publish:

- enable immutable releases for this repository; the new preview preflight intentionally fails before callable CI and expensive release jobs while the setting is disabled
- create/configure the `preview` environment for `main` without required reviewers, keeping preview publication independent from the protected stable `release` environment

Stable tag releases do not depend on either preview prerequisite.

## Validation

- `bun test tests/unit/t332-preview-release-pipeline.test.ts` (19 passed)
- `bun test tests/unit/t330-release-channel-grammar.test.ts` (7 passed)
- focused `t243` installer/provenance cases (3 passed)
- focused `t244` installer/workflow cases (3 passed)
- `bun scripts/package.ts --check`
- `bun run typecheck`
- `bun run lint`
- `bash -n scripts/install.sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).