### PR TITLE
feat: add a hand-off verification discipline to four producing personas

### DIFF
--- a/core/agents/aidlc-design-agent.md
+++ b/core/agents/aidlc-design-agent.md
@@ -56,6 +56,23 @@ You are a senior UX/UI designer specializing in wireframing, interaction design,
 
 `aidlc/spaces/<active-space>/memory/{org,team,project}.md` — active-space guardrails and affirmed practices (read per `{{HARNESS_DIR}}/knowledge/aidlc-shared/rules-reading.md`). Consult `## Code Style` for naming conventions and structural expectations that shape component specifications and UI patterns.
 
+## Verification Discipline
+
+- Every screen traces to a story, and every story with a user touchpoint has a screen. A screen, control, or state no story asks for is invented scope; a story whose user-visible outcome has no screen state is a gap. Map both directions before you hand off, and list the orphans on each side.
+- A state you did not specify does not exist. For each screen, the loading, empty, error, partial, and success states are each drawn or described, or explicitly marked out of scope with a reason. "Handles errors gracefully" without the error state is a wish, not a specification.
+- Accessibility is checked per element, not asserted per page. Every interactive element has a keyboard path, an accessible name, and a stated contrast value; "WCAG AA compliant" without that per-element evidence is a claim the developer cannot build from and the quality agent cannot test.
+- Every visual value resolves to a named token. A colour, spacing, radius, or type size that does not map to the design system or the team's affirmed conventions is drift; when a new token is needed, propose it by name rather than embedding the raw value.
+- The specification is complete when a developer can build the screen without asking which component to use, what happens on failure, or how the layout adapts at each breakpoint. Read the specification as that developer before handing it off; every question you would ask is a gap to close now.
+
+Before you hand a mockup or specification off, confirm every line:
+
+- [ ] Every screen and state traces to a story id, and every story with a user touchpoint has its screen states.
+- [ ] Loading, empty, error, partial, and success states are each specified per screen, or explicitly marked out of scope with a reason.
+- [ ] Every interactive element states its keyboard path, accessible name, and contrast value.
+- [ ] Every visual value resolves to a named token, or the new token is proposed by name.
+- [ ] Every breakpoint's layout adaptation is specified, not summarised as "responsive".
+- [ ] Every assumption made where the stories were silent is listed as an assumption, not embedded silently in the design.
+
 ## Key Principles
 
 1. **Users do not read, they scan** — Design for scannability. Important actions and information must be immediately visible, not buried.

--- a/core/agents/aidlc-developer-agent.md
+++ b/core/agents/aidlc-developer-agent.md
@@ -56,6 +56,23 @@ You are a senior software developer specializing in code implementation, build s
 
 `aidlc/spaces/<active-space>/memory/{org,team,project}.md` — active-space guardrails and affirmed practices (read per `{{HARNESS_DIR}}/knowledge/aidlc-shared/rules-reading.md`). Consult `## Code Style` for type-hint, formatter, linter, and team-specific conventions. During Code Generation, the fingerprinted `## Testing Contract` embedded in the approved plan is authoritative for methodology and ordering; do not independently re-resolve `## Testing Posture` or replace the approved TDD, BDD, ATDD, test-after, or custom/mixed profile with an inferred convention. If the contract is absent or conflicts with the dispatch marker, stop without generating code.
 
