### PR TITLE
fix: keep review bookkeeping out of the artifact, and out of the reviewer's findings

### DIFF
--- a/core/aidlc-common/protocols/stage-protocol-reviewer.md
+++ b/core/aidlc-common/protocols/stage-protocol-reviewer.md
@@ -240,9 +240,13 @@ Everything else in this section is silent. Nothing is said about invoking, handi
    revision counter or revision-round label, not a list or table of which of its
    findings a revision applied, not a finding's status, not the stage's own review
    state (`draft`, `awaiting review`, `awaiting re-review`, `reviewed`), not a
-   review-record path. Such a copy is
-   unverified and it goes stale by construction rather than by mistake: the gate
-   can approve while the artifact's own note still says a review is pending. An
+   review-record path. Such a copy is unverified and it goes stale by construction
+   rather than by mistake: the gate can approve while the artifact's own note still
+   says a review is pending. What the artifact says about its own subject is
+   untouched: a decision record's lifecycle status - the
+   `## Status: [Proposed | Accepted | Deprecated | Superseded by ADR-NNN]` heading an
+   ADR is told to carry - or any state the customer's own process owns, is content
+   and stays. An
    inline provenance tag is different only when it preserves a tag already carried
    by a consumed upstream artifact or cites an upstream stage's finding as the
    source of a downstream claim. A tag naming this stage's own finding or review

--- a/core/aidlc-common/protocols/stage-protocol-reviewer.md
+++ b/core/aidlc-common/protocols/stage-protocol-reviewer.md
@@ -78,7 +78,7 @@ Everything else in this section is silent. Nothing is said about invoking, handi
      - For a **per-unit** stage (`directive.unit` present) these include the shared inception contracts that pin cross-unit boundaries (`components.md`, `contract-summary.md`, `unit-of-work.md`).
      - For a **workflow-level** stage with no `directive.unit` (e.g. `contract-design`), these are the upstream artifacts that justify the produced output - the unit DAG (`unit-of-work.md`, `unit-of-work-dependency.md`), the component catalogue (`components.md`), and `requirements.md` - so the reviewer can verify the contracts against the boundaries, entities, and NFRs they formalise rather than reviewing the summary in isolation.
    - The validation tools list from the stage definition's frontmatter (if any)
-   - The review-content boundary: tell the reviewer not to raise a finding whose sole subject is this stage's own review bookkeeping. Treat text as this stage's own review bookkeeping when its sole purpose is to record a review iteration or revision count, list or status this stage's findings, or name this stage's review-record path; judge the product claims instead. An inline tag naming an upstream stage's finding is provenance; a tag naming this stage's own finding is bookkeeping.
+   - The review-content boundary: tell the reviewer not to raise a finding whose sole subject is this stage's own review bookkeeping. Treat text as this stage's own review bookkeeping when its sole purpose is to record a review iteration, revision count or revision-round label, to list or status this stage's findings in any form including a table or a section of its own, to state the stage's own review state (`draft`, `awaiting review`, `awaiting re-review`, `reviewed`), or to name this stage's review-record path; judge the product claims instead. An inline tag naming an upstream stage's finding is provenance; a tag naming this stage's own finding is bookkeeping.
    - For a per-unit `workspace_requires` stage, the unit's
      `source-manifest.json` path and its claimed source paths. Review the
      implementation differentially at those paths rather than sweeping the
@@ -235,9 +235,12 @@ Everything else in this section is silent. Nothing is said about invoking, handi
    **Review bookkeeping is not artifact content.** The review record carries the
    verdict, findings, reviewer, request id and artifact fingerprint; the ledger
    carries the human dispositions; and `REVIEW_COMPLETED` pins the record's digest.
-   So do not copy this stage's own review history into a `produces[]` artifact -
-   not a revision counter, not a note listing which of its findings a revision
-   applied, not a finding's status, not a review-record path. Such a copy is
+   So do not copy this stage's own review history into a `produces[]` artifact, in
+   any form - a header line, a heading, a table, or a section of its own: not a
+   revision counter or revision-round label, not a list or table of which of its
+   findings a revision applied, not a finding's status, not the stage's own review
+   state (`draft`, `awaiting review`, `awaiting re-review`, `reviewed`), not a
+   review-record path. Such a copy is
    unverified and it goes stale by construction rather than by mistake: the gate
    can approve while the artifact's own note still says a review is pending. An
    inline provenance tag is different only when it preserves a tag already carried

