### PR TITLE
feat: grant Construction autonomy on demand

### DIFF
--- a/core/aidlc-common/protocols/stage-protocol-construction.md
+++ b/core/aidlc-common/protocols/stage-protocol-construction.md
@@ -42,20 +42,38 @@ EXECUTE stage (`isSkeletonGateStage`) always presents a stage-level approval
 gate regardless of autonomy mode. That gate covers that stage's artifacts
 across the Units that have settled — not a Bolt's combined design artifacts
 and generated code. Audit: emit `GATE_APPROVED` as usual. `BOLT_COMPLETED`
-is not emitted on this gate. Skeleton-off uses the ordinary first-stage gate;
+is not emitted on this gate. Skeleton-off uses the ordinary first-stage gate,
+which follows `Construction Autonomy Mode` like every other Construction stage
+gate — so an on-demand `autonomous` grant made before that stage runs skips it;
 a zero-Unit stage has no skeleton or Bolt ceremony at all.
 
 > **Planned (non-executable).** A later Bolt-major walk would present a
 > Bolt-level gate covering that Bolt's design artifacts and generated code
 > together, with the enclosing `BOLT_COMPLETED` tying the gate to the Bolt.
 
-**Ladder prompt (fires once, immediately after walking skeleton gate)**
+**Autonomy grant — the ladder prompt, and the on-demand path**
 
-After an actual walking skeleton's gate approves, present exactly one ladder
-prompt. Do not present it for skeleton-off or zero-Unit execution:
+`Construction Autonomy Mode` is the human's grant and governs the remaining
+Construction stage gates. Two paths set it, and both record it exactly the same
+way, through `aidlc-bolt.ts set-autonomy --mode <choice>`:
+
+- **The ladder prompt** — the prompted path, under skeleton-on. Present exactly
+  one per intent, after the walking-skeleton gate approves: the skeleton is the
+  evidence that the path works end to end, so the prompted grant follows it. Do
+  not present it for zero-Unit execution.
+- **On demand** — at ANY point during Construction, whenever the human asks in
+  a typed message ("run the rest autonomously", "gate every stage from here").
+  This is the only path available under `skeleton: off`, where there is no
+  skeleton gate to hang a prompt on, and it is equally available under
+  skeleton-on to a human who wants the grant earlier than the skeleton gate or
+  wants to revoke it later. Never infer it: act only on an explicit request.
+
+Either way the escalation to `autonomous` still requires a fresh human turn —
+`set-autonomy` refuses otherwise — so an unattended run cannot grant itself more
+autonomy. De-escalation to `gated` carries no presence requirement.
 
 ```question
-prompt: "The walking skeleton shipped. How should the remaining Bolts run?"
+prompt: "How should the remaining Construction stages run?"
 header: Autonomy
 multiSelect: false
 options:
@@ -70,7 +88,11 @@ The shipped option labels still say "remaining Bolts" / "Gate every Bolt"; they 
 - Record the answer in `aidlc-state.md` as `Construction Autonomy Mode: autonomous` or `Construction Autonomy Mode: gated` via `aidlc-bolt.ts set-autonomy --mode <choice>` (which emits `AUTONOMY_MODE_SET` itself).
 - The ladder choice is set-autonomy-owned, like an approval choice is report-owned: do NOT call `aidlc-log.ts decision` or `aidlc-log.ts answer` for it. Switching to `autonomous` requires the human's fresh turn (the ladder answer) — logging the choice as an interview answer first would consume that turn and the mode switch would refuse.
 - On the default walk, `autonomous` skips the remaining Construction stage gates except halt-and-ask, the Build-and-Test loop-back's rung 4, and the swarm settle `gate: true` re-entry (the conductor auto-approves that settle under autonomy).
-- Session resume: if `Construction Autonomy Mode: unset` but the walking skeleton is already `[x]` complete, re-fire the ladder prompt before executing the next Construction stage.
+- Session resume: under skeleton-on, if `Construction Autonomy Mode: unset`
+  and the walking skeleton is already `[x]` complete, re-fire the ladder prompt
+  before executing the next Construction stage. Under skeleton-off there is no
+  prompt to re-fire; the mode stays `unset` (treated as `gated`) until the human
+  asks for a grant on demand.
 
 **Subsequent Bolt gate (per autonomy mode)**
 

--- a/core/aidlc-common/protocols/stage-protocol-construction.md
+++ b/core/aidlc-common/protocols/stage-protocol-construction.md
@@ -42,9 +42,9 @@ EXECUTE stage (`isSkeletonGateStage`) always presents a stage-level approval
 gate regardless of autonomy mode. That gate covers that stage's artifacts
 across the Units that have settled — not a Bolt's combined design artifacts
 and generated code. Audit: emit `GATE_APPROVED` as usual. `BOLT_COMPLETED`
-is not emitted on this gate. Skeleton-off uses the ordinary first-stage gate,
-which follows `Construction Autonomy Mode` like every other Construction stage
-gate — so an on-demand `autonomous` grant made before that stage runs skips it;
+is not emitted on this gate. Skeleton-off retains the ordinary first-stage
+approval too. An on-demand `autonomous` grant may be recorded before that stage,
+but it waives only subsequent eligible completion gates, not this first review;
 a zero-Unit stage has no skeleton or Bolt ceremony at all.
 
 > **Planned (non-executable).** A later Bolt-major walk would present a
@@ -58,9 +58,10 @@ Construction stage gates. Two paths set it, and both record it exactly the same
 way, through `aidlc-bolt.ts set-autonomy --mode <choice>`:
 
 - **The ladder prompt** — the prompted path, under skeleton-on. Present exactly
-  one per intent, after the walking-skeleton gate approves: the skeleton is the
-  evidence that the path works end to end, so the prompted grant follows it. Do
-  not present it for zero-Unit execution.
+  one per intent, after the walking-skeleton stage gate approves, if no autonomy
+  choice has already been recorded. On the shipped stage-major walk this is a
+  review of the first Construction stage, not proof that a whole Bolt shipped.
+  Do not present it for zero-Unit execution or repeat an on-demand choice.
 - **On demand** — at ANY point during Construction, whenever the human asks in
   a typed message ("run the rest autonomously", "gate every stage from here").
   This is the only path available under `skeleton: off`, where there is no
@@ -71,6 +72,12 @@ way, through `aidlc-bolt.ts set-autonomy --mode <choice>`:
 Either way the escalation to `autonomous` still requires a fresh human turn —
 `set-autonomy` refuses otherwise — so an unattended run cannot grant itself more
 autonomy. De-escalation to `gated` carries no presence requirement.
+
+The grant changes completion approval policy; it does not approve unanswered
+Code Generation plans, change iteration order, or turn unit-major execution
+into a swarm. The first Construction-stage approval remains human-owned in
+every stance. Under the existing unit-major walk, per-unit stages also retain
+their late human approval cascade.
 
 ```question
 prompt: "How should the remaining Construction stages run?"

