### PR TITLE
fix: remove AI review context size limits

### DIFF
--- a/.github/prompts/ai-pr-review-common.md
+++ b/.github/prompts/ai-pr-review-common.md
@@ -32,10 +32,10 @@ install dependencies, push commits, post comments, approve, or merge. The
 checked-out tree is the trusted base revision. Read the proposed change from `.ai-review-context/pr.diff`;
 metadata and immutable SHAs are in `.ai-review-context/pr.json`; the complete
 changed-file and changed-line manifest is
-`.ai-review-context/changed-files.json`. Bounded full snapshots of files at
+`.ai-review-context/changed-files.json`. Full snapshots of files at
 the proposed head are under `.ai-review-context/head/`. Deleted files remain
 available in the checked-out base tree. Context creation fails closed when a
-changed head file cannot be snapshotted within the configured bounds.
+changed head file cannot be snapshotted.
 
 Read `AGENTS.md`, `CONTRIBUTING.md`, and relevant base-branch reference material.
 Inspect every changed file represented in the diff. Read related definitions,

--- a/.github/scripts/ai-pr-review.ts
+++ b/.github/scripts/ai-pr-review.ts
@@ -10,9 +10,6 @@ import {
 import { dirname, join, relative, resolve, sep } from "node:path";
 
 const MAX_CHANGED_FILES = 500;
-const MAX_DIFF_BYTES = 5_000_000;
-const MAX_FILE_BYTES = 1_000_000;
-const MAX_SNAPSHOT_BYTES = 20_000_000;
 const MAX_REVIEW_BYTES = 100_000;
 
 export type Priority = "P0" | "P1" | "P2" | "P3";
@@ -104,7 +101,7 @@ function git(args: string[], encoding?: BufferEncoding, cwd = process.cwd()): Bu
   return execFileSync("git", args, {
     cwd,
     encoding,
-    maxBuffer: MAX_SNAPSHOT_BYTES + MAX_DIFF_BYTES,
+    maxBuffer: Number.POSITIVE_INFINITY,
     stdio: ["ignore", "pipe", "pipe"],
   });
 }
@@ -171,12 +168,9 @@ function rangesFromDiff(
   });
 }
 