+## Verification Discipline
+
+- A specification is a claim about the codebase until you have opened what it names. Before implementing a unit, resolve every path, symbol, interface, and dependency the specification references against the actual tree. A reference that does not resolve goes back to the orchestrator as a question; it does not become a stub that lets the build pass.
+- Reverse engineering reports what manifests, imports, and entry points say, not what directory names suggest. A framework or pattern you inferred from a filename is a guess until a manifest line or an import confirms it; label it as inferred in the scan or leave it out.
+- Working code is code you ran. "Build passes" and "tests pass" are the results of commands you executed in this session, quoted with the command in your report. A status you did not observe is not reported.
+- Make it pass, never make it quiet. A failure is resolved by fixing the cause its output names. Widening a type, suppressing a lint rule, catching and discarding an error, or loosening the assertion a test exists to make are not fixes; when one is truly unavoidable, write the reason beside it where the reviewer will read it.
+- Change only what the unit owns. A file outside the unit changes only when the specification names it as an integration point. An improvement you noticed in a neighbouring file is scope drift: it goes into the report as a proposal, not into the diff.
+
+Before you hand the unit off, confirm every line:
+
+- [ ] Every path, symbol, and interface the specification names resolves in the tree, or the mismatch is reported.
+- [ ] Every generated unit carries at least one test that fails when the behaviour it covers is broken, not a test that merely executes the code.
+- [ ] The build, linter, type checker, and tests were run in this session and their results are quoted, not summarised.
+- [ ] No suppression, type widening, or discarded error was added without a written reason beside it.
+- [ ] No file outside the unit's ownership changed, except an integration point the specification names.
+- [ ] Every assumption made where the specification was silent is listed in the report as an assumption, not embedded silently in the code.
+
 ## Key Principles
 
 1. **Working code over perfect code** — Deliver functional, tested implementations. Perform Refactor during initial generation when the approved Testing Contract includes that step (TDD, BDD, ATDD, or custom); otherwise defer opportunistic refactors to subsequent iterations.

--- a/core/agents/aidlc-devsecops-agent.md
+++ b/core/agents/aidlc-devsecops-agent.md
@@ -63,6 +63,23 @@ You are a senior security engineer and DevSecOps specialist. You ensure that sec
 
 `aidlc/spaces/<active-space>/memory/{org,team,project}.md` — active-space guardrails and affirmed practices (read per `{{HARNESS_DIR}}/knowledge/aidlc-shared/rules-reading.md`). Consult `## Deployment` for the team's promotion-gate stance when designing CI gates and deployment guardrails.
 
+## Verification Discipline
+
+- A threat is anchored to something that exists. Enumerate the entry points, trust boundaries, and data stores from the design or code in front of you - the actual endpoints, the actual policies, the actual dependency manifest - before applying STRIDE to them. A threat that names no component, no boundary, and no asset is generic guidance, not a finding.
+- Rate by what the system actually stores, protects, or exposes. Severity is exploitability against the asset behind the boundary, not the pattern's textbook rating: a theoretical path to nothing sensitive is not Critical, and a trivial path to credentials is not Low.
+- A control is present only when you have seen it. "The gateway handles auth" is a claim until the gateway configuration, the policy statement, or the middleware is opened. Record where each control was confirmed, or record it as unverified; never carry a claimed control into the risk score.
+- Every finding is actionable as written. It names the location (component, file, resource, or policy statement), the failure mode, and the control that closes it, so the developer can act without asking what you meant.
+- Record what turned out safe. When a suspicious pattern is investigated and found not to be a problem, write down why in one line, so the next reviewer does not repeat the work and the audit trail does not hold an open question.
+
+Before you hand off a threat model, review, or gate, confirm every line:
+
+- [ ] Every threat names the entry point or boundary it enters through and the asset it reaches.
+- [ ] Every severity rating states the exploitability and the impact on that asset.
+- [ ] Every control claimed as present names where it was confirmed, or is marked unverified.
+- [ ] Every finding names its location, its failure mode, and the control that closes it.
+- [ ] Every investigated non-issue is recorded with its reason.
+- [ ] No secret encountered during review is copied into any artifact; only its location and the remediation are.
+
 ## Key Principles
 
 1. **Defense in depth** — No single security control should be a single point of failure. Layer controls so that one failure does not compromise the system.

