### PR TITLE
fix: remove AI review egress blocking

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -216,20 +216,6 @@ jobs:
       - name: Install pinned review CLI before assuming AWS role
         run: npm install --global "@openai/codex@$CODEX_VERSION"
 
-      - name: Restrict model-phase network egress
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            bedrock-runtime.us-east-1.amazonaws.com:443
-            bedrock.us-east-1.amazonaws.com:443
-            sts.amazonaws.com:443
-            sts.us-east-1.amazonaws.com:443
-            token.actions.githubusercontent.com:443
-            results-receiver.actions.githubusercontent.com:443
-            *.blob.core.windows.net:443
-
       - name: Configure ChatGPT Sol
         run: |
           mkdir -p "$HOME/.codex"
@@ -318,20 +304,6 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.14'
-
-      - name: Restrict model-phase network egress
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: block
-          disable-telemetry: true
-          allowed-endpoints: >
-            bedrock-runtime.us-east-1.amazonaws.com:443
-            bedrock.us-east-1.amazonaws.com:443
-            sts.amazonaws.com:443
-            sts.us-east-1.amazonaws.com:443
-            token.actions.githubusercontent.com:443
-            results-receiver.actions.githubusercontent.com:443
-            *.blob.core.windows.net:443
 
       - name: Configure ChatGPT Sol
         run: |

--- a/tests/unit/t300-ai-pr-review.test.ts
+++ b/tests/unit/t300-ai-pr-review.test.ts
@@ -344,10 +344,8 @@ describe("t300 adversarial AI PR review", () => {
     expect(WORKFLOW).toContain(`role-to-assume: \${{ secrets.AWS_AI_PR_REVIEW_ROLE_ARN }}`);
     expect(WORKFLOW).toContain('model = "openai.gpt-5.6-sol"');
     expect(WORKFLOW).toContain('exclude = ["AWS_*", "ACTIONS_*", "GITHUB_*", "GH_*"]');
-    expect(WORKFLOW).toContain("step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920");
-    expect(WORKFLOW).toContain("egress-policy: block");
-    expect(WORKFLOW).toContain("results-receiver.actions.githubusercontent.com:443");
-    expect(WORKFLOW).toContain("*.blob.core.windows.net:443");
+    expect(WORKFLOW).not.toContain("step-security/harden-runner");
+    expect(WORKFLOW).not.toContain("egress-policy:");
     expect(WORKFLOW).toContain("codex exec --sandbox read-only");
     expect(WORKFLOW).not.toMatch(/ref:\s+\$\{\{\s*needs\.context\.outputs\.head/);
     expect(WORKFLOW).toContain("current_head");
@@ -386,8 +384,8 @@ describe("t300 adversarial AI PR review", () => {
       WORKFLOW.indexOf("  synthesize:"),
       WORKFLOW.indexOf("  publish:"),
     );
-    expect(synthesisJob.indexOf("oven-sh/setup-bun")).toBeLessThan(
-      synthesisJob.indexOf("step-security/harden-runner"),
+    expect(synthesisJob.indexOf("Install pinned review CLI")).toBeLessThan(
+      synthesisJob.indexOf("configure-aws-credentials"),
     );
   });
 


### PR DESCRIPTION
## Summary

- remove `harden-runner` egress blocking from the AI review lens and synthesis jobs
- retain the current same-repository PR gate, trusted-base checkout, non-persisted Git credentials, scoped OIDC role, filtered credential environment, and read-only Codex sandbox
- update the workflow contract test to prevent the blocking policy from being reintroduced while fork reviews remain disabled

## Rationale

The `harden-runner` action applies its blocking policy in a pre-step before `actions/checkout`, despite appearing later in the YAML. As a result, all three review lenses in [run 34657356432](https://github.com/awslabs/aidlc-workflows/actions/runs/34657356432) failed to fetch the trusted base from `github.com`; no model review ran. The workflow currently rejects fork PRs, so this blocking layer is being removed rather than expanding its allowlist and exposing the same endpoints during model execution.

## Validation

- `bun test tests/unit/t300-ai-pr-review.test.ts` (13 pass)
- `./node_modules/.bin/tsc --noEmit -p tsconfig.tests.json --pretty false`
- `./node_modules/.bin/biome check --error-on-warnings tests/unit/t300-ai-pr-review.test.ts`
- `git diff --check`

No release metadata bump: this is an internal CI correction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).