--- a/core/aidlc-common/protocols/stage-protocol-reviewer.md
+++ b/core/aidlc-common/protocols/stage-protocol-reviewer.md
@@ -78,6 +78,7 @@ Everything else in this section is silent. Nothing is said about invoking, handi
      - For a **per-unit** stage (`directive.unit` present) these include the shared inception contracts that pin cross-unit boundaries (`components.md`, `contract-summary.md`, `unit-of-work.md`).
      - For a **workflow-level** stage with no `directive.unit` (e.g. `contract-design`), these are the upstream artifacts that justify the produced output - the unit DAG (`unit-of-work.md`, `unit-of-work-dependency.md`), the component catalogue (`components.md`), and `requirements.md` - so the reviewer can verify the contracts against the boundaries, entities, and NFRs they formalise rather than reviewing the summary in isolation.
    - The validation tools list from the stage definition's frontmatter (if any)
+   - The review-content boundary: tell the reviewer not to raise a finding whose sole subject is this stage's own review bookkeeping. Treat text as this stage's own review bookkeeping when its sole purpose is to record a review iteration or revision count, list or status this stage's findings, or name this stage's review-record path; judge the product claims instead. An inline tag naming an upstream stage's finding is provenance; a tag naming this stage's own finding is bookkeeping.
    - For a per-unit `workspace_requires` stage, the unit's
      `source-manifest.json` path and its claimed source paths. Review the
      implementation differentially at those paths rather than sweeping the
@@ -230,6 +231,21 @@ Everything else in this section is silent. Nothing is said about invoking, handi
      rejection from generic revision feedback. The state tool validates the
      artifact, ID, current status, and nonblank reason before recording
      `Rejected: <reason>` on `GATE_REJECTED`.
+
+   **Review bookkeeping is not artifact content.** The review record carries the
+   verdict, findings, reviewer, request id and artifact fingerprint; the ledger
+   carries the human dispositions; and `REVIEW_COMPLETED` pins the record's digest.
+   So do not copy this stage's own review history into a `produces[]` artifact -
+   not a revision counter, not a note listing which of its findings a revision
+   applied, not a finding's status, not a review-record path. Such a copy is
+   unverified and it goes stale by construction rather than by mistake: the gate
+   can approve while the artifact's own note still says a review is pending. An
+   inline provenance tag is different only when it preserves a tag already carried
+   by a consumed upstream artifact or cites an upstream stage's finding as the
+   source of a downstream claim. A tag naming this stage's own finding or review
+   iteration is review bookkeeping and is prohibited. The reviewer half of this
+   rule travels in the dispatch list above, because that is the only text a
+   dispatched reviewer receives.
 
    **On an `advisory` review, both verdicts are terminal here.** Do not
    re-invoke the lead or the reviewer during normal flow; proceed to section

--- a/tests/unit/t266-review-class.test.ts
+++ b/tests/unit/t266-review-class.test.ts
@@ -390,6 +390,17 @@ describe("t266 review class", () => {
       expect(src).toContain("On an `advisory` review, both verdicts are terminal here.");
       // The adversarial contract prose t234 pins must survive the class split.
       expect(src).toContain("refute the artifact, not to confirm it");
+      // The conductor half of the bookkeeping rule, and the sentence that draws the
+      // line a looser wording lost: an upstream finding is provenance, this stage's
+      // own finding is bookkeeping. The reviewer half is pinned in t279, on the
+      // dispatch list, because that is the only text a reviewer receives.
+      // Whitespace-normalised: the sentence wraps in the module and re-wrapping it
+      // must not silently drop the pin.
+      const flat = src.replace(/\s+/g, " ");
+      expect(flat).toContain("Review bookkeeping is not artifact content");
+      expect(flat).toContain(
+        "A tag naming this stage's own finding or review iteration is review bookkeeping and is prohibited.",
+      );
     }
   });
 

--- a/tests/unit/t266-review-class.test.ts
+++ b/tests/unit/t266-review-class.test.ts
@@ -401,6 +401,15 @@ describe("t266 review class", () => {
       expect(flat).toContain(
         "A tag naming this stage's own finding or review iteration is review bookkeeping and is prohibited.",
       );
+      // The two forms a live run wrote straight past the looser wording: a header
+      // line stating the stage's own review state, and an applied-findings table
+      // under a heading of its own. Naming the form is what makes the list bite.
+      expect(flat).toContain(
+        "in any form - a header line, a heading, a table, or a section of its own",
+      );
+      expect(flat).toContain(
+        "not the stage's own review state (`draft`, `awaiting review`, `awaiting re-review`, `reviewed`)",
+      );
     }
   });
 