--- a/core/agents/aidlc-quality-agent.md
+++ b/core/agents/aidlc-quality-agent.md
@@ -56,6 +56,23 @@ You are a senior QA engineer and performance specialist responsible for all test
 
 `aidlc/spaces/<active-space>/memory/{org,team,project}.md` — active-space guardrails and affirmed practices (read per `{{HARNESS_DIR}}/knowledge/aidlc-shared/rules-reading.md`). Consult `## Testing Posture` for TDD/BDD cadence, tests-after policy, and coverage stance when designing test plans and quality gates.
 
+## Verification Discipline
+
+- A test proves a behaviour only if it fails when that behaviour breaks. A test that executes code and asserts nothing, asserts the value it just wrote, or mocks the thing under test is coverage on paper; count it as untested.
+- Green is something you observed. Report a suite as passing only from a run you executed in this session, with the command and its pass and fail counts. A pass you did not see is not reported.
+- A failing test is evidence, not an obstacle. Fix the cause or route the defect to the developer; never loosen an assertion, skip the test, or widen a tolerance to reach green. A test that passes and fails across runs with no code change is flaky, and flaky is a defect of its own, not a re-run.
+- Map before you measure. Coverage tells you which lines ran; the acceptance criteria tell you what must be true. Every AC id in the unit's stories maps to a named test or is listed as untested. A percentage is never the answer to "is this unit tested?".
+- A performance verdict names the load profile, the environment, the duration, and the observed number beside the NFR target. "Meets target" without the observation is a gap in the validation matrix, not a pass.
+
+Before you report a quality gate, confirm every line:
+
+- [ ] Every AC id maps to a named test, or is listed as untested.
+- [ ] Every test asserts an observable behaviour that a broken implementation would fail.
+- [ ] Every "passing" claim quotes the command run in this session and its counts.
+- [ ] No assertion was loosened, test skipped, or tolerance widened to reach green; each failure is fixed at its cause or filed as a defect.
+- [ ] Every flaky test is recorded as a defect, not re-run until it passes.
+- [ ] Every NFR verdict states the target, the observed value, and the load profile that produced it.
+
 ## Key Principles
 
 1. **Test the requirement, not the implementation** — Tests validate that the system does what was specified, not how it was coded.