-function writeSnapshot(outputDir: string, head: string, file: ChangedFile, repoDir: string): number {
-  if (file.status.startsWith("D")) return 0;
+function writeSnapshot(outputDir: string, head: string, file: ChangedFile, repoDir: string): void {
+  if (file.status.startsWith("D")) return;
   const content = git(["show", `${head}:${file.path}`], undefined, repoDir) as Buffer;
-  if (content.byteLength > MAX_FILE_BYTES) {
-    throw new Error(`${file.path} exceeds the ${MAX_FILE_BYTES}-byte snapshot limit`);
-  }
   const snapshot = join("head", file.path);
   const destination = resolve(outputDir, snapshot);
   const root = `${resolve(outputDir)}${sep}`;
@@ -184,7 +178,6 @@ function writeSnapshot(outputDir: string, head: string, file: ChangedFile, repoD
   mkdirSync(dirname(destination), { recursive: true });
   writeFileSync(destination, content);
   file.snapshot = snapshot;
-  return content.byteLength;
 }
 
 function contextDigest(root: string): string {
@@ -222,9 +215,6 @@ export function buildContext(
     undefined,
     repoDir,
   ) as Buffer;
-  if (diff.byteLength > MAX_DIFF_BYTES) {
-    throw new Error(`PR diff exceeds ${MAX_DIFF_BYTES} bytes`);
-  }
   writeFileSync(join(outputDir, "pr.diff"), diff);
 
   const entries = parseNameStatus(
@@ -239,13 +229,9 @@ export function buildContext(
   }
   const ranges = rangesFromDiff(diff.toString("utf8"), entries.length);
 
-  let snapshotBytes = 0;
   const files = entries.map((entry, index) => {
     const file: ChangedFile = { ...entry, ...ranges[index] };
-    snapshotBytes += writeSnapshot(outputDir, head, file, repoDir);
-    if (snapshotBytes > MAX_SNAPSHOT_BYTES) {
-      throw new Error(`head snapshots exceed ${MAX_SNAPSHOT_BYTES} bytes`);
-    }
+    writeSnapshot(outputDir, head, file, repoDir);
     return file;
   });
   const manifest = { base, head, files };

--- a/tests/unit/t300-ai-pr-review.test.ts
+++ b/tests/unit/t300-ai-pr-review.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -264,6 +264,63 @@ describe("t300 adversarial AI PR review", () => {
     expect(modeOnly?.added).toEqual([]);
     expect(modeOnly?.deleted).toEqual([]);
     expect(modeOnly?.fileLevelEvidence).toBe(true);
+  });
+
+  test("context builder accepts large files, diffs, and aggregate snapshots", () => {
+    const repo = mkdtempSync(join(tmpdir(), "aidlc-ai-review-large-context-"));
+    const run = (...args: string[]): string =>
+      execFileSync("git", args, {
+        cwd: repo,
+        encoding: "utf8",
+        maxBuffer: Number.POSITIVE_INFINITY,
+      }).trim();
+    run("init", "--quiet");
+    run("config", "user.name", "AI Review Test");
+    run("config", "user.email", "ai-review@example.invalid");
+    writeFileSync(join(repo, "large-diff.txt"), "a".repeat(6_000_000));
+    const aggregateContent = "x\n".repeat(475_000);
+    for (let index = 0; index < 16; index++) {
+      writeFileSync(join(repo, `aggregate-${index}.txt`), aggregateContent);
+    }
+    run("add", ".");
+    run("commit", "--quiet", "-m", "base");
+    const base = run("rev-parse", "HEAD");
+
+    writeFileSync(join(repo, "large-diff.txt"), "b".repeat(6_000_000));
+    for (let index = 0; index < 16; index++) {
+      writeFileSync(join(repo, `aggregate-${index}.txt`), `${aggregateContent}changed\n`);
+    }
+    run("add", ".");
+    run("commit", "--quiet", "-m", "head");
+    const head = run("rev-parse", "HEAD");
+
+    const output = join(repo, "context");
+    const manifest = buildContext(base, head, output, repo);
+    const snapshotSizes = manifest.files.map(file => statSync(join(output, file.snapshot!)).size);
+    expect(statSync(join(output, "pr.diff")).size).toBeGreaterThan(5_000_000);
+    expect(Math.max(...snapshotSizes)).toBeGreaterThan(1_000_000);
+    expect(snapshotSizes.reduce((total, size) => total + size, 0)).toBeGreaterThan(20_000_000);
+  });
+
+  test("context builder still rejects more than 500 changed files", () => {
+    const repo = mkdtempSync(join(tmpdir(), "aidlc-ai-review-file-limit-"));
+    const run = (...args: string[]): string =>
+      execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim();
+    run("init", "--quiet");
+    run("config", "user.name", "AI Review Test");
+    run("config", "user.email", "ai-review@example.invalid");
+    run("commit", "--quiet", "--allow-empty", "-m", "base");
+    const base = run("rev-parse", "HEAD");
+    for (let index = 0; index < 501; index++) {
+      writeFileSync(join(repo, `file-${index}.txt`), `${index}\n`);
+    }
+    run("add", ".");
+    run("commit", "--quiet", "-m", "head");
+    const head = run("rev-parse", "HEAD");
+
+    expect(() => buildContext(base, head, join(repo, "context"), repo)).toThrow(
+      "PR changes 501 files; limit is 500",
+    );
   });
 
   test("workflow reviews internal PRs only and isolates model credentials from publication", () => {


### PR DESCRIPTION
## Summary

- remove the 5 MB diff, 1 MB per-file, and 20 MB aggregate snapshot limits from AI PR review context creation
- keep the independent 500 changed-file limit
- update the reviewer prompt to describe complete, unbounded head snapshots
- add regression coverage for contexts exceeding every removed byte limit and for the retained 500-file gate

## Rationale

The byte limits reject normal repository changes. In a sample of 58 recently updated, measurable same-repository PRs targeting `main`, two valid context snapshots exceeded 20 MB (23.34 MiB and 25.05 MiB), and the current `core/tools/aidlc-lib.ts` already exceeds the former 1 MB per-file limit. The changed-file count remains the explicit resource bound.

## Validation

- `bun test tests/unit/t300-ai-pr-review.test.ts` (13 pass)
- `bunx tsc --noEmit -p tsconfig.tests.json`
- `bunx biome check --error-on-warnings .github/scripts/ai-pr-review.ts tests/unit/t300-ai-pr-review.test.ts`
- `git diff --check`

No release metadata bump: this is an internal CI correction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).