### PR TITLE
feat: add a verification discipline to the two reviewer personas

### DIFF
--- a/core/agents/aidlc-architecture-reviewer-agent.md
+++ b/core/agents/aidlc-architecture-reviewer-agent.md
@@ -47,6 +47,23 @@ If the stage definition lists validation tools, **run them** before writing your
 
 When the dispatch brief says the review is ADVISORY (a single pass whose findings go to the human at the approval gate), keep the evidence-grounding rule above but drop the refute-until-READY posture: this pass is decision support, not a repair loop. Report only findings the human should weigh before approving, ranked by severity, and expect no fix-and-re-review cycle behind you - a Request Changes at the gate is how your findings become revisions. Your verdict line still reads READY or NOT-READY; it informs the human, it does not gate.
 
+## Verification Discipline
+
+- Presentation earns no credit. The lead that produced this design is itself a sub-agent, and it writes fluent, complete-looking prose whether or not the references behind it resolve. A tidy component table or a confident dependency paragraph tells you the author was thorough at writing, not that the pieces fit. Open the file, the ID, the contract line - never grade the description of a thing in place of the thing.
+- Verify before you flag AND before you pass. A finding you have not checked is a question, not a finding; a section you have not checked is not READY, it is unreviewed. Never let the turn budget turn "unread" into "fine".
+- Before declaring a gap, hold at least two readings: the item is missing, or it lives under a different name, or a passed contract already pins it. Rule the alternatives out with a lookup, then report the gap. A gap that survives that check is a finding; one that does not was a lookup you owed the author.
+- Trace one request end-to-end per artifact under review - entry point, every component boundary it crosses, every failure it can meet - and write down where the trace breaks. A break is a finding; a trace you could not complete is a NOT-READY question.
+- Rank findings by blast radius before writing: what blocks a developer from building, what would fail in production, what is merely unclear. Lead with the first class; never bury a blocker under style remarks.
+
+Before you write the verdict, confirm every line:
+
+- [ ] Every NOT-READY finding names a checkable anchor: an entity or component ID, a file, a contract line, or a validation-tool output.
+- [ ] Every cross-reference in the artifacts under review was resolved or is listed as a broken-reference finding.
+- [ ] Listed validation tools were run and their output is cited, not paraphrased.
+- [ ] No finding rests on architectural taste alone; each one names what breaks.
+- [ ] No sibling-unit path was opened beyond the single owning-file spot-check the review scope allows.
+- [ ] Concerns you ran out of turns to verify appear as questions in the findings list, not as verdict-bearing findings.
+
 ## Key Principles
 
 - Cross-reference everything within the artifacts under review and the contracts you were passed. If it's referenced there, it must exist there or in the passed contracts. If it exists in the artifacts under review, it should be referenced. Do not flag shared-contract entries that belong to other units as unreferenced - the contracts cover the whole system.

--- a/core/agents/aidlc-product-lead-agent.md
+++ b/core/agents/aidlc-product-lead-agent.md
@@ -53,6 +53,23 @@ produce this source register or inline citation format.
 
 When the dispatch brief says the review is ADVISORY (a single pass whose findings go to the human at the approval gate), keep the evidence-grounding rule above but drop the refute-until-READY posture: this pass is decision support, not a repair loop. Report only findings the human should weigh before approving, ranked by severity, and expect no fix-and-re-review cycle behind you - a Request Changes at the gate is how your findings become revisions. Your verdict line still reads READY or NOT-READY; it informs the human, it does not gate.
 
+## Verification Discipline
+
+- Presentation earns no credit. The lead that produced these stories is itself a sub-agent, and it writes fluent, complete-looking prose whether or not a criterion behind it can be tested. A filled-in traceability matrix tells you the author was thorough at filling in tables, not that every requirement is covered. Read the criterion and ask what test proves it; look up the requirement the story claims to cover.
+- Verify before you flag AND before you pass. A gap you have not checked is a question, not a finding; a story you have not read is not READY, it is unreviewed. Never let the turn budget turn "unread" into "fine".
+- Before declaring something missing, hold at least two readings: it is absent, or it lives under another story or requirement, or the Q&A already settles it. Rule the alternatives out with a lookup, then report the gap. Charging the author with an omission you could have resolved yourself is a wasted revision round.
+- Walk one user journey per artifact under review - the happy path, then the first failure the user can hit - and write down where the stories stop describing what happens. A silent step is a finding; a journey you could not complete is a NOT-READY question.
+- Rank findings by cost to the customer before writing: what a developer would build wrong, what QA could not test, what is merely unclear. Lead with the first class; never bury an untestable criterion under wording remarks.
+
+Before you write the verdict, confirm every line:
+
+- [ ] Every NOT-READY finding names a checkable anchor: a story ID, a requirement ID, a criterion, a Q&A answer, or a stage-definition section.
+- [ ] Every requirement was traced to a story and every story to a requirement, or the orphan is listed as a finding.
+- [ ] Every acceptance criterion was read against the question "could QA write a test from this?", and the ones that fail are listed.
+- [ ] No finding rests on your taste alone; each one names what the customer loses or what engineering cannot build.
+- [ ] Scope additions that arrived disguised as requirements are called out, not silently accepted.
+- [ ] Concerns you ran out of turns to verify appear as questions in the findings list, not as verdict-bearing findings.
+
 ## Key Principles
 
 - You are NOT the builder's friend. You are the customer's advocate.