--- a/tests/unit/t339-producer-verification-discipline.test.ts
+++ b/tests/unit/t339-producer-verification-discipline.test.ts
@@ -1,0 +1,126 @@
+// covers: file:agents/aidlc-developer-agent.md,
+// file:agents/aidlc-quality-agent.md,
+// file:agents/aidlc-devsecops-agent.md,
+// file:agents/aidlc-design-agent.md
+//
+// Pins the verification discipline in four producing personas. Each already
+// states responsibilities and principles; none said what the persona must
+// have checked before it hands its artifact to the next stage - that a
+// specification's references were resolved against the tree, that "passing"
+// is a run the agent observed, that a threat names the boundary and asset it
+// reaches, that a screen state not drawn does not exist. Without that text the
+// hand-off carries claims the receiving stage cannot tell from evidence.
+//
+// Mechanism = none: pure text invariants over authored files plus the shipped
+// dist/claude projection (the other trees come from the same generated source,
+// so one projection pin suffices). A rewording should update these pins
+// deliberately, not drop the discipline.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { REPO_ROOT } from "../harness/fixtures.ts";
+
+// One domain-specific line per persona: the rule that only that domain owns.
+const PRODUCERS: ReadonlyArray<readonly [file: string, ownRule: string]> = [
+  [
+    "aidlc-developer-agent.md",
+    "A specification is a claim about the codebase until you have opened what it names",
+  ],
+  [
+    "aidlc-quality-agent.md",
+    "A test proves a behaviour only if it fails when that behaviour breaks",
+  ],
+  [
+    "aidlc-devsecops-agent.md",
+    "A threat is anchored to something that exists",
+  ],
+  [
+    "aidlc-design-agent.md",
+    "A state you did not specify does not exist",
+  ],
+];
+
+const corePath = (file: string) => join(REPO_ROOT, "core", "agents", file);
+const distPath = (file: string) =>
+  join(REPO_ROOT, "dist", "claude", ".claude", "agents", file);
+
+const SECTION = "## Verification Discipline";
+
+// The section body: from its heading to the next H2.
+function section(src: string): string {
+  const start = src.indexOf(SECTION);
+  expect(start).toBeGreaterThan(-1);
+  const rest = src.slice(start + SECTION.length);
+  const end = rest.search(/\n## /);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe("t339 producer verification discipline pins", () => {
+  for (const [file, ownRule] of PRODUCERS) {
+    describe(file, () => {
+      const src = readFileSync(corePath(file), "utf-8");
+
+      test("carries the section between Memory Focus and Key Principles", () => {
+        const memory = src.indexOf("## Memory Focus");
+        const discipline = src.indexOf(SECTION);
+        const principles = src.indexOf("## Key Principles");
+        expect(memory).toBeGreaterThan(-1);
+        expect(discipline).toBeGreaterThan(memory);
+        expect(principles).toBeGreaterThan(discipline);
+        // Exactly one such section - a duplicate would split the checklist.
+        expect(src.indexOf(SECTION, discipline + 1)).toBe(-1);
+      });
+
+      test("states the rule its own domain owns", () => {
+        expect(section(src)).toContain(ownRule);
+      });
+
+      test("hand-off checklist is a checkbox list of at least six lines", () => {
+        const body = section(src);
+        expect(body).toMatch(/^Before you .*, confirm every line:$/m);
+        const boxes = body.match(/^- \[ \] /gm) ?? [];
+        expect(boxes.length).toBeGreaterThanOrEqual(6);
+      });
+
+      test("the existing collaboration boundary and principles survive", () => {
+        expect(src).toContain("This agent does not invoke other agents directly.");
+        expect(src).toContain("## Key Principles");
+      });
+
+      test("shipped dist/claude projection carries the same section", () => {
+        const dist = readFileSync(distPath(file), "utf-8");
+        expect(section(dist)).toBe(section(src));
+      });
+    });
+  }
+
+  test("developer: a status the agent did not observe is not reported", () => {
+    const body = section(readFileSync(corePath("aidlc-developer-agent.md"), "utf-8"));
+    expect(body).toContain("Working code is code you ran");
+    expect(body).toContain("Make it pass, never make it quiet");
+    expect(body).toContain(
+      "- [ ] No file outside the unit's ownership changed",
+    );
+  });
+
+  test("quality: green is observed, failures are fixed at the cause, AC ids map to tests", () => {
+    const body = section(readFileSync(corePath("aidlc-quality-agent.md"), "utf-8"));
+    expect(body).toContain("Green is something you observed");
+    expect(body).toContain("never loosen an assertion, skip the test, or widen a tolerance");
+    expect(body).toContain("- [ ] Every AC id maps to a named test, or is listed as untested.");
+  });
+
+  test("devsecops: controls are seen, severity follows the asset, secrets never land in artifacts", () => {
+    const body = section(readFileSync(corePath("aidlc-devsecops-agent.md"), "utf-8"));
+    expect(body).toContain("A control is present only when you have seen it");
+    expect(body).toContain("Rate by what the system actually stores, protects, or exposes");
+    expect(body).toContain("- [ ] No secret encountered during review is copied into any artifact");
+  });
+
+  test("design: screens trace to stories, accessibility is per element, values are tokens", () => {
+    const body = section(readFileSync(corePath("aidlc-design-agent.md"), "utf-8"));
+    expect(body).toContain("Every screen traces to a story");
+    expect(body).toContain("Accessibility is checked per element, not asserted per page");
+    expect(body).toContain("- [ ] Every visual value resolves to a named token");
+  });
+});


### PR DESCRIPTION
# Summary

The four producing personas that hand an artifact to a downstream stage - `aidlc-developer-agent`, `aidlc-quality-agent`, `aidlc-devsecops-agent`, `aidlc-design-agent` - state responsibilities and principles but not what each must have *checked* before the hand-off. The receiving stage, the reviewer, and the human at the gate then cannot tell a claim ("tests pass", "80% coverage", "auth is handled by the gateway", "handles errors gracefully") from evidence. A grep of `core/agents/` finds no hand-off checklist in any producing persona.

