### PR TITLE
fix: measure the review budget against the engine's own ordinal, not the caller's

### DIFF
--- a/core/tools/aidlc-log.ts
+++ b/core/tools/aidlc-log.ts
@@ -2076,13 +2076,20 @@ function handleReview(args: string[]): void {
             message,
           );
         }
-        if (!recoveryEligible && budget !== null && iteration > budget) {
-          refuseAttemptGuard(
-            "REVIEW_BUDGET_EXHAUSTED",
-            "Review requests do not exceed the configured attempt budget.",
-            reviewBudgetMessage(flags.stage, iteration, budget),
-          );
-        }
+        // The budget is measured against `expected` ONLY. `iteration` is the
+        // caller's claim about which pass this is, and it is validated against
+        // `expected` further down with a message that names the right ordinal.
+        // Measuring the budget against the claim instead turned a recoverable
+        // off-by-one into an unrecoverable refusal: after a gate rejection the
+        // accounting floor moves (reviewAttemptAccounting treats GATE_REJECTED as
+        // an attempt boundary), so `expected` is 1 again while a conductor that
+        // kept counting passes `--iteration 2`. On an `advisory` stage, whose
+        // budget is 1, that claim alone produced REVIEW_BUDGET_EXHAUSTED - and
+        // its guidance ("do not ask the reviewer again; include the findings in
+        // the approval summary") then routes to a gate that refuses for
+        // REVIEW_EVIDENCE_MISSING, because the revision path needs the fresh
+        // receipt the refusal just forbade. The only remedy left is a redo jump,
+        // which discards the attempt the human was mid-revision on.
         if (!recoveryEligible && budget !== null && expected > budget) {
           refuseAttemptGuard(
             "REVIEW_BUDGET_EXHAUSTED",

--- a/tests/unit/t271-review-iteration-ceiling.test.ts
+++ b/tests/unit/t271-review-iteration-ceiling.test.ts
@@ -448,6 +448,46 @@ describe("t271 review iteration ceiling", () => {
     expect(rows.length).toBe(1);
   });
 
+  test("a gate rejection resets the ordinal, so a stale --iteration is corrected rather than refused as over budget", () => {
+    // Regression: the budget was measured against the CALLER's `--iteration` as
+    // well as against the engine's own `expected`. A gate rejection is an attempt
+    // boundary, so after one the next request is ordinal 1 again - but a conductor
+    // that kept counting asks for 2, and on an advisory stage (budget 1) that
+    // claim alone produced REVIEW_BUDGET_EXHAUSTED. Its guidance sends the
+    // conductor to the gate, which then refuses for REVIEW_EVIDENCE_MISSING
+    // because the revision path needs the very receipt the refusal forbade, and
+    // the only remedy left discards the attempt. Measured on a live run.
+    const proj = seedProject("feature"); // requirements-analysis declares advisory
+    const base = [
+      "--stage", "requirements-analysis",
+      "--reviewer", "aidlc-product-lead-agent",
+    ];
+    expect(runReview(proj, [...base, "--iteration", "1"]).status).toBe(0);
+    expect(
+      runReview(proj, [...base, "--iteration", "1", "--verdict", "READY"]).status,
+    ).toBe(0);
+
+    // Timestamps are second-precision, and a rejection sharing a second with the
+    // review it invalidates is the tie the attempt reducer warns about. Wait it out
+    // so this case pins the ordinal reset, not the tiebreak.
+    const second = Math.floor(Date.now() / 1000);
+    while (Math.floor(Date.now() / 1000) === second) {}
+    appendAuditEntry("GATE_REJECTED", {
+      Stage: "requirements-analysis",
+      Feedback: "add the missing section",
+    }, proj);
+
+    const stale = runReview(proj, [...base, "--iteration", "2"]);
+    expect(stale.status).not.toBe(0);
+    // The refusal names the ordinal to retry with, and does NOT claim the budget
+    // is spent - the caller's arithmetic was wrong, the budget was not.
+    expect(stale.stderr).toContain("the next iteration is 1");
+    expect(stale.stderr).not.toContain("allows 1 review pass");
+
+    // And the corrected ordinal is accepted, which is what the revision path needs.
+    expect(runReview(proj, [...base, "--iteration", "1"]).status).toBe(0);
+  });
+
   test("advisory stale receipt gets one recovery request at the next ordinal", () => {
     const proj = seedProject("feature");
     writeReviewedArtifact(proj, "requirements-analysis", "reviewed requirements\n");
@@ -619,6 +659,16 @@ describe("t271 review iteration ceiling", () => {
 
   test("scope review_cap lowers an adversarial budget to 1 (bugfix)", () => {
     const proj = seedProject("bugfix");
+    // Spend the one pass the cap allows FIRST. Without it the attempt's next
+    // ordinal is still 1, so asking for 2 is a wrong ordinal rather than an
+    // exhausted budget - and this case is about the cap, not about arithmetic.
+    expect(
+      runReview(proj, [
+        "--stage", "code-generation",
+        "--reviewer", "aidlc-architecture-reviewer-agent",
+        "--iteration", "1",
+      ]).status,
+    ).toBe(0);
     const over = runReview(proj, [
       "--stage", "code-generation",
       "--reviewer", "aidlc-architecture-reviewer-agent",
@@ -670,6 +720,17 @@ describe("t271 review iteration ceiling", () => {
       "Walking skeleton": "false",
       "Bolt slug": "unit-alpha",
     }, proj);
+    // The Bolt boundary opens a fresh attempt, so the pass above no longer counts
+    // against this one. Spend this attempt's single pass before asking for a
+    // second, or the refusal would be about the ordinal rather than the cap.
+    expect(
+      runReview(proj, [
+        "--stage", "functional-design",
+        "--reviewer", "aidlc-architecture-reviewer-agent",
+        "--unit", "unit-alpha",
+        "--iteration", "1",
+      ]).status,
+    ).toBe(0);
     const over = runReview(proj, [
       "--stage", "functional-design",
       "--reviewer", "aidlc-architecture-reviewer-agent",


### PR DESCRIPTION
Replaces #1154, closed unintentionally: a brief visibility change on the head fork detached it
from this repository's fork network, which closed the pull request and made reopening impossible.
Nothing about the change itself was reconsidered. The head commit is the same one that was approved
in #1154 (5e06b8cb9ee91c87b227c32121de3d6df4296c3f), and that review is still on the closed pull
request.

---

## Problem

An `advisory` stage cannot absorb a Request Changes at its approval gate. The only way forward
discards the attempt the human was mid-revision on.

A gate rejection is an attempt boundary — `reviewAttemptAccounting` moves the floor on
`GATE_REJECTED` — so the next review request is ordinal 1 again. `stage-protocol-reviewer.md` says
exactly that should happen on the Part 0 revision path: *"an `advisory` review re-runs as one fresh
advisory pass"*. But a conductor that keeps counting its own passes asks for `--iteration 2`, and the
budget is measured against that claim as well as against the engine's own `expected`:

```ts
if (!recoveryEligible && budget !== null && iteration > budget) { ... }  // the caller's claim
if (!recoveryEligible && budget !== null && expected > budget) { ... }   // the engine's count
...
if (iteration !== expected) { /* "the next iteration is N. Retry with --iteration N." */ }
```

On an advisory stage the budget is 1, so the wrong claim alone raises `REVIEW_BUDGET_EXHAUSTED`
twenty lines before the check that would have named the right ordinal. From there the run has no
forward move:

- the budget refusal says *"do not ask the reviewer again; include the findings in the approval
  summary for the human"*, so the conductor reports `revised`;
- `report --result revised` refuses with `REVIEW_EVIDENCE_MISSING`, because the revision path needs
  the fresh receipt the first refusal just forbade;
- the guard-recovery ask offers a single remedy for a stage in `revising` — a redo jump, which
  restarts the stage.

Two guards, each correct on its own, prescribe what the other refuses. That is the shape #978 named
and #1000 (`d7521b19`, "Supersedes #978") built the machinery for; #885 addressed the neighbouring
case where the stale-receipt recovery pass is already spent. This is a surviving instance, and its
surviving cause is narrow: one of the two guards reads an argument where the other reads state.

The stale-receipt recovery from #758 does not apply here. After a gate rejection the earlier receipt
is not stale — it is outside the attempt window entirely, because the same boundary moved the receipt
scan's floor. `scopeStale` is therefore false and `recoveryEligible` never opens.

## Evidence

Reproduced independently on both Kiro surfaces in one end-to-end run of `rough-mockups`
(`review_class: advisory`), from the audit ledger:

```
10:37:43Z  REVIEW_COMPLETED       iteration 1, READY — terminal receipt
10:48:44Z  GATE_REJECTED          the human asked for changes
10:51–52Z  ARTIFACT_UPDATED ×3    the revision the rejection unfroze
10:52:19Z  ERROR_LOGGED           --iteration 2 → REVIEW_BUDGET_EXHAUSTED, remedies: [redo-jump] only
                                  (report --result revised → REVIEW_EVIDENCE_MISSING)
11:06:31Z  STAGE_JUMPED           the human took the redo; the attempt is gone
```

The refusal names *"review pass 2"*, which is `reviewBudgetMessage(stage, iteration, budget)` — the
caller's number. Had the engine's own count been the subject it would have said pass 1, because the
rejection had already reset it.

## Fix

Delete the `iteration`-based branch.

Admission does not widen: `iteration === expected && iteration > budget && expected <= budget` is
unsatisfiable, so whenever only the deleted branch matched, `iteration !== expected` still refuses —
now with the ordinal to retry. Genuine exhaustion is unchanged, measured by `expected` as before.

What changes is the diagnosis for a wrong ordinal: a retryable error naming the next ordinal, instead
of a typed budget refusal whose only remedy discards the stage.

## Tests

- **New**: an advisory stage where request 1 is recorded READY, the gate is rejected, and
  `--iteration 2` is then refused with *"the next iteration is 1"* rather than *"allows 1 review
  pass"* — and the corrected ordinal is accepted. Fails without this change.
- **Two existing cap cases updated.** Both reached `--iteration 2` while the attempt's next ordinal
  was still 1 — one with no prior request at all, one after an appended `BOLT_STARTED` boundary reset
  it — so they asserted the budget message for what was really an ordinal error. They now spend the
  attempt's single pass first, which is what "the cap is 1" is about.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).