--- a/core/tools/aidlc-bolt.ts
+++ b/core/tools/aidlc-bolt.ts
@@ -61,7 +61,6 @@ import {
   requireLiveClaimForTeamUnit,
   resolveBoltDag,
   resolveProjectDir,
-  setFieldStrict,
   setOrInsertField,
   validateUnitName,
   slugify,
@@ -1134,9 +1133,25 @@ function handleSetAutonomy(args: string[]): void {
     }
 
     // Validate state-file shape before the audit-first mutation.
+    //
+    // `Construction Autonomy Mode` is declared by the shipped state template
+    // (knowledge/aidlc-shared/state-template.md, under `## Current Status`) but
+    // the generator does not emit it, so a real state file usually lacks the
+    // line. setFieldStrict throws "Field not found in state file" in that case,
+    // which made the grant unrecordable and `autonomous` unreachable — see
+    // issue #1045. setOrInsertField writes it where the template declares it,
+    // healing both freshly generated and pre-existing state files without an
+    // init-time shape change or a migration. The shape check survives:
+    // appendUnderHeading throws when `## Current Status` is absent, so a
+    // malformed state file still fails closed before the audit-first mutation.
     let updated: string;
     try {
-      updated = setFieldStrict(content, "Construction Autonomy Mode", flags.mode);
+      updated = setOrInsertField(
+        content,
+        "## Current Status",
+        "Construction Autonomy Mode",
+        flags.mode,
+      );
     } catch (e) {
       error(`State update failed: ${errorMessage(e)}`);
     }

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -7627,6 +7627,28 @@ export function isAutonomousConstructionDecision(
   return stagePhase === "construction" && isAutonomousMode(stateContent);
 }
 
+function firstConstructionApprovalStage(
+  scope: string,
+  stateContent: string,
+): StageEntry | null {
+  const mapping = loadScopeMapping()[scope];
+  if (!mapping) return null;
+  const overrides = parseStateStageSuffixes(stateContent);
+  const skipped = new Set(
+    parseCheckboxes(stateContent)
+      .filter((entry) => entry.state === "skipped")
+      .map((entry) => entry.slug),
+  );
+  // Conditional skips move the first actual approval; completed stages do not.
+  // Keep [x] in the search so approving the anchor does not protect every
+  // subsequent stage in turn. Plan overrides use the router's precedence.
+  return loadStageGraph().find((stage) =>
+    stage.phase === "construction" &&
+    !skipped.has(stage.slug) &&
+    (overrides.get(stage.slug) ?? mapping.stages[stage.slug]) === "EXECUTE"
+  ) ?? null;
+}
+
 // Completion approvals have a narrower grant than ordinary Construction
 // decisions. In particular, an early on-demand grant cannot approve the first
 // Construction stage, and the existing unit-major walk keeps its stage gates.
@@ -7639,7 +7661,7 @@ export function isAutonomousConstructionGate(
   if (!isAutonomousConstructionDecision(stateContent, stage.phase)) return false;
   const scope = stateContent ? getField(stateContent, "Scope")?.trim() : null;
   if (!scope) return false;
-  const first = firstInScopeStageOfPhase("construction", scope);
+  const first = firstConstructionApprovalStage(scope, stateContent!);
   if (first === null || first.slug === stage.slug) return false;
   return !(
     getField(stateContent!, "Construction Iteration")?.trim() === "unit-major" &&

--- a/core/tools/aidlc-lib.ts
+++ b/core/tools/aidlc-lib.ts
@@ -7627,6 +7627,26 @@ export function isAutonomousConstructionDecision(
   return stagePhase === "construction" && isAutonomousMode(stateContent);
 }
 
+// Completion approvals have a narrower grant than ordinary Construction
+// decisions. In particular, an early on-demand grant cannot approve the first
+// Construction stage, and the existing unit-major walk keeps its stage gates.
+// Keep report and state mutation on the same policy instead of interpreting
+// gate:true independently in each caller.
+export function isAutonomousConstructionGate(
+  stateContent: string | null,
+  stage: { slug: string; phase: string; for_each?: string },
+): boolean {
+  if (!isAutonomousConstructionDecision(stateContent, stage.phase)) return false;
+  const scope = stateContent ? getField(stateContent, "Scope")?.trim() : null;
+  if (!scope) return false;
+  const first = firstInScopeStageOfPhase("construction", scope);
+  if (first === null || first.slug === stage.slug) return false;
+  return !(
+    getField(stateContent!, "Construction Iteration")?.trim() === "unit-major" &&
+    stage.for_each === "unit-of-work"
+  );
+}
+
 // True when any stage sits at [?] (awaiting-approval) in the state file: the
 // "a gate is actually OPEN" predicate for the per-harness preToolUse floors.
 // Without it a floor would keep refusing tool calls AFTER a legitimate approval

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -137,6 +137,7 @@ import {
   guardRefusalStreakView,
   type GuardRemedy,
   humanAuthorityState,
+  isAutonomousConstructionGate,
   recordGuardRefusal,
   currentGuardRecoveryAskMarker,
   type SummaryConfirmationEvidence,
@@ -8558,7 +8559,6 @@ function handleReport(args: string[], projectDir: string | undefined): void {
       const status = unitGateStatus(pd, slug, unit, gateScope);
       const protectedTeamHumanGate =
         stageCheckbox.state !== "completed" &&
-        readAutonomyMode(stateContent) !== "autonomous" &&
         process.env.AIDLC_SKIP_HUMAN_PRESENCE_GUARD !== "1";
       const sequence: string[][] = [];
       if (flags.result === "awaiting-approval") {
@@ -8670,7 +8670,7 @@ function handleReport(args: string[], projectDir: string | undefined): void {
   const protectedHumanGate =
     isGated &&
     stageCheckbox.state !== "completed" &&
-    readAutonomyMode(stateContent) !== "autonomous" &&
+    !isAutonomousConstructionGate(stateContent, node) &&
     resolveProjectFlag("AIDLC_SKIP_HUMAN_PRESENCE_GUARD") !== "1";
 
   if (flags.overrideBlockingSensors) {

--- a/core/tools/aidlc-orchestrate.ts
+++ b/core/tools/aidlc-orchestrate.ts
@@ -2435,10 +2435,17 @@ function scopeDefaultSkeletonStance(scope: string): SkeletonStance {
 // Both skeleton-on AND skeleton-off present a gate at Bolt 1: skeleton-on forces
 // an always-gate "regardless of Construction Autonomy Mode" (SKILL.md Step 5 /
 // "When skeleton-on" §1); skeleton-off runs Bolt 1 "as a regular Bolt with the
-// standard batch-gate path", and since `Construction Autonomy Mode` is `unset`
-// (treated as `gated`) until the post-Bolt-1 ladder prompt sets it, that batch
-// gate IS presented (it is only skipped when `autonomous`, which cannot be true
-// before Bolt 1 ships). The stance changes the CEREMONY (solo + always-gate +
+// standard batch-gate path". NOTE the NODE gate this function resolves is not
+// the Bolt-level gate: this one is the stage approval gate for the skeleton-gate
+// stage (the first in-scope Construction EXECUTE stage — a design stage such as
+// functional-design in scopes that run one, code-generation in scopes that do
+// not), and it stays `true` in every stance so that stage is always reviewed.
+// The autonomy-governed gates are the REMAINING Construction stage gates, and
+// the human can now grant autonomy ON DEMAND at any point in Construction (see
+// aidlc-common/protocols/stage-protocol-construction.md § Autonomy grant), so an
+// `autonomous` grant can predate the first of them. The earlier rationale here —
+// that autonomy "cannot be true before Bolt 1 ships" — no longer holds and must
+// not be relied on. The stance changes the CEREMONY (solo + always-gate +
 // ladder prompt vs regular Bolt + batch gate) — orchestration the conductor
 // runs — not whether a gate is presented at Bolt 1. The gate axis is on for all
 // construction work (only bootstrap init stages auto-proceed; gate-axis ≠
@@ -2459,8 +2466,9 @@ function resolveSkeletonGate(stance: SkeletonStance, scope: string): boolean {
       // skeleton-on: always-gate at Bolt 1.
       return true;
     case "off":
-      // skeleton-off: regular Bolt; the standard gate is still presented at
-      // Bolt 1 (autonomy is gated until the post-Bolt-1 ladder sets it).
+      // skeleton-off: regular Bolt. This NODE gate (the skeleton-gate stage's
+      // own approval gate) is still presented — the autonomy-governed gates are
+      // the REMAINING Construction stage gates.
       return true;
     case "scope-dependent": {
       // Fall back to the active scope's metadata to SELECT the ceremony.
@@ -5172,14 +5180,23 @@ function applySettledSwarmShape(
 //
 // On any trigger miss it returns false and emits nothing, so the caller falls
 // back to the normal run-stage emit (which keeps its computed gate, including the
-// skeleton round-trip sentinel). The skeleton Bolt 1 is protected two ways:
-// temporally (autonomy stays unset until the ladder fires after Bolt 1 ships) AND
-// structurally: the isSkeletonGateStage guard below refuses to swarm the
-// walking-skeleton gate stage regardless of autonomy state. The structural guard
-// matters for scopes where the per-unit build stage (code-generation) IS the
-// skeleton-gate stage (poc / bugfix / security-patch): there the skeleton's
-// always-gated approval must never be bypassed by a stray autonomous setting, so
-// the engine enforces it rather than trusting the conductor's ordering.
+// skeleton round-trip sentinel). The skeleton Bolt 1 is protected STRUCTURALLY:
+// the isSkeletonGateStage guard below refuses to swarm the walking-skeleton gate
+// stage regardless of autonomy state. That structural guard is now the only
+// protection, and it is sufficient: it matters for scopes where the per-unit
+// build stage (code-generation) IS the skeleton-gate stage (poc / bugfix /
+// security-patch), where the skeleton's always-gated approval must never be
+// bypassed by a stray autonomous setting, so the engine enforces it rather than
+// trusting the conductor's ordering.
+//
+// It used to ALSO be protected temporally ("autonomy stays unset until the
+// ladder fires after Bolt 1 ships"). That premise no longer holds: the human can
+// grant autonomy on demand at any point in Construction, so an autonomous grant
+// can predate the first Unit-building stage by design (see
+// aidlc-common/protocols/stage-protocol-construction.md § Autonomy grant).
+// Scopes whose first Construction EXECUTE stage is a design stage therefore DO
+// swarm code-generation from the first Unit; scopes where code-generation is
+// itself the skeleton-gate stage still cannot, via the structural guard.
 function tryEmitSwarm(
   slug: string,
   scope: string,

--- a/core/tools/aidlc-state.ts
+++ b/core/tools/aidlc-state.ts
@@ -80,7 +80,7 @@ import {
   humanPresenceGuardDisabled,
   unattendedHumanPresenceHint,
   intentRepos,
-  isAutonomousConstructionDecision,
+  isAutonomousConstructionGate,
   isAutonomousMode,
   isAutonomousSwarmStage,
   isTeamUnitOwnership,
@@ -5373,7 +5373,7 @@ function verifyApprovalDecision(
   forceHuman = false,
 ): { approvalInput: string | undefined; autonomousDecision: boolean } {
   const autonomousDecision =
-    !forceHuman && isAutonomousConstructionDecision(content, stage.phase);
+    !forceHuman && isAutonomousConstructionGate(content, stage);
   const approvalInput = userInput?.trim();
   const approvalAuthorship =
     autonomousDecision || humanPresenceGuardDisabled()
@@ -5845,7 +5845,7 @@ function handleReject(args: string[]): void {
     );
   }
   const autonomousDecision =
-    !teamGate && isAutonomousConstructionDecision(content, stage.phase);
+    !teamGate && isAutonomousConstructionGate(content, stage);
   if (
     !autonomousDecision &&
     feedbackStatus === "not-applicable" &&

--- a/docs/guide/12-cli-commands.md
+++ b/docs/guide/12-cli-commands.md
@@ -1019,6 +1019,31 @@ projection implements the same operations with Bun/TypeScript tools under the
 harness directory, and direct tool calls remain useful for plumbing that has no
 public route. Prefer `aidlc` whenever a route is documented below.
 
+### `aidlc engine bolt set-autonomy` - change Construction approvals
+
+During Construction, ask in a typed message to "run the rest autonomously" or
+"gate every stage from here". Both requests work with skeleton-on or
+`skeleton: off`; skeleton-off has no automatic ladder prompt. The conductor
+records the explicit choice through:
+
+```bash
+aidlc engine bolt set-autonomy --mode autonomous
+aidlc engine bolt set-autonomy --mode gated
+```
+
+Both commands update `Construction Autonomy Mode` in `aidlc-state.md` and emit
+`AUTONOMY_MODE_SET`. Granting `autonomous` requires a fresh human turn; switching
+back to `gated` restores subsequent human approvals without requiring a fresh
+turn.
+
+On the default stage-major walk, autonomy skips later eligible Construction
+completion approvals. The first in-scope Construction stage still requires its
+own human approval, even if autonomy was granted earlier, and each Unit's Code
+Generation Plan Approval remains mandatory. Existing unit-major execution stays
+serial, suppresses swarm, and retains human stage gates for per-unit stages.
+See [Construction Execution](../reference/03-orchestrator.md#construction-execution)
+for the ladder and failure-handling rules.
+
 ### `aidlc engine workspace codekb` - resolve the code knowledge directory
 
 Use the public read-only query:

--- a/docs/reference/03-orchestrator.md
+++ b/docs/reference/03-orchestrator.md
@@ -243,8 +243,8 @@ Construction stage has a checkbox per Unit from `unit-of-work-dependency.md`;
 Unit and one cell per applicable per-Unit Construction stage plus its Unit gate;
 the Stage Progress rows remain one row per stage and become derived from those
 columns. `Construction Autonomy Mode: [unset|autonomous|gated]` is recorded
-under **Current Status** — written after the ladder prompt fires and honoured
-on session resume.
+under **Current Status** — written by a ladder answer or an explicit on-demand
+grant or revocation, and honoured on session resume.
 
 During active team fan-out, unscoped main emits a turn-terminal `notice` whose
 message is the deterministic Team Construction board: Unit Progress, locally
@@ -481,7 +481,30 @@ Shipped per-stage structure:
 2. After the last Unit of that stage settles, the engine re-emits the stage with `gate: true` — one stage-level approval.
 3. Code Generation's per-Unit completion gate inside `code-generation.md` is **suppressed**; Step 3 Plan Approval remains a hard stop. Under an autonomous swarm the Code Generation stage gate is presented only after the **final** DAG batch has converged.
 
-The **walking-skeleton gate** is the first in-scope Construction EXECUTE stage (`isSkeletonGateStage`). Immediately after that gate approves, the orchestrator fires the **ladder prompt** exactly once per workflow, records `Construction Autonomy Mode: autonomous|gated` in `aidlc-state.md`, and emits `AUTONOMY_MODE_SET`. On the default walk, `autonomous` skips the remaining Construction *stage* gates (except halt-and-ask, the Build-and-Test loop-back's rung 4, and the swarm settle `gate: true` re-entry, which the conductor auto-approves under autonomy). Opt-in `Construction Iteration: unit-major` suppresses swarm and **retains** the per-stage gate cascade.
+The first in-scope Construction EXECUTE stage always requires its own human
+approval, including under `skeleton: off` and when autonomy was granted earlier.
+Under skeleton-on with a non-empty Unit DAG, this is the **walking-skeleton
+gate**. After it approves, the conductor presents the **ladder prompt** once per
+intent if no autonomy choice has already been recorded. Skeleton-off has no
+automatic ladder prompt.
+
+The human can grant or revoke autonomy on demand at any point during
+Construction, under either skeleton stance: "run the rest autonomously" or
+"gate every stage from here". The conductor records either an on-demand request
+or a ladder answer through `aidlc engine bolt set-autonomy --mode autonomous|gated`,
+which writes `Construction Autonomy Mode` and emits `AUTONOMY_MODE_SET`. Escalation
+requires a fresh human turn; revocation to `gated` does not. An existing choice
+is honoured on resume and is not repeated at the ladder. See the
+[command reference](../guide/12-cli-commands.md#aidlc-engine-bolt-set-autonomy---change-construction-approvals)
+for invocation examples.
+
+On the default stage-major walk, `autonomous` skips subsequent eligible
+Construction *stage* gates. The first stage's approval and each Unit's Code
+Generation Plan Approval remain human-owned. Halt-and-ask and the Build-and-Test
+loop-back's rung 4 still stop for the human; the swarm settle `gate: true`
+re-entry is auto-approved by the conductor under autonomy. Existing opt-in
+`Construction Iteration: unit-major` stays serial, suppresses swarm, and
+**retains human stage gates for per-unit stages**.
 
 Units eligible to run in parallel (dependency prerequisites satisfied, no mutual dependency) form a **batch**. The orchestrator may dispatch stage 3.5 Code Generation for a batch by issuing **N `Task` calls in a single assistant message**. `BOLT_STARTED` / `BOLT_COMPLETED` fire per Unit/worktree on the swarm path; `SWARM_COMPLETED` closes the batch. A default gated run records none of those `BOLT_*` rows.
 
@@ -493,6 +516,8 @@ Failure handling is **halt-and-ask** and runs regardless of autonomy mode:
 
 - Solo Code Generation failure: halt, emit `BOLT_FAILED` on the swarm/worktree path, present retry / skip / abort.
 - Parallel batch partial failure: wait for all parallel Tasks to return, preserve successful Units' artifacts on disk, emit `BOLT_FAILED` with `Succeeded=[names]`, present the same choices scoped to the failed Unit. Retry re-runs only the failed Unit; the batch siblings stay `[x]`.
+
+This example assumes skeleton-on and no previously recorded autonomy choice:
 
 ```mermaid
 sequenceDiagram
@@ -512,6 +537,8 @@ sequenceDiagram
 
     Note over O,T: Remaining design stages stage-major, then Code Generation
     Note over O,T: Units B + C eligible in parallel CG batch
+    O->>U: Plan Approval for each Unit in the batch
+    U->>O: Approve each Unit's plan
     O->>T: Task(B code-gen) + Task(C code-gen) in ONE message
     par Parallel execution
         T->>UB: spawn subagent for Unit B
@@ -525,7 +552,7 @@ sequenceDiagram
     O->>O: All Units done → run 3.6 Build and Test, then 3.7 CI Pipeline
 ```
 
-<!-- Text fallback: The orchestrator reads unit-of-work-dependency.md. It runs the first Construction EXECUTE stage for every Unit, the user approves that walking-skeleton gate, and the ladder prompt fires once. User picks "Continue autonomously". Remaining stages run stage-major. For Units B and C (eligible in parallel at Code Generation), the orchestrator issues both Task calls in a single message. Each Unit/worktree may emit BOLT_COMPLETED; SWARM_COMPLETED closes the batch. The swarm presents one Code Generation stage gate after the final DAG batch. Then 3.6 and 3.7 run once. -->
+<!-- Text fallback: With skeleton-on and no recorded autonomy choice, the orchestrator reads unit-of-work-dependency.md. It runs the first Construction EXECUTE stage for every Unit, the user approves that walking-skeleton gate, and the ladder prompt fires once. User picks "Continue autonomously". Remaining stages run stage-major. For Units B and C (eligible in parallel at Code Generation), the user approves each Unit's plan before the orchestrator issues both Task calls in a single message. Each Unit/worktree may emit BOLT_COMPLETED; SWARM_COMPLETED closes the batch. The swarm presents one Code Generation stage gate after the final DAG batch. Then 3.6 and 3.7 run once. -->
 
 State and audit safety under parallel dispatch: `aidlc-audit.ts` uses mkdir-based locking so concurrent appends are safe. Lifecycle writes happen only after all required Task results return and the conductor reports one outcome; the engine serialises the internal state transition. No state-race risk.
 

--- a/docs/reference/03-orchestrator.md
+++ b/docs/reference/03-orchestrator.md
@@ -495,7 +495,7 @@ or a ladder answer through `aidlc engine bolt set-autonomy --mode autonomous|gat
 which writes `Construction Autonomy Mode` and emits `AUTONOMY_MODE_SET`. Escalation
 requires a fresh human turn; revocation to `gated` does not. An existing choice
 is honoured on resume and is not repeated at the ladder. See the
-[command reference](../guide/12-cli-commands.md#aidlc-engine-bolt-set-autonomy---change-construction-approvals)
+[command reference](../guide/12-cli-commands.md#aidlc-engine-bolt-set-autonomy-change-construction-approvals)
 for invocation examples.
 
 On the default stage-major walk, `autonomous` skips subsequent eligible

--- a/tests/.coverage-ratchet.json
+++ b/tests/.coverage-ratchet.json
@@ -1,7 +1,7 @@
 {
   "note": "Committed baseline: covered-unit count per class. The --check ratchet fails CI if any class's covered count DROPS below these numbers without a reviewed deferred entry. Monotonic anti-regression: you can cover more, never silently less. Regenerate with: bun tests/gen-coverage-registry.ts",
   "coveredByClass": {
-    "function": 390,
+    "function": 391,
     "audit": 56,
     "scope": 11,
     "stage": 11,

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -20,9 +20,9 @@
     "render-surface": "tui"
   },
   "counts": {
-    "total": 965,
+    "total": 966,
     "enumeratedByClass": {
-      "function": 656,
+      "function": 657,
       "audit": 98,
       "scope": 11,
       "stage": 33,
@@ -31,7 +31,7 @@
       "render-surface": 7
     },
     "coveredByClass": {
-      "function": 390,
+      "function": 391,
       "audit": 56,
       "scope": 11,
       "stage": 11,
@@ -3443,6 +3443,18 @@
         {
           "file": "tests/unit/t261-audit-authority-floor.test.ts",
           "mechanism": "cli"
+        }
+      ],
+      "status": "covered"
+    },
+    {
+      "unitClass": "function",
+      "unitId": "function:isAutonomousConstructionGate",
+      "minMechanism": "none",
+      "coveredBy": [
+        {
+          "file": "tests/unit/t339-construction-autonomy-gates.test.ts",
+          "mechanism": "none"
         }
       ],
       "status": "covered"
@@ -9298,6 +9310,10 @@
         {
           "file": "tests/unit/t33.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t339-construction-autonomy-gates.test.ts",
+          "mechanism": "none"
         }
       ],
       "status": "covered"
@@ -10288,6 +10304,10 @@
         {
           "file": "tests/unit/t335-change-control-review-summary.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t339-construction-autonomy-gates.test.ts",
+          "mechanism": "none"
         }
       ],
       "status": "covered"

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -3454,7 +3454,7 @@
       "coveredBy": [
         {
           "file": "tests/unit/t339-construction-autonomy-gates.test.ts",
-          "mechanism": "none"
+          "mechanism": "cli"
         }
       ],
       "status": "covered"
@@ -9313,7 +9313,7 @@
         },
         {
           "file": "tests/unit/t339-construction-autonomy-gates.test.ts",
-          "mechanism": "none"
+          "mechanism": "cli"
         }
       ],
       "status": "covered"
@@ -10307,7 +10307,7 @@
         },
         {
           "file": "tests/unit/t339-construction-autonomy-gates.test.ts",
-          "mechanism": "none"
+          "mechanism": "cli"
         }
       ],
       "status": "covered"

--- a/tests/.coverage-registry.json
+++ b/tests/.coverage-registry.json
@@ -10070,6 +10070,10 @@
         {
           "file": "tests/unit/t335-change-control-review-summary.test.ts",
           "mechanism": "cli"
+        },
+        {
+          "file": "tests/unit/t339-construction-autonomy-gates.test.ts",
+          "mechanism": "cli"
         }
       ],
       "status": "covered"

--- a/tests/unit/gen-coverage-registry.test.ts
+++ b/tests/unit/gen-coverage-registry.test.ts
@@ -905,6 +905,7 @@ describe("mechanismsOf is body-derived (milestone 3)", () => {
     // t337 spawns the shipped doctor to pin the "Workspace source boundary
     // binds" row, which reads a real source walk against a real workspace.
     "unit/t337-source-boundary-reason.test.ts",
+    "unit/t339-construction-autonomy-gates.test.ts",
     "integration/t102.test.ts",
     "integration/t104.test.ts",
     "integration/t105.test.ts",

--- a/tests/unit/t261-audit-authority-floor.test.ts
+++ b/tests/unit/t261-audit-authority-floor.test.ts
@@ -319,13 +319,15 @@ describe("t261 public audit CLI refuses authority-bearing receipts", () => {
 describe("t261 set-autonomy escalation requires and consumes a human turn", () => {
   function constructionProject(): string {
     const p = createTestProject();
+    // Deliberately NOT seeding `Construction Autonomy Mode`. The fixture omits
+    // it exactly as the generated state file does, so these tests exercise the
+    // real production shape: set-autonomy has to CREATE the line. An earlier
+    // version of this helper appended `- **Construction Autonomy Mode**: gated`
+    // here, which manufactured the one precondition the production path lacks
+    // and made every assertion below incapable of catching issue #1045 (the
+    // grant threw `Field not found in state file` before reaching the audit
+    // emission).
     seedStateFile(p, join(FIXTURES, "state-construction.md"));
-    const statePath = seededStateFile(p);
-    writeFileSync(
-      statePath,
-      `${readFileSync(statePath, "utf-8")}\n- **Construction Autonomy Mode**: gated\n`,
-      "utf-8",
-    );
     // Seed one row so the empty-ledger fail-open path does not apply.
     const seed = guarded(AUDIT, ["append", "ERROR_LOGGED", "--field", "Details=seed"], p);
     if (seed.rc !== 0) throw new Error(seed.out);
@@ -381,6 +383,57 @@ describe("t261 set-autonomy escalation requires and consumes a human turn", () =
     ).toBe(1);
     expect(readFileSync(seededStateFile(proj), "utf-8")).toContain(
       "Construction Autonomy Mode**: autonomous",
+    );
+  });
+
+  // Issue #1045. The field is runtime metadata the generator does not emit,
+  // though the shipped state template declares it under `## Current Status`.
+  // The write must therefore CREATE it, in that section, exactly once.
+  test("the grant creates the field under ## Current Status when absent", () => {
+    proj = constructionProject();
+    const before = readFileSync(seededStateFile(proj), "utf-8");
+    expect(before).not.toContain("Construction Autonomy Mode");
+
+    mintHumanTurn(proj);
+    expect(guarded(BOLT, ["set-autonomy", "--mode", "autonomous"], proj).rc).toBe(0);
+
+    const after = readFileSync(seededStateFile(proj), "utf-8");
+    // Section membership, not line ordering: the insert lands at the end of the
+    // section rather than at the template's exact offset, and nothing reads it
+    // positionally.
+    const currentStatus = after.slice(
+      after.indexOf("## Current Status"),
+      after.indexOf("## Session Resume Point"),
+    );
+    expect(currentStatus).toContain("- **Construction Autonomy Mode**: autonomous");
+    expect(after.match(/Construction Autonomy Mode/g)?.length).toBe(1);
+  });
+
+  test("a second grant updates the field in place instead of duplicating it", () => {
+    proj = constructionProject();
+    mintHumanTurn(proj);
+    expect(guarded(BOLT, ["set-autonomy", "--mode", "autonomous"], proj).rc).toBe(0);
+    expect(guarded(BOLT, ["set-autonomy", "--mode", "gated"], proj).rc).toBe(0);
+
+    const after = readFileSync(seededStateFile(proj), "utf-8");
+    expect(after.match(/Construction Autonomy Mode/g)?.length).toBe(1);
+    expect(after).toContain("- **Construction Autonomy Mode**: gated");
+    expect(after).not.toContain("Construction Autonomy Mode**: autonomous");
+  });
+
+  test("a state file without the ## Current Status heading still fails closed", () => {
+    proj = constructionProject();
+    const statePath = seededStateFile(proj);
+    writeFileSync(
+      statePath,
+      readFileSync(statePath, "utf-8").replace("## Current Status", "## Current Status Renamed"),
+      "utf-8",
+    );
+    const refused = guarded(BOLT, ["set-autonomy", "--mode", "gated"], proj);
+    expect(refused.rc).not.toBe(0);
+    expect(refused.out).toContain("State update failed");
+    expect(readFileSync(statePath, "utf-8")).not.toContain(
+      "- **Construction Autonomy Mode**:",
     );
   });
 });

--- a/tests/unit/t339-construction-autonomy-gates.test.ts
+++ b/tests/unit/t339-construction-autonomy-gates.test.ts
@@ -1,0 +1,100 @@
+// covers: function:isAutonomousConstructionGate, subcommand:aidlc-bolt:set-autonomy, subcommand:aidlc-state:approve
+//
+// An early human grant must not double as the first stage's approval.
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  AIDLC_SRC,
+  cleanupTestProject,
+  createTestProject,
+  seededStateFile,
+  seedStateFile,
+} from "../harness/fixtures.ts";
+import { appendAuditEntry } from "../../dist/claude/.claude/tools/aidlc-audit.ts";
+import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
+
+let project = "";
+afterEach(() => {
+  if (project) cleanupTestProject(project);
+  project = "";
+});
+
+function run(tool: string, args: string[]) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    AIDLC_ALLOW_DIRECT_STATE_TRANSITIONS: "1",
+    AIDLC_SKIP_ARTIFACT_GUARD: "1",
+  };
+  delete env.AIDLC_SKIP_HUMAN_PRESENCE_GUARD;
+  delete env.AIDLC_ALLOW_DIRECT_AUDIT_EVENTS;
+  const result = spawnSync(
+    process.execPath,
+    [join(AIDLC_SRC, "tools", `aidlc-${tool}.ts`), ...args, "--project-dir", project],
+    { encoding: "utf-8", env },
+  );
+  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+}
+
+function setup(stage: string, stance: string, iteration = "stage-major") {
+  project = createTestProject();
+  seedStateFile(project, join(import.meta.dir, "../fixtures/state-construction-bolt1.md"));
+  const path = seededStateFile(project);
+  const state = readFileSync(path, "utf-8")
+    .replace(`- [ ] ${stage} — EXECUTE`, `- [?] ${stage} — EXECUTE`)
+    .replace("**Current Stage**: functional-design", `**Current Stage**: ${stage}`)
+    .replace("## Runtime State", [
+      "## Runtime State",
+      `- **Skeleton Stance**: ${stance}`,
+      `- **Construction Iteration**: ${iteration}`,
+    ].join("\n"));
+  writeFileSync(path, state);
+  appendAuditEntry("STAGE_AWAITING_APPROVAL", { Stage: stage }, project);
+  appendAuditEntry("HUMAN_TURN", {}, project);
+  const grant = run("bolt", ["set-autonomy", "--mode", "autonomous"]);
+  expect(grant.status, grant.output).toBe(0);
+}
+
+describe("t339 on-demand autonomy preserves protected stage approvals", () => {
+  for (const stance of ["on", "off", "scope-dependent"]) {
+    test(`the first ${stance} stage still needs its own human approval`, () => {
+      setup("functional-design", stance);
+      const before = readFileSync(seededStateFile(project), "utf-8");
+      const refused = run("state", ["approve", "functional-design", "--user-input", "Approve"]);
+      expect(refused.status).not.toBe(0);
+      expect(refused.output).toContain("no new human reply");
+      expect(readFileSync(seededStateFile(project), "utf-8")).toBe(before);
+      expect(readAllAuditShards(project)).not.toContain("**Event**: GATE_APPROVED");
+
+      appendAuditEntry("HUMAN_TURN", {}, project);
+      const approved = run("state", ["approve", "functional-design", "--user-input", "Approve"]);
+      // This focused fixture has no reviewer artifacts. The real human reply
+      // passes the authority check and reaches the independent review guard.
+      expect(approved.output).not.toContain("no new human reply");
+      expect(approved.output).toContain("has not reviewed the current output");
+    });
+  }
+
+  test("a later stage-major completion uses the recorded grant", () => {
+    setup("build-and-test", "off");
+    const approved = run("state", ["approve", "build-and-test"]);
+    expect(approved.status, approved.output).toBe(0);
+    expect(readAllAuditShards(project)).toContain("**Event**: GATE_APPROVED");
+  });
+
+  test("unit-major retains its human stage approvals", () => {
+    setup("nfr-requirements", "off", "unit-major");
+    const refused = run("state", ["approve", "nfr-requirements", "--user-input", "Approve"]);
+    expect(refused.status).not.toBe(0);
+    expect(refused.output).toContain("no new human reply");
+  });
+
+  test("revocation restores a later stage's human approval", () => {
+    setup("nfr-requirements", "off");
+    expect(run("bolt", ["set-autonomy", "--mode", "gated"]).status).toBe(0);
+    const refused = run("state", ["approve", "nfr-requirements", "--user-input", "Approve"]);
+    expect(refused.status).not.toBe(0);
+    expect(refused.output).toContain("no new human reply");
+  });
+});

--- a/tests/unit/t339-construction-autonomy-gates.test.ts
+++ b/tests/unit/t339-construction-autonomy-gates.test.ts
@@ -1,4 +1,4 @@
-// covers: function:isAutonomousConstructionGate, subcommand:aidlc-bolt:set-autonomy, subcommand:aidlc-state:approve
+// covers: function:isAutonomousConstructionGate, subcommand:aidlc-bolt:set-autonomy, subcommand:aidlc-state:approve, subcommand:aidlc-orchestrate:report
 //
 // An early human grant must not double as the first stage's approval.
 import { afterEach, describe, expect, test } from "bun:test";
@@ -13,7 +13,10 @@ import {
   seedStateFile,
 } from "../harness/fixtures.ts";
 import { appendAuditEntry } from "../../dist/claude/.claude/tools/aidlc-audit.ts";
-import { readAllAuditShards } from "../../dist/claude/.claude/tools/aidlc-lib.ts";
+import {
+  isAutonomousConstructionGate,
+  readAllAuditShards,
+} from "../../dist/claude/.claude/tools/aidlc-lib.ts";
 
 let project = "";
 afterEach(() => {
@@ -21,8 +24,12 @@ afterEach(() => {
   project = "";
 });
 
-function run(tool: "bolt" | "state", args: string[]) {
-  const tools = { bolt: "aidlc-bolt.ts", state: "aidlc-state.ts" };
+function run(tool: "bolt" | "state" | "orchestrate", args: string[]) {
+  const tools = {
+    bolt: "aidlc-bolt.ts",
+    state: "aidlc-state.ts",
+    orchestrate: "aidlc-orchestrate.ts",
+  };
   const env: Record<string, string | undefined> = {
     ...process.env,
     AIDLC_ALLOW_DIRECT_STATE_TRANSITIONS: "1",
@@ -35,15 +42,24 @@ function run(tool: "bolt" | "state", args: string[]) {
     [join(AIDLC_SRC, "tools", tools[tool]), ...args, "--project-dir", project],
     { encoding: "utf-8", env },
   );
-  return { status: result.status, output: `${result.stdout}${result.stderr}` };
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    output: `${result.stdout}${result.stderr}`,
+  };
 }
 
-function setup(stage: string, stance: string, iteration = "stage-major") {
+function setup(
+  stage: string,
+  stance: string,
+  iteration = "stage-major",
+  status: "in-progress" | "awaiting-approval" = "awaiting-approval",
+) {
   project = createTestProject();
   seedStateFile(project, join(import.meta.dir, "../fixtures/state-construction-bolt1.md"));
   const path = seededStateFile(project);
   const state = readFileSync(path, "utf-8")
-    .replace(`- [ ] ${stage} — EXECUTE`, `- [?] ${stage} — EXECUTE`)
+    .replace(`- [ ] ${stage} — EXECUTE`, `- [${status === "in-progress" ? "-" : "?"}] ${stage} — EXECUTE`)
     .replace("**Current Stage**: functional-design", `**Current Stage**: ${stage}`)
     .replace("## Runtime State", [
       "## Runtime State",
@@ -51,7 +67,11 @@ function setup(stage: string, stance: string, iteration = "stage-major") {
       `- **Construction Iteration**: ${iteration}`,
     ].join("\n"));
   writeFileSync(path, state);
-  appendAuditEntry("STAGE_AWAITING_APPROVAL", { Stage: stage }, project);
+  appendAuditEntry(
+    status === "in-progress" ? "STAGE_STARTED" : "STAGE_AWAITING_APPROVAL",
+    { Stage: stage },
+    project,
+  );
   appendAuditEntry("HUMAN_TURN", {}, project);
   const grant = run("bolt", ["set-autonomy", "--mode", "autonomous"]);
   expect(grant.status, grant.output).toBe(0);
@@ -82,6 +102,73 @@ describe("t339 on-demand autonomy preserves protected stage approvals", () => {
     const approved = run("state", ["approve", "build-and-test"]);
     expect(approved.status, approved.output).toBe(0);
     expect(readAllAuditShards(project)).toContain("**Event**: GATE_APPROVED");
+  });
+
+  test("a conditional skip protects the next approval without moving it after completion", () => {
+    setup("functional-design", "on", "stage-major", "in-progress");
+    const path = seededStateFile(project);
+    // Isolate approval authority from reviewer work; the fixture already uses
+    // the unit runner's artifact/summary guard exemptions, never its human one.
+    writeFileSync(path, readFileSync(path, "utf-8").replace(
+      "## Runtime State",
+      "## Runtime State\n- **Review Override**: none",
+    ));
+
+    const skipped = run("orchestrate", [
+      "report", "--stage", "functional-design", "--result", "skipped",
+      "--reason", "Simple logic changes with no new business logic",
+    ]);
+    expect(skipped.status, skipped.output).toBe(0);
+    expect(JSON.parse(skipped.stdout).kind).toBe("done");
+    expect(readFileSync(path, "utf-8")).toContain("- [S] functional-design — EXECUTE");
+    expect(readFileSync(path, "utf-8")).toContain("**Current Stage**: nfr-requirements");
+    expect(readAllAuditShards(project)).toContain("**Skip Kind**: conditional-runtime");
+
+    const opened = run("state", ["gate-start", "nfr-requirements"]);
+    expect(opened.status, opened.output).toBe(0);
+    const before = readFileSync(path, "utf-8");
+    const reportRefused = run("orchestrate", [
+      "report", "--stage", "nfr-requirements", "--result", "approved",
+    ]);
+    expect(JSON.parse(reportRefused.stdout).kind).toBe("error");
+    expect(reportRefused.output).toContain("did not match an offered choice");
+    const refused = run("state", [
+      "approve", "nfr-requirements", "--user-input", "Approve",
+    ]);
+    expect(refused.status).not.toBe(0);
+    expect(refused.output).toContain("no new human reply");
+    expect(readFileSync(path, "utf-8")).toBe(before);
+    expect(readAllAuditShards(project)).not.toContain("**Event**: GATE_APPROVED");
+
+    appendAuditEntry("HUMAN_TURN", {}, project);
+    const approved = run("state", [
+      "approve", "nfr-requirements", "--user-input", "Approve",
+    ]);
+    expect(approved.status, approved.output).toBe(0);
+    expect(readFileSync(path, "utf-8")).toContain("- [x] nfr-requirements — EXECUTE");
+
+    // No additional HUMAN_TURN or --user-input: [x] remains the anchor.
+    const later = run("orchestrate", [
+      "report", "--stage", "nfr-design", "--result", "approved",
+    ]);
+    expect(later.status, later.output).toBe(0);
+    expect(readFileSync(path, "utf-8")).toContain("- [x] nfr-design — EXECUTE");
+  });
+
+  test("approved overrides select the anchor in graph order, not checkbox order", () => {
+    const state = [
+      "- **Scope**: infra",
+      "- **Construction Autonomy Mode**: autonomous",
+      "- [ ] nfr-requirements — EXECUTE",
+      "- [ ] functional-design — EXECUTE",
+    ].join("\n");
+    const functional = { slug: "functional-design", phase: "construction" };
+    const nfr = { slug: "nfr-requirements", phase: "construction" };
+    // The approved plan promotes Functional Design ahead of infra's stock anchor.
+    expect(isAutonomousConstructionGate(state, functional)).toBe(false);
+    expect(isAutonomousConstructionGate(state, nfr)).toBe(true);
+    const skippedPlan = state.replace("functional-design — EXECUTE", "functional-design — SKIP");
+    expect(isAutonomousConstructionGate(skippedPlan, nfr)).toBe(false);
   });
 
   test("unit-major retains its human stage approvals", () => {

--- a/tests/unit/t339-construction-autonomy-gates.test.ts
+++ b/tests/unit/t339-construction-autonomy-gates.test.ts
@@ -21,7 +21,8 @@ afterEach(() => {
   project = "";
 });
 
-function run(tool: string, args: string[]) {
+function run(tool: "bolt" | "state", args: string[]) {
+  const tools = { bolt: "aidlc-bolt.ts", state: "aidlc-state.ts" };
   const env: Record<string, string | undefined> = {
     ...process.env,
     AIDLC_ALLOW_DIRECT_STATE_TRANSITIONS: "1",
@@ -31,7 +32,7 @@ function run(tool: string, args: string[]) {
   delete env.AIDLC_ALLOW_DIRECT_AUDIT_EVENTS;
   const result = spawnSync(
     process.execPath,
-    [join(AIDLC_SRC, "tools", `aidlc-${tool}.ts`), ...args, "--project-dir", project],
+    [join(AIDLC_SRC, "tools", tools[tool]), ...args, "--project-dir", project],
     { encoding: "utf-8", env },
   );
   return { status: result.status, output: `${result.stdout}${result.stderr}` };


### PR DESCRIPTION
# Summary

Users can explicitly grant or revoke Construction autonomy during Construction, including workflows with `skeleton: off`. An existing choice survives resume and is not asked again at the ladder.

## Changes

- Keep the first actual Construction approval human after conditional skips or approved stage overrides; completing that stage keeps its anchor fixed.

- Keep the on-demand path and existing ladder path on the same recorded grant.
- Preserve the first Construction-stage human approval after an early grant.
- Share completion-approval policy between report and state mutation; existing unit-major per-unit-stage gates remain human-owned.
- Document actual first-stage review behavior and update coverage metadata.

Depends on #1143. Together they address #1045; closes #1142. Original on-demand change by @jstrunk, followed by maintainer integration fixes.

## User experience

A user can say “run the rest autonomously” or “gate every stage from here.” The first stage's review, Code Generation Plan Approval, and failure stops retain their own requirements. A recorded autonomy answer is not repeated.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [ ] If this change adds an input to any fingerprint, epoch, or receipt identity, the description names the human-visible change it detects

## Test plan

The smoke/unit slice completed 304 files. Runtime regressions passed; the coverage registry was refreshed and its checks passed. Two fixture-discovery failures passed with Git discovery bounded to the fixture directory. Fifteen Windows-only cases were skipped.

Focused t261, t339, t120-classify-roundtrip, and t47-construction-bolts passed, as did the distribution build, determinism check, and TypeScript checks. No live-harness merge gate is claimed.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).

Local follow-up validation: the conditional-skip regression passed 8 cases; the final stacked routing/coverage slice passed 58.