This adds a `## Verification Discipline` section to each of the four, with the same heading and shape as the reviewer section in #1135 so one convention covers the roster.

Closes #1136.

## Changes

* `core/agents/aidlc-developer-agent.md` - resolve the specification's paths, symbols, and interfaces against the tree before implementing; reverse-engineering reports what manifests and imports say; "build passes" / "tests pass" are runs made in this session and quoted; fix the cause, never make the failure quiet (type widening, lint suppression, discarded errors, loosened assertions); change only what the unit owns. Six-line hand-off checklist.
* `core/agents/aidlc-quality-agent.md` - a test counts only if it fails when the behaviour breaks; green is observed, not assumed; failures are fixed at the cause or filed, never loosened or skipped; flaky is a defect; every AC id maps to a named test or is listed as untested; NFR verdicts state target vs observed with the load profile. Six-line checklist.
* `core/agents/aidlc-devsecops-agent.md` - threats are anchored to entry points, boundaries, and assets that exist in the artifact; severity follows the asset actually behind the boundary; a control is present only when its configuration was opened; every finding names location, failure mode, and closing control; investigated non-issues are recorded; secrets never land in artifacts. Six-line checklist.
* `core/agents/aidlc-design-agent.md` - screens and stories trace both ways; a state not specified does not exist; accessibility is checked per element (keyboard path, accessible name, contrast value); every visual value resolves to a named token; the spec is complete when a developer can build without asking. Six-line checklist.
* `tests/unit/t339-producer-verification-discipline.test.ts` - pins the section's placement (between `## Memory Focus` and `## Key Principles`), one domain-owned rule per persona, the checklist shape (>= 6 checkboxes behind a "confirm every line" preface), the survival of the "does not invoke other agents directly" boundary, and byte-equality of the section in the `dist/claude` projection.

Section placed between `## Memory Focus` and `## Key Principles` in each file; nothing existing is edited. Frontmatter untouched (t04, t216 green); no harness-dir literal (t146 green). No version bump, badge, or CHANGELOG entry, per the Release Metadata Policy in `AGENTS.md`. The adding-an-agent guide's body-structure sentence is left for the PR that completes the series, to avoid two PRs editing the same line.

## User experience

Before: an implementation report can say "tests pass" from a run nobody made; a quality gate can report a coverage percentage with no AC mapping; a threat model can rate a textbook pattern Critical against an asset that holds nothing sensitive; a mockup can omit the error state without saying so. Each is discovered a review iteration or a revision round later, or in production.

After: each persona confirms a fixed hand-off checklist and its report carries the evidence - the command it ran and its counts, the AC-to-test map, the boundary and asset behind each threat, the state matrix per screen - so the reviewer and the human at the gate read evidence, not claims. Turn cost is unchanged in shape: the checklist is confirmed where the agent already writes its report; no reading pass is added. Tier and tools are unchanged.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] If this change adds an input to any fingerprint, epoch, or receipt identity, the description names the human-visible change it detects

## Test plan

On `c0eb2921` (2.8.2):

```
bun scripts/package.ts
bun test tests/unit/t339-producer-verification-discipline.test.ts   # 24 pass
bun test tests/unit/t04-agent-frontmatter.test.ts \
         tests/unit/t146-core-hygiene.test.ts \
         tests/unit/t216-agent-tier-projection.test.ts              # all pass
bun run lint && bun run typecheck
bun scripts/package.ts --check                                      # deterministic, 7 harnesses
bun tests/run-tests.ts                                              # full default suite running on this branch; result posted below when it finishes
```

The new pin fails without the persona edits: `git stash push -- core/agents && bun test tests/unit/t339-producer-verification-discipline.test.ts` reports 20 failures.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
