### PR TITLE
fix: keep review bookkeeping out of the artifact, and out of the reviewer's findings

### DIFF
--- a/core/aidlc-common/protocols/stage-protocol-reviewer.md
+++ b/core/aidlc-common/protocols/stage-protocol-reviewer.md
@@ -78,6 +78,7 @@ Everything else in this section is silent. Nothing is said about invoking, handi
      - For a **per-unit** stage (`directive.unit` present) these include the shared inception contracts that pin cross-unit boundaries (`components.md`, `contract-summary.md`, `unit-of-work.md`).
      - For a **workflow-level** stage with no `directive.unit` (e.g. `contract-design`), these are the upstream artifacts that justify the produced output - the unit DAG (`unit-of-work.md`, `unit-of-work-dependency.md`), the component catalogue (`components.md`), and `requirements.md` - so the reviewer can verify the contracts against the boundaries, entities, and NFRs they formalise rather than reviewing the summary in isolation.
    - The validation tools list from the stage definition's frontmatter (if any)
+   - The review-content boundary: tell the reviewer not to raise a finding whose sole subject is this stage's own review bookkeeping. Treat text as this stage's own review bookkeeping when its sole purpose is to record a review iteration or revision count, list or status this stage's findings, or name this stage's review-record path; judge the product claims instead. An inline tag naming an upstream stage's finding is provenance; a tag naming this stage's own finding is bookkeeping.
    - For a per-unit `workspace_requires` stage, the unit's
      `source-manifest.json` path and its claimed source paths. Review the
      implementation differentially at those paths rather than sweeping the
@@ -230,6 +231,21 @@ Everything else in this section is silent. Nothing is said about invoking, handi
      rejection from generic revision feedback. The state tool validates the
      artifact, ID, current status, and nonblank reason before recording
      `Rejected: <reason>` on `GATE_REJECTED`.
+
+   **Review bookkeeping is not artifact content.** The review record carries the
+   verdict, findings, reviewer, request id and artifact fingerprint; the ledger
+   carries the human dispositions; and `REVIEW_COMPLETED` pins the record's digest.
+   So do not copy this stage's own review history into a `produces[]` artifact -
+   not a revision counter, not a note listing which of its findings a revision
+   applied, not a finding's status, not a review-record path. Such a copy is
+   unverified and it goes stale by construction rather than by mistake: the gate
+   can approve while the artifact's own note still says a review is pending. An
+   inline provenance tag is different only when it preserves a tag already carried
+   by a consumed upstream artifact or cites an upstream stage's finding as the
+   source of a downstream claim. A tag naming this stage's own finding or review
+   iteration is review bookkeeping and is prohibited. The reviewer half of this
+   rule travels in the dispatch list above, because that is the only text a
+   dispatched reviewer receives.
 
    **On an `advisory` review, both verdicts are terminal here.** Do not
    re-invoke the lead or the reviewer during normal flow; proceed to section

--- a/tests/unit/t266-review-class.test.ts
+++ b/tests/unit/t266-review-class.test.ts
@@ -390,6 +390,17 @@ describe("t266 review class", () => {
       expect(src).toContain("On an `advisory` review, both verdicts are terminal here.");
       // The adversarial contract prose t234 pins must survive the class split.
       expect(src).toContain("refute the artifact, not to confirm it");
+      // The conductor half of the bookkeeping rule, and the sentence that draws the
+      // line a looser wording lost: an upstream finding is provenance, this stage's
+      // own finding is bookkeeping. The reviewer half is pinned in t279, on the
+      // dispatch list, because that is the only text a reviewer receives.
+      // Whitespace-normalised: the sentence wraps in the module and re-wrapping it
+      // must not silently drop the pin.
+      const flat = src.replace(/\s+/g, " ");
+      expect(flat).toContain("Review bookkeeping is not artifact content");
+      expect(flat).toContain(
+        "A tag naming this stage's own finding or review iteration is review bookkeeping and is prohibited.",
+      );
     }
   });
 

