### PR TITLE
fix: persist Construction autonomy choices

### DIFF
--- a/core/tools/aidlc-bolt.ts
+++ b/core/tools/aidlc-bolt.ts
@@ -61,7 +61,6 @@ import {
   requireLiveClaimForTeamUnit,
   resolveBoltDag,
   resolveProjectDir,
-  setFieldStrict,
   setOrInsertField,
   validateUnitName,
   slugify,
@@ -1134,9 +1133,25 @@ function handleSetAutonomy(args: string[]): void {
     }
 
     // Validate state-file shape before the audit-first mutation.
+    //
+    // `Construction Autonomy Mode` is declared by the shipped state template
+    // (knowledge/aidlc-shared/state-template.md, under `## Current Status`) but
+    // the generator does not emit it, so a real state file usually lacks the
+    // line. setFieldStrict throws "Field not found in state file" in that case,
+    // which made the grant unrecordable and `autonomous` unreachable — see
+    // issue #1045. setOrInsertField writes it where the template declares it,
+    // healing both freshly generated and pre-existing state files without an
+    // init-time shape change or a migration. The shape check survives:
+    // appendUnderHeading throws when `## Current Status` is absent, so a
+    // malformed state file still fails closed before the audit-first mutation.
     let updated: string;
     try {
-      updated = setFieldStrict(content, "Construction Autonomy Mode", flags.mode);
+      updated = setOrInsertField(
+        content,
+        "## Current Status",
+        "Construction Autonomy Mode",
+        flags.mode,
+      );
     } catch (e) {
       error(`State update failed: ${errorMessage(e)}`);
     }

--- a/tests/unit/t261-audit-authority-floor.test.ts
+++ b/tests/unit/t261-audit-authority-floor.test.ts
@@ -319,13 +319,15 @@ describe("t261 public audit CLI refuses authority-bearing receipts", () => {
 describe("t261 set-autonomy escalation requires and consumes a human turn", () => {
   function constructionProject(): string {
     const p = createTestProject();
+    // Deliberately NOT seeding `Construction Autonomy Mode`. The fixture omits
+    // it exactly as the generated state file does, so these tests exercise the
+    // real production shape: set-autonomy has to CREATE the line. An earlier
+    // version of this helper appended `- **Construction Autonomy Mode**: gated`
+    // here, which manufactured the one precondition the production path lacks
+    // and made every assertion below incapable of catching issue #1045 (the
+    // grant threw `Field not found in state file` before reaching the audit
+    // emission).
     seedStateFile(p, join(FIXTURES, "state-construction.md"));
-    const statePath = seededStateFile(p);
-    writeFileSync(
-      statePath,
-      `${readFileSync(statePath, "utf-8")}\n- **Construction Autonomy Mode**: gated\n`,
-      "utf-8",
-    );
     // Seed one row so the empty-ledger fail-open path does not apply.
     const seed = guarded(AUDIT, ["append", "ERROR_LOGGED", "--field", "Details=seed"], p);
     if (seed.rc !== 0) throw new Error(seed.out);
@@ -381,6 +383,57 @@ describe("t261 set-autonomy escalation requires and consumes a human turn", () =
     ).toBe(1);
     expect(readFileSync(seededStateFile(proj), "utf-8")).toContain(
       "Construction Autonomy Mode**: autonomous",
+    );
+  });
+
+  // Issue #1045. The field is runtime metadata the generator does not emit,
+  // though the shipped state template declares it under `## Current Status`.
+  // The write must therefore CREATE it, in that section, exactly once.
+  test("the grant creates the field under ## Current Status when absent", () => {
+    proj = constructionProject();
+    const before = readFileSync(seededStateFile(proj), "utf-8");
+    expect(before).not.toContain("Construction Autonomy Mode");
+
+    mintHumanTurn(proj);
+    expect(guarded(BOLT, ["set-autonomy", "--mode", "autonomous"], proj).rc).toBe(0);
+
+    const after = readFileSync(seededStateFile(proj), "utf-8");
+    // Section membership, not line ordering: the insert lands at the end of the
+    // section rather than at the template's exact offset, and nothing reads it
+    // positionally.
+    const currentStatus = after.slice(
+      after.indexOf("## Current Status"),
+      after.indexOf("## Session Resume Point"),
+    );
+    expect(currentStatus).toContain("- **Construction Autonomy Mode**: autonomous");
+    expect(after.match(/Construction Autonomy Mode/g)?.length).toBe(1);
+  });
+
+  test("a second grant updates the field in place instead of duplicating it", () => {
+    proj = constructionProject();
+    mintHumanTurn(proj);
+    expect(guarded(BOLT, ["set-autonomy", "--mode", "autonomous"], proj).rc).toBe(0);
+    expect(guarded(BOLT, ["set-autonomy", "--mode", "gated"], proj).rc).toBe(0);
+
+    const after = readFileSync(seededStateFile(proj), "utf-8");
+    expect(after.match(/Construction Autonomy Mode/g)?.length).toBe(1);
+    expect(after).toContain("- **Construction Autonomy Mode**: gated");
+    expect(after).not.toContain("Construction Autonomy Mode**: autonomous");
+  });
+
+  test("a state file without the ## Current Status heading still fails closed", () => {
+    proj = constructionProject();
+    const statePath = seededStateFile(proj);
+    writeFileSync(
+      statePath,
+      readFileSync(statePath, "utf-8").replace("## Current Status", "## Current Status Renamed"),
+      "utf-8",
+    );
+    const refused = guarded(BOLT, ["set-autonomy", "--mode", "gated"], proj);
+    expect(refused.rc).not.toBe(0);
+    expect(refused.out).toContain("State update failed");
+    expect(readFileSync(statePath, "utf-8")).not.toContain(
+      "- **Construction Autonomy Mode**:",
     );
   });
 });


### PR DESCRIPTION
# Summary

`set-autonomy` can now save the user's choice when the state file lacks `Construction Autonomy Mode`. The missing field is inserted under `Current Status`, so existing workflows work without a migration.

## Changes

- Replace the strict field update with insert-or-update behavior.
- Exercise the production-shaped state fixture, missing-field insertion, updates without duplicates, and refusal when the required insertion heading is absent.
- Preserve the fresh-human-turn check and audit-first ordering.

Addresses the persistence portion of #1045. #1140 supplies the on-demand protocol path. Original implementation and regression tests by @jstrunk; original author credit is preserved.

## User experience

Before, choosing autonomy could fail with “Field not found in state file.” After, the choice is saved and existing Construction behavior can honor it.

## Checklist

* [x] I have reviewed the [contributing guidelines](https://github.com/awslabs/aidlc-workflows/blob/main/CONTRIBUTING.md)
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [ ] If this change adds an input to any fingerprint, epoch, or receipt identity, the description names the human-visible change it detects

## Test plan

t261: 69 passing cases. Distribution build, independent-build determinism, and all TypeScript projects passed. This is focused local validation, not a completed live-harness merge gate.

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
