### PR TITLE
fix(claim-sources): fold multi-line assumption confirmations before matching

### DIFF
--- a/core/tools/aidlc-sensor-claim-sources.ts
+++ b/core/tools/aidlc-sensor-claim-sources.ts
@@ -462,9 +462,8 @@ function parseSourceUniverse(
 	}
 	const assumptionAnswer = assumptionAnswers[0] ?? "";
 	const acceptedAssumptions = new Set(
-		confirmation
-			.filter((line) => isListItem(line))
-			.filter((line) => sourceTags(line, labels).includes("assumption"))
+		foldListItemBlocks(confirmation)
+			.filter((block) => sourceTags(block, labels).includes("assumption"))
 			.map(normalizedAssumption)
 			.filter((entry) => entry.length > 0),
 	);
@@ -478,6 +477,39 @@ function parseSourceUniverse(
 			pastedDocumentPresent: authority.pastedDocumentPresent,
 			findings,
 	};
+}
+
+/**
+ * Groups a flat line array into logical list-item blocks: a line matching
+ * `isListItem` starts a new block, and subsequent non-blank, non-list-item
+ * lines are folded into it as wrapped continuation text (joined with "\n",
+ * matching how `normalizedAssumption` collapses whitespace). A blank line
+ * or the next list item ends the current block. Lines that appear before
+ * any list item are ignored, matching the previous per-line filter's
+ * behavior of only ever keeping list-item lines.
+ */
+function foldListItemBlocks(lines: string[]): string[] {
+	const blocks: string[] = [];
+	let pending: string[] = [];
+
+	const flush = (): void => {
+		if (pending.length > 0) blocks.push(pending.join("\n"));
+		pending = [];
+	};
+
+	for (const line of lines) {
+		if (isListItem(line)) {
+			flush();
+			pending.push(line);
+		} else if (line.trim().length === 0) {
+			flush();
+		} else if (pending.length > 0) {
+			pending.push(line);
+		}
+	}
+	flush();
+
+	return blocks;
 }
 
 function isTableSeparator(line: string): boolean {

--- a/tests/unit/t247-claim-sources-sensor.test.ts
+++ b/tests/unit/t247-claim-sources-sensor.test.ts
@@ -415,6 +415,25 @@ describe("t247 claim-sources sensor", () => {
     );
   });
 
+  test("a wrapped multi-line assumption confirmation still matches the retained assumption", () => {
+    const dir = makeStageDir();
+    replaceInFile(
+      dir,
+      "stakeholder-map.md",
+      "None.",
+      "- A procurement reviewer may be needed for all international purchases over the annual threshold. [assumption]",
+    );
+    const questionsPath = join(dir, "intent-capture-questions.md");
+    writeFileSync(
+      questionsPath,
+      `${readFileSync(questionsPath, "utf-8")}\n\n## Assumption Confirmation\n\n- A procurement reviewer may be needed for all international\n  purchases over the annual threshold. [assumption]\n\nA. Accept assumptions\nB. Convert to follow-up questions\n\n[Answer]: A. Accept assumptions\n`,
+      "utf-8",
+    );
+    const result = run(dir, "intent-capture-questions.md");
+    expect(result.pass).toBe(true);
+    expect(result.findings).toEqual([]);
+  });
+
   for (const answer of [
     "A. Accept assumptions? No",
     "A. Accept assumptions with caveats",


### PR DESCRIPTION
Fixes #1118.

`acceptedAssumptions` in `core/tools/aidlc-sensor-claim-sources.ts` built its accepted-assumption set by mapping each **line** of the `## Assumption Confirmation` section through `normalizedAssumption()` individually:

```ts
const acceptedAssumptions = new Set(
  confirmation
    .filter((line) => isListItem(line))
    .filter((line) => sourceTags(line, labels).includes("assumption"))
    .map(normalizedAssumption)
    .filter((entry) => entry.length > 0),
);
```

`isListItem` only matches a line that *starts* with a list marker, so a wrapped confirmation entry contributes only its first line — continuation lines are silently dropped.

The deliverable side (`inspectDeliverable`) compares the **whole block**: `claimBlocks()` already folds a list item's continuation lines into one `.text` string before `normalizedAssumption()` collapses whitespace. So the two sides of the comparison operate at different granularities — a correctly-authored assumption wrapped over more than one physical line can never be found "accepted," and the finding names the deliverable's heading, sending the reader to fix the wrong file.

### Fix

Added `foldListItemBlocks()`, a small local helper next to `isListItem` that groups a flat line array into logical list-item blocks — a list-item line starts a block, subsequent non-blank/non-list-item lines fold into it, a blank line or the next list item ends it. This mirrors `claimBlocks()`'s own list-item handling (deliberately not reusing `claimBlocks()` directly, since these lines have already been through markdown preprocessing earlier in the function and re-running it would be redundant). Replaced the per-line filter/map with `foldListItemBlocks(confirmation)` feeding the same `sourceTags`/`normalizedAssumption` calls, so both sides of the comparison now use block-level granularity.

### How did you test it

Added `t247-claim-sources-sensor.test.ts`'s `"a wrapped multi-line assumption confirmation still matches the retained assumption"`, reproducing the issue's exact scenario (a two-line confirmation entry vs. a single-line deliverable assumption with equivalent text). Confirmed it fails against pre-fix code (`git stash`) and passes after — the existing 84 tests in this file are unaffected.

- `bun test tests/unit/t247-claim-sources-sensor.test.ts`: 85 pass, 0 fail
- `bun scripts/package.ts --check`: deterministic across two independent builds
- `bun run lint` (biome): clean, 0 errors
- `bun run typecheck` (all 3 tsconfigs): clean
- `bun tests/run-tests.ts` (full 422-file suite, default profile): 9 pre-existing failures, none touching this file or `t247`. Spot-checked 3 of the 9 (`t241-opencode-adapter`, `t19`, `t278-per-unit-wave`) in isolation — all pass cleanly with this change, confirming the full-run failures are pre-existing flakiness/resource contention. Confirmed a 4th (`t92`, a `tsc`/`.tsbuildinfo` caching test) fails identically with this change reverted, i.e. pre-existing and unrelated to this fix.