--- a/docs/harness-engineering/03-adding-an-agent.md
+++ b/docs/harness-engineering/03-adding-an-agent.md
@@ -170,7 +170,11 @@ Mirroring the reference recipe, here is the workflow end to end.
    agents ship it today (see the reviewer personas' `## Turn Budget` section
    for the pairing convention).
    Write the body to match the shipped files' structure (Core Responsibilities,
-   Collaboration, optional Memory Focus, Key Principles).
+   Collaboration, optional Memory Focus, Key Principles). A review-only
+   persona follows the reviewer shape instead (Adversarial Posture, Advisory
+   Dispatch, Verification Discipline, Key Principles, Output Contract, Turn
+   Budget); the shipped reviewers are the reference and unit tests pin the
+   posture, discipline, and budget text.
 2. **Add knowledge files** under `core/knowledge/aidlc-<slug>-agent/` for the
    methodology the persona should load on activation.
 3. **Wire it into stages** — add the slug to the `lead_agent` /

--- a/tests/unit/t338-reviewer-verification-discipline.test.ts
+++ b/tests/unit/t338-reviewer-verification-discipline.test.ts
@@ -1,0 +1,113 @@
+// covers: file:agents/aidlc-architecture-reviewer-agent.md,
+// file:agents/aidlc-product-lead-agent.md
+//
+// Pins the reviewer verification discipline in the two review-only personas.
+// The adversarial contract (t234) fixes the posture - refute, ground findings
+// in evidence - and the turn budget (t279) fixes the cutoff plan. Neither says
+// what the reviewer owes BETWEEN those two: that an unread section cannot count
+// toward READY, that a suspected gap is looked up under its alternative names
+// before it is charged to the author, that findings are ranked by what breaks,
+// and that a pre-verdict checklist is confirmed line by line. Without that
+// text the observed degradation is silent: turns run out, nothing was flagged,
+// and READY is written over material nobody read.
+//
+// Mechanism = none: pure text invariants over authored files plus the shipped
+// dist/claude projection (the other trees come from the same generated source,
+// so one projection pin suffices). A rewording should update these pins
+// deliberately, not drop the discipline.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { REPO_ROOT } from "../harness/fixtures.ts";
+
+const REVIEWERS = [
+  "aidlc-architecture-reviewer-agent.md",
+  "aidlc-product-lead-agent.md",
+] as const;
+
+const corePath = (file: string) => join(REPO_ROOT, "core", "agents", file);
+const distPath = (file: string) =>
+  join(REPO_ROOT, "dist", "claude", ".claude", "agents", file);
+
+const SECTION = "## Verification Discipline";
+
+// The section body: from its heading to the next H2.
+function section(src: string): string {
+  const start = src.indexOf(SECTION);
+  expect(start).toBeGreaterThan(-1);
+  const rest = src.slice(start + SECTION.length);
+  const end = rest.search(/\n## /);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("t338 reviewer verification discipline pins", () => {
+  for (const file of REVIEWERS) {
+    describe(file, () => {
+      const src = readFileSync(corePath(file), "utf-8");
+
+      test("carries the section between Advisory Dispatch and Key Principles", () => {
+        const advisory = src.indexOf("## Advisory Dispatch");
+        const discipline = src.indexOf(SECTION);
+        const principles = src.indexOf("## Key Principles");
+        expect(advisory).toBeGreaterThan(-1);
+        expect(discipline).toBeGreaterThan(advisory);
+        expect(principles).toBeGreaterThan(discipline);
+        // Exactly one such section - a duplicate would split the checklist.
+        expect(src.indexOf(SECTION, discipline + 1)).toBe(-1);
+      });
+
+      test("verify-before-pass: unread material never counts toward READY", () => {
+        const body = section(src);
+        expect(body).toContain("Verify before you flag AND before you pass");
+        expect(body).toContain('Never let the turn budget turn "unread" into "fine"');
+      });
+
+      test("presentation earns no credit: the lead is itself a sub-agent", () => {
+        const body = section(src);
+        expect(body).toContain("Presentation earns no credit");
+        expect(body).toContain("is itself a sub-agent");
+      });
+
+      test("a suspected gap is looked up before it is charged to the author", () => {
+        const body = section(src);
+        expect(body).toContain("hold at least two readings");
+        expect(body).toContain("Rule the alternatives out with a lookup");
+      });
+
+      test("findings are ranked before they are written", () => {
+        const body = section(src);
+        expect(body).toMatch(/Rank findings by .* before writing/);
+        expect(body).toContain("Lead with the first class");
+      });
+
+      test("pre-verdict checklist is a checkbox list of at least six lines", () => {
+        const body = section(src);
+        expect(body).toContain("Before you write the verdict, confirm every line:");
+        const boxes = body.match(/^- \[ \] /gm) ?? [];
+        expect(boxes.length).toBeGreaterThanOrEqual(6);
+        // Every NOT-READY finding needs an anchor - the t234 evidence rule,
+        // restated as a checkbox the reviewer ticks.
+        expect(body).toContain(
+          "- [ ] Every NOT-READY finding names a checkable anchor",
+        );
+        // Unverified concerns route to questions, the same channel the Turn
+        // Budget names when turns run short - the two sections must agree.
+        expect(body).toContain(
+          "appear as questions in the findings list, not as verdict-bearing findings",
+        );
+      });
+
+      test("the pinned adversarial, output-contract, and turn-budget text survives", () => {
+        expect(src).toContain("## Adversarial Posture");
+        expect(src).toContain("## Output Contract");
+        expect(src).toContain("## Turn Budget");
+        expect(src).toContain(`**Reviewer:** ${file.replace(/\.md$/, "")}`);
+      });
+
+      test("shipped dist/claude projection carries the same section", () => {
+        const dist = readFileSync(distPath(file), "utf-8");
+        expect(section(dist)).toBe(section(src));
+      });
+    });
+  }
+});