--- a/tests/unit/t279-reviewer-turn-budget.test.ts
+++ b/tests/unit/t279-reviewer-turn-budget.test.ts
@@ -371,6 +371,12 @@ describe("t279 reviewer turn budget is stated on every surface", () => {
       expect(labelled).toContain("Before every dispatch, not only the first");
       expect(labelled).toContain("returns `requestId` and `reviewFile`");
       expect(labelled).toContain("aidlc-review-brief.ts context");
+      // The reviewer half of the bookkeeping rule lives in the dispatch list, the
+      // only text a dispatched reviewer receives. Every shipped copy must carry it.
+      expect(labelled).toContain("The review-content boundary: tell the reviewer");
+      expect(labelled).toContain(
+        "a tag naming this stage's own finding is bookkeeping",
+      );
       expect(labelled).toContain(
         "durable human dispositions from the audit ledger",
       );


### PR DESCRIPTION
## Problem

An advisory stage's revision loop can feed itself. Measured on one live run of
`requirements-analysis`: three Request Changes at the gate, four review passes,
and the findings list grew by exactly one each pass — 5, 6, 7, 8.

Only the first of those additions was a product defect (an unspecified freshness
contract between two functional requirements). The next two were about the
revision's own bookkeeping: one reported that the artifact's note still said
"revision 1 / R-01–R-05" after a later revision, and the next reported that the
note now said "R-01–R-07" while a section further down said "R-01–R-06". In this
run R-07 sent the human back to Request Changes; that revision then created R-08,
which the human accepted as risk at the final gate.

Nothing asks for that prose. On this run `required-sections` used its generic
≥2-H2 check. A `## Sources` register is required by Intent Capture and stated as
that stage's own form; the Product Lead persona says other stages do not produce
it. `upstream-coverage` requires a reference to the upstream artifacts, which is
content, not review history. And the history already has an owner: the review
record carries the verdict, findings, reviewer, request id and artifact
fingerprint; the ledger carries the human dispositions; and `REVIEW_COMPLETED`
pins the record's digest. The copy in the artifact is unverified and goes stale by
construction — in that run the artifact still said a review was pending after the
ledger had recorded the approval.

The reviewer side is the other half. An `advisory` pass is defined to report only
findings the human should weigh before approving, and the Product Lead's criteria
are implementability, testability and product scope. Neither bookkeeping finding
moves any of those; the second says outright that a reader is unlikely to be
misled.

## Fix

Two texts, because the two actors read different ones.

The conductor rule goes in the module, next to the existing rule that gate
dispositions are receipt-safe audit data and never artifact edits: do not copy
this stage's own review history into a `produces[]` artifact.

The reviewer rule goes in the dispatch list — the `Pass:` items — because that is
the only text a dispatched reviewer receives; the module itself never reaches it.
It names what counts as bookkeeping rather than leaving the reviewer to judge:
text whose sole purpose is to record a review iteration or revision count, to list
or status this stage's findings, or to name this stage's review-record path.

The boundary is stated once and identically on both sides: an inline tag naming an
upstream stage's finding is provenance, and a tag naming this stage's own finding
is bookkeeping. A second live run showed why that line matters — its requirements
carried `[Q(<upstream stage> R-04)]` tags on individual requirements. A rule
written against "finding ids" would have outlawed those.

A broad lexical sensor over `R-01`, revision language, or Sources headings would be
noisy. Reliably identifying this stage's own review history is semantic, so prose
owns the contract; a future exact-path advisory check could cover only a narrow
subset.

## Tests

The conductor half is pinned in `t266` across core and the projected copy,
whitespace-normalised so re-wrapping the sentence cannot silently drop the pin.
The reviewer half is pinned in `t279`'s per-harness module loop, so every shipped
copy must carry the dispatch item.

Both pins were negative-controlled independently: removing the module paragraph
fails `t266` and removing the dispatch item fails `t279`, and restoring each
passes. `typecheck`, `lint` and `package.ts --check` are clean. The one failure in
`t271` in this worktree (`--unit requires an authoritative DAG or a matching
active or merged Bolt`) is present at the unmodified base and unrelated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