--- a/tests/unit/t279-reviewer-turn-budget.test.ts
+++ b/tests/unit/t279-reviewer-turn-budget.test.ts
@@ -373,17 +373,27 @@ describe("t279 reviewer turn budget is stated on every surface", () => {
       expect(labelled).toContain("aidlc-review-brief.ts context");
       // The reviewer half of the bookkeeping rule lives in the dispatch list, the
       // only text a dispatched reviewer receives. Every shipped copy must carry it.
-      expect(labelled).toContain("The review-content boundary: tell the reviewer");
-      expect(labelled).toContain(
+      // The reviewer half must be INSIDE the dispatch list, not merely somewhere in
+      // the module: that list is the only text a dispatched reviewer receives, so a
+      // copy that moved the clause out of it would ship a rule no reviewer reads.
+      // Scope the assertion to `Pass:` .. `Do NOT pass:` and normalise whitespace,
+      // so re-wrapping the bullet cannot break the pin and relocating it cannot pass.
+      const passStart = module.indexOf("\n   Pass:\n");
+      const passEnd = module.indexOf("Do NOT pass:", passStart);
+      expect(
+        `harness ${harness.name}: Pass: .. Do NOT pass: anchors\n${passStart} ${passEnd}`,
+      ).not.toContain("-1");
+      const dispatchList = module.slice(passStart, passEnd).replace(/\s+/g, " ");
+      const inList = `harness ${harness.name} dispatch list\n${dispatchList}`;
+      expect(inList).toContain("The review-content boundary: tell the reviewer");
+      expect(inList).toContain(
         "a tag naming this stage's own finding is bookkeeping",
       );
       // The two forms a live run produced: a stage-review-state header line, and an
       // applied-findings table. The reviewer half must name them too, or the pass
       // that reads only this list still reports them.
-      expect(labelled).toContain(
-        "to state the stage's own review state",
-      );
-      expect(labelled).toContain(
+      expect(inList).toContain("to state the stage's own review state");
+      expect(inList).toContain(
         "in any form including a table or a section of its own",
       );
       expect(labelled).toContain(

--- a/tests/unit/t279-reviewer-turn-budget.test.ts
+++ b/tests/unit/t279-reviewer-turn-budget.test.ts
@@ -377,6 +377,15 @@ describe("t279 reviewer turn budget is stated on every surface", () => {
       expect(labelled).toContain(
         "a tag naming this stage's own finding is bookkeeping",
       );
+      // The two forms a live run produced: a stage-review-state header line, and an
+      // applied-findings table. The reviewer half must name them too, or the pass
+      // that reads only this list still reports them.
+      expect(labelled).toContain(
+        "to state the stage's own review state",
+      );
+      expect(labelled).toContain(
+        "in any form including a table or a section of its own",
+      );
       expect(labelled).toContain(
         "durable human dispositions from the audit ledger",
       );

--- a/tests/unit/t279-reviewer-turn-budget.test.ts
+++ b/tests/unit/t279-reviewer-turn-budget.test.ts
@@ -371,6 +371,12 @@ describe("t279 reviewer turn budget is stated on every surface", () => {
       expect(labelled).toContain("Before every dispatch, not only the first");
       expect(labelled).toContain("returns `requestId` and `reviewFile`");
       expect(labelled).toContain("aidlc-review-brief.ts context");
+      // The reviewer half of the bookkeeping rule lives in the dispatch list, the
+      // only text a dispatched reviewer receives. Every shipped copy must carry it.
+      expect(labelled).toContain("The review-content boundary: tell the reviewer");
+      expect(labelled).toContain(
+        "a tag naming this stage's own finding is bookkeeping",
+      );
       expect(labelled).toContain(
         "durable human dispositions from the audit ledger",
       );


### PR DESCRIPTION
Replaces #1155, closed unintentionally: a brief visibility change on the head fork detached it
from this repository's fork network, which closed the pull request and made reopening impossible.
Nothing about the change itself was reconsidered. The head also carries two commits made after that
closure, from an adversarial review of the original change; they are described under Fix and Tests
below.

---

## Problem

An advisory stage's revision loop can feed itself. Measured on two live runs, on two
different stages:

**`requirements-analysis`** — three Request Changes at the gate, four review passes, and the
findings list grew by exactly one each pass: 5, 6, 7, 8. Only the first addition was a product
defect (an unspecified freshness contract between two functional requirements). The next two
were about the revision's own bookkeeping: one reported that the artifact's note still named
revision 1 and findings R-01–R-05 after a later revision; the next reported that the note now
named R-01–R-07 while a section further down named R-01–R-06. The second says outright that a
reader is unlikely to be misled.

**`refined-mockups`**, a second run — again three Request Changes and four review passes, with
the findings list at 5, 7, 8, 9. Here only the last addition is bookkeeping, and it is the same
shape: the artifact carries a heading whose label names the finding range a revision applied
(R-01–R-05) over a table that lists eight (R-01–R-08), and the finding reports the mismatch
between the two, calling itself non-blocking document hygiene.

So the prose a revision writes to record what it applied becomes the next pass's finding. In the
first run that finding is what sent the human back to Request Changes. In the second the same
pattern survived as a non-blocking finding, carried to the gate and closed as `Accepted risk` at
approval — so the cost is not always another rejection; sometimes it is a finding the human has
to triage that was never about the product.

Nothing asks for that prose. `required-sections` checks an H2 count. A `## Sources` register is
required by Intent Capture and stated as that stage's own form; the Product Lead persona says
other stages do not produce it. `upstream-coverage` requires a reference to the upstream
artifacts, which is content, not review history. And the history already has an owner with a
digest: the review record carries the verdict, findings, reviewer, request id and artifact
fingerprint, the ledger carries the human dispositions, and `REVIEW_COMPLETED` pins the record.

The copy in the artifact is unverified and goes stale by construction. Both runs show it. In the
first, the artifact still said a review was pending after the ledger had recorded the approval.
In the second the same thing happens at the gate that closes the stage: `GATE_APPROVED` and
`STAGE_COMPLETED` are recorded while the approved artifact's header line still says it is a draft
awaiting re-review, and that line was last written over five hours earlier.

The reviewer side is the other half. An `advisory` pass is defined to report only findings the
human should weigh before approving, and the Product Lead's criteria are implementability,
testability and product scope. None of the three bookkeeping findings moves any of those; two of
them say so themselves. They are not gate findings.

## Fix

One paragraph in the shared reviewer protocol module, next to the existing rule that gate
dispositions are receipt-safe audit data and never artifact edits, plus the reviewer half of the
same rule in the dispatch list — because that list is the only text a dispatched reviewer
receives. The conductor does not copy this stage's own review history into a `produces[]`
artifact, and the reviewer does not raise a finding from that bookkeeping being stale or
self-inconsistent. Citing upstream artifacts and real sources is untouched and stays required
where a stage asks; a tag naming an upstream stage's finding is provenance.

The rule names the **form** as well as the subject, because a form it did not name is what got
written. In the `refined-mockups` run the artifact carried a header line stating the stage's own
review state and an applied-findings table under a heading of its own with a revision-round
label. Neither is a "finding's status" or a "note", so an earlier wording that prohibited those
two did not reach either. The list now reads: in any form — a header line, a heading, a table, or
a section of its own — not a revision counter or revision-round label, not a list or table of
which of its findings a revision applied, not a finding's status, not the stage's own review
state, not a review-record path.

Naming the form makes one carve-out necessary, so it is stated: what the artifact says about its
own subject is untouched. A decision record's lifecycle status — including the
`## Status: [Proposed | Accepted | Deprecated | Superseded by ADR-NNN]` heading an ADR is told to
carry — and any state the customer's own process owns are content and stay. The rule is about this
stage's review history, not about headings.

What this does and does not claim: it names the forms two measured runs produced and puts them
where each side of the review actually reads. It is prose, and the `refined-mockups` run wrote
two of these forms while the module was in the conductor's context, so this is a sharpened rule
rather than a demonstrated fix. Two limits on reading that run: its artifacts were authored in
another language, so a localised status line is a weaker test of an English prohibition than it
looks; and the reviewer half was not present in the copy that run executed, so the reviewer's
behaviour there is not evidence either way.

Prose rather than a sensor, for now. A broad token scan for `R-01`, "revision" or a Sources
section would be mostly false positives, because all three are legitimate in a customer's own
domain document. A narrower structural check is conceivable and this PR does not rule it out: the
review record path and the finding IDs are framework-owned, so a check keyed to the current
stage's own record — a heading or table enumerating several of that record's finding IDs, or the
record path appearing in a `produces[]` artifact — would catch the table form measured here
without touching domain prose. A localised status line is harder to detect that way. Worth
evaluating separately rather than folding into this fix.

## Tests

`t266` whitespace-normalises the conductor half and pins it across core and the projected copy.
`t279` reads every shipped harness copy of the module, extracts the dispatch list between `Pass:`
and `Do NOT pass:`, normalises its whitespace, and pins the reviewer half **inside that range** —
so a copy that keeps the sentence but moves it out of the list fails, which is the case that
matters, because that list is the only text a dispatched reviewer receives.

The negative control was run one item at a time with the removal confirmed at each step: dropping
the conductor-half form list fails `t266` on that pin alone; dropping the reviewer-half clause
fails `t279` on that pin alone; relocating that clause out of the dispatch list while leaving the
sentence in the module also fails `t279`; and restoring each returns its suite to green.

`typecheck`, `lint` and `package.ts --check` are clean. The one failure in `t271` in this
worktree (`--unit requires an authoritative DAG or a matching active or merged Bolt`) is present
at the unmodified base and unrelated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/aidlc-workflows/blob/main/LICENSE).