### PR DESCRIPTION
# Summary

The two review-only personas (`aidlc-architecture-reviewer-agent`, `aidlc-product-lead-agent`) carry an `## Adversarial Posture` (refute; ground every finding in evidence - pinned by t234) and a `## Turn Budget` (plan for the cutoff - pinned by t279), but nothing in between says what the reviewer owes while it works: that an unread section cannot count toward READY, that a suspected gap is looked up under its alternative names before it is charged to the author, that findings are ranked by what breaks, and that a fixed checklist is confirmed before the verdict is written. A grep of `core/agents/` finds no pre-verdict checklist in any persona.

The failure this closes is silent: turns run out, nothing was flagged, and READY is written over material nobody read. Under the adversarial class that burns an iteration on a repair loop that never converges; under the advisory class the human at the gate reads "no findings" as "reviewed".

Closes #1134.

## Changes

* `core/agents/aidlc-architecture-reviewer-agent.md`, `core/agents/aidlc-product-lead-agent.md` - new `## Verification Discipline` section between `## Advisory Dispatch` and `## Key Principles`, voiced per domain (blast radius / end-to-end request trace for the architecture reviewer; customer cost / user-journey walk for the product lead). Five rules plus a six-line pre-verdict checklist. The pinned `## Adversarial Posture`, `## Output Contract`, and `## Turn Budget` text is untouched; frontmatter is untouched.
* `tests/unit/t338-reviewer-verification-discipline.test.ts` - pins the section's placement, its verify-before-pass rule, the lookup-before-charging rule, the ranking rule, the checklist shape (>= 6 checkboxes, anchor line, questions-not-findings line that must agree with `## Turn Budget`), the survival of the t234/t279 text, and byte-equality of the section in the `dist/claude` projection.

Prose only in `core/`; harness-neutral (no harness-dir literal, t146 green). No version bump, badge, or CHANGELOG entry, per the Release Metadata Policy in `AGENTS.md`.

## User experience

Before: a reviewer that ran out of turns with nothing flagged returns READY; the human sees an empty findings list and cannot tell "verified clean" from "unread".

After: the reviewer must record what it did not verify as questions in the findings list, must name a checkable anchor on every NOT-READY finding, and must lead with the finding that blocks a developer or fails in production. The verdict line, the identity marker, and the 60-turn cap are unchanged, so the orchestrator's §12a parse and the audit trail see no difference in shape - only in what the findings contain.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [ ] If this change adds an input to any fingerprint, epoch, or receipt identity, the description names the human-visible change it detects

## Test plan

On `c0eb2921` (2.8.2):

```
bun scripts/package.ts
bun test tests/unit/t338-reviewer-verification-discipline.test.ts   # 16 pass
bun tests/run-tests.ts --filter t209                                # PASS (runner env)
bun test tests/unit/t234-reviewer-adversarial-contract.test.ts \
         tests/unit/t279-reviewer-turn-budget.test.ts \
         tests/unit/t146-core-hygiene.test.ts \
         tests/unit/t04-agent-frontmatter.test.ts \
         tests/unit/t216-agent-tier-projection.test.ts \
         tests/unit/t217-reviewer-read-scope.test.ts                # all pass
bun run lint && bun run typecheck
bun scripts/package.ts --check                                      # deterministic, 7 harnesses
bun tests/run-tests.ts                                              # full default suite running on this branch; result posted below when it finishes
```

The new pin fails without the persona edits: `git stash push -- core/agents && bun test tests/unit/t338-reviewer-verification-discipline.test.ts` reports 14 failures.